### PR TITLE
Run SDK publish workflow serially

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -18,29 +18,12 @@ permissions:
 
 jobs:
   publish:
-    name: Publish ${{ matrix.package_dir }}
+    name: Publish SDK packages
     runs-on: ubuntu-latest
     environment: npm-production
     concurrency:
       group: npm-production
       cancel-in-progress: false
-    strategy:
-      fail-fast: false
-      matrix:
-        package_dir:
-          - contracts
-          - runtime/sdk
-          - runtime/embed
-          - runtime/spreadsheet-app
-          - views/sheet-view
-          - compute/wasm/npm
-          - compute/napi/npm/darwin-arm64
-          - compute/napi/npm/darwin-x64
-          - compute/napi/npm/linux-arm64-gnu
-          - compute/napi/npm/linux-arm64-musl
-          - compute/napi/npm/linux-x64-gnu
-          - compute/napi/npm/linux-x64-musl
-          - compute/napi/npm/win32-x64-msvc
 
     steps:
       - uses: actions/checkout@v4
@@ -53,11 +36,10 @@ jobs:
         with:
           node-version: 22.14.0
           registry-url: https://registry.npmjs.org
-          cache: pnpm
 
       - run: npm install -g npm@^11.5.1
 
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --no-frozen-lockfile
 
       - run: pnpm build:public-artifacts
 
@@ -68,10 +50,30 @@ jobs:
           exit 1
 
       - name: Publish package
-        working-directory: ${{ matrix.package_dir }}
         run: |
+          package_dirs=(
+            contracts
+            runtime/sdk
+            runtime/embed
+            runtime/spreadsheet-app
+            views/sheet-view
+            compute/wasm/npm
+            compute/napi/npm/darwin-arm64
+            compute/napi/npm/darwin-x64
+            compute/napi/npm/linux-arm64-gnu
+            compute/napi/npm/linux-arm64-musl
+            compute/napi/npm/linux-x64-gnu
+            compute/napi/npm/linux-x64-musl
+            compute/napi/npm/win32-x64-msvc
+          )
+
+          publish_args=(--access public)
           if [ "${{ inputs.dry_run }}" = "true" ]; then
-            npm publish --access public --dry-run
-          else
-            npm publish --access public
+            publish_args+=(--dry-run)
           fi
+
+          for package_dir in "${package_dirs[@]}"; do
+            echo "::group::Publish ${package_dir}"
+            (cd "${package_dir}" && npm publish "${publish_args[@]}")
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
## Summary
- replace the publish matrix with a single environment-gated job that publishes packages sequentially
- remove setup-node pnpm cache because public main does not include pnpm-lock.yaml
- install dependencies with --no-frozen-lockfile for the current public repo state

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-sdk.yml")'
- pnpm validate:packages