### PR TITLE
Deploy Mog CLI from main

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,100 @@
+name: Publish Mog CLI
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Build artifacts and print release output without uploading
+        required: true
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    name: Package Mog CLI (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    concurrency:
+      group: mog-cli-package-${{ matrix.os }}
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm -C compute/napi build:release
+
+      - run: pnpm --filter @mog/cli package:standalone
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: mog-cli-${{ matrix.os }}
+          path: artifacts/mog-cli-*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: Publish Mog CLI release
+    runs-on: ubuntu-latest
+    needs: package
+    concurrency:
+      group: mog-cli-release
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: mog-cli-*
+          path: artifacts
+          merge-multiple: true
+
+      - run: pnpm --filter @mog/cli package:skill
+
+      - run: pnpm --filter @mog/cli package:installer
+
+      - name: Check CLI version contract
+        run: |
+          CLI_VERSION=$(node -p "require('./cli/package.json').version")
+          SDK_VERSION=$(node -p "require('./runtime/sdk/package.json').version")
+          if [ "$CLI_VERSION" != "$SDK_VERSION" ]; then
+            echo "@mog/cli version ${CLI_VERSION} does not match @mog-sdk/node ${SDK_VERSION}."
+            exit 1
+          fi
+
+      - name: Publish CLI raw GitHub release
+        env:
+          MOG_CLI_RELEASE_DRY_RUN: ${{ inputs.dry_run }}
+        run: node cli/scripts/publish-raw-release.mjs

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@mog/cli",
+  "version": "0.8.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "mog": "./dist/mog.cjs"
+  },
+  "scripts": {
+    "build": "pnpm -w run build:public-artifacts -- --through @mog-sdk/node --skip-native-build --skip-host-native-artifact --skip-wasm-build && tsup",
+    "package:npm": "pnpm run build && node scripts/package-npm.mjs",
+    "package:release": "pnpm run package:standalone && pnpm run package:skill",
+    "package:installer": "node scripts/package-installer.mjs",
+    "package:standalone": "node scripts/package-standalone.mjs",
+    "package:skill": "node scripts/package-skill.mjs",
+    "publish:raw": "pnpm run package:release && node scripts/publish-raw-release.mjs",
+    "test:npm-local": "pnpm run package:npm && node testing/npm-local-e2e.mjs",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "pnpm test:e2e",
+    "test:e2e": "pnpm build && node testing/e2e.mjs"
+  },
+  "dependencies": {
+    "@mog-sdk/node": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "tsup": "^8.5.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/cli/scripts/install-standalone.sh
+++ b/cli/scripts/install-standalone.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+MOG_CLI_VERSION="${MOG_CLI_VERSION:-0.6.0}"
+BASE_URL="${MOG_CLI_BASE_URL:-https://raw.githubusercontent.com/fundamental-research-labs/mog/cli-releases/mog-cli-v$MOG_CLI_VERSION}"
+INSTALL_DIR="${MOG_CLI_INSTALL_DIR:-$HOME/.mog/cli}"
+BIN_DIR="${MOG_CLI_BIN_DIR:-$HOME/.local/bin}"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Mog CLI requires Node.js 18+ on PATH." >&2
+  echo "Install Node.js first, then rerun this installer." >&2
+  exit 1
+fi
+
+node_major="$(node -p 'process.versions.node.split(".")[0]')"
+if [ "$node_major" -lt 18 ]; then
+  echo "Mog CLI requires Node.js 18+ on PATH. Found: $(node -v)" >&2
+  exit 1
+fi
+
+platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+
+case "$platform:$arch" in
+  darwin:arm64) target="darwin-arm64" ;;
+  darwin:x86_64) target="darwin-x64" ;;
+  linux:x86_64)
+    if ldd --version 2>&1 | grep -qi musl; then
+      target="linux-x64-musl"
+    else
+      target="linux-x64-gnu"
+    fi
+    ;;
+  linux:aarch64|linux:arm64)
+    if ldd --version 2>&1 | grep -qi musl; then
+      target="linux-arm64-musl"
+    else
+      target="linux-arm64-gnu"
+    fi
+    ;;
+  msys*:x86_64|mingw*:x86_64|cygwin*:x86_64) target="win32-x64-msvc" ;;
+  *) echo "Unsupported platform: $platform/$arch" >&2; exit 1 ;;
+esac
+
+url="${MOG_CLI_TARBALL_URL:-$BASE_URL/mog-cli-$target.tar.gz}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+mkdir -p "$INSTALL_DIR" "$BIN_DIR"
+curl -fsSL "$url" -o "$tmp/mog-cli.tar.gz"
+rm -rf "$INSTALL_DIR"/*
+tar -xzf "$tmp/mog-cli.tar.gz" -C "$INSTALL_DIR" --strip-components=1
+
+ln -sf "$INSTALL_DIR/bin/mog.cjs" "$BIN_DIR/mog"
+
+echo "Installed mog to $BIN_DIR/mog"
+echo "If needed, add $BIN_DIR to PATH."

--- a/cli/scripts/package-installer.mjs
+++ b/cli/scripts/package-installer.mjs
@@ -1,0 +1,43 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(cliRoot, '..');
+const artifactsDir = resolve(repoRoot, 'artifacts');
+const installerPath = resolve(artifactsDir, 'install-mog-cli.sh');
+const packageVersion = releasePackageVersion();
+
+mkdirSync(artifactsDir, { recursive: true });
+writeFileSync(installerPath, installerSource(packageVersion));
+
+console.log(JSON.stringify({ ok: true, version: packageVersion, installerPath }, null, 2));
+
+function releasePackageVersion() {
+  const packageJson = readJson(resolve(cliRoot, 'package.json'));
+  const sdkPackageJson = readJson(resolve(repoRoot, 'runtime', 'sdk', 'package.json'));
+  if (packageJson.version !== sdkPackageJson.version) {
+    throw new Error(
+      `@mog/cli version ${packageJson.version} must match @mog-sdk/node version ${sdkPackageJson.version}`,
+    );
+  }
+  return packageJson.version;
+}
+
+function installerSource(version) {
+  const sourcePath = resolve(cliRoot, 'scripts', 'install-standalone.sh');
+  if (!existsSync(sourcePath)) throw new Error(`Installer source not found: ${sourcePath}`);
+  const source = readFileSync(sourcePath, 'utf8');
+  const updated = source.replace(
+    /^MOG_CLI_VERSION="\$\{MOG_CLI_VERSION:-[^}]+}"$/m,
+    `MOG_CLI_VERSION="\${MOG_CLI_VERSION:-${version}}"`,
+  );
+  if (!updated.includes(`MOG_CLI_VERSION="\${MOG_CLI_VERSION:-${version}}"`)) {
+    throw new Error('Installer version line was not found');
+  }
+  return updated;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}

--- a/cli/scripts/package-npm.mjs
+++ b/cli/scripts/package-npm.mjs
@@ -1,0 +1,113 @@
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(cliRoot, '..');
+const artifactsDir = resolve(repoRoot, 'artifacts', 'npm');
+const packageDir = resolve(artifactsDir, 'mog-cli');
+const version = releasePackageVersion();
+
+const distFile = resolve(cliRoot, 'dist', 'mog.cjs');
+const distMapFile = resolve(cliRoot, 'dist', 'mog.cjs.map');
+if (!existsSync(distFile)) {
+  throw new Error(`Missing built CLI at ${distFile}. Run pnpm --filter @mog/cli build first.`);
+}
+
+rmSync(packageDir, { recursive: true, force: true });
+mkdirSync(resolve(packageDir, 'dist'), { recursive: true });
+cpSync(distFile, resolve(packageDir, 'dist', 'mog.cjs'));
+if (existsSync(distMapFile)) cpSync(distMapFile, resolve(packageDir, 'dist', 'mog.cjs.map'));
+chmodSync(resolve(packageDir, 'dist', 'mog.cjs'), 0o755);
+
+writeFileSync(
+  resolve(packageDir, 'package.json'),
+  `${JSON.stringify(npmManifest(version), null, 2)}\n`,
+);
+writeFileSync(
+  resolve(packageDir, 'README.md'),
+  [
+    '# Mog CLI',
+    '',
+    'Minimal command-line interface for operating Mog workbooks with the headless SDK.',
+    '',
+    '```bash',
+    'npm install -g @mog/cli',
+    'mog create --name model --path .',
+    '```',
+    '',
+  ].join('\n'),
+);
+
+const output = execFileSync('npm', ['pack', '--pack-destination', artifactsDir, '--json'], {
+  cwd: packageDir,
+  encoding: 'utf8',
+});
+const packed = JSON.parse(output);
+const filename = packed.at(0)?.filename;
+if (!filename) throw new Error(`npm pack did not report a filename: ${output}`);
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      version,
+      packageDir,
+      tarballPath: resolve(artifactsDir, filename),
+    },
+    null,
+    2,
+  ),
+);
+
+function npmManifest(packageVersion) {
+  return {
+    name: '@mog/cli',
+    version: packageVersion,
+    description: 'Minimal command-line interface for operating Mog workbooks with the headless SDK',
+    license: 'MIT',
+    type: 'commonjs',
+    bin: {
+      mog: './dist/mog.cjs',
+    },
+    files: ['dist', 'README.md'],
+    engines: {
+      node: '>=18',
+    },
+    repository: {
+      type: 'git',
+      url: 'https://github.com/fundamental-research-labs/mog',
+      directory: 'cli',
+    },
+    publishConfig: {
+      access: 'public',
+    },
+    dependencies: {
+      '@mog-sdk/node': packageVersion,
+    },
+  };
+}
+
+function releasePackageVersion() {
+  const packageJson = readJson(resolve(cliRoot, 'package.json'));
+  const sdkPackageJson = readJson(resolve(repoRoot, 'runtime', 'sdk', 'package.json'));
+  if (packageJson.version !== sdkPackageJson.version) {
+    throw new Error(
+      `@mog/cli version ${packageJson.version} must match @mog-sdk/node version ${sdkPackageJson.version}`,
+    );
+  }
+  return packageJson.version;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}

--- a/cli/scripts/package-skill.mjs
+++ b/cli/scripts/package-skill.mjs
@@ -1,0 +1,153 @@
+import { deflateRawSync } from 'node:zlib';
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(cliRoot, '..');
+const skillRoot = resolve(cliRoot, 'skill');
+const artifactsDir = resolve(repoRoot, 'artifacts');
+const zipPath = resolve(artifactsDir, 'mog-cli-kernel.skill.zip');
+const crcTable = makeCrc32Table();
+const packageVersion = releasePackageVersion();
+
+mkdirSync(artifactsDir, { recursive: true });
+rmSync(zipPath, { force: true });
+
+const entries = collectFiles(skillRoot).map((path) => {
+  const name = relative(skillRoot, path).split(sep).join('/');
+  return { name, data: fileData(name, path) };
+});
+
+writeFileSync(zipPath, makeZip(entries));
+
+console.log(
+  JSON.stringify({ ok: true, zipPath, entries: entries.map((entry) => entry.name) }, null, 2),
+);
+
+function collectFiles(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(dir, entry.name);
+    if (entry.isDirectory()) return collectFiles(path);
+    if (entry.isFile()) return [path];
+    return [];
+  });
+}
+
+function fileData(name, path) {
+  const data = readFileSync(path);
+  if (name !== 'SKILL.md') return data;
+  return Buffer.from(
+    data
+      .toString('utf8')
+      .replace(
+        /mog-cli-v[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9_.-]+)?/g,
+        `mog-cli-v${packageVersion}`,
+      ),
+    'utf8',
+  );
+}
+
+function releasePackageVersion() {
+  const packageJson = JSON.parse(readFileSync(resolve(cliRoot, 'package.json'), 'utf8'));
+  const sdkPackageJson = JSON.parse(
+    readFileSync(resolve(repoRoot, 'runtime', 'sdk', 'package.json'), 'utf8'),
+  );
+  if (packageJson.version !== sdkPackageJson.version) {
+    throw new Error(
+      `@mog/cli version ${packageJson.version} must match @mog-sdk/node version ${sdkPackageJson.version}`,
+    );
+  }
+  return packageJson.version;
+}
+
+function makeZip(files) {
+  const localParts = [];
+  const centralParts = [];
+  let offset = 0;
+
+  for (const file of files) {
+    const name = Buffer.from(file.name, 'utf8');
+    const compressed = deflateRawSync(file.data);
+    const crc = crc32(file.data);
+    const { dosTime, dosDate } = dosDateTime(new Date());
+
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt16LE(0, 6);
+    localHeader.writeUInt16LE(8, 8);
+    localHeader.writeUInt16LE(dosTime, 10);
+    localHeader.writeUInt16LE(dosDate, 12);
+    localHeader.writeUInt32LE(crc, 14);
+    localHeader.writeUInt32LE(compressed.length, 18);
+    localHeader.writeUInt32LE(file.data.length, 22);
+    localHeader.writeUInt16LE(name.length, 26);
+    localHeader.writeUInt16LE(0, 28);
+
+    localParts.push(localHeader, name, compressed);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(20, 4);
+    centralHeader.writeUInt16LE(20, 6);
+    centralHeader.writeUInt16LE(0, 8);
+    centralHeader.writeUInt16LE(8, 10);
+    centralHeader.writeUInt16LE(dosTime, 12);
+    centralHeader.writeUInt16LE(dosDate, 14);
+    centralHeader.writeUInt32LE(crc, 16);
+    centralHeader.writeUInt32LE(compressed.length, 20);
+    centralHeader.writeUInt32LE(file.data.length, 24);
+    centralHeader.writeUInt16LE(name.length, 28);
+    centralHeader.writeUInt16LE(0, 30);
+    centralHeader.writeUInt16LE(0, 32);
+    centralHeader.writeUInt16LE(0, 34);
+    centralHeader.writeUInt16LE(0, 36);
+    centralHeader.writeUInt32LE(0, 38);
+    centralHeader.writeUInt32LE(offset, 42);
+    centralParts.push(centralHeader, name);
+
+    offset += localHeader.length + name.length + compressed.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(0, 4);
+  end.writeUInt16LE(0, 6);
+  end.writeUInt16LE(files.length, 8);
+  end.writeUInt16LE(files.length, 10);
+  end.writeUInt32LE(centralDirectory.length, 12);
+  end.writeUInt32LE(offset, 16);
+  end.writeUInt16LE(0, 20);
+
+  return Buffer.concat([...localParts, centralDirectory, end]);
+}
+
+function dosDateTime(date) {
+  const year = Math.max(date.getFullYear(), 1980);
+  return {
+    dosTime: (date.getHours() << 11) | (date.getMinutes() << 5) | Math.floor(date.getSeconds() / 2),
+    dosDate: ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate(),
+  };
+}
+
+function crc32(data) {
+  let crc = 0xffffffff;
+  for (const byte of data) {
+    crc = (crc >>> 8) ^ crcTable[(crc ^ byte) & 0xff];
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function makeCrc32Table() {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < table.length; i += 1) {
+    let value = i;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+    }
+    table[i] = value >>> 0;
+  }
+  return table;
+}

--- a/cli/scripts/package-standalone.mjs
+++ b/cli/scripts/package-standalone.mjs
@@ -1,0 +1,175 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync, cpSync, writeFileSync } from 'node:fs';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(cliRoot, '..');
+const artifactsDir = resolve(repoRoot, 'artifacts');
+const standaloneDist = resolve(cliRoot, 'dist-standalone');
+const platform = currentPlatform();
+const packageName = `mog-cli-${platform}`;
+const stageRoot = resolve(artifactsDir, packageName);
+const tarballPath = resolve(artifactsDir, `${packageName}.tar.gz`);
+const installerPath = resolve(artifactsDir, 'install-mog-cli.sh');
+const nativeSource = resolve(repoRoot, 'compute', 'napi', 'compute-core-napi.node');
+const nativePackageName = platformPackageName(platform);
+const nativePackageInstallDir = resolve(stageRoot, 'node_modules', '@mog-sdk', platform);
+const nativePackageSourceDir = resolve(repoRoot, 'compute', 'napi', 'npm', platform);
+const version = await releasePackageVersion();
+
+if (!existsSync(nativeSource)) {
+  throw new Error(
+    `Native addon not found at ${nativeSource}. Build it first with: pnpm --filter @mog/compute-core-napi build:release`,
+  );
+}
+if (!existsSync(resolve(nativePackageSourceDir, 'package.json'))) {
+  throw new Error(`Native package metadata not found: ${nativePackageSourceDir}`);
+}
+
+run(
+  'pnpm',
+  [
+    '-w',
+    'run',
+    'build:public-artifacts',
+    '--',
+    '--through',
+    '@mog-sdk/node',
+    '--skip-native-build',
+    '--skip-host-native-artifact',
+    '--skip-wasm-build',
+  ],
+  repoRoot,
+);
+run('pnpm', ['exec', 'tsup', '--config', 'tsup.config.ts'], cliRoot, {
+  ...process.env,
+  MOG_CLI_STANDALONE: '1',
+  MOG_CLI_OUT_DIR: relative(cliRoot, standaloneDist),
+});
+
+rmSync(stageRoot, { recursive: true, force: true });
+mkdirSync(resolve(stageRoot, 'bin'), { recursive: true });
+mkdirSync(nativePackageInstallDir, { recursive: true });
+
+cpSync(resolve(standaloneDist, 'mog.cjs'), resolve(stageRoot, 'bin', 'mog.cjs'));
+cpSync(resolve(standaloneDist, 'mog.cjs.map'), resolve(stageRoot, 'bin', 'mog.cjs.map'));
+cpSync(
+  resolve(nativePackageSourceDir, 'package.json'),
+  resolve(nativePackageInstallDir, 'package.json'),
+);
+cpSync(nativeSource, resolve(nativePackageInstallDir, 'compute-core-napi.node'));
+
+writeFileSync(
+  resolve(stageRoot, 'package.json'),
+  `${JSON.stringify(
+    {
+      name: '@mog/cli-standalone',
+      version,
+      private: true,
+      type: 'commonjs',
+      bin: {
+        mog: './bin/mog.cjs',
+      },
+      bundledPlatform: platform,
+      bundledNativePackage: nativePackageName,
+      engines: {
+        node: '>=18',
+      },
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+rmSync(tarballPath, { force: true });
+run('tar', ['-czf', tarballPath, '-C', artifactsDir, packageName], repoRoot);
+run('node', ['scripts/package-installer.mjs'], cliRoot);
+
+await smokeTestTarball();
+
+console.log(JSON.stringify({ ok: true, platform, tarballPath, installerPath }, null, 2));
+
+function run(command, args, cwd, env = process.env) {
+  execFileSync(command, args, { cwd, env, stdio: 'inherit' });
+}
+
+async function releasePackageVersion() {
+  const packageJson = JSON.parse(await readFile(resolve(cliRoot, 'package.json'), 'utf8'));
+  const sdkPackageJson = JSON.parse(
+    await readFile(resolve(repoRoot, 'runtime', 'sdk', 'package.json'), 'utf8'),
+  );
+  if (packageJson.version !== sdkPackageJson.version) {
+    throw new Error(
+      `@mog/cli version ${packageJson.version} must match @mog-sdk/node version ${sdkPackageJson.version}`,
+    );
+  }
+  return packageJson.version;
+}
+
+async function smokeTestTarball() {
+  const root = await mkdtemp(join(tmpdir(), 'mog-cli-standalone-smoke-'));
+  const installRoot = resolve(root, 'install');
+  const workbookDir = resolve(root, 'workbooks');
+  mkdirSync(installRoot, { recursive: true });
+  mkdirSync(workbookDir, { recursive: true });
+
+  try {
+    run('tar', ['-xzf', tarballPath, '-C', installRoot, '--strip-components=1'], repoRoot);
+    const mog = resolve(installRoot, 'bin', 'mog.cjs');
+    const created = JSON.parse(
+      execFileSync(process.execPath, [mog, 'create', '--name', 'smoke', '--path', workbookDir], {
+        cwd: root,
+        encoding: 'utf8',
+      }),
+    );
+    if (!created.id)
+      throw new Error(`Standalone create did not return an id: ${JSON.stringify(created)}`);
+
+    const executed = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          mog,
+          'execute',
+          '--id',
+          created.id,
+          '--code',
+          'await ws.setCell("A1", "standalone"); return await ws.getValue("A1");',
+        ],
+        { cwd: root, encoding: 'utf8' },
+      ),
+    );
+    if (executed.result !== 'standalone') {
+      throw new Error(`Standalone execute returned ${JSON.stringify(executed)}`);
+    }
+
+    execFileSync(process.execPath, [mog, 'commit', '--id', created.id], {
+      cwd: root,
+      stdio: 'ignore',
+    });
+    execFileSync(process.execPath, [mog, 'unload', '--id', created.id], {
+      cwd: root,
+      stdio: 'ignore',
+    });
+    execFileSync(process.execPath, [mog, 'shutdown'], { cwd: root, stdio: 'ignore' });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function currentPlatform() {
+  if (process.platform === 'darwin') return `darwin-${process.arch}`;
+  if (process.platform === 'win32' && process.arch === 'x64') return 'win32-x64-msvc';
+  if (process.platform === 'linux') {
+    const glibc = process.report?.getReport?.().header?.glibcVersionRuntime;
+    return `linux-${process.arch}-${glibc ? 'gnu' : 'musl'}`;
+  }
+  throw new Error(`Unsupported platform: ${process.platform}/${process.arch}`);
+}
+
+function platformPackageName(platformName) {
+  return `@mog-sdk/${platformName}`;
+}

--- a/cli/scripts/publish-raw-release.mjs
+++ b/cli/scripts/publish-raw-release.mjs
@@ -1,0 +1,194 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(cliRoot, '..');
+const artifactsDir = resolve(repoRoot, 'artifacts');
+const packageVersion = releasePackageVersion();
+const releaseVersion = process.env.MOG_CLI_RELEASE_VERSION || packageVersion;
+const releaseName = `mog-cli-v${releaseVersion}`;
+const releaseBranch = process.env.MOG_CLI_RAW_RELEASE_BRANCH || 'cli-releases';
+const dryRun = ['1', 'true'].includes(
+  String(process.env.MOG_CLI_RELEASE_DRY_RUN || '').toLowerCase(),
+);
+const rawBaseUrl = `https://raw.githubusercontent.com/fundamental-research-labs/mog/${releaseBranch}/${releaseName}`;
+
+if (releaseVersion !== packageVersion) {
+  throw new Error(
+    `MOG_CLI_RELEASE_VERSION ${releaseVersion} must match @mog/cli ${packageVersion}`,
+  );
+}
+
+const assets = [
+  asset('install-mog-cli.sh'),
+  asset('mog-cli-kernel.skill.zip'),
+  ...readdirSync(artifactsDir)
+    .filter((name) => /^mog-cli-.+\.tar\.gz$/.test(name))
+    .sort()
+    .map(asset),
+];
+
+validateInstallerVersionAndBase(assets[0]);
+writeChecksums(assets);
+assets.push(asset('SHA256SUMS'));
+
+if (!dryRun) {
+  publishRawBranch();
+}
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      dryRun,
+      version: releaseVersion,
+      releaseBranch,
+      releaseName,
+      rawBaseUrl,
+      installCommand: `curl -fsSL ${rawBaseUrl}/install-mog-cli.sh | sh`,
+      assets: assets.map((entry) => ({
+        name: entry.name,
+        url: `${rawBaseUrl}/${entry.name}`,
+        sha256: sha256(readFileSync(entry.path)),
+      })),
+    },
+    null,
+    2,
+  ),
+);
+
+function publishRawBranch() {
+  const root = mkdtempSync(join(tmpdir(), 'mog-cli-raw-release-'));
+  const worktree = resolve(root, 'worktree');
+  try {
+    fetchReleaseBranch();
+    if (hasRef(`refs/remotes/origin/${releaseBranch}`)) {
+      run('git', ['worktree', 'add', '--detach', worktree, `origin/${releaseBranch}`]);
+      run('git', ['checkout', '-B', releaseBranch], worktree);
+    } else {
+      run('git', ['worktree', 'add', '--detach', worktree, 'HEAD']);
+      run('git', ['checkout', '--orphan', releaseBranch], worktree);
+      run('git', ['rm', '-rf', '--quiet', '.'], worktree, { allowFailure: true });
+    }
+
+    if (process.env.GITHUB_ACTIONS) {
+      run('git', ['config', 'user.name', 'github-actions[bot]'], worktree);
+      run(
+        'git',
+        ['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com'],
+        worktree,
+      );
+    }
+
+    const releaseDir = resolve(worktree, releaseName);
+    rmSync(releaseDir, { recursive: true, force: true });
+    mkdirSync(releaseDir, { recursive: true });
+    for (const entry of assets) {
+      cpSync(entry.path, resolve(releaseDir, entry.name));
+    }
+    writeFileSync(
+      resolve(releaseDir, 'README.md'),
+      `# Mog CLI ${releaseVersion}\n\nInstall:\n\n\`\`\`bash\ncurl -fsSL ${rawBaseUrl}/install-mog-cli.sh | sh\n\`\`\`\n`,
+    );
+
+    run('git', ['add', releaseName], worktree);
+    if (isWorktreeClean(worktree)) return;
+    run('git', ['commit', '-m', `Publish Mog CLI ${releaseVersion} raw artifacts`], worktree);
+    run('git', ['push', 'origin', `HEAD:refs/heads/${releaseBranch}`], worktree);
+  } finally {
+    run('git', ['worktree', 'remove', '--force', worktree], repoRoot, { allowFailure: true });
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function fetchReleaseBranch() {
+  run(
+    'git',
+    ['fetch', 'origin', `refs/heads/${releaseBranch}:refs/remotes/origin/${releaseBranch}`],
+    repoRoot,
+    { allowFailure: true },
+  );
+}
+
+function isWorktreeClean(cwd) {
+  return execFileSync('git', ['status', '--porcelain'], { cwd, encoding: 'utf8' }).trim() === '';
+}
+
+function hasRef(ref) {
+  try {
+    execFileSync('git', ['show-ref', '--verify', '--quiet', ref], { cwd: repoRoot });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function asset(name) {
+  const path = resolve(artifactsDir, name);
+  if (!existsSync(path)) {
+    throw new Error(
+      `Missing release artifact: ${path}. Run pnpm --filter @mog/cli package:release first.`,
+    );
+  }
+  return { name, path };
+}
+
+function validateInstallerVersionAndBase(entry) {
+  const text = readFileSync(entry.path, 'utf8');
+  const expectedVersion = `MOG_CLI_VERSION="\${MOG_CLI_VERSION:-${packageVersion}}"`;
+  if (!text.includes(expectedVersion)) {
+    throw new Error(`${entry.name} must default to @mog/cli version ${packageVersion}`);
+  }
+  if (!text.includes('https://raw.githubusercontent.com/fundamental-research-labs/mog/')) {
+    throw new Error(`${entry.name} must default to raw.githubusercontent.com`);
+  }
+}
+
+function releasePackageVersion() {
+  const packageJson = readJson(resolve(cliRoot, 'package.json'));
+  const sdkPackageJson = readJson(resolve(repoRoot, 'runtime', 'sdk', 'package.json'));
+  if (packageJson.version !== sdkPackageJson.version) {
+    throw new Error(
+      `@mog/cli version ${packageJson.version} must match @mog-sdk/node version ${sdkPackageJson.version}`,
+    );
+  }
+  return packageJson.version;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function writeChecksums(entries) {
+  const lines = entries
+    .map((entry) => `${sha256(readFileSync(entry.path))}  ${entry.name}`)
+    .sort()
+    .join('\n');
+  writeFileSync(resolve(artifactsDir, 'SHA256SUMS'), `${lines}\n`);
+}
+
+function run(command, args, cwd = repoRoot, options = {}) {
+  try {
+    execFileSync(command, args, { cwd, stdio: 'inherit' });
+  } catch (error) {
+    if (options.allowFailure) return;
+    throw error;
+  }
+}
+
+function sha256(data) {
+  return createHash('sha256').update(data).digest('hex');
+}

--- a/cli/skill/SKILL.md
+++ b/cli/skill/SKILL.md
@@ -1,0 +1,374 @@
+---
+name: mog-cli-kernel
+description: Use when operating Mog workbooks through the minimal `mog` CLI, executing code against the headless @mog-sdk/node workbook API, committing workbook changes, unloading handles, or discovering the workbook/worksheet API from the bundled generated API JSON.
+---
+
+# Mog CLI Kernel
+
+Use this skill when a user wants Claude/Cowork to load a workbook, run code
+against the Mog kernel API, save it, or inspect the available workbook and
+worksheet API.
+
+## Skill Installation
+
+This skill teaches the agent how to use the Mog CLI. Install both:
+
+- the `mog` standalone CLI bundle
+- this skill folder
+
+### Install The Mog CLI
+
+Preferred Co-work setup is the standalone CLI bundle. It includes the Mog CLI
+JavaScript and the platform native SDK addon, and requires Node.js 18+ on
+`PATH`. Install from the raw GitHub release artifacts:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/fundamental-research-labs/mog/cli-releases/mog-cli-v0.6.0/install-mog-cli.sh | sh
+```
+
+Use the `raw.githubusercontent.com` URL exactly as written when installing in
+Claude Co-work. Some sandboxes allow `raw.githubusercontent.com` but block
+GitHub Release asset redirects and `r2.dev` URLs.
+
+If the release URL is different, pass it explicitly:
+
+```bash
+curl -fsSL <release-download-base-url>/install-mog-cli.sh | MOG_CLI_BASE_URL=<release-download-base-url> sh
+```
+
+`MOG_CLI_BASE_URL` should be the directory containing `install-mog-cli.sh`,
+`mog-cli-linux-x64-gnu.tar.gz`, `mog-cli-darwin-arm64.tar.gz`, and
+`SHA256SUMS`, for example:
+
+```bash
+MOG_CLI_BASE_URL=https://raw.githubusercontent.com/fundamental-research-labs/mog/cli-releases/mog-cli-v0.6.0
+```
+
+The installer downloads `mog-cli-<platform>.tar.gz`, installs it under
+`~/.mog/cli`, and links `mog` into `~/.local/bin`. Make sure `~/.local/bin` is
+on `PATH`.
+
+For local development only, the CLI can also be run from a Mog repo checkout:
+
+```bash
+corepack enable
+pnpm install
+pnpm --filter @mog/cli build
+pnpm --filter @mog/cli exec mog --help
+```
+
+### Install The Skill
+
+The release bundle for Co-work upload is:
+
+```text
+mog-cli-kernel.skill.zip
+```
+
+That zip contains `SKILL.md` at the archive root plus `references/api-spec.json`.
+Upload that zip directly in the Co-work skill UI.
+
+To build the skill zip from a repo checkout:
+
+```bash
+pnpm --filter @mog/cli package:skill
+```
+
+The generated zip is written to `artifacts/mog-cli-kernel.skill.zip`.
+
+Release maintainers publish the CLI bundle and skill zip to the versioned
+raw GitHub artifact branch with:
+
+```bash
+pnpm --filter @mog/cli publish:raw
+```
+
+This repository stores the unpacked skill source at:
+
+```text
+cli/skill
+```
+
+For Claude Code / Claude Co-work project-scope loading, expose it under
+`.claude/skills` from the Mog repo root:
+
+```bash
+mkdir -p .claude/skills
+ln -s ../../cli/skill .claude/skills/mog-cli-kernel
+```
+
+If symlinks are not supported in the host environment, copy the folder instead:
+
+```bash
+mkdir -p .claude/skills
+rm -rf .claude/skills/mog-cli-kernel
+cp -R cli/skill .claude/skills/mog-cli-kernel
+```
+
+For Codex or another agent host, install the same `cli/skill` folder into that
+host's configured skill root under the directory name `mog-cli-kernel`.
+
+After installing, make sure the agent session is started with project skills
+enabled. For Claude Agent SDK tests, use `settingSources: ['project']` and
+`skills: ['mog-cli-kernel']` or `skills: 'all'`.
+
+## CLI Contract
+
+Use the standalone `mog` binary when it is installed:
+
+```bash
+mog create --name <workbook-name> --path <directory>
+```
+
+In a development checkout, use the workspace command form:
+
+```bash
+pnpm --filter @mog/cli exec mog create --name <workbook-name> --path <directory>
+```
+
+The examples below use the workspace command so they also work while developing
+Mog. If `mog` is on `PATH`, use `mog ...` directly.
+
+Create a new blank workbook by name inside a directory and keep it alive in the
+local Mog daemon:
+
+```bash
+pnpm --filter @mog/cli exec mog create --name <workbook-name> --path <directory>
+```
+
+Standalone equivalent:
+
+```bash
+mog create --name <workbook-name> --path <directory>
+```
+
+The CLI appends `.xlsx` to the name when needed, creates parent directories, and
+refuses to overwrite an existing workbook.
+
+You can also create at an exact workbook file path:
+
+```bash
+pnpm --filter @mog/cli exec mog create <path-to-new-workbook.xlsx>
+```
+
+Load an existing workbook and keep it alive in the local Mog daemon:
+
+```bash
+pnpm --filter @mog/cli exec mog load <path-to-workbook.xlsx>
+```
+
+Both commands return JSON containing an `id`. Use that id for later commands.
+
+Execute code against the loaded workbook:
+
+```bash
+pnpm --filter @mog/cli exec mog execute --id <workbook-id> --code '<code>'
+```
+
+For larger code snippets, write a temporary script and use:
+
+```bash
+pnpm --filter @mog/cli exec mog execute --id <workbook-id> --code-file <script.js>
+```
+
+The code runs in an async function with these bindings:
+
+- `wb` and `workbook`: the loaded `Workbook`
+- `ws` and `activeSheet`: `workbook.activeSheet`
+- `api`: SDK API introspection object
+- `Utils`: SDK utility facade
+- `console`: captured console whose logs are returned in command JSON
+
+Return values must be explicit:
+
+```js
+await ws.setCell("A1", 42);
+return await ws.getValue("A1");
+```
+
+## Basic Mog API Examples
+
+All workbook and worksheet methods are async unless the API spec says otherwise.
+Use `await`, use `workbook.activeSheet` for the active worksheet, and never guess
+method names from Excel/Office/Sheets APIs.
+
+Read context before editing:
+
+```js
+const summary = await ws.summarize();
+const used = await ws.getUsedRange();
+const context = await ws.describeRange(used ?? "A1:J20");
+return { summary, used, context };
+```
+
+Read values, formulas, and display text:
+
+```js
+return {
+  value: await ws.getValue("B12"),
+  display: await ws.getDisplayValue("B12"),
+  formula: await ws.getFormula("B12"),
+  range: await ws.getRange("A1:D10"),
+};
+```
+
+Write cells:
+
+```js
+await ws.setCell("A1", "Revenue");
+await ws.setCell("B1", 123);
+await ws.setCell("C1", "=B1*1.1");
+return await ws.getValue("C1");
+```
+
+Use range and scattered bulk writes instead of loops:
+
+```js
+await ws.setRange("A1:C3", [
+  ["Metric", "2025", "2026"],
+  ["Revenue", 100, 125],
+  ["EBITDA", 30, 40],
+]);
+
+await ws.setCells([
+  { addr: "E1", value: "Margin" },
+  { addr: "E2", value: "=C2/C3" },
+]);
+```
+
+Work with sheets:
+
+```js
+const model = await workbook.getOrCreateSheet("Model");
+await workbook.sheets.rename("Sheet1", "Inputs");
+return await workbook.getSheetNames();
+```
+
+Format and adjust layout:
+
+```js
+await ws.formats.setRange("A1:C1", { font: { bold: true }, fill: { color: "#D9EAF7" } });
+await ws.layout.autoFitColumns("A:C");
+await ws.view.freezeRows(1);
+```
+
+Calculate formulas, including circular-model cases:
+
+```js
+await wb.calculate();
+await wb.calculate({ iterative: { maxIterations: 100, maxChange: 0.001 } });
+```
+
+Save changes back to the workbook's original path:
+
+```bash
+pnpm --filter @mog/cli exec mog commit --id <workbook-id>
+```
+
+Save to a different path:
+
+```bash
+pnpm --filter @mog/cli exec mog commit --id <workbook-id> --path <output.xlsx>
+```
+
+Dispose the workbook handle:
+
+```bash
+pnpm --filter @mog/cli exec mog unload --id <workbook-id>
+```
+
+List active handles:
+
+```bash
+pnpm --filter @mog/cli exec mog list
+```
+
+## API Discovery
+
+The generated SDK API spec is bundled at:
+
+```text
+references/api-spec.json
+```
+
+It has the same useful structure as Shortcut's JSON API reference:
+
+- `subApis.wb` and `subApis.ws`: namespace to interface mappings
+- `interfaces.<InterfaceName>.functions`: method signatures, docstrings, used
+  types
+- `types`: type and enum definitions
+
+Use `rg` or `jq` over that file before guessing method names. Preferred search
+patterns:
+
+```bash
+API_REF=cli/skill/references/api-spec.json
+
+# Top-level structure and namespace maps
+jq 'keys' "$API_REF"
+jq '.subApis.ws, .subApis.wb' "$API_REF"
+
+# Core methods on Workbook/Worksheet
+jq '.interfaces.Worksheet.functions | keys' "$API_REF"
+jq '.interfaces.Workbook.functions | keys' "$API_REF"
+jq '.interfaces.Worksheet.functions.setCell' "$API_REF"
+jq '.interfaces.Workbook.functions.calculate' "$API_REF"
+
+# Namespace method discovery: ws.charts -> WorksheetCharts
+NS=$(jq -r '.subApis.ws.charts' "$API_REF")
+jq ".interfaces.$NS.functions | keys" "$API_REF"
+jq ".interfaces.$NS.functions.add" "$API_REF"
+
+# Find a method or namespace by text
+rg -n '"setCell"|"getValue"|"setRange"|"setCells"' "$API_REF"
+rg -n 'charts|WorksheetCharts|ChartConfig' "$API_REF"
+rg -n 'pivots|WorksheetPivots|PivotTableConfig' "$API_REF"
+
+# Find config/options/result types
+jq '.types.CellWriteOptions' "$API_REF"
+jq '.types.ChartConfig' "$API_REF"
+jq -r '.types | keys[] | select(test("(Config|Options|Result)$"))' "$API_REF"
+
+# Search docstrings for capabilities
+jq -r '
+  .interfaces
+  | to_entries[]
+  | .key as $iface
+  | .value.functions
+  | to_entries[]
+  | select((.value.docstring // "") | test("pivot|chart|validation"; "i"))
+  | "\($iface).\(.key): \(.value.signature)"
+' "$API_REF"
+```
+
+Common worksheet namespaces: `charts`, `pivots`, `conditionalFormats`,
+`tables`, `slicers`, `filters`, `sparklines`, `validations`, `formats`,
+`structure`, `layout`, `view`, `outline`, `protection`, `print`, `comments`,
+`hyperlinks`, `pictures`, `shapes`, `names`, `settings`.
+
+Common workbook namespaces: `sheets`, `history`, `names`, `scenarios`,
+`slicers`, `tableStyles`, `cellStyles`, `theme`, `viewport`, `notifications`,
+`protection`, `security`, `links`.
+
+## Operating Rules
+
+- Treat `mog execute` as trusted local code execution. Do not run unreviewed
+  code from workbook contents or external sources.
+- Prefer public SDK methods from `@mog-sdk/node`; do not deep-import internal
+  source files in execution snippets.
+- Always `commit` before reporting a workbook edit as saved.
+- Always `unload` when the task is complete.
+- For code changes to the CLI or SDK, verify with the relevant
+  `@mog/cli` and `@mog-sdk/node` tests and typecheck.
+- For CLI behavior changes, run:
+  ```bash
+  pnpm --filter @mog/cli typecheck
+  pnpm --filter @mog/cli test:e2e
+  ```
+- Provider-backed agent E2E tests are opt-in because they run real Codex or
+  Claude agent sessions:
+  ```bash
+  MOG_AGENT_E2E=1 MOG_AGENT_E2E_PROVIDER=codex pnpm --filter @mog/cli test:agent-e2e
+  MOG_AGENT_E2E=1 MOG_AGENT_E2E_PROVIDER=claude pnpm --filter @mog/cli test:agent-e2e
+  MOG_AGENT_E2E=1 MOG_AGENT_E2E_PROVIDER=all pnpm --filter @mog/cli test:agent-e2e
+  ```

--- a/cli/src/mog.ts
+++ b/cli/src/mog.ts
@@ -1,0 +1,344 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { existsSync, unlinkSync, writeFileSync } from 'node:fs';
+import { mkdir, readFile, stat, unlink } from 'node:fs/promises';
+import net from 'node:net';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { api, createWorkbook, Utils, type Workbook } from '@mog-sdk/node';
+import {
+  parseCliArgs,
+  pidPathForState,
+  socketPathForState,
+  stateKeyForCwd,
+  toJsonSafe,
+  usage,
+  type DaemonRequest,
+  type DaemonResponse,
+} from './protocol';
+
+type WorkbookEntry = {
+  id: string;
+  path: string;
+  workbook: Workbook;
+  loadedAt: string;
+};
+
+const workbooks = new Map<string, WorkbookEntry>();
+
+async function main(): Promise<void> {
+  const command = parseCliArgs(process.argv.slice(2));
+
+  if (command.kind === 'help') {
+    console.log(usage());
+    return;
+  }
+
+  if (command.kind === 'daemon') {
+    await runDaemon(command.stateKey);
+    return;
+  }
+
+  const stateKey = stateKeyForCwd();
+  const request = await commandToRequest(command);
+  const response = await sendWithAutoStart(stateKey, request);
+  if (!response.ok) {
+    console.error(JSON.stringify(response, null, 2));
+    process.exitCode = 1;
+    return;
+  }
+  console.log(JSON.stringify(response.result, null, 2));
+}
+
+async function commandToRequest(
+  command: Exclude<ReturnType<typeof parseCliArgs>, { kind: 'help' | 'daemon' }>,
+): Promise<DaemonRequest> {
+  switch (command.kind) {
+    case 'create':
+      return {
+        method: 'create',
+        path: command.path,
+        ...(command.name ? { name: command.name } : {}),
+      };
+    case 'load':
+      return { method: 'load', path: command.path };
+    case 'execute': {
+      const code = command.codeFile
+        ? await readFile(resolve(command.codeFile), 'utf8')
+        : command.code;
+      if (!code) {
+        throw new Error('Usage: mog execute --id <workbookId> --code <code>');
+      }
+      return { method: 'execute', id: command.id, code };
+    }
+    case 'commit':
+      return {
+        method: 'commit',
+        id: command.id,
+        ...(command.path ? { path: resolve(command.path) } : {}),
+      };
+    case 'unload':
+      return { method: 'unload', id: command.id };
+    case 'list':
+      return { method: 'list' };
+    case 'shutdown':
+      return { method: 'shutdown' };
+  }
+}
+
+async function sendWithAutoStart(
+  stateKey: string,
+  request: DaemonRequest,
+): Promise<DaemonResponse> {
+  try {
+    return await sendRequest(stateKey, request);
+  } catch {
+    await startDaemon(stateKey);
+    await waitForDaemon(stateKey);
+    return sendRequest(stateKey, request);
+  }
+}
+
+async function startDaemon(stateKey: string): Promise<void> {
+  const cliPath = fileURLToPath(import.meta.url);
+  const child = spawn(process.execPath, [cliPath, '_daemon', stateKey], {
+    detached: true,
+    stdio: 'ignore',
+    env: process.env,
+  });
+  child.unref();
+}
+
+async function waitForDaemon(stateKey: string): Promise<void> {
+  const started = Date.now();
+  let lastError: unknown;
+  while (Date.now() - started < 5000) {
+    try {
+      await sendRequest(stateKey, { method: 'ping' });
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+    }
+  }
+  throw new Error(`Mog daemon did not start: ${String(lastError)}`);
+}
+
+function sendRequest(stateKey: string, request: DaemonRequest): Promise<DaemonResponse> {
+  const socketPath = socketPathForState(stateKey);
+  return new Promise((resolveRequest, rejectRequest) => {
+    const client = net.createConnection(socketPath);
+    let data = '';
+    client.setEncoding('utf8');
+    client.setTimeout(5000);
+    client.on('connect', () => {
+      client.end(JSON.stringify(request));
+    });
+    client.on('data', (chunk) => {
+      data += chunk;
+    });
+    client.on('end', () => {
+      try {
+        resolveRequest(JSON.parse(data) as DaemonResponse);
+      } catch (error) {
+        rejectRequest(error);
+      }
+    });
+    client.on('timeout', () => {
+      client.destroy(new Error('Timed out waiting for Mog daemon response.'));
+    });
+    client.on('error', rejectRequest);
+  });
+}
+
+async function runDaemon(stateKey: string): Promise<void> {
+  const socketPath = socketPathForState(stateKey);
+  const pidPath = pidPathForState(stateKey);
+  if (existsSync(socketPath)) {
+    unlinkSync(socketPath);
+  }
+
+  const server = net.createServer({ allowHalfOpen: true }, (socket) => {
+    let data = '';
+    socket.setEncoding('utf8');
+    socket.on('data', (chunk) => {
+      data += chunk;
+    });
+    socket.on('end', () => {
+      void handleRawRequest(data, server).then((response) => {
+        socket.end(JSON.stringify(response));
+      });
+    });
+  });
+
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once('error', rejectListen);
+    server.listen(socketPath, () => {
+      server.off('error', rejectListen);
+      writeFileSync(pidPath, String(process.pid));
+      resolveListen();
+    });
+  });
+
+  const cleanup = async () => {
+    for (const entry of workbooks.values()) {
+      await Promise.resolve(entry.workbook.dispose());
+    }
+    workbooks.clear();
+    await unlink(socketPath).catch(() => undefined);
+    await unlink(pidPath).catch(() => undefined);
+  };
+
+  process.once('SIGTERM', () => {
+    void cleanup().finally(() => process.exit(0));
+  });
+  process.once('SIGINT', () => {
+    void cleanup().finally(() => process.exit(0));
+  });
+}
+
+async function handleRawRequest(raw: string, server: net.Server): Promise<DaemonResponse> {
+  try {
+    const request = JSON.parse(raw) as DaemonRequest;
+    return { ok: true, result: await handleRequest(request, server) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        message: error instanceof Error ? error.message : String(error),
+        ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+      },
+    };
+  }
+}
+
+async function handleRequest(request: DaemonRequest, server: net.Server): Promise<unknown> {
+  switch (request.method) {
+    case 'ping':
+      return { status: 'ok', handles: workbooks.size };
+    case 'create': {
+      if (existsSync(request.path)) {
+        throw new Error(`Workbook already exists: ${request.path}`);
+      }
+      await mkdir(dirname(request.path), { recursive: true });
+      const workbook = request.name
+        ? await createWorkbook({ documentId: request.name })
+        : await createWorkbook();
+      await workbook.save(request.path);
+      const id = randomUUID();
+      const entry = { id, path: request.path, workbook, loadedAt: new Date().toISOString() };
+      workbooks.set(id, entry);
+      return describeEntry(entry);
+    }
+    case 'load': {
+      await stat(request.path);
+      const workbook = await createWorkbook(request.path);
+      const id = randomUUID();
+      const entry = { id, path: request.path, workbook, loadedAt: new Date().toISOString() };
+      workbooks.set(id, entry);
+      return describeEntry(entry);
+    }
+    case 'execute': {
+      const entry = requireWorkbook(request.id);
+      const logs: string[] = [];
+      const scopedConsole = makeScopedConsole(logs);
+      const AsyncFunction = Object.getPrototypeOf(async function () {
+        // TypeScript target helper.
+      }).constructor as new (...args: string[]) => (...args: unknown[]) => Promise<unknown>;
+      const fn = new AsyncFunction(
+        'wb',
+        'workbook',
+        'ws',
+        'activeSheet',
+        'api',
+        'Utils',
+        'console',
+        `"use strict";\n${request.code}`,
+      );
+      const result = await fn(
+        entry.workbook,
+        entry.workbook,
+        entry.workbook.activeSheet,
+        entry.workbook.activeSheet,
+        api,
+        Utils,
+        scopedConsole,
+      );
+      return { result: toJsonSafe(result), logs };
+    }
+    case 'commit': {
+      const entry = requireWorkbook(request.id);
+      const path = request.path ?? entry.path;
+      const bytes = await entry.workbook.save(path);
+      return { id: entry.id, path, bytes: bytes.byteLength };
+    }
+    case 'unload': {
+      const entry = requireWorkbook(request.id);
+      await Promise.resolve(entry.workbook.dispose());
+      workbooks.delete(entry.id);
+      return { id: entry.id, unloaded: true };
+    }
+    case 'list':
+      return [...workbooks.values()].map(describeEntry);
+    case 'shutdown':
+      for (const entry of workbooks.values()) {
+        await Promise.resolve(entry.workbook.dispose());
+      }
+      workbooks.clear();
+      server.close();
+      return { shutdown: true };
+  }
+}
+
+function requireWorkbook(id: string): WorkbookEntry {
+  const entry = workbooks.get(id);
+  if (!entry) throw new Error(`Unknown workbook id: ${id}`);
+  return entry;
+}
+
+function describeEntry(entry: WorkbookEntry): object {
+  return {
+    id: entry.id,
+    path: entry.path,
+    loadedAt: entry.loadedAt,
+  };
+}
+
+function makeScopedConsole(logs: string[]): Pick<Console, 'log' | 'warn' | 'error' | 'info'> {
+  const push = (level: string, args: unknown[]) => {
+    logs.push(`[${level}] ${args.map(formatLogArg).join(' ')}`);
+  };
+  return {
+    log: (...args: unknown[]) => push('log', args),
+    info: (...args: unknown[]) => push('info', args),
+    warn: (...args: unknown[]) => push('warn', args),
+    error: (...args: unknown[]) => push('error', args),
+  };
+}
+
+function formatLogArg(arg: unknown): string {
+  if (typeof arg === 'string') return arg;
+  try {
+    return JSON.stringify(toJsonSafe(arg));
+  } catch {
+    return String(arg);
+  }
+}
+
+main().catch((error) => {
+  console.error(
+    JSON.stringify(
+      {
+        ok: false,
+        error: {
+          message: error instanceof Error ? error.message : String(error),
+          ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  process.exitCode = 1;
+});

--- a/cli/src/protocol.ts
+++ b/cli/src/protocol.ts
@@ -1,0 +1,208 @@
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+
+export type CliCommand =
+  | { kind: 'help' }
+  | { kind: 'daemon'; stateKey: string }
+  | { kind: 'create'; path: string; name?: string }
+  | { kind: 'load'; path: string }
+  | { kind: 'execute'; id: string; code?: string; codeFile?: string }
+  | { kind: 'commit'; id: string; path?: string }
+  | { kind: 'unload'; id: string }
+  | { kind: 'list' }
+  | { kind: 'shutdown' };
+
+export type DaemonRequest =
+  | { method: 'ping' }
+  | { method: 'create'; path: string; name?: string }
+  | { method: 'load'; path: string }
+  | { method: 'execute'; id: string; code: string }
+  | { method: 'commit'; id: string; path?: string }
+  | { method: 'unload'; id: string }
+  | { method: 'list' }
+  | { method: 'shutdown' };
+
+export type DaemonResponse =
+  | { ok: true; result: unknown }
+  | { ok: false; error: { message: string; stack?: string } };
+
+export function parseCliArgs(argv: readonly string[]): CliCommand {
+  const [command, ...rest] = argv;
+
+  switch (command) {
+    case undefined:
+    case '-h':
+    case '--help':
+    case 'help':
+      return { kind: 'help' };
+    case '_daemon': {
+      const stateKey = rest[0];
+      if (!stateKey) throw new Error('Internal error: _daemon requires a state key.');
+      return { kind: 'daemon', stateKey };
+    }
+    case 'create': {
+      return parseCreateCommand(rest);
+    }
+    case 'load': {
+      const path = rest[0];
+      if (!path) throw new Error('Usage: mog load <path>');
+      return { kind: 'load', path: resolve(path) };
+    }
+    case 'execute': {
+      return {
+        kind: 'execute',
+        id: requiredOption(rest, '--id', 'Usage: mog execute --id <workbookId> --code <code>'),
+        code: optionalOption(rest, '--code'),
+        codeFile: optionalOption(rest, '--code-file'),
+      };
+    }
+    case 'commit':
+      return {
+        kind: 'commit',
+        id: requiredOption(rest, '--id', 'Usage: mog commit --id <workbookId> [--path <path>]'),
+        path: optionalOption(rest, '--path'),
+      };
+    case 'unload':
+      return {
+        kind: 'unload',
+        id: requiredOption(rest, '--id', 'Usage: mog unload --id <workbookId>'),
+      };
+    case 'list':
+      return { kind: 'list' };
+    case 'shutdown':
+      return { kind: 'shutdown' };
+    default:
+      throw new Error(`Unknown command: ${command}\n\n${usage()}`);
+  }
+}
+
+export function stateKeyForCwd(cwd = process.cwd()): string {
+  return createHash('sha256').update(cwd).digest('hex').slice(0, 20);
+}
+
+export function socketPathForState(stateKey: string): string {
+  return process.env.MOG_CLI_SOCKET ?? join(tmpdir(), `mog-${stateKey}.sock`);
+}
+
+export function pidPathForState(stateKey: string): string {
+  return process.env.MOG_CLI_PID ?? join(tmpdir(), `mog-${stateKey}.pid`);
+}
+
+export function toJsonSafe(value: unknown): unknown {
+  return toJsonSafeInner(value, new WeakSet<object>());
+}
+
+export function usage(): string {
+  return [
+    'Usage:',
+    '  mog create <path>',
+    '  mog create --name <workbookName> --path <directory>',
+    '  mog load <path>',
+    '  mog execute --id <workbookId> --code <code>',
+    '  mog execute --id <workbookId> --code-file <path>',
+    '  mog commit --id <workbookId> [--path <path>]',
+    '  mog unload --id <workbookId>',
+    '  mog list',
+    '',
+    'Execute code runs inside the Mog daemon with these bindings:',
+    '  wb, workbook, ws, activeSheet, api, Utils, console',
+    '',
+    'Example:',
+    '  mog execute --id abc --code "await ws.setCell(\\"A1\\", 42); return ws.getValue(\\"A1\\");"',
+  ].join('\n');
+}
+
+function parseCreateCommand(args: readonly string[]): Extract<CliCommand, { kind: 'create' }> {
+  const directPath = args[0] && !args[0].startsWith('--') ? args[0] : undefined;
+  const name = optionalOption(args, '--name');
+  const directory = optionalOption(args, '--path');
+
+  if (directPath) {
+    if (name || directory) {
+      throw new Error(
+        'Usage: mog create <path>\n       mog create --name <workbookName> --path <directory>',
+      );
+    }
+    return {
+      kind: 'create',
+      path: resolve(directPath),
+      name: workbookNameFromPath(directPath),
+    };
+  }
+
+  if (!name || !directory) {
+    throw new Error(
+      'Usage: mog create <path>\n       mog create --name <workbookName> --path <directory>',
+    );
+  }
+
+  return {
+    kind: 'create',
+    path: resolve(directory, workbookFileName(name)),
+    name: workbookNameFromPath(name),
+  };
+}
+
+function requiredOption(args: readonly string[], name: string, errorMessage: string): string {
+  const value = optionalOption(args, name);
+  if (!value) throw new Error(errorMessage);
+  return value;
+}
+
+function optionalOption(args: readonly string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  if (index === -1) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`Missing value for ${name}`);
+  }
+  return value;
+}
+
+function workbookFileName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) throw new Error('Workbook name must not be empty.');
+  if (trimmed.includes('/') || trimmed.includes('\\')) {
+    throw new Error('Workbook name must not contain path separators.');
+  }
+  return trimmed.toLowerCase().endsWith('.xlsx') ? trimmed : `${trimmed}.xlsx`;
+}
+
+function workbookNameFromPath(path: string): string {
+  return basename(path).replace(/\.xlsx$/i, '');
+}
+
+function toJsonSafeInner(value: unknown, seen: WeakSet<object>): unknown {
+  if (value == null) return value;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'function') {
+    return `[Function ${(value as { name?: string }).name || 'anonymous'}]`;
+  }
+  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Uint8Array) {
+    return {
+      type: 'Uint8Array',
+      length: value.byteLength,
+      base64: Buffer.from(value).toString('base64'),
+    };
+  }
+  if (Array.isArray(value)) return value.map((entry) => toJsonSafeInner(entry, seen));
+  if (value instanceof Map) {
+    return Object.fromEntries(
+      [...value.entries()].map(([key, entry]) => [String(key), toJsonSafeInner(entry, seen)]),
+    );
+  }
+  if (value instanceof Set) return [...value].map((entry) => toJsonSafeInner(entry, seen));
+  if (typeof value === 'object') {
+    if (seen.has(value)) return '[Circular]';
+    seen.add(value);
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, toJsonSafeInner(entry, seen)]),
+    );
+  }
+  return String(value);
+}

--- a/cli/testing/e2e.mjs
+++ b/cli/testing/e2e.mjs
@@ -1,0 +1,138 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, symlinkSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { createWorkbook } from '@mog-sdk/node';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..');
+const cliPath = resolve(repoRoot, 'cli', 'dist', 'mog.cjs');
+const nativeAddon = resolve(repoRoot, 'compute', 'napi', 'compute-core-napi.node');
+const platformAddon = resolve(
+  repoRoot,
+  'compute',
+  'napi',
+  'npm',
+  currentPlatformPackageDir(),
+  'compute-core-napi.node',
+);
+
+if (!existsSync(cliPath)) {
+  throw new Error(`Built CLI not found: ${cliPath}. Run pnpm --filter @mog/cli build first.`);
+}
+
+let temporaryPlatformAddon = false;
+if (!existsSync(platformAddon) && existsSync(nativeAddon)) {
+  symlinkSync('../../compute-core-napi.node', platformAddon);
+  temporaryPlatformAddon = true;
+}
+
+const root = mkdtempSync(join(tmpdir(), 'mog-cli-e2e-'));
+const workbookPath = join(root, 'book.xlsx');
+const createdWorkbookName = 'created-by-cli';
+const createdWorkbookPath = join(root, `${createdWorkbookName}.xlsx`);
+
+function run(args) {
+  const stdout = execFileSync(process.execPath, [cliPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return JSON.parse(stdout);
+}
+
+let id;
+
+try {
+  const created = run(['create', '--name', createdWorkbookName, '--path', root]);
+  id = created.id;
+  if (!id) throw new Error(`create did not return an id: ${JSON.stringify(created)}`);
+  if (created.path !== createdWorkbookPath) {
+    throw new Error(`create path was ${created.path}, expected ${createdWorkbookPath}`);
+  }
+
+  const createExecuted = run([
+    'execute',
+    '--id',
+    id,
+    '--code',
+    'await ws.setCell("B1", "created"); return await ws.getValue("B1");',
+  ]);
+  if (createExecuted.result !== 'created') {
+    throw new Error(`created workbook execute failed: ${JSON.stringify(createExecuted)}`);
+  }
+  run(['commit', '--id', id]);
+  run(['unload', '--id', id]);
+  id = undefined;
+
+  const reopenedCreated = await createWorkbook(createdWorkbookPath);
+  const createdValue = await reopenedCreated.activeSheet.getValue('B1');
+  await reopenedCreated.dispose();
+  if (createdValue !== 'created') {
+    throw new Error(`created workbook B1 was ${createdValue}, expected "created"`);
+  }
+
+  const wb = await createWorkbook();
+  await wb.activeSheet.setCell('A1', 10);
+  await wb.save(workbookPath);
+  await wb.dispose();
+
+  const loaded = run(['load', workbookPath]);
+  id = loaded.id;
+  if (!id) throw new Error(`load did not return an id: ${JSON.stringify(loaded)}`);
+
+  const executed = run([
+    'execute',
+    '--id',
+    id,
+    '--code',
+    'await ws.setCell("A2", "=A1*2"); return await ws.getValue("A2");',
+  ]);
+  if (executed.result !== 20) {
+    throw new Error(`execute returned ${JSON.stringify(executed)}, expected result 20`);
+  }
+
+  const committed = run(['commit', '--id', id]);
+  if (committed.bytes <= 0) {
+    throw new Error(`commit did not report saved bytes: ${JSON.stringify(committed)}`);
+  }
+
+  const unloaded = run(['unload', '--id', id]);
+  id = undefined;
+  if (unloaded.unloaded !== true) {
+    throw new Error(`unload failed: ${JSON.stringify(unloaded)}`);
+  }
+
+  const reopened = await createWorkbook(workbookPath);
+  const value = await reopened.activeSheet.getValue('A2');
+  await reopened.dispose();
+  if (value !== 20) throw new Error(`reopened A2 was ${value}, expected 20`);
+
+  run(['shutdown']);
+  console.log(
+    JSON.stringify({ ok: true, workbookPath, createdWorkbookPath, value, createdValue }, null, 2),
+  );
+} finally {
+  if (id) {
+    try {
+      run(['unload', '--id', id]);
+    } catch {
+      // Best-effort cleanup.
+    }
+  }
+  try {
+    run(['shutdown']);
+  } catch {
+    // Best-effort cleanup.
+  }
+  rmSync(root, { recursive: true, force: true });
+  if (temporaryPlatformAddon) rmSync(platformAddon, { force: true });
+}
+
+function currentPlatformPackageDir() {
+  if (process.platform === 'darwin') return `darwin-${process.arch}`;
+  if (process.platform === 'win32') return `win32-${process.arch}-msvc`;
+  if (process.platform === 'linux') {
+    const glibc = process.report?.getReport?.().header?.glibcVersionRuntime;
+    return `linux-${process.arch}-${glibc ? 'gnu' : 'musl'}`;
+  }
+  throw new Error(`Unsupported platform for Mog CLI E2E: ${process.platform}/${process.arch}`);
+}

--- a/cli/testing/npm-local-e2e.mjs
+++ b/cli/testing/npm-local-e2e.mjs
@@ -1,0 +1,71 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(cliRoot, '..');
+const npmArtifactsDir = resolve(repoRoot, 'artifacts', 'npm');
+const tarballPath = latestCliTarball();
+const root = await mkdtemp(resolve(tmpdir(), 'mog-cli-npm-local-'));
+const prefix = resolve(root, 'prefix');
+const workbooks = resolve(root, 'workbooks');
+mkdirSync(prefix, { recursive: true });
+mkdirSync(workbooks, { recursive: true });
+
+try {
+  execFileSync('npm', ['install', '--prefix', prefix, '--global', tarballPath], {
+    cwd: root,
+    stdio: 'inherit',
+  });
+
+  const mog = resolve(prefix, 'bin', 'mog');
+  if (!existsSync(mog)) throw new Error(`Installed mog binary not found: ${mog}`);
+
+  const created = JSON.parse(
+    execFileSync(mog, ['create', '--name', 'npm-local-smoke', '--path', workbooks], {
+      cwd: root,
+      encoding: 'utf8',
+    }),
+  );
+  if (!created.id) throw new Error(`create did not return an id: ${JSON.stringify(created)}`);
+
+  const executed = JSON.parse(
+    execFileSync(
+      mog,
+      [
+        'execute',
+        '--id',
+        created.id,
+        '--code',
+        'await ws.setCell("A1", "npm local ok"); return await ws.getValue("A1");',
+      ],
+      { cwd: root, encoding: 'utf8' },
+    ),
+  );
+  if (executed.result !== 'npm local ok') {
+    throw new Error(`execute returned ${JSON.stringify(executed)}`);
+  }
+
+  execFileSync(mog, ['commit', '--id', created.id], { cwd: root, stdio: 'ignore' });
+  execFileSync(mog, ['unload', '--id', created.id], { cwd: root, stdio: 'ignore' });
+  execFileSync(mog, ['shutdown'], { cwd: root, stdio: 'ignore' });
+
+  const workbookPath = resolve(workbooks, 'npm-local-smoke.xlsx');
+  if (!existsSync(workbookPath)) throw new Error(`Workbook was not written: ${workbookPath}`);
+
+  writeFileSync(resolve(root, 'result.json'), `${JSON.stringify({ ok: true, workbookPath }, null, 2)}\n`);
+  console.log(JSON.stringify({ ok: true, tarballPath, workbookPath }, null, 2));
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}
+
+function latestCliTarball() {
+  const { version } = JSON.parse(readFileSync(resolve(cliRoot, 'package.json'), 'utf8'));
+  const tarball = resolve(npmArtifactsDir, `mog-cli-${version}.tgz`);
+  if (!existsSync(tarball)) throw new Error(`No @mog/cli npm tarball found at ${tarball}`);
+  return tarball;
+}

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "incremental": true,
+    "noEmit": false,
+    "rootDir": ".",
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "testing"]
+}

--- a/cli/tsup.config.ts
+++ b/cli/tsup.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from 'tsup';
+
+const standalone = process.env.MOG_CLI_STANDALONE === '1';
+const outDir = process.env.MOG_CLI_OUT_DIR ?? 'dist';
+
+export default defineConfig({
+  entry: { mog: 'src/mog.ts' },
+  format: ['cjs'],
+  target: 'node18',
+  outDir,
+  tsconfig: 'tsconfig.json',
+  dts: false,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  shims: true,
+  noExternal: standalone ? ['@mog-sdk/node'] : [],
+  external: [
+    ...(standalone ? [] : ['@mog-sdk/node']),
+    '@mog-sdk/darwin-arm64',
+    '@mog-sdk/darwin-x64',
+    '@mog-sdk/linux-x64-gnu',
+    '@mog-sdk/linux-x64-musl',
+    '@mog-sdk/linux-arm64-gnu',
+    '@mog-sdk/linux-arm64-musl',
+    '@mog-sdk/win32-x64-msvc',
+    'node:child_process',
+    'node:crypto',
+    'node:fs',
+    'node:fs/promises',
+    'node:net',
+    'node:os',
+    'node:path',
+    'node:url',
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -609,6 +609,22 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  cli:
+    dependencies:
+      '@mog-sdk/node':
+        specifier: workspace:*
+        version: link:../runtime/sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.9.1
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.3)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   compute/napi:
     devDependencies:
       '@napi-rs/cli':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ packages:
   - 'canvas/overlay'
   - 'canvas/spatial'
   - 'charts'
+  - 'cli'
   - 'compute/napi'
   - 'compute/napi/npm/darwin-arm64'
   - 'compute/napi/npm/darwin-x64'

--- a/tools/build-public-artifacts.mjs
+++ b/tools/build-public-artifacts.mjs
@@ -24,6 +24,16 @@ const checkOnly = process.argv.includes('--check-only');
 const skipTsBuild = process.argv.includes('--skip-ts-build') || checkOnly;
 const skipNativeBuild = process.argv.includes('--skip-native-build') || checkOnly;
 const skipWasmBuild = process.argv.includes('--skip-wasm-build') || checkOnly;
+const skipHostNativeArtifact = process.argv.includes('--skip-host-native-artifact') || checkOnly;
+const throughPackage = argValue('--through');
+
+function argValue(name) {
+  const index = process.argv.indexOf(name);
+  if (index >= 0) return process.argv[index + 1] ?? null;
+  const prefix = `${name}=`;
+  const arg = process.argv.find((value) => value.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : null;
+}
 
 function loadJsonc(filePath) {
   const raw = readFileSync(filePath, 'utf-8');
@@ -408,6 +418,13 @@ console.log('=== TS public facade artifacts ===');
 let shipPublicNames = [];
 try {
   shipPublicNames = orderedShipPublicPackages(inventory, workspacePackages);
+  if (throughPackage) {
+    const throughIndex = shipPublicNames.indexOf(throughPackage);
+    if (throughIndex === -1) {
+      throw new Error(`${throughPackage}: --through package is not a ship-public package`);
+    }
+    shipPublicNames = shipPublicNames.slice(0, throughIndex + 1);
+  }
   console.log(`  build order: ${shipPublicNames.join(' -> ')}`);
 } catch (error) {
   errors.push(error.message);
@@ -453,7 +470,14 @@ for (const name of generatedAssetPrerequisites) {
 
 buildDeclarationPrerequisites(workspacePackages, errors);
 
-const wasmPkg = buildWasmArtifact(workspacePackages, errors);
+const needsWasmArtifact = shipPublicNames.some((name) =>
+  ['@mog-sdk/embed', '@mog-sdk/spreadsheet-app'].includes(name),
+);
+const wasmPkg = needsWasmArtifact ? buildWasmArtifact(workspacePackages, errors) : null;
+if (!needsWasmArtifact) {
+  console.log('\n=== WASM asset artifact ===');
+  console.log(`  SKIP WASM build (not required by selected ship-public packages)`);
+}
 let kernelArtifactBuilt = false;
 
 for (const name of shipPublicNames) {
@@ -498,7 +522,11 @@ if (shipPublicNames.includes('@mog-sdk/contracts') && !skipTsBuild) {
 
 console.log('\n=== Host native artifact ===');
 const hostNative = hostNativePackageName();
-if (!hostNative) {
+if (skipHostNativeArtifact) {
+  console.log(
+    `  SKIP host native artifact (${checkOnly ? 'check-only' : 'skip-host-native-artifact'})`,
+  );
+} else if (!hostNative) {
   errors.push(`unsupported host native platform: ${process.platform}/${process.arch}`);
 } else if (!inventory[hostNative]) {
   errors.push(`${hostNative}: host native package missing from inventory`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,6 +58,9 @@
       "path": "./charts"
     },
     {
+      "path": "./cli"
+    },
+    {
       "path": "./contracts"
     },
     {


### PR DESCRIPTION
## Summary\n- Add the Mog CLI package and raw GitHub publish workflow to main\n- Align @mog/cli with main's @mog-sdk/node@0.8.0\n- Add targeted public artifact build support for building through @mog-sdk/node without app/wasm/native package checks\n\n## Verification\n- pnpm install --frozen-lockfile\n- node --check tools/build-public-artifacts.mjs and CLI release scripts\n- pnpm run build:public-artifacts -- --through @mog-sdk/node --skip-native-build --skip-host-native-artifact --skip-wasm-build\n- pnpm --filter @mog/cli typecheck\n- pnpm --filter @mog/cli test:npm-local\n- pnpm -C compute/napi build:release\n- pnpm --filter @mog/cli package:standalone\n- pnpm --filter @mog/cli package:skill\n- MOG_CLI_RELEASE_DRY_RUN=true node cli/scripts/publish-raw-release.mjs