### PR TITLE
Add packaged CLI agent and Docker E2E tests

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -11,6 +11,8 @@
     "package:npm": "pnpm run build && node scripts/package-npm.mjs",
     "package:release": "pnpm run package:npm && pnpm run package:skill",
     "package:skill": "node scripts/package-skill.mjs",
+    "test:codex-binary-e2e": "pnpm run package:npm && node testing/codex-binary-e2e.mjs",
+    "test:npm-docker": "pnpm run package:npm && node testing/npm-docker-e2e.mjs",
     "test:npm-local": "pnpm run package:npm && node testing/npm-local-e2e.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "pnpm test:e2e",
@@ -20,6 +22,7 @@
     "@mog-sdk/node": "workspace:*"
   },
   "devDependencies": {
+    "@openai/codex-sdk": "^0.136.0",
     "@types/node": "^25.5.0",
     "tsup": "^8.5.0",
     "typescript": "^5.7.0"

--- a/cli/testing/codex-binary-e2e.mjs
+++ b/cli/testing/codex-binary-e2e.mjs
@@ -1,0 +1,203 @@
+import { execFileSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..');
+const cliRoot = resolve(repoRoot, 'cli');
+const skillSource = resolve(cliRoot, 'skill');
+const tarballPath = latestCliTarball();
+
+if (process.env.MOG_CODEX_BINARY_E2E !== '1') {
+  console.log(
+    JSON.stringify({
+      skipped: true,
+      reason: 'Set MOG_CODEX_BINARY_E2E=1 to run the Codex-backed packaged CLI E2E test.',
+    }),
+  );
+  process.exit(0);
+}
+
+if (!existsSync(skillSource)) throw new Error(`Skill source not found: ${skillSource}`);
+
+const root = mkdtempSync(join(tmpdir(), 'mog-codex-binary-e2e-'));
+const prefix = join(root, 'prefix');
+const binDir = join(prefix, 'bin');
+const project = join(root, 'project');
+const workbookDir = join(root, 'workbooks');
+const workbookName = `codex-binary-${Date.now()}`;
+const workbookPath = join(workbookDir, `${workbookName}.xlsx`);
+const expectedValue = 'codex packaged binary ok';
+const expectedFormulaValue = expectedValue.length;
+
+try {
+  mkdirSync(prefix, { recursive: true });
+  mkdirSync(project, { recursive: true });
+  mkdirSync(workbookDir, { recursive: true });
+  prepareAgentProject(project);
+
+  execFileSync('npm', ['install', '--prefix', prefix, '--global', tarballPath], {
+    cwd: root,
+    stdio: 'inherit',
+  });
+
+  const mog = resolve(binDir, 'mog');
+  if (!existsSync(mog)) throw new Error(`Installed mog binary not found: ${mog}`);
+
+  const prompt = buildPrompt();
+  const transcript = await runCodexAgent({
+    cwd: project,
+    prompt,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ''}`,
+    },
+  });
+
+  const reported = parseFinalJson(transcript.finalResponse);
+  if (reported.workbookPath !== workbookPath) {
+    throw new Error(`Codex reported workbookPath ${reported.workbookPath}, expected ${workbookPath}`);
+  }
+  if (reported.value !== expectedValue) {
+    throw new Error(`Codex reported value ${JSON.stringify(reported.value)}, expected ${expectedValue}`);
+  }
+  if (reported.formulaValue !== expectedFormulaValue) {
+    throw new Error(
+      `Codex reported formulaValue ${reported.formulaValue}, expected ${expectedFormulaValue}`,
+    );
+  }
+
+  const reloaded = JSON.parse(
+    execFileSync(mog, ['load', workbookPath], { cwd: project, encoding: 'utf8' }),
+  );
+  const verified = JSON.parse(
+    execFileSync(
+      mog,
+      [
+        'execute',
+        '--id',
+        reloaded.id,
+        '--code',
+        'return { a1: await ws.getValue("A1"), b1: await ws.getValue("B1") };',
+      ],
+      { cwd: project, encoding: 'utf8' },
+    ),
+  );
+  execFileSync(mog, ['unload', '--id', reloaded.id], { cwd: project, stdio: 'ignore' });
+
+  const value = verified.result?.a1;
+  const formulaValue = verified.result?.b1;
+
+  if (value !== expectedValue) {
+    throw new Error(`Workbook A1=${JSON.stringify(value)}, expected ${expectedValue}`);
+  }
+  if (formulaValue !== expectedFormulaValue) {
+    throw new Error(`Workbook B1=${JSON.stringify(formulaValue)}, expected ${expectedFormulaValue}`);
+  }
+
+  execFileSync(mog, ['shutdown'], { cwd: project, stdio: 'ignore' });
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        provider: 'codex',
+        tarballPath,
+        mog,
+        workbookPath,
+        value,
+        formulaValue,
+        commandCount: transcript.commandCount,
+        finalResponse: transcript.finalResponse,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  try {
+    execFileSync(resolve(binDir, 'mog'), ['shutdown'], { cwd: project, stdio: 'ignore' });
+  } catch {
+    // Best-effort daemon cleanup.
+  }
+  rmSync(root, { recursive: true, force: true });
+}
+
+function prepareAgentProject(projectRoot) {
+  execFileSync('git', ['init'], { cwd: projectRoot, stdio: 'ignore' });
+  writeFileSync(join(projectRoot, 'README.md'), 'Mog Codex packaged binary E2E sandbox.\n');
+  mkdirSync(join(projectRoot, '.codex', 'skills'), { recursive: true });
+  cpSync(skillSource, join(projectRoot, '.codex', 'skills', 'mog-cli-kernel'), { recursive: true });
+}
+
+function buildPrompt() {
+  return `
+You are running a Codex E2E test for the npm-packaged Mog CLI.
+
+Use the installed "mog" command on PATH. Do not use pnpm, npm install, node scripts, source files, or a Mog repo checkout.
+The local skill is available at .codex/skills/mog-cli-kernel/SKILL.md.
+
+Task:
+1. Verify the CLI command with: command -v mog
+2. Create a new workbook using the Mog CLI with name "${workbookName}" at directory "${workbookDir}".
+3. Execute Mog code against the returned workbook id to set A1 to "${expectedValue}" and B1 to "=LEN(A1)".
+4. Commit the workbook and unload the workbook handle.
+5. Respond only with minified JSON exactly matching this shape:
+{"provider":"codex","workbookPath":"${workbookPath}","value":"${expectedValue}","formulaValue":${expectedFormulaValue}}
+`.trim();
+}
+
+async function runCodexAgent({ cwd, prompt, env }) {
+  const { Codex } = await import('@openai/codex-sdk');
+  const codex = new Codex({
+    env,
+    config: {
+      sandbox_workspace_write: { network_access: true },
+    },
+  });
+  const thread = codex.startThread({
+    workingDirectory: cwd,
+    skipGitRepoCheck: true,
+    sandboxMode: 'danger-full-access',
+    approvalPolicy: 'never',
+    networkAccessEnabled: true,
+  });
+  const turn = await thread.run(prompt, {
+    outputSchema: finalJsonSchema(),
+  });
+  return {
+    finalResponse: turn.finalResponse,
+    commandCount: turn.items.filter((item) => item.type === 'command_execution').length,
+  };
+}
+
+function parseFinalJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    const match = text.match(/\{[\s\S]*\}/);
+    if (!match) throw new Error(`Codex response did not contain JSON: ${text}`);
+    return JSON.parse(match[0]);
+  }
+}
+
+function finalJsonSchema() {
+  return {
+    type: 'object',
+    properties: {
+      provider: { type: 'string' },
+      workbookPath: { type: 'string' },
+      value: { type: 'string' },
+      formulaValue: { type: 'number' },
+    },
+    required: ['provider', 'workbookPath', 'value', 'formulaValue'],
+    additionalProperties: false,
+  };
+}
+
+function latestCliTarball() {
+  const { version } = JSON.parse(readFileSync(resolve(cliRoot, 'package.json'), 'utf8'));
+  const tarball = resolve(repoRoot, 'artifacts', 'npm', `mog-cli-${version}.tgz`);
+  if (!existsSync(tarball)) throw new Error(`No @mog/cli npm tarball found at ${tarball}`);
+  return tarball;
+}

--- a/cli/testing/npm-docker-e2e.mjs
+++ b/cli/testing/npm-docker-e2e.mjs
@@ -1,0 +1,80 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..');
+const cliRoot = resolve(repoRoot, 'cli');
+const tarballPath = latestCliTarball();
+const root = mkdtempSync(join(tmpdir(), 'mog-cli-docker-e2e-'));
+const workdir = join(root, 'work');
+const image = process.env.MOG_CLI_DOCKER_IMAGE ?? 'node:22-bookworm';
+const platformArgs = process.env.MOG_CLI_DOCKER_PLATFORM
+  ? ['--platform', process.env.MOG_CLI_DOCKER_PLATFORM]
+  : [];
+
+try {
+  mkdirSync(workdir, { recursive: true });
+
+  const script = `
+set -euo pipefail
+mkdir -p /tmp/mog-prefix /work/workbooks
+npm install --prefix /tmp/mog-prefix --global /artifacts/${basename(tarballPath)} >&2
+MOG=/tmp/mog-prefix/bin/mog
+test -x "$MOG"
+"$MOG" --help >/dev/null
+created="$("$MOG" create --name docker-smoke --path /work/workbooks)"
+id="$(node -e 'console.log(JSON.parse(process.argv[1]).id)' "$created")"
+test -n "$id"
+executed="$("$MOG" execute --id "$id" --code 'await ws.setCell("A1", "docker ok"); await ws.setCell("B1", "=LEN(A1)"); return { a1: await ws.getValue("A1"), b1: await ws.getValue("B1") };')"
+node -e 'const result = JSON.parse(process.argv[1]).result; if (result.a1 !== "docker ok" || result.b1 !== 9) throw new Error(JSON.stringify(result));' "$executed"
+"$MOG" commit --id "$id" >/dev/null
+"$MOG" unload --id "$id" >/dev/null
+"$MOG" shutdown >/dev/null
+test -f /work/workbooks/docker-smoke.xlsx
+node -e 'console.log(JSON.stringify({ ok: true, workbookPath: "/work/workbooks/docker-smoke.xlsx" }, null, 2))'
+`.trim();
+
+  const output = execFileSync(
+    'docker',
+    [
+      'run',
+      '--rm',
+      ...platformArgs,
+      '-v',
+      `${tarballPath}:/artifacts/${basename(tarballPath)}:ro`,
+      '-v',
+      `${workdir}:/work`,
+      '-w',
+      '/work',
+      image,
+      'bash',
+      '-lc',
+      script,
+    ],
+    { cwd: repoRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] },
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        image,
+        platform: process.env.MOG_CLI_DOCKER_PLATFORM ?? null,
+        tarballPath,
+        containerResult: JSON.parse(output),
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}
+
+function latestCliTarball() {
+  const { version } = JSON.parse(readFileSync(resolve(cliRoot, 'package.json'), 'utf8'));
+  const tarball = resolve(repoRoot, 'artifacts', 'npm', `mog-cli-${version}.tgz`);
+  if (!existsSync(tarball)) throw new Error(`No @mog/cli npm tarball found at ${tarball}`);
+  return tarball;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -615,6 +615,9 @@ importers:
         specifier: workspace:*
         version: link:../runtime/sdk
     devDependencies:
+      '@openai/codex-sdk':
+        specifier: ^0.136.0
+        version: 0.136.0
       '@types/node':
         specifier: ^25.5.0
         version: 25.9.1
@@ -3575,6 +3578,51 @@ packages:
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@openai/codex-sdk@0.136.0':
+    resolution: {integrity: sha512-qrSirrVxrpVHR1YIQQ4WSouneaQrQrRAAlQWJYRflvMCcruFXorsmIPeIbDqFXOa8A9H9FHHyc+2U4tdbEGGiQ==}
+    engines: {node: '>=18'}
+
+  '@openai/codex@0.136.0':
+    resolution: {integrity: sha512-yu+diXznSOt8h296/CDOf2CNi55z1raA7aZ6sejjGy1QWPqn72YkBc2ByTzZG6G+1yiUqlm2G5Hid54hm3/kaA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  '@openai/codex@0.136.0-darwin-arm64':
+    resolution: {integrity: sha512-9xnEohnUO9l6qtPSDbG0Y2UXX5mBZ9Lsn0VMgjtkREGfWL9TawNC1d7D1ERMSJtHTlVvieoaFyK9LHPLQCO9Vw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@openai/codex@0.136.0-darwin-x64':
+    resolution: {integrity: sha512-HD9YLalPg0cv+CiZSmRWOl/8sefuJlxJcAmxyzb8mSaAMchD3V+2yS6M6E1Z2I6NX1irp4Polt1fPsjGdlHYhQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@openai/codex@0.136.0-linux-arm64':
+    resolution: {integrity: sha512-xDxTOk5ClEX/nzlQseqEoiubjIzVZfcWKn9nmKkHOLKknz+c7n6tbmw7eY4mwt29zTAAoFoecdRnbbsPZUHJ1g==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@openai/codex@0.136.0-linux-x64':
+    resolution: {integrity: sha512-Q6yZHRtUWD+27B5yAiOYyPAtM0BzW0Mm23YGaXDmfNEO5BYgHuUT80VDofUpjSyo2+ShYoZQUFVQAsNPKqd+Sw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@openai/codex@0.136.0-win32-arm64':
+    resolution: {integrity: sha512-mAHZXfygQxBg1JjZ9+bAZfBXe6fg8MabJhuDYhj5z0VF++orKSFsC1lMiv6PksQN36ikQefgVjc9EOlaE4lt7g==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@openai/codex@0.136.0-win32-x64':
+    resolution: {integrity: sha512-zS6DAmvjdWeAB1CL9KTUMkwzTwfXtxHy8GAtePw2a93jIqawoG07fBxAXuyoHZ3QXQkwEgqBx1zEEh33gdIKAw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -9507,6 +9555,37 @@ snapshots:
   '@octokit/types@16.0.0':
     dependencies:
       '@octokit/openapi-types': 27.0.0
+
+  '@openai/codex-sdk@0.136.0':
+    dependencies:
+      '@openai/codex': 0.136.0
+
+  '@openai/codex@0.136.0':
+    optionalDependencies:
+      '@openai/codex-darwin-arm64': '@openai/codex@0.136.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.136.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.136.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.136.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.136.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.136.0-win32-x64'
+
+  '@openai/codex@0.136.0-darwin-arm64':
+    optional: true
+
+  '@openai/codex@0.136.0-darwin-x64':
+    optional: true
+
+  '@openai/codex@0.136.0-linux-arm64':
+    optional: true
+
+  '@openai/codex@0.136.0-linux-x64':
+    optional: true
+
+  '@openai/codex@0.136.0-win32-arm64':
+    optional: true
+
+  '@openai/codex@0.136.0-win32-x64':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true


### PR DESCRIPTION
## Summary
- add a Codex-backed E2E that installs the local @mog/cli npm tarball into a temp prefix and requires Codex to operate through the installed mog command
- verify the Codex-created workbook by reloading it through the same packaged CLI, not the workspace SDK
- add a Docker Linux E2E that installs the local tarball inside node:22-bookworm and exercises create/execute/commit/unload/shutdown

## Verification
- pnpm install --no-frozen-lockfile
- pnpm install --frozen-lockfile
- node --check cli/testing/codex-binary-e2e.mjs && node --check cli/testing/npm-docker-e2e.mjs && node --check cli/testing/npm-local-e2e.mjs
- pnpm --filter @mog/cli test:npm-local
- pnpm --filter @mog/cli typecheck
- MOG_CODEX_BINARY_E2E=1 node cli/testing/codex-binary-e2e.mjs
- node cli/testing/npm-docker-e2e.mjs
- pnpm --filter @mog/cli test:npm-docker
- git diff --check