### PR TITLE
Release v0.8.1

### DIFF
--- a/apps/spreadsheet/src/chrome/formula-bar/FormulaBarContainer.tsx
+++ b/apps/spreadsheet/src/chrome/formula-bar/FormulaBarContainer.tsx
@@ -706,13 +706,16 @@ function FormulaBarContainerImpl() {
         )}
 
       {/* Argument Hint Tooltip */}
-      {autocomplete.isArgumentHintOpen && autocomplete.currentFunctionInfo && (
-        <FormulaArgumentHint
-          functionInfo={autocomplete.currentFunctionInfo}
-          currentArgIndex={autocomplete.formulaContext?.currentArgIndex ?? 0}
-          position={autocomplete.argumentHintPosition}
-        />
-      )}
+      {autocomplete.isArgumentHintOpen &&
+        autocomplete.currentFunctionInfo &&
+        autocomplete.argumentHintAnchor && (
+          <FormulaArgumentHint
+            functionInfo={autocomplete.currentFunctionInfo}
+            currentArgIndex={autocomplete.formulaContext?.currentArgIndex ?? 0}
+            anchor={autocomplete.argumentHintAnchor}
+            preferredPlacement={autocomplete.argumentHintPlacement}
+          />
+        )}
     </div>
   );
 }

--- a/apps/spreadsheet/src/components/editor/FormulaArgumentHint.tsx
+++ b/apps/spreadsheet/src/components/editor/FormulaArgumentHint.tsx
@@ -2,30 +2,56 @@
  * Formula Argument Hint Component
  *
  * Displays a tooltip showing the current function's signature with the
- * current argument highlighted. Similar to Excel's IntelliSense.
+ * current argument highlighted, as an inline IntelliSense-style tooltip.
  *
  * Design principles:
  * - Stateless component - all state from editor machine via props
  * - Pure UI - no business logic
+ * - Self-positioning: clamps to the viewport using its OWN measured size
+ *   rather than a guessed width/height, so it never overflows the screen or
+ *   covers its anchor (e.g. the formula bar).
  * - Follows existing Tailwind patterns from InsertFunctionDialog
  *
  */
 
-import { useMemo } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import type { FunctionInfo } from '@mog-sdk/contracts/api';
 import type { FunctionArgument } from '@mog-sdk/contracts/utils';
 // =============================================================================
+// Constants
+// =============================================================================
+
+/** Minimum distance the tooltip keeps from the viewport edges. */
+const VIEWPORT_PADDING = 8;
+/** Gap between the tooltip and its anchor. */
+const ANCHOR_GAP = 4;
+
+// =============================================================================
 // Types
 // =============================================================================
+
+/** Anchor rect (viewport coordinates) the tooltip is positioned against. */
+export interface ArgumentHintAnchor {
+  left: number;
+  top: number;
+  bottom: number;
+}
 
 export interface FormulaArgumentHintProps {
   /** Function metadata from calculator bridge */
   functionInfo: FunctionInfo;
   /** Current argument index (0-based) */
   currentArgIndex: number;
-  /** Screen position for the tooltip */
-  position: { x: number; y: number };
+  /** Anchor rect (viewport coordinates) the tooltip is positioned against. */
+  anchor: ArgumentHintAnchor;
+  /**
+   * Preferred placement relative to the anchor. Flips to the other side when
+   * there isn't room (measured against the tooltip's real height). Defaults to
+   * 'above' (used for in-cell editing). The formula bar uses 'below' since it
+   * sits at the top of the viewport.
+   */
+  preferredPlacement?: 'above' | 'below';
   /** Optional maximum width */
   maxWidth?: number;
 }
