### PR TITLE
Rename CLI package to SDK scope

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   publish:
-    name: Publish @mog/cli to npm
+    name: Publish @mog-sdk/cli to npm
     runs-on: ubuntu-latest
     environment: npm-production
     concurrency:
@@ -47,13 +47,13 @@ jobs:
           CLI_VERSION=$(node -p "require('./cli/package.json').version")
           SDK_VERSION=$(node -p "require('./runtime/sdk/package.json').version")
           if [ "$CLI_VERSION" != "$SDK_VERSION" ]; then
-            echo "@mog/cli version ${CLI_VERSION} does not match @mog-sdk/node ${SDK_VERSION}."
+            echo "@mog-sdk/cli version ${CLI_VERSION} does not match @mog-sdk/node ${SDK_VERSION}."
             exit 1
           fi
 
-      - run: pnpm --filter @mog/cli test:npm-local
+      - run: pnpm --filter @mog-sdk/cli test:npm-local
 
-      - run: pnpm --filter @mog/cli package:skill
+      - run: pnpm --filter @mog-sdk/cli package:skill
 
       - uses: actions/upload-artifact@v4
         with:
@@ -63,7 +63,7 @@ jobs:
 
       - name: Publish CLI package
         run: |
-          TARBALL=$(ls artifacts/npm/mog-cli-*.tgz)
+          TARBALL=$(ls artifacts/npm/mog-sdk-cli-*.tgz)
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             npm publish "$TARBALL" --access public --dry-run
           else

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mog/cli",
+  "name": "@mog-sdk/cli",
   "version": "0.8.0",
   "private": true,
   "type": "module",

--- a/cli/scripts/package-npm.mjs
+++ b/cli/scripts/package-npm.mjs
@@ -20,7 +20,7 @@ const version = releasePackageVersion();
 const distFile = resolve(cliRoot, 'dist', 'mog.cjs');
 const distMapFile = resolve(cliRoot, 'dist', 'mog.cjs.map');
 if (!existsSync(distFile)) {
-  throw new Error(`Missing built CLI at ${distFile}. Run pnpm --filter @mog/cli build first.`);
+  throw new Error(`Missing built CLI at ${distFile}. Run pnpm --filter @mog-sdk/cli build first.`);
 }
 
 rmSync(packageDir, { recursive: true, force: true });
