### PR TITLE
Publish spreadsheet app SDK package

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -31,6 +31,7 @@ jobs:
           - contracts
           - runtime/sdk
           - runtime/embed
+          - runtime/spreadsheet-app
           - views/sheet-view
           - compute/wasm/npm
           - compute/napi/npm/darwin-arm64


### PR DESCRIPTION
## Summary
- add runtime/spreadsheet-app to the SDK publish workflow matrix
- npm trusted publisher is configured for @mog-sdk/spreadsheet-app

## Verification
- pnpm validate:packages
- npm trust list @mog-sdk/spreadsheet-app --json