@@ -41,7 +67,8 @@ export interface FormulaArgumentHintProps {
 export function FormulaArgumentHint({
   functionInfo,
   currentArgIndex,
-  position,
+  anchor,
+  preferredPlacement = 'above',
   maxWidth = 400,
 }: FormulaArgumentHintProps) {
   const args = functionInfo.arguments ?? [];
@@ -61,84 +88,197 @@ export function FormulaArgumentHint({
 
   const currentArg = displayArgIndex >= 0 ? args[displayArgIndex] : null;
 
+  // The hint shows just the one-line function signature by default so it covers
+  // as little of the grid as possible. Hovering expands it to reveal the
+  // argument and function descriptions.
+  const [expanded, setExpanded] = useState(false);
+  const hasDetails = Boolean(currentArg) || Boolean(functionInfo.description);
+
+  // Position from the tooltip's MEASURED size so it never overflows the
+  // viewport or covers its anchor. coords is null until the first measurement
+  // completes; we render hidden during that frame to avoid a flash at the
+  // unclamped position.
+  const ref = useRef<HTMLDivElement>(null);
+  const [coords, setCoords] = useState<{ left: number; top: number } | null>(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const { width, height } = el.getBoundingClientRect();
+    const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1920;
+    const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 1080;
+
+    // Horizontal: align with the anchor's left edge, shift in if it overflows.
+    let left = anchor.left;
+    if (left + width > viewportWidth - VIEWPORT_PADDING) {
+      left = viewportWidth - width - VIEWPORT_PADDING;
+    }
+    if (left < VIEWPORT_PADDING) left = VIEWPORT_PADDING;
+
+    // Vertical: honour the preferred side, flip to the other when it doesn't
+    // fit, fall back to clamping when neither side has room.
+    const aboveTop = anchor.top - height - ANCHOR_GAP;
+    const belowTop = anchor.bottom + ANCHOR_GAP;
+    const fitsAbove = aboveTop >= VIEWPORT_PADDING;
+    const fitsBelow = belowTop + height <= viewportHeight - VIEWPORT_PADDING;
+
+    let top: number;
+    if (preferredPlacement === 'below') {
+      top = fitsBelow ? belowTop : fitsAbove ? aboveTop : VIEWPORT_PADDING;
+    } else {
+      top = fitsAbove
+        ? aboveTop
+        : fitsBelow
+          ? belowTop
+          : Math.max(VIEWPORT_PADDING, viewportHeight - height - VIEWPORT_PADDING);
+    }
+
+    setCoords((prev) => (prev && prev.left === left && prev.top === top ? prev : { left, top }));
+  }, [
+    anchor.left,
+    anchor.top,
+    anchor.bottom,
+    preferredPlacement,
+    // Content/size affects the measured rect, so re-measure when it changes.
+    functionInfo,
+    displayArgIndex,
+    expanded,
+  ]);
+
+  // Expand/collapse is driven by pointer position (below) rather than
+  // onMouseEnter/Leave so the hint can stay pointer-events-none: clicks pass
+  // through to the grid, preserving click-to-insert-reference while editing a
+  // formula. We toggle `expanded` when the pointer is over the hint's rect.
+  useEffect(() => {
+    if (!hasDetails) return;
+    const onMove = (event: MouseEvent) => {
+      const el = ref.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      const inside =
+        event.clientX >= r.left &&
+        event.clientX <= r.right &&
+        event.clientY >= r.top &&
+        event.clientY <= r.bottom;
+      setExpanded((prev) => (prev === inside ? prev : inside));
+    };
+    window.addEventListener('mousemove', onMove);
+    return () => window.removeEventListener('mousemove', onMove);
+  }, [hasDetails]);
+
+  const containerStyle = {
+    left: coords?.left ?? anchor.left,
+    top: coords?.top ?? anchor.top,
+    maxWidth,
+    visibility: coords ? ('visible' as const) : ('hidden' as const),
+  };
+
+  // Collapsed it's a single line sized to fit within the column-header height
+  // (≈24px): compact font + tight padding. Expanded gets more breathing room.
+  // pointer-events-none keeps clicks passing through to the cells underneath.
+  const containerClassName = `fixed z-ss-popover pointer-events-none bg-ss-surface border border-ss-border rounded shadow-ss-lg text-caption ${
+    expanded ? 'px-3 py-2' : 'px-2 py-0.5'
+  }`;
+
+  // Small affordance that the hint expands on hover (no-op visually otherwise).
+  const expandChevron = hasDetails ? (
+    <span
+      aria-hidden
+      className={`ml-2 inline-block text-caption text-text-muted transition-transform ${
+        expanded ? 'rotate-180' : ''
+      }`}
+    >
+      ▾
+    </span>
+  ) : null;
+
   // If no arguments metadata available, show basic syntax
   if (args.length === 0) {
     return (
       <div
-        className="fixed z-ss-popover pointer-events-none bg-ss-surface border border-ss-border rounded shadow-ss-lg p-3 text-body"
-        style={{
-          left: position.x,
-          top: position.y,
-          maxWidth,
-        }}
+        ref={ref}
+        className={containerClassName}
+        style={containerStyle}
         role="tooltip"
         aria-live="polite"
       >
-        {/* Function name and basic syntax */}
-        <div className="font-ss-mono text-text-ss-primary">
-          <span className="font-semibold text-ss-primary">{functionInfo.name}</span>
-          <span className="text-ss-text-secondary">
-            ({functionInfo.syntax.replace(/^[^(]*\(/, '').replace(/\)$/, '')})
+        {/* Function name and basic syntax (always shown) */}
+        <div className="flex items-baseline font-ss-mono text-text-ss-primary">
+          <span className="whitespace-nowrap">
+            <span className="font-semibold text-ss-primary">{functionInfo.name}</span>
+            <span className="text-ss-text-secondary">
+              ({functionInfo.syntax.replace(/^[^(]*\(/, '').replace(/\)$/, '')})
+            </span>
           </span>
+          {expandChevron}
         </div>
 
-        {/* Function description */}
-        <div className="mt-2 text-body-sm text-ss-text-secondary border-t border-ss-border-light pt-2">
-          {functionInfo.description}
-        </div>
+        {/* Function description (revealed on hover) */}
+        {expanded && functionInfo.description && (
+          <div className="mt-2 text-body-sm text-ss-text-secondary border-t border-ss-border-light pt-2">
+            {functionInfo.description}
+          </div>
+        )}
       </div>
     );
   }
 
   return (
     <div
-      className="fixed z-ss-popover pointer-events-none bg-ss-surface border border-ss-border rounded shadow-ss-lg p-3 text-body"
-      style={{
-        left: position.x,
-        top: position.y,
-        maxWidth,
-      }}
+      ref={ref}
+      className={containerClassName}
+      style={containerStyle}
       role="tooltip"
       aria-live="polite"
     >
-      {/* Function signature with current argument highlighted */}
-      <div className="font-ss-mono text-text-ss-primary leading-relaxed">
-        <span className="font-semibold text-ss-primary">{functionInfo.name}</span>
-        <span className="text-ss-text-secondary">(</span>
-        {args.map((arg: FunctionArgument, i: number) => (
-          <span key={arg.name}>
-            <span
-              className={
-                i === displayArgIndex
-                  ? 'font-bold text-ss-primary bg-ss-primary-lighter px-1 rounded'
-                  : 'text-ss-text-secondary'
-              }
-            >
-              {arg.optional ? '[' : ''}
-              {arg.name}
-              {arg.repeating ? ', ...' : ''}
-              {arg.optional ? ']' : ''}
+      {/* Function signature with current argument highlighted (always shown) */}
+      <div className="flex items-baseline font-ss-mono text-text-ss-primary leading-tight">
+        <span className="whitespace-nowrap">
+          <span className="font-semibold text-ss-primary">{functionInfo.name}</span>
+          <span className="text-ss-text-secondary">(</span>
+          {args.map((arg: FunctionArgument, i: number) => (
+            <span key={arg.name}>
+              <span
+                className={
+                  i === displayArgIndex
+                    ? 'font-bold text-ss-primary bg-ss-primary-lighter px-1 rounded'
+                    : 'text-ss-text-secondary'
+                }
+              >
+                {arg.optional ? '[' : ''}
+                {arg.name}
+                {arg.repeating ? ', ...' : ''}
+                {arg.optional ? ']' : ''}
+              </span>
+              {i < args.length - 1 ? <span className="text-text-muted">, </span> : ''}
             </span>
-            {i < args.length - 1 ? <span className="text-text-muted">, </span> : ''}
-          </span>
-        ))}
-        <span className="text-ss-text-secondary">)</span>
+          ))}
+          <span className="text-ss-text-secondary">)</span>
+        </span>
+        {expandChevron}
       </div>
 
-      {/* Current argument description */}
-      {currentArg && (
-        <div className="mt-2 text-body-sm text-text border-t border-ss-border-light pt-2">
-          <span className="font-medium text-text-ss-primary">{currentArg.name}</span>
-          <span className="text-text-muted"> ({currentArg.type})</span>
-          {currentArg.optional && <span className="text-text-muted italic"> - optional</span>}
-          <div className="mt-1 text-ss-text-secondary">{currentArg.description}</div>
-        </div>
+      {/* Details (revealed on hover) */}
+      {expanded && (
+        <>
+          {/* Current argument description */}
+          {currentArg && (
+            <div className="mt-2 text-body-sm text-text border-t border-ss-border-light pt-2">
+              <span className="font-medium text-text-ss-primary">{currentArg.name}</span>
+              <span className="text-text-muted"> ({currentArg.type})</span>
+              {currentArg.optional && <span className="text-text-muted italic"> - optional</span>}
+              <div className="mt-1 text-ss-text-secondary">{currentArg.description}</div>
+            </div>
+          )}
+
+          {/* Function description */}
+          {functionInfo.description && (
+            <div className="mt-2 text-caption text-text-muted border-t border-ss-border-light pt-2">
+              {functionInfo.description}
+            </div>
+          )}
+        </>
       )}
-
-      {/* Function description (collapsed at bottom) */}
-      <div className="mt-2 text-caption text-text-muted border-t border-ss-border-light pt-2">
-        {functionInfo.description}
-      </div>
     </div>
   );
 }

--- a/apps/spreadsheet/src/components/grid/editors/InlineCellEditor.tsx
+++ b/apps/spreadsheet/src/components/grid/editors/InlineCellEditor.tsx
@@ -493,6 +493,29 @@ export function InlineCellEditor({ workbookSettings }: InlineCellEditorProps) {
       break;
   }
 
+  // Single source of truth for the editor's glyph typography. BOTH the
+  // caret-owning <textarea> and (for formulas) the FormulaHighlighter overlay
+  // read from this, so the visible text and the caret can never drift out of
+  // size/baseline alignment again.
+  //
+  // The size is the cell's *resolved* font scaled by zoom (textPosition.
+  // scaledFont) — never a hardcoded value — so large user fonts and any zoom
+  // level flow through to the editor automatically.
+  //
+  // IMPORTANT: never merge this with `undefined` font longhands in the same
+  // style object. React writes '' for undefined style values, and a trailing
+  // `fontFamily: undefined` after the `font` shorthand clears the shorthand,
+  // collapsing the layer back to the inherited 16px default (the regression
+  // that made formula text huge and misaligned).
+  const textTypography: React.CSSProperties = textPosition
+    ? { font: textPosition.scaledFont, lineHeight: `${scaledLineHeight}px` }
+    : {
+        fontFamily: cellStyles.fontFamily,
+        fontSize: cellStyles.fontSize,
+        fontWeight: cellStyles.fontWeight,
+        lineHeight: cellStyles.lineHeight,
+      };
+
   const baseEditorStyle = textPosition
     ? {
         // WYSIWYG: Use exact position from computeTextPosition()
@@ -505,8 +528,7 @@ export function InlineCellEditor({ workbookSettings }: InlineCellEditorProps) {
         height: effectiveCellRect.height,
         // Typography from resolved style - use scaledFont for zoom-correct rendering
         // Canvas uses ctx.scale(zoom) to scale text; DOM needs explicit font size scaling
-        font: textPosition.scaledFont,
-        lineHeight: `${scaledLineHeight}px`,
+        ...textTypography,
         color: style.color,
         backgroundColor: cellFormat?.backgroundColor || 'var(--color-ss-surface, #ffffff)',
         // Padding matching canvas
@@ -698,11 +720,10 @@ export function InlineCellEditor({ workbookSettings }: InlineCellEditorProps) {
           <div
             className="absolute inset-0 overflow-hidden"
             style={{
-              font: textPosition?.scaledFont,
-              fontFamily: textPosition ? undefined : cellStyles.fontFamily,
-              fontSize: textPosition ? undefined : cellStyles.fontSize,
-              fontWeight: textPosition ? undefined : cellStyles.fontWeight,
-              lineHeight: textPosition ? undefined : cellStyles.lineHeight,
+              // Same typography object the caret-owning textarea uses, so the
+              // highlighted formula text renders at the exact size/baseline as
+              // the caret (and as the canvas would draw it).
+              ...textTypography,
               paddingLeft: style.paddingX,
               paddingRight: style.paddingX,
               paddingTop: verticalPaddingTop,

--- a/apps/spreadsheet/src/components/grid/editors/InlineCellEditor.tsx
+++ b/apps/spreadsheet/src/components/grid/editors/InlineCellEditor.tsx
@@ -597,6 +597,18 @@ export function InlineCellEditor({ workbookSettings }: InlineCellEditorProps) {
     // by alt-mode "no-leak" scenarios that assert the keystream did not
     // bleed into the editor while a different mode owned the keys.
     'data-testid': 'inline-cell-editor',
+    // The textarea is a focusable overlay that owns its own pointer behavior:
+    // a click landing on it must position the text caret / drag a selection,
+    // NOT be reinterpreted by the grid's native pointerdown path. Without this
+    // opt-out, clicking inside the cell you are currently editing bubbles to
+    // the grid container listener (use-grid-mouse handlePointerDown), which —
+    // while editing — preventDefault()s the native caret placement and routes
+    // the click through interceptCellClick. In edit mode (e.g. after a
+    // double-click) that path sends COMMIT, so the click silently commits the
+    // formula and exits the editor instead of moving the caret. Clicks on OTHER
+    // cells land on the canvas (no data-no-grid-pointer) and still flow through
+    // the grid for commit-and-move / formula-reference insertion.
+    'data-no-grid-pointer': true,
     // Only auto-focus when not editing via formula bar
     // When formula bar has focus, show the editor but don't steal focus
     autoFocus: !isFormulaBarFocused,

--- a/apps/spreadsheet/src/components/grid/editors/InlineCellEditor.tsx
+++ b/apps/spreadsheet/src/components/grid/editors/InlineCellEditor.tsx
@@ -678,9 +678,17 @@ export function InlineCellEditor({ workbookSettings }: InlineCellEditorProps) {
           width: '100%',
           height: '100%',
           color: 'transparent',
-          backgroundColor: cellFormat?.backgroundColor || '#ffffff',
+          // The parent formula-edit-overlay div paints the opaque cell fill, so
+          // the textarea itself MUST be transparent — otherwise its opaque
+          // background would cover the FormulaHighlighter glyphs beneath it.
+          backgroundColor: 'transparent',
           caretColor: style.color,
-          zIndex: 1,
+          // Sit ABOVE the highlighter overlay (zIndex:2). The native text caret
+          // is painted in this textarea's layer; any element stacked above it —
+          // even a transparent one — occludes the caret. Keeping the textarea
+          // on top makes the caret visible while the (transparent-text) value
+          // still lets the highlighter's colored glyphs show through.
+          zIndex: 3,
         }
       : baseEditorStyle,
   };

--- a/apps/spreadsheet/src/hooks/editing/use-formula-autocomplete.ts
+++ b/apps/spreadsheet/src/hooks/editing/use-formula-autocomplete.ts
@@ -284,10 +284,7 @@ export function useFormulaAutocomplete(): UseFormulaAutocompleteReturn {
   // Whether the formula bar (rather than the in-cell editor) owns focus. Used to
   // decide where the argument hint is anchored: below the formula bar when it has
   // focus, above the editing cell otherwise.
-  const isFormulaBarFocused = useSelector(
-    paneFocusActor,
-    (state) => state.value === 'formulaBar',
-  );
+  const isFormulaBarFocused = useSelector(paneFocusActor, (state) => state.value === 'formulaBar');
 
   // Ref to input element for positioning
   const inputElementRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);

--- a/apps/spreadsheet/src/hooks/editing/use-formula-autocomplete.ts
+++ b/apps/spreadsheet/src/hooks/editing/use-formula-autocomplete.ts
@@ -33,10 +33,10 @@ import type { FunctionInfo } from '@mog-sdk/contracts/api';
 import type { FunctionArgument } from '@mog-sdk/contracts/utils';
 import {
   clampToViewport,
-  getArgumentHintPosition,
   getAutoCompletePosition,
   type CursorScreenPosition,
 } from '../../domain/editor/cursor-position';
+import type { ArgumentHintAnchor } from '../../components/editor/FormulaArgumentHint';
 import {
   detectTableRefContext,
   formatNameForInsertion,
@@ -88,8 +88,11 @@ export interface UseFormulaAutocompleteReturn {
   /** Screen position for suggestions popup */
   suggestionsPosition: CursorScreenPosition;
 
-  /** Screen position for argument hint tooltip */
-  argumentHintPosition: CursorScreenPosition;
+  /** Anchor rect (viewport coords) for the argument hint tooltip, or null. */
+  argumentHintAnchor: ArgumentHintAnchor | null;
+
+  /** Preferred placement of the argument hint relative to its anchor. */
+  argumentHintPlacement: 'above' | 'below';
 
   /** Combined suggestion count (functions + names) */
   totalSuggestionCount: number;
@@ -276,6 +279,15 @@ function metadataToFunctionInfo(meta: FunctionMetadata): FunctionInfo {
 export function useFormulaAutocomplete(): UseFormulaAutocompleteReturn {
   const coordinator = useCoordinator();
   const editorActor = coordinator.grid.access.actors.editor;
+  const paneFocusActor = coordinator.input.access.actors.paneFocus;
+
+  // Whether the formula bar (rather than the in-cell editor) owns focus. Used to
+  // decide where the argument hint is anchored: below the formula bar when it has
+  // focus, above the editing cell otherwise.
+  const isFormulaBarFocused = useSelector(
+    paneFocusActor,
+    (state) => state.value === 'formulaBar',
+  );
 
   // Ref to input element for positioning
   const inputElementRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
@@ -452,28 +464,38 @@ export function useFormulaAutocomplete(): UseFormulaAutocompleteReturn {
     return clampToViewport(rawPos, { width: 400, height: 300 });
   }, [geometry, editingCell, cursorPosition, coordinator]);
 
-  // Argument hint position (above input)
-  const argumentHintPosition = useMemo((): CursorScreenPosition => {
-    const coordLike = geometry
-      ? {
-          getCellRect: (cell: { row: number; col: number }) => {
-            return geometry.getCellRect(cell);
-          },
-          getContainerRect: () => {
-            const container = coordinator.renderer.getContainer();
-            return container?.getBoundingClientRect() ?? new DOMRect(0, 0, 800, 600);
-          },
-        }
-      : null;
+  // Argument hint anchor + placement.
+  //
+  // We hand the hint an anchor rect (viewport coords) and a preferred side; the
+  // FormulaArgumentHint component clamps to the viewport using its own measured
+  // size, so there are no guessed popup dimensions here.
+  //
+  // - Formula bar focused: anchor to the formula bar input, prefer BELOW it. The
+  //   bar sits at the top of the viewport, so an "above" hint would cover it.
+  // - In-cell editing: anchor to the editing cell, prefer ABOVE it.
+  const argumentHintPlacement: 'above' | 'below' = isFormulaBarFocused ? 'below' : 'above';
+  const argumentHintAnchor = useMemo((): ArgumentHintAnchor | null => {
+    const inputEl = inputElementRef.current;
+    if (isFormulaBarFocused && inputEl) {
+      const rect = inputEl.getBoundingClientRect();
+      return { left: rect.left, top: rect.top, bottom: rect.bottom };
+    }
 
-    const rawPos = getArgumentHintPosition(
-      coordLike,
-      editingCell ?? { row: 0, col: 0 },
-      null,
-      150, // estimated hint height
-    );
-    return clampToViewport(rawPos, { width: 400, height: 150 });
-  }, [geometry, editingCell, coordinator]);
+    if (geometry) {
+      const cellRect = geometry.getCellRect(editingCell ?? { row: 0, col: 0 });
+      if (cellRect) {
+        const container = coordinator.renderer.getContainer();
+        const containerRect = container?.getBoundingClientRect() ?? new DOMRect(0, 0, 800, 600);
+        const top = containerRect.top + cellRect.y;
+        return { left: containerRect.left + cellRect.x, top, bottom: top + cellRect.height };
+      }
+    }
+
+    return null;
+    // cursorPosition is included so the anchor recomputes as the user types
+    // (picking up the input element ref once it is attached), matching
+    // suggestionsPosition above.
+  }, [geometry, editingCell, coordinator, isFormulaBarFocused, cursorPosition]);
 
   // ═══════════════════════════════════════════════════════════════════════════
   // ACTIONS
@@ -535,7 +557,8 @@ export function useFormulaAutocomplete(): UseFormulaAutocompleteReturn {
       nameSuggestions,
       currentFunctionInfo,
       suggestionsPosition,
-      argumentHintPosition,
+      argumentHintAnchor,
+      argumentHintPlacement,
       totalSuggestionCount,
 
       // Actions
@@ -554,7 +577,8 @@ export function useFormulaAutocomplete(): UseFormulaAutocompleteReturn {
       nameSuggestions,
       currentFunctionInfo,
       suggestionsPosition,
-      argumentHintPosition,
+      argumentHintAnchor,
+      argumentHintPlacement,
       totalSuggestionCount,
       acceptCurrentSuggestion,
       acceptSuggestion,

--- a/compute/core/src/storage/engine/services/structural/dimensions.rs
+++ b/compute/core/src/storage/engine/services/structural/dimensions.rs
@@ -1,17 +1,89 @@
 use cell_types::SheetId;
 use compute_document::hex::id_to_hex;
+use compute_document::undo::ORIGIN_USER_EDIT;
 use domain_types::units::{CharWidth, Pixels};
 use value_types::ComputeError;
+use yrs::{Map, Origin, Out, Transact};
 
 use crate::snapshot::{ChangeKind, MutationResult, VisibilityChange};
 use crate::storage::engine::stores::EngineStores;
 use crate::storage::sheet::dimensions;
+use crate::storage::sheet_dimensions::SheetDimensionsMut;
 
 use super::floating_bounds::recompute_floating_object_bounds;
 
 // -------------------------------------------------------------------
 // Dimension Operations (self-contained core logic)
 // -------------------------------------------------------------------
+
+/// True when the sheet stores its axis identities in compact (`Runs`) form
+/// under `gridIndex`. Compact axes are authoritative on reload, so an
+/// auto-grow that only appends to `rowOrder`/`colOrder` would be discarded —
+/// the caller must materialize dense axes when this returns `true`.
+fn sheet_has_compact_axes(txn: &yrs::TransactionMut<'_>, sheet_map: &yrs::MapRef) -> bool {
+    use compute_document::schema::{KEY_GRID_COL_AXIS, KEY_GRID_INDEX, KEY_GRID_ROW_AXIS};
+    match sheet_map.get(txn, KEY_GRID_INDEX) {
+        Some(Out::YMap(grid_index)) => {
+            grid_index.get(txn, KEY_GRID_ROW_AXIS).is_some()
+                || grid_index.get(txn, KEY_GRID_COL_AXIS).is_some()
+        }
+        _ => false,
+    }
+}
+
+/// Ensure the sheet's axis identities cover `(row, col)` before a dimension
+/// write.
+///
+/// Resizing addresses a row/column by *physical index*, but the storage layer
+/// keys widths/heights by the stable RowId/ColId resolved from that index via
+/// the `GridIndex` axis store. When the index lies beyond the materialized
+/// extent (e.g. a sparse or compact-persisted document), that lookup returns
+/// `None` and the write historically failed with a misleading
+/// [`ComputeError::SheetNotFound`].
+///
+/// This mirrors the cell-write auto-grow path: it expands both the in-memory
+/// `GridIndex` and the Yrs `rowOrder`/`colOrder` arrays (and materializes
+/// compact axes to dense so the grow survives reload), using the same freshly
+/// allocated identities on both sides. No-op when the index is already covered.
+fn ensure_axis_capacity(
+    stores: &mut EngineStores,
+    sheet_id: &SheetId,
+    row: u32,
+    col: u32,
+) -> Result<(), ComputeError> {
+    if !stores.grid_indexes.contains_key(sheet_id) {
+        return Err(ComputeError::SheetNotFound {
+            sheet_id: sheet_id.to_uuid_string(),
+        });
+    }
+
+    let sheet_hex = id_to_hex(sheet_id.as_u128());
+    let doc = stores.storage.doc();
+    let sheets = stores.storage.sheets();
+    // User-edit origin so the implicit grow groups with the resize for undo.
+    let mut txn = doc.transact_mut_with(Origin::from(ORIGIN_USER_EDIT));
+
+    let compact_axes = match sheets.get(&txn, sheet_hex.as_str()) {
+        Some(Out::YMap(sheet_map)) => sheet_has_compact_axes(&txn, &sheet_map),
+        _ => {
+            return Err(ComputeError::SheetNotFound {
+                sheet_id: sheet_id.to_uuid_string(),
+            });
+        }
+    };
+
+    // `contains_key` checked above, so the sheet is present in the index map.
+    let grid = stores
+        .grid_indexes
+        .get_mut(sheet_id)
+        .expect("grid index present");
+    let mut dims = SheetDimensionsMut::from_grid_index(doc, sheets, grid);
+    dims.ensure_capacity(&mut txn, *sheet_id, row, col)?;
+    if compact_axes {
+        dims.materialize_dense_axes_and_remove_compact_keys(&mut txn, *sheet_id)?;
+    }
+    Ok(())
+}
 
 /// Set row height.
 ///
@@ -23,6 +95,9 @@ pub(in crate::storage::engine) fn set_row_height(
     row: u32,
     height_px: Pixels,
 ) -> Result<MutationResult, ComputeError> {
+    // Auto-grow the axis so resizing a row beyond the materialized extent
+    // works instead of failing with a misleading SheetNotFound.
+    ensure_axis_capacity(stores, sheet_id, row, 0)?;
     // Store canonical units (points) in Yrs
     let height_pt = domain_types::units::pixels_to_points(height_px);
     dimensions::set_row_height(
@@ -61,6 +136,9 @@ pub(in crate::storage::engine) fn set_col_width(
     col: u32,
     width_px: Pixels,
 ) -> Result<MutationResult, ComputeError> {
+    // Auto-grow the axis so resizing a column beyond the materialized extent
+    // works instead of failing with a misleading SheetNotFound.
+    ensure_axis_capacity(stores, sheet_id, 0, col)?;
     // Store canonical units (char-width) in Yrs
     let mdw = domain_types::units::platform_mdw();
     let width_cw = domain_types::units::pixels_to_char_width(width_px, mdw);
@@ -100,6 +178,11 @@ pub(in crate::storage::engine) fn set_col_widths(
     sheet_id: &SheetId,
     widths: &[(u32, Pixels)],
 ) -> Result<MutationResult, ComputeError> {
+    // Auto-grow once to cover the widest target so out-of-extent columns in the
+    // batch resolve to a stable identity instead of failing SheetNotFound.
+    if let Some(max_col) = widths.iter().map(|(col, _)| *col).max() {
+        ensure_axis_capacity(stores, sheet_id, 0, max_col)?;
+    }
     let mdw = domain_types::units::platform_mdw();
     let mut result = MutationResult::empty();
 
@@ -138,6 +221,7 @@ pub(in crate::storage::engine) fn set_col_width_chars(
     col: u32,
     width_cw: CharWidth,
 ) -> Result<MutationResult, ComputeError> {
+    ensure_axis_capacity(stores, sheet_id, 0, col)?;
     dimensions::set_col_width(
         stores.storage.doc(),
         stores.storage.sheets(),
@@ -172,6 +256,9 @@ pub(in crate::storage::engine) fn set_col_widths_chars(
     sheet_id: &SheetId,
     widths: &[(u32, CharWidth)],
 ) -> Result<MutationResult, ComputeError> {
+    if let Some(max_col) = widths.iter().map(|(col, _)| *col).max() {
+        ensure_axis_capacity(stores, sheet_id, 0, max_col)?;
+    }
     let mdw = domain_types::units::platform_mdw();
     let mut result = MutationResult::empty();
 

--- a/compute/core/tests/resize_unmaterialized_axis.rs
+++ b/compute/core/tests/resize_unmaterialized_axis.rs
@@ -1,0 +1,131 @@
+//! Regression: resizing a column/row whose physical index lies beyond the
+//! sheet's materialized axis-identity extent must succeed (auto-grow), not
+//! fail with a (misleading) `SheetNotFound`.
+//!
+//! Root cause this pins: `set_col_width` / `set_row_height` resolve the
+//! physical index to a stable RowId/ColId via the `GridIndex` axis store and,
+//! when no identity exists for that index, historically returned
+//! `ComputeError::SheetNotFound` — even though the sheet is present and renders
+//! fine. Cell writes already auto-grow the axis via
+//! `SheetDimensionsMut::ensure_capacity`; the dimension write path did not.
+//!
+//! Repro shape mirrors the field report (debug recording
+//! "SheetNotFoundColumnResizeIssue"): viewport/read calls on the sheet all
+//! succeed, only the resize write throws.
+
+use compute_core::storage::engine::YrsComputeEngine;
+use snapshot_types::{CellData, SheetSnapshot, WorkbookSnapshot};
+use value_types::{CellValue, FiniteF64};
+
+const SHEET_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+
+/// A tiny sheet: 3x3 materialized extent, content only near the origin.
+/// Columns/rows past index 2 have no materialized axis identity.
+fn small_snapshot() -> WorkbookSnapshot {
+    WorkbookSnapshot {
+        sheets: vec![SheetSnapshot {
+            id: SHEET_ID.to_string(),
+            name: "Resize".to_string(),
+            rows: 3,
+            cols: 3,
+            cells: vec![CellData {
+                cell_id: "a0000000-0000-0000-0000-000000000001".to_string(),
+                row: 0,
+                col: 0,
+                value: CellValue::Number(FiniteF64::must(1.0)),
+                formula: None,
+                identity_formula: None,
+                array_ref: None,
+            }],
+            ranges: vec![],
+        }],
+        ..Default::default()
+    }
+}
+
+fn sheet_id(engine: &YrsComputeEngine) -> cell_types::SheetId {
+    *engine.mirror().sheet_ids().next().expect("sheet present")
+}
+
+#[test]
+fn set_col_width_beyond_materialized_extent_succeeds() {
+    let (mut engine, _) = YrsComputeEngine::from_snapshot(small_snapshot()).expect("from_snapshot");
+    let sid = sheet_id(&engine);
+
+    // Column 8 is well past the 3-column materialized extent.
+    let target_col = 8u32;
+    let width_px = 188.0;
+
+    let res = engine.set_col_width(&sid, target_col, width_px);
+    assert!(
+        res.is_ok(),
+        "resizing a column beyond the materialized extent must succeed, got {:?}",
+        res.err()
+    );
+
+    // The new width must be readable back (auto-grow persisted the identity).
+    let got = engine.get_col_width_query(&sid, target_col);
+    assert!(
+        (got - width_px).abs() < 1.0,
+        "expected col {target_col} width ~{width_px}px after resize, got {got}px"
+    );
+}
+
+#[test]
+fn set_row_height_beyond_materialized_extent_succeeds() {
+    let (mut engine, _) = YrsComputeEngine::from_snapshot(small_snapshot()).expect("from_snapshot");
+    let sid = sheet_id(&engine);
+
+    let target_row = 8u32;
+    let height_px = 94.5;
+
+    let res = engine.set_row_height(&sid, target_row, height_px);
+    assert!(
+        res.is_ok(),
+        "resizing a row beyond the materialized extent must succeed, got {:?}",
+        res.err()
+    );
+}
+
+#[test]
+fn set_col_widths_batch_beyond_extent_succeeds() {
+    let (mut engine, _) = YrsComputeEngine::from_snapshot(small_snapshot()).expect("from_snapshot");
+    let sid = sheet_id(&engine);
+
+    // Mix in-extent (col 1) and out-of-extent (col 7) targets in one batch.
+    let writes = [(1u32, 137.0f64), (7u32, 211.0f64)];
+    let res = engine.set_col_widths(&sid, &writes);
+    assert!(
+        res.is_ok(),
+        "batch resize spanning the materialized extent must succeed, got {:?}",
+        res.err()
+    );
+
+    let got = engine.get_col_width_query(&sid, 7);
+    assert!(
+        (got - 211.0).abs() < 1.0,
+        "expected col 7 width ~211px after batch resize, got {got}px"
+    );
+}
+
+/// The auto-grown width must survive a serialize → reload round-trip, i.e. the
+/// axis identity is persisted in Yrs (not just in the in-memory GridIndex).
+#[test]
+fn auto_grown_col_width_persists_across_reload() {
+    let (mut engine, _) = YrsComputeEngine::from_snapshot(small_snapshot()).expect("from_snapshot");
+    let sid = sheet_id(&engine);
+
+    engine
+        .set_col_width(&sid, 8, 188.0)
+        .expect("resize must succeed");
+
+    let bytes = engine.export_to_xlsx_bytes().expect("export xlsx");
+    let (reloaded, _) = YrsComputeEngine::from_xlsx_bytes(&bytes).expect("reload xlsx");
+    let rsid = sheet_id(&reloaded);
+
+    let got = reloaded.get_col_width_query(&rsid, 8);
+    assert!(
+        (got - 188.0).abs() < 2.0,
+        "col 8 width must persist across reload, got {got}px"
+    );
+}


### PR DESCRIPTION
Promote dev-v0.8.1 to main for the v0.8.1 release.

## Commits
- fix(spreadsheet): formula-edit overlay must render at the cell font, not the inherited default
- Fix formula argument hint covering the formula bar; collapse to one line with hover-to-expand
- fix(compute): auto-grow axis on column/row resize beyond materialized extent
- fix(spreadsheet): make the in-cell formula caret visible
- Fix formula edit mode committing when clicking inside the edited cell
- style: apply prettier formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)