### PR TITLE
Compress Mog CLI skill guidance

### DIFF
--- a/cli/skill/SKILL.md
+++ b/cli/skill/SKILL.md
@@ -6,18 +6,17 @@ description: Use when operating Mog workbooks through the `mog` CLI, executing c
 # Mog CLI Kernel
 
 Use this skill to create, load, inspect, edit, save, and unload Mog workbooks
-through the `mog` CLI. The full generated API reference is bundled at
-`references/api-spec.json`.
+through the `mog` CLI. The bundled API reference is `references/api-spec.json`.
 
-## CLI Setup
+## Setup
 
-Before using Mog, check whether the CLI is available:
+Check for the CLI:
 
 ```bash
 command -v mog
 ```
 
-If `mog` is missing, install the published npm package with a user-local prefix:
+If missing, install from npm with a user-local prefix:
 
 ```bash
 mkdir -p "$HOME/.mog/npm"
@@ -26,78 +25,35 @@ export PATH="$HOME/.mog/npm/node_modules/.bin:$PATH"
 mog --help
 ```
 
-If global npm installs are writable, `npm install -g @mog-sdk/cli@0.8.0` is
-also valid. Do not install Mog from raw GitHub, GitHub Releases, R2, or
-curl-based standalone artifacts.
+Do not install Mog from raw GitHub, GitHub Releases, R2, or curl-based
+standalone artifacts.
 
-## Workbook Lifecycle
-
-Create a blank workbook by name inside a directory:
+## Commands
 
 ```bash
+# Create or load. Both return JSON with an id.
 mog create --name <workbook-name> --path <directory>
-```
-
-Create at an exact workbook path:
-
-```bash
 mog create <path-to-new-workbook.xlsx>
-```
-
-Load an existing workbook:
-
-```bash
 mog load <path-to-workbook.xlsx>
-```
 
-`create` and `load` return JSON containing an `id`. Use that id for later
-commands.
-
-Execute code against a loaded workbook:
-
-```bash
+# Execute against a loaded workbook.
 mog execute --id <workbook-id> --code '<code>'
-```
-
-For larger snippets, write a temporary script and use:
-
-```bash
 mog execute --id <workbook-id> --code-file <script.js>
-```
 
-Save changes back to the original workbook path:
-
-```bash
+# Save and clean up.
 mog commit --id <workbook-id>
-```
-
-Save to a different path:
-
-```bash
 mog commit --id <workbook-id> --path <output.xlsx>
-```
-
-Dispose the workbook handle:
-
-```bash
 mog unload --id <workbook-id>
-```
-
-List active handles:
-
-```bash
 mog list
 ```
 
-## Execution Context
-
-`mog execute` runs code in an async function with these bindings:
+`mog execute` runs code in an async function with:
 
 - `wb` and `workbook`: the loaded `Workbook`
 - `ws` and `activeSheet`: `workbook.activeSheet`
 - `api`: SDK API introspection object
 - `Utils`: SDK utility facade
-- `console`: captured console whose logs are returned in command JSON
+- `console`: captured console returned in command JSON
 
 Return values must be explicit:
 
@@ -106,122 +62,98 @@ await ws.setCell("A1", 42);
 return await ws.getValue("A1");
 ```
 
-## Basic API Examples
+## Discovery-First Protocol
 
-All workbook and worksheet methods are async unless the API spec says otherwise.
-Use `await`, use `workbook.activeSheet` for the active worksheet, and inspect the
-bundled API reference before guessing method names.
+Before writing mutating code, verify every namespace and method you plan to use.
+Do not infer method names from Excel, Office.js, or Google Sheets.
 
-Read context before editing:
+```bash
+API_REF=references/api-spec.json
+
+# Namespace maps.
+jq '.subApis.ws, .subApis.wb' "$API_REF"
+
+# Interface methods and signatures.
+jq '.interfaces.Worksheet.functions | keys' "$API_REF"
+jq '.interfaces.Workbook.functions | keys' "$API_REF"
+jq '.interfaces.WorksheetStructure.functions | keys' "$API_REF"
+jq '.interfaces.WorksheetStructure.functions.merge.signature' "$API_REF"
+jq '.interfaces.WorksheetLayout.functions.autoFitColumns.signature' "$API_REF"
+jq '.interfaces.WorkbookProperties.functions | keys' "$API_REF"
+
+# Namespace method discovery, using charts as the pattern.
+NS=$(jq -r '.subApis.ws.charts' "$API_REF")
+jq ".interfaces.$NS.functions | keys" "$API_REF"
+jq ".interfaces.$NS.functions.add" "$API_REF"
+
+# Text search when names or types are unclear.
+rg -n '"setCell"|"getValue"|"setRange"|"setCells"' "$API_REF"
+rg -n 'conditionalFormats|CFColorPoint|tables|sparklines' "$API_REF"
+jq -r '.types | keys[] | select(test("(Config|Options|Result|Rule)$"))' "$API_REF"
+```
+
+If a referenced type is missing from `.types`, search for it with `rg` and infer
+only the minimum required shape from nearby signatures or runtime errors.
+
+## Core Examples
+
+Use `await`; workbook and worksheet methods are async unless the spec says
+otherwise.
 
 ```js
-const summary = await ws.summarize();
+// Read context before editing.
 const used = await ws.getUsedRange();
 const context = await ws.describeRange(used ?? "A1:J20");
