### PR TITLE
Add npm token fallback for CLI publish

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -77,6 +77,16 @@ jobs:
 
       - run: npm install -g npm@^11.5.1
 
+      - name: Configure npm token fallback
+        run: |
+          if [ -n "${NPM_TOKEN:-}" ]; then
+            npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+          else
+            echo "NPM_TOKEN is not configured; npm will use trusted publishing if available."
+          fi
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - uses: actions/download-artifact@v4
         with:
           name: mog-sdk-cli-npm-package
@@ -104,6 +114,16 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - run: npm install -g npm@^11.5.1
+
+      - name: Configure npm token fallback
+        run: |
+          if [ -n "${NPM_TOKEN:-}" ]; then
+            npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+          else
+            echo "NPM_TOKEN is not configured; npm will use trusted publishing if available."
+          fi
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- allow the CLI publish workflow to use an existing NPM_TOKEN secret when one is exposed to the repo/environment
- retain npm trusted publishing as the fallback path when no token is configured

## Why
- @mog-sdk/cli is a new npm package and npm rejected trusted publishing with E404/permission during first publish
- existing SDK workflows use trusted publishing for already-configured packages; this gives the new CLI package a token-based bootstrap path if the org token is available

## Verification
- git diff --check
- Ruby YAML parse check for publish-cli.yml