@@ -41,7 +41,7 @@ writeFileSync(
     'Minimal command-line interface for operating Mog workbooks with the headless SDK.',
     '',
     '```bash',
-    'npm install -g @mog/cli',
+    'npm install -g @mog-sdk/cli',
     'mog create --name model --path .',
     '```',
     '',
@@ -71,7 +71,7 @@ console.log(
 
 function npmManifest(packageVersion) {
   return {
-    name: '@mog/cli',
+    name: '@mog-sdk/cli',
     version: packageVersion,
     description: 'Minimal command-line interface for operating Mog workbooks with the headless SDK',
     license: 'MIT',
@@ -102,7 +102,7 @@ function releasePackageVersion() {
   const sdkPackageJson = readJson(resolve(repoRoot, 'runtime', 'sdk', 'package.json'));
   if (packageJson.version !== sdkPackageJson.version) {
     throw new Error(
-      `@mog/cli version ${packageJson.version} must match @mog-sdk/node version ${sdkPackageJson.version}`,
+      `@mog-sdk/cli version ${packageJson.version} must match @mog-sdk/node version ${sdkPackageJson.version}`,
     );
   }
   return packageJson.version;

--- a/cli/scripts/package-skill.mjs
+++ b/cli/scripts/package-skill.mjs
@@ -46,7 +46,7 @@ function fileData(name, path) {
       )
       .replace(
         /@mog\/cli@[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9_.-]+)?/g,
-        `@mog/cli@${packageVersion}`,
+        `@mog-sdk/cli@${packageVersion}`,
       ),
     'utf8',
   );
@@ -59,7 +59,7 @@ function releasePackageVersion() {
   );
   if (packageJson.version !== sdkPackageJson.version) {
     throw new Error(
-      `@mog/cli version ${packageJson.version} must match @mog-sdk/node version ${sdkPackageJson.version}`,
+      `@mog-sdk/cli version ${packageJson.version} must match @mog-sdk/node version ${sdkPackageJson.version}`,
     );
   }
   return packageJson.version;

--- a/cli/skill/SKILL.md
+++ b/cli/skill/SKILL.md
@@ -13,7 +13,7 @@ worksheet API.
 
 This skill teaches the agent how to use the Mog CLI. Install both:
 
-- the `@mog/cli` npm package
+- the `@mog-sdk/cli` npm package
 - this skill folder
 
 ### Install The Mog CLI
@@ -26,7 +26,7 @@ Use a user-local npm prefix when global installs are not writable:
 
 ```bash
 mkdir -p "$HOME/.mog/npm"
-npm install --prefix "$HOME/.mog/npm" @mog/cli@0.8.0
+npm install --prefix "$HOME/.mog/npm" @mog-sdk/cli@0.8.0
 export PATH="$HOME/.mog/npm/node_modules/.bin:$PATH"
 mog --help
 ```
@@ -34,7 +34,7 @@ mog --help
 If global npm installs are supported, this is also valid:
 
 ```bash
-npm install -g @mog/cli@0.8.0
+npm install -g @mog-sdk/cli@0.8.0
 mog --help
 ```
 
@@ -46,8 +46,8 @@ For local development only, the CLI can also be run from a Mog repo checkout:
 ```bash
 corepack enable
 pnpm install
-pnpm --filter @mog/cli build
-pnpm --filter @mog/cli exec mog --help
+pnpm --filter @mog-sdk/cli build
+pnpm --filter @mog-sdk/cli exec mog --help
 ```
 
 ### Install The Skill
@@ -64,7 +64,7 @@ Upload that zip directly in the Co-work skill UI.
 To build the skill zip from a repo checkout:
 
 ```bash
-pnpm --filter @mog/cli package:skill
+pnpm --filter @mog-sdk/cli package:skill
 ```
 
 The generated zip is written to `artifacts/mog-cli-kernel.skill.zip`.
@@ -72,10 +72,10 @@ The generated zip is written to `artifacts/mog-cli-kernel.skill.zip`.
 Release maintainers build the CLI npm package candidate and skill zip with:
 
 ```bash
-pnpm --filter @mog/cli package:release
+pnpm --filter @mog-sdk/cli package:release
 ```
 
-The `Publish Mog CLI` GitHub workflow publishes the generated `@mog/cli`
+The `Publish Mog CLI` GitHub workflow publishes the generated `@mog-sdk/cli`
 package to npm.
 
 This repository stores the unpacked skill source at:
@@ -115,7 +115,7 @@ Before using the CLI, check whether `mog` is available:
 command -v mog
 ```
 
-If it is missing, install `@mog/cli` from npm using the user-local npm prefix
+If it is missing, install `@mog-sdk/cli` from npm using the user-local npm prefix
 commands above. Do not substitute a raw artifact installer.
 
 Use the npm-installed `mog` command when it is installed:
@@ -127,7 +127,7 @@ mog create --name <workbook-name> --path <directory>
 In a development checkout, use the workspace command form:
 
 ```bash
-pnpm --filter @mog/cli exec mog create --name <workbook-name> --path <directory>
+pnpm --filter @mog-sdk/cli exec mog create --name <workbook-name> --path <directory>
 ```
 
 The examples below use the workspace command so they also work while developing
@@ -137,7 +137,7 @@ Create a new blank workbook by name inside a directory and keep it alive in the
 local Mog daemon:
 
 ```bash
-pnpm --filter @mog/cli exec mog create --name <workbook-name> --path <directory>
+pnpm --filter @mog-sdk/cli exec mog create --name <workbook-name> --path <directory>
 ```
 
 Installed command equivalent:
@@ -152,13 +152,13 @@ refuses to overwrite an existing workbook.
 You can also create at an exact workbook file path:
 
 ```bash
-pnpm --filter @mog/cli exec mog create <path-to-new-workbook.xlsx>
+pnpm --filter @mog-sdk/cli exec mog create <path-to-new-workbook.xlsx>
 ```
 
 Load an existing workbook and keep it alive in the local Mog daemon:
 
 ```bash
-pnpm --filter @mog/cli exec mog load <path-to-workbook.xlsx>
+pnpm --filter @mog-sdk/cli exec mog load <path-to-workbook.xlsx>
 ```
 
 Both commands return JSON containing an `id`. Use that id for later commands.
@@ -166,13 +166,13 @@ Both commands return JSON containing an `id`. Use that id for later commands.
 Execute code against the loaded workbook:
 
 ```bash
-pnpm --filter @mog/cli exec mog execute --id <workbook-id> --code '<code>'
+pnpm --filter @mog-sdk/cli exec mog execute --id <workbook-id> --code '<code>'
 ```
 
 For larger code snippets, write a temporary script and use:
 
 ```bash
-pnpm --filter @mog/cli exec mog execute --id <workbook-id> --code-file <script.js>
+pnpm --filter @mog-sdk/cli exec mog execute --id <workbook-id> --code-file <script.js>
 ```
 
 The code runs in an async function with these bindings:
@@ -266,25 +266,25 @@ await wb.calculate({ iterative: { maxIterations: 100, maxChange: 0.001 } });
 Save changes back to the workbook's original path:
 
 ```bash
-pnpm --filter @mog/cli exec mog commit --id <workbook-id>
+pnpm --filter @mog-sdk/cli exec mog commit --id <workbook-id>
 ```
 
 Save to a different path:
 
 ```bash
-pnpm --filter @mog/cli exec mog commit --id <workbook-id> --path <output.xlsx>
+pnpm --filter @mog-sdk/cli exec mog commit --id <workbook-id> --path <output.xlsx>
 ```
 
 Dispose the workbook handle:
 
 ```bash
-pnpm --filter @mog/cli exec mog unload --id <workbook-id>
+pnpm --filter @mog-sdk/cli exec mog unload --id <workbook-id>
 ```
 
 List active handles:
 
 ```bash
-pnpm --filter @mog/cli exec mog list
+pnpm --filter @mog-sdk/cli exec mog list
 ```
 
 ## API Discovery
@@ -363,16 +363,16 @@ Common workbook namespaces: `sheets`, `history`, `names`, `scenarios`,
 - Always `commit` before reporting a workbook edit as saved.
 - Always `unload` when the task is complete.
 - For code changes to the CLI or SDK, verify with the relevant
-  `@mog/cli` and `@mog-sdk/node` tests and typecheck.
+  `@mog-sdk/cli` and `@mog-sdk/node` tests and typecheck.
 - For CLI behavior changes, run:
   ```bash
-  pnpm --filter @mog/cli typecheck
-  pnpm --filter @mog/cli test:e2e
+  pnpm --filter @mog-sdk/cli typecheck
+  pnpm --filter @mog-sdk/cli test:e2e
   ```
 - Provider-backed agent E2E tests are opt-in because they run real Codex or
   Claude agent sessions:
   ```bash
-  MOG_AGENT_E2E=1 MOG_AGENT_E2E_PROVIDER=codex pnpm --filter @mog/cli test:agent-e2e
-  MOG_AGENT_E2E=1 MOG_AGENT_E2E_PROVIDER=claude pnpm --filter @mog/cli test:agent-e2e
-  MOG_AGENT_E2E=1 MOG_AGENT_E2E_PROVIDER=all pnpm --filter @mog/cli test:agent-e2e
+  MOG_AGENT_E2E=1 MOG_AGENT_E2E_PROVIDER=codex pnpm --filter @mog-sdk/cli test:agent-e2e
+  MOG_AGENT_E2E=1 MOG_AGENT_E2E_PROVIDER=claude pnpm --filter @mog-sdk/cli test:agent-e2e
+  MOG_AGENT_E2E=1 MOG_AGENT_E2E_PROVIDER=all pnpm --filter @mog-sdk/cli test:agent-e2e
   ```

--- a/cli/testing/e2e.mjs
+++ b/cli/testing/e2e.mjs
@@ -17,7 +17,7 @@ const platformAddon = resolve(
 );
 
 if (!existsSync(cliPath)) {
-  throw new Error(`Built CLI not found: ${cliPath}. Run pnpm --filter @mog/cli build first.`);
+  throw new Error(`Built CLI not found: ${cliPath}. Run pnpm --filter @mog-sdk/cli build first.`);
 }
 
 let temporaryPlatformAddon = false;

--- a/cli/testing/npm-local-e2e.mjs
+++ b/cli/testing/npm-local-e2e.mjs
@@ -65,7 +65,7 @@ try {
 
 function latestCliTarball() {
   const { version } = JSON.parse(readFileSync(resolve(cliRoot, 'package.json'), 'utf8'));
-  const tarball = resolve(npmArtifactsDir, `mog-cli-${version}.tgz`);
-  if (!existsSync(tarball)) throw new Error(`No @mog/cli npm tarball found at ${tarball}`);
+  const tarball = resolve(npmArtifactsDir, `mog-sdk-cli-${version}.tgz`);
+  if (!existsSync(tarball)) throw new Error(`No @mog-sdk/cli npm tarball found at ${tarball}`);
   return tarball;
 }


### PR DESCRIPTION
## Summary
- rename the CLI npm package from @mog/cli to @mog-sdk/cli for SDK package consistency
- update the publish workflow, generated npm manifest, npm-local E2E tarball lookup, and Co-work skill install instructions
- cancel the pending @mog/cli publish run so the old package name is not published by approval

## Verification
- node --check cli/scripts/package-npm.mjs && node --check cli/scripts/package-skill.mjs && node --check cli/testing/e2e.mjs && node --check cli/testing/npm-local-e2e.mjs
- pnpm --filter @mog-sdk/cli test:npm-local
- pnpm --filter @mog-sdk/cli typecheck
- pnpm --filter @mog-sdk/cli package:skill
- tar -xOf artifacts/npm/mog-sdk-cli-0.8.0.tgz package/package.json
- npm view @mog-sdk/cli versions --json returned E404, confirming the package is not already published
- generated skill zip inspection
- git diff --check