### PR TITLE
Point public package metadata at public repo

### DIFF
--- a/compute/napi/npm/darwin-arm64/package.json
+++ b/compute/napi/npm/darwin-arm64/package.json
@@ -18,6 +18,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fundamental-research-labs/mog-internal"
+    "url": "https://github.com/fundamental-research-labs/mog"
   }
 }

--- a/compute/napi/npm/darwin-x64/package.json
+++ b/compute/napi/npm/darwin-x64/package.json
@@ -18,6 +18,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fundamental-research-labs/mog-internal"
+    "url": "https://github.com/fundamental-research-labs/mog"
   }
 }

--- a/compute/napi/npm/linux-arm64-gnu/package.json
+++ b/compute/napi/npm/linux-arm64-gnu/package.json
@@ -18,6 +18,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fundamental-research-labs/mog-internal"
+    "url": "https://github.com/fundamental-research-labs/mog"
   }
 }

--- a/compute/napi/npm/linux-arm64-musl/package.json
+++ b/compute/napi/npm/linux-arm64-musl/package.json
@@ -21,6 +21,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fundamental-research-labs/mog-internal"
+    "url": "https://github.com/fundamental-research-labs/mog"
   }
 }

--- a/compute/napi/npm/linux-x64-gnu/package.json
+++ b/compute/napi/npm/linux-x64-gnu/package.json
@@ -18,6 +18,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fundamental-research-labs/mog-internal"
+    "url": "https://github.com/fundamental-research-labs/mog"
   }
 }

--- a/compute/napi/npm/linux-x64-musl/package.json
+++ b/compute/napi/npm/linux-x64-musl/package.json
@@ -21,6 +21,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fundamental-research-labs/mog-internal"
+    "url": "https://github.com/fundamental-research-labs/mog"
   }
 }

--- a/compute/napi/npm/win32-x64-msvc/package.json
+++ b/compute/napi/npm/win32-x64-msvc/package.json
@@ -18,6 +18,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fundamental-research-labs/mog-internal"
+    "url": "https://github.com/fundamental-research-labs/mog"
   }
 }

--- a/compute/wasm/npm/package.json
+++ b/compute/wasm/npm/package.json
@@ -33,7 +33,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fundamental-research-labs/mog-internal",
+    "url": "https://github.com/fundamental-research-labs/mog",
     "directory": "compute/wasm"
   },
   "publishConfig": {

--- a/runtime/sdk/package.json
+++ b/runtime/sdk/package.json
@@ -51,7 +51,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/fundamental-research-labs/mog-internal",
+    "url": "https://github.com/fundamental-research-labs/mog",
     "directory": "runtime/sdk"
   },
   "publishConfig": {

--- a/views/sheet-view/package.json
+++ b/views/sheet-view/package.json
@@ -36,7 +36,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fundamental-research-labs/mog-internal",
+    "url": "https://github.com/fundamental-research-labs/mog",
     "directory": "views/sheet-view"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary
- update published @mog-sdk package repository metadata from mog-internal to the public mog repo
- keep trusted publishing/provenance metadata aligned with the GitHub Actions source repo

## Verification
- pnpm validate:packages