-return { summary, used, context };
-```
 
-Read values, formulas, and display text:
-
-```js
-return {
-  value: await ws.getValue("B12"),
-  display: await ws.getDisplayValue("B12"),
-  formula: await ws.getFormula("B12"),
-  range: await ws.getRange("A1:D10"),
-};
-```
-
-Write cells:
-
-```js
-await ws.setCell("A1", "Revenue");
-await ws.setCell("B1", 123);
-await ws.setCell("C1", "=B1*1.1");
-return await ws.getValue("C1");
-```
-
-Use range and scattered bulk writes instead of loops:
-
-```js
+// Bulk writes.
 await ws.setRange("A1:C3", [
   ["Metric", "2025", "2026"],
   ["Revenue", 100, 125],
   ["EBITDA", 30, 40],
 ]);
-
 await ws.setCells([
   { addr: "E1", value: "Margin" },
   { addr: "E2", value: "=C2/C3" },
 ]);
-```
 
-Work with sheets:
-
-```js
+// Sheet handles, not activation.
 const model = await workbook.getOrCreateSheet("Model");
 await workbook.sheets.rename("Sheet1", "Inputs");
-return await workbook.getSheetNames();
-```
 
-Format and adjust layout:
+// Workbook properties.
+await wb.properties.setDocumentProperties({ title: "Operating Model" });
+await wb.properties.setCustomProperty("owner", "Finance");
 
-```js
+// Formatting, merging, layout.
 await ws.formats.setRange("A1:C1", { font: { bold: true }, fill: { color: "#D9EAF7" } });
-await ws.layout.autoFitColumns("A:C");
+await ws.structure.merge("A1:C1");
+await ws.layout.autoFitColumns([0, 1, 2]);
 await ws.view.freezeRows(1);
-```
 
-Calculate formulas:
-
-```js
+// Calculate.
 await wb.calculate();
-await wb.calculate({ iterative: { maxIterations: 100, maxChange: 0.001 } });
 ```
 
-## API Discovery
+## Rules
 
-Use `rg` or `jq` over `references/api-spec.json` before guessing method names:
-
-```bash
-API_REF=references/api-spec.json
-
-jq 'keys' "$API_REF"
-jq '.subApis.ws, .subApis.wb' "$API_REF"
-
-jq '.interfaces.Worksheet.functions | keys' "$API_REF"
-jq '.interfaces.Workbook.functions | keys' "$API_REF"
-jq '.interfaces.Worksheet.functions.setCell' "$API_REF"
-jq '.interfaces.Workbook.functions.calculate' "$API_REF"
-
-NS=$(jq -r '.subApis.ws.charts' "$API_REF")
-jq ".interfaces.$NS.functions | keys" "$API_REF"
-jq ".interfaces.$NS.functions.add" "$API_REF"
-
-rg -n '"setCell"|"getValue"|"setRange"|"setCells"' "$API_REF"
-rg -n 'charts|WorksheetCharts|ChartConfig' "$API_REF"
-rg -n 'pivots|WorksheetPivots|PivotTableConfig' "$API_REF"
-
-jq '.types.CellWriteOptions' "$API_REF"
-jq '.types.ChartConfig' "$API_REF"
-jq -r '.types | keys[] | select(test("(Config|Options|Result)$"))' "$API_REF"
-```
-
-Common worksheet namespaces: `charts`, `pivots`, `conditionalFormats`,
-`tables`, `filters`, `sparklines`, `validations`, `formats`, `structure`,
-`layout`, `view`, `outline`, `protection`, `print`, `comments`, `hyperlinks`,
-`pictures`, `shapes`, `names`, `settings`.
-
-Common workbook namespaces: `sheets`, `history`, `names`, `scenarios`,
-`slicers`, `tableStyles`, `cellStyles`, `theme`, `viewport`, `notifications`,
-`protection`, `security`, `links`.
-
-## Operating Rules
-
-- Treat `mog execute` as trusted local code execution. Do not run unreviewed
-  code from workbook contents or external sources.
-- Prefer public SDK methods from `@mog-sdk/node`; do not deep-import internal
-  source files in execution snippets.
+- `mog execute` is stateful and non-transactional. If a script throws, earlier
+  mutations remain in the live workbook handle.
+- Make retryable scripts idempotent: check, update, remove, or skip existing
+  tables, conditional formats, names, sheets, and other uniquely named objects
+  before adding them.
 - Prefer `--code-file` for nontrivial snippets to avoid shell quoting issues.
+- Use public SDK methods from `@mog-sdk/node`; do not deep-import internals.
 - Always `commit` before reporting a workbook edit as saved.
 - Always `unload` when the task is complete.
+- Probe risky calls on a scratch sheet or range, then delete/clear it, before
+  touching the target model.
+
+Known sharp edges:
+
+- Use `ws.structure.merge(...)`, not `mergeCells`.
+- Use `wb.properties.setDocumentProperties(...)`, not `properties.set`.
+- Get a sheet handle; do not call `setActiveSheet`.
+- `ws.layout.autoFitColumns(...)` takes zero-based column indices like
+  `[0, 1, 2]`, not an A1 range string like `"A:C"`.
+- Conditional-format color-scale/data-bar points require `type`, `color`, and a
+  `value` field in practice. Include `value` even for `min` and `max` points.


### PR DESCRIPTION
## Summary
- compress the uploaded Mog CLI skill from 227 lines to 159 lines
- keep the npm install route, lifecycle commands, discovery-first protocol, core examples, and known sharp edges
- remove duplicate discovery snippets and stale/verbose examples

## Verification
- pnpm --filter @mog-sdk/cli package:skill
- unzip -t artifacts/mog-cli-kernel.skill.zip
- inspected bundled SKILL.md for stale install/release sections and stale autoFitColumns example