### PR TITLE
docs: add live link to mog.shortcut.ai in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Mog is a spreadsheet engine, app runtime, and SDK stack for building
 workbook-aware agents, automations, and embedded spreadsheet experiences.
 
+Try it live at [mog.shortcut.ai](https://mog.shortcut.ai/).
+
 ## Choose Your Path
 
 | I want to... | Start here | Useful command |


### PR DESCRIPTION
Adds a "Try it live" link to [mog.shortcut.ai](https://mog.shortcut.ai/) near the top of the README so readers can reach the hosted app directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)