### PR TITLE
Merge SDK v0.9.0 release back to main

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -138,7 +138,6 @@ jobs:
             "@mog-sdk/linux-arm64-musl"
             "@mog-sdk/win32-x64-msvc"
             "@mog-sdk/wasm"
-            "@mog-sdk/chart-raster-wasm"
             "@mog-sdk/contracts"
             "@mog-sdk/sheet-view"
             "@mog-sdk/spreadsheet-app"
@@ -518,7 +517,7 @@ jobs:
             NPM_TAG_ARGS=(--tag "${{ steps.npm-tag.outputs.tag }}")
           fi
           VERSION="${{ needs.version.outputs.version }}"
-          for dir in artifacts/public-packages/mog-sdk__darwin-arm64 artifacts/public-packages/mog-sdk__darwin-x64 artifacts/public-packages/mog-sdk__linux-x64-gnu artifacts/public-packages/mog-sdk__linux-arm64-gnu artifacts/public-packages/mog-sdk__linux-x64-musl artifacts/public-packages/mog-sdk__linux-arm64-musl artifacts/public-packages/mog-sdk__win32-x64-msvc artifacts/public-packages/mog-sdk__wasm artifacts/public-packages/mog-sdk__chart-raster-wasm; do
+          for dir in artifacts/public-packages/mog-sdk__darwin-arm64 artifacts/public-packages/mog-sdk__darwin-x64 artifacts/public-packages/mog-sdk__linux-x64-gnu artifacts/public-packages/mog-sdk__linux-arm64-gnu artifacts/public-packages/mog-sdk__linux-x64-musl artifacts/public-packages/mog-sdk__linux-arm64-musl artifacts/public-packages/mog-sdk__win32-x64-msvc artifacts/public-packages/mog-sdk__wasm; do
             PACKAGE_NAME=$(node -p "require('./$dir/package.json').name")
             if npm view "$PACKAGE_NAME@$VERSION" version 2>/dev/null; then
               echo "$PACKAGE_NAME@$VERSION already published; skipping."
@@ -563,7 +562,6 @@ jobs:
             "@mog-sdk/linux-arm64-musl"
             "@mog-sdk/win32-x64-msvc"
             "@mog-sdk/wasm"
-            "@mog-sdk/chart-raster-wasm"
             "@mog-sdk/contracts"
             "@mog-sdk/sheet-view"
             "@mog-sdk/spreadsheet-app"
@@ -629,7 +627,6 @@ jobs:
           echo "- \`@mog-sdk/linux-arm64-musl@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`@mog-sdk/win32-x64-msvc@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`@mog-sdk/wasm@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- \`@mog-sdk/chart-raster-wasm@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`@mog-sdk/sheet-view@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`@mog-sdk/spreadsheet-app@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`@mog-sdk/embed@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -416,6 +416,16 @@ jobs:
       - name: Install trusted publishing npm
         run: npm install -g "npm@$NPM_VERSION"
 
+      - name: Configure npm auth fallback
+        run: |
+          if [ -n "${NPM_TOKEN:-}" ]; then
+            npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+          else
+            echo "NPM_TOKEN is not configured; npm will use trusted publishing if available."
+          fi
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Download all artifacts (current run)
         if: ${{ inputs.source-run-id == '' }}
         uses: actions/download-artifact@v7

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -111,6 +111,7 @@ jobs:
             compute/napi/npm/linux-arm64-musl/package.json
             compute/napi/npm/win32-x64-msvc/package.json
             compute/wasm/npm/package.json
+            compute/chart-render-wasm/npm/package.json
           )
           for manifest in "${manifests[@]}"; do
             PACKAGE_VERSION=$(node -p "require('./${manifest}').version")
@@ -137,6 +138,7 @@ jobs:
             "@mog-sdk/linux-arm64-musl"
             "@mog-sdk/win32-x64-msvc"
             "@mog-sdk/wasm"
+            "@mog-sdk/chart-raster-wasm"
             "@mog-sdk/contracts"
             "@mog-sdk/sheet-view"
             "@mog-sdk/spreadsheet-app"
@@ -291,6 +293,39 @@ jobs:
           if-no-files-found: error
           retention-days: 3
 
+  build-chart-raster-wasm:
+    name: Build chart raster WASM
+    needs: [version]
+    if: ${{ inputs.source-run-id == '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.version.outputs.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --version "$WASM_PACK_VERSION" --locked
+
+      - name: Build chart raster WASM (release profile)
+        run: bash compute/chart-render-wasm/build.sh --profile release
+
+      - name: Verify chart raster WASM package
+        run: node compute/chart-render-wasm/npm/scripts/verify-package.mjs
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: chart-raster-wasm
+          path: compute/chart-render-wasm/npm/
+          if-no-files-found: error
+          retention-days: 3
+
   build-python:
     name: Build Python - ${{ matrix.artifact }}
     needs: [version]
@@ -347,13 +382,14 @@ jobs:
 
   publish:
     name: Publish packages
-    needs: [version, build-native, build-wasm, build-python]
+    needs: [version, build-native, build-wasm, build-chart-raster-wasm, build-python]
     if: |
       always() &&
       needs.version.outputs.dry-run != 'true' &&
       needs.version.result == 'success' &&
       (needs.build-native.result == 'success' || needs.build-native.result == 'skipped') &&
       (needs.build-wasm.result == 'success' || needs.build-wasm.result == 'skipped') &&
+      (needs.build-chart-raster-wasm.result == 'success' || needs.build-chart-raster-wasm.result == 'skipped') &&
       (needs.build-python.result == 'success' || needs.build-python.result == 'skipped')
     runs-on: ubuntu-latest
     environment: npm-production
@@ -401,6 +437,8 @@ jobs:
           done
           cp artifacts/wasm/* compute/wasm/npm/
           echo "wasm: $(ls -lh compute/wasm/npm/compute_core_wasm_bg.wasm | awk '{print $5}')"
+          cp artifacts/chart-raster-wasm/* compute/chart-render-wasm/npm/
+          echo "chart raster wasm: $(ls -lh compute/chart-render-wasm/npm/compute_chart_render_wasm_bg.wasm | awk '{print $5}')"
 
       - name: Resolve npm publish tag
         id: npm-tag
@@ -470,7 +508,7 @@ jobs:
             NPM_TAG_ARGS=(--tag "${{ steps.npm-tag.outputs.tag }}")
           fi
           VERSION="${{ needs.version.outputs.version }}"
-          for dir in artifacts/public-packages/mog-sdk__darwin-arm64 artifacts/public-packages/mog-sdk__darwin-x64 artifacts/public-packages/mog-sdk__linux-x64-gnu artifacts/public-packages/mog-sdk__linux-arm64-gnu artifacts/public-packages/mog-sdk__linux-x64-musl artifacts/public-packages/mog-sdk__linux-arm64-musl artifacts/public-packages/mog-sdk__win32-x64-msvc artifacts/public-packages/mog-sdk__wasm; do
+          for dir in artifacts/public-packages/mog-sdk__darwin-arm64 artifacts/public-packages/mog-sdk__darwin-x64 artifacts/public-packages/mog-sdk__linux-x64-gnu artifacts/public-packages/mog-sdk__linux-arm64-gnu artifacts/public-packages/mog-sdk__linux-x64-musl artifacts/public-packages/mog-sdk__linux-arm64-musl artifacts/public-packages/mog-sdk__win32-x64-msvc artifacts/public-packages/mog-sdk__wasm artifacts/public-packages/mog-sdk__chart-raster-wasm; do
             PACKAGE_NAME=$(node -p "require('./$dir/package.json').name")
             if npm view "$PACKAGE_NAME@$VERSION" version 2>/dev/null; then
               echo "$PACKAGE_NAME@$VERSION already published; skipping."
@@ -515,6 +553,7 @@ jobs:
             "@mog-sdk/linux-arm64-musl"
             "@mog-sdk/win32-x64-msvc"
             "@mog-sdk/wasm"
+            "@mog-sdk/chart-raster-wasm"
             "@mog-sdk/contracts"
             "@mog-sdk/sheet-view"
             "@mog-sdk/spreadsheet-app"
@@ -580,6 +619,7 @@ jobs:
           echo "- \`@mog-sdk/linux-arm64-musl@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`@mog-sdk/win32-x64-msvc@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`@mog-sdk/wasm@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`@mog-sdk/chart-raster-wasm@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`@mog-sdk/sheet-view@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`@mog-sdk/spreadsheet-app@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`@mog-sdk/embed@${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -437,7 +437,7 @@ jobs:
           done
           cp artifacts/wasm/* compute/wasm/npm/
           echo "wasm: $(ls -lh compute/wasm/npm/compute_core_wasm_bg.wasm | awk '{print $5}')"
-          cp artifacts/chart-raster-wasm/* compute/chart-render-wasm/npm/
+          cp -R artifacts/chart-raster-wasm/. compute/chart-render-wasm/npm/
           echo "chart raster wasm: $(ls -lh compute/chart-render-wasm/npm/compute_chart_render_wasm_bg.wasm | awk '{print $5}')"
 
       - name: Resolve npm publish tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "compute-core-pyo3"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bridge-pyo3",
  "bridge-types",

--- a/compute/chart-render-wasm/npm/package.json
+++ b/compute/chart-render-wasm/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/chart-raster-wasm",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Mog chart raster backend for browsers, edge runtimes, and headless WASM hosts",
   "type": "module",
   "main": "compute_chart_render_wasm.js",

--- a/compute/napi/npm/darwin-arm64/package.json
+++ b/compute/napi/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/darwin-arm64",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "os": [
     "darwin"
   ],

--- a/compute/napi/npm/darwin-x64/package.json
+++ b/compute/napi/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/darwin-x64",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "os": [
     "darwin"
   ],

--- a/compute/napi/npm/linux-arm64-gnu/package.json
+++ b/compute/napi/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/linux-arm64-gnu",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "os": [
     "linux"
   ],

--- a/compute/napi/npm/linux-arm64-musl/package.json
+++ b/compute/napi/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/linux-arm64-musl",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "os": [
     "linux"
   ],

--- a/compute/napi/npm/linux-x64-gnu/package.json
+++ b/compute/napi/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/linux-x64-gnu",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "os": [
     "linux"
   ],

--- a/compute/napi/npm/linux-x64-musl/package.json
+++ b/compute/napi/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/linux-x64-musl",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "os": [
     "linux"
   ],

--- a/compute/napi/npm/win32-x64-msvc/package.json
+++ b/compute/napi/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/win32-x64-msvc",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "os": [
     "win32"
   ],

--- a/compute/pyo3/Cargo.toml
+++ b/compute/pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compute-core-pyo3"
-version = "0.8.0"
+version = "0.9.0"
 publish = false
 edition.workspace = true
 

--- a/compute/pyo3/pyproject.toml
+++ b/compute/pyo3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mog-sdk"
-version = "0.8.0"
+version = "0.9.0"
 description = "Mog spreadsheet engine — Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/compute/wasm/npm/package.json
+++ b/compute/wasm/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/wasm",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Mog compute engine for browsers — WASM build of compute-core with full formula, formatting, and XLSX support",
   "type": "module",
   "main": "compute_core_wasm.js",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/contracts",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "SEE LICENSE IN LICENSE",
   "repository": "https://github.com/fundamental-research-labs/mog",
   "private": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1211,9 +1211,6 @@ importers:
 
   runtime/sdk:
     dependencies:
-      '@mog-sdk/chart-raster-wasm':
-        specifier: workspace:*
-        version: link:../../compute/chart-render-wasm/npm
       '@mog-sdk/contracts':
         specifier: workspace:*
         version: link:../../contracts
@@ -1227,6 +1224,9 @@ importers:
       '@microsoft/api-extractor':
         specifier: ^7.58.7
         version: 7.58.7(@types/node@25.9.1)
+      '@mog-sdk/chart-raster-wasm':
+        specifier: workspace:*
+        version: link:../../compute/chart-render-wasm/npm
       '@mog-sdk/kernel':
         specifier: workspace:*
         version: link:../../kernel

--- a/runtime/embed/package.json
+++ b/runtime/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/embed",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "SEE LICENSE IN LICENSE",
   "repository": "https://github.com/fundamental-research-labs/mog",
   "description": "Embeddable read-only Mog spreadsheet component",

--- a/runtime/sdk/package.json
+++ b/runtime/sdk/package.json
@@ -141,7 +141,6 @@
     }
   },
   "dependencies": {
-    "@mog-sdk/chart-raster-wasm": "workspace:*",
     "@mog-sdk/contracts": "workspace:*",
     "@mog-sdk/wasm": "workspace:*",
     "@types/node": "^25.5.0"
@@ -157,6 +156,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.58.7",
+    "@mog-sdk/chart-raster-wasm": "workspace:*",
     "@mog-sdk/kernel": "workspace:*",
     "@mog-sdk/types-host": "workspace:*",
     "@mog/kernel-host-internal": "workspace:*",

--- a/runtime/sdk/package.json
+++ b/runtime/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Headless spreadsheet engine with native Node and WASM runtime bindings",
   "type": "module",
   "main": "dist/index.cjs",

--- a/runtime/spreadsheet-app/package.json
+++ b/runtime/spreadsheet-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/spreadsheet-app",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "SEE LICENSE IN LICENSE",
   "description": "Policy-driven full Mog spreadsheet app embed for trusted same-origin hosts",
   "type": "module",

--- a/tools/build-public-artifacts.mjs
+++ b/tools/build-public-artifacts.mjs
@@ -410,6 +410,32 @@ function buildWasmArtifact(workspacePackages, errors) {
   return wasmPkg;
 }
 
+function buildChartRasterWasmArtifact(workspacePackages, errors) {
+  console.log('\n=== Chart raster WASM asset artifact ===');
+  const chartRasterPkg = workspacePackages.get('@mog-sdk/chart-raster-wasm');
+  if (!chartRasterPkg) {
+    errors.push('@mog-sdk/chart-raster-wasm: binary-wrapper package missing from workspace');
+    return null;
+  }
+
+  if (!skipWasmBuild) {
+    try {
+      run('bash', ['compute/chart-render-wasm/build.sh', '--profile', 'release']);
+    } catch (error) {
+      errors.push(`@mog-sdk/chart-raster-wasm: ${error.message}`);
+    }
+  } else {
+    console.log(`  SKIP chart raster WASM build (${checkOnly ? 'check-only' : 'skip-wasm-build'})`);
+  }
+
+  const missing = verifyPackageFiles(chartRasterPkg.manifest, chartRasterPkg.dir);
+  if (missing.length > 0) {
+    errors.push(`@mog-sdk/chart-raster-wasm: missing packaged WASM file(s): ${missing.join(', ')}`);
+  }
+
+  return chartRasterPkg;
+}
+
 const inventory = loadJsonc(join(ROOT, 'tools/package-inventory.jsonc'));
 const workspacePackages = discoverWorkspacePackages();
 const errors = [];
@@ -477,6 +503,14 @@ const wasmPkg = needsWasmArtifact ? buildWasmArtifact(workspacePackages, errors)
 if (!needsWasmArtifact) {
   console.log('\n=== WASM asset artifact ===');
   console.log(`  SKIP WASM build (not required by selected ship-public packages)`);
+}
+const needsChartRasterWasmArtifact = shipPublicNames.includes('@mog-sdk/sdk');
+const chartRasterWasmPkg = needsChartRasterWasmArtifact
+  ? buildChartRasterWasmArtifact(workspacePackages, errors)
+  : null;
+if (!needsChartRasterWasmArtifact) {
+  console.log('\n=== Chart raster WASM asset artifact ===');
+  console.log(`  SKIP chart raster WASM build (not required by selected ship-public packages)`);
 }
 let kernelArtifactBuilt = false;
 let sdkArtifactBuilt = false;
@@ -582,6 +616,9 @@ console.log(
 );
 console.log(`  host native package: ${hostNative ?? '(unsupported)'}`);
 console.log(`  wasm package: ${wasmPkg ? '@mog-sdk/wasm' : '(missing)'}`);
+console.log(
+  `  chart raster wasm package: ${chartRasterWasmPkg ? '@mog-sdk/chart-raster-wasm' : '(missing)'}`,
+);
 
 if (errors.length > 0) {
   console.error(

--- a/views/sheet-view/package.json
+++ b/views/sheet-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/sheet-view",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "SEE LICENSE IN LICENSE",
   "files": [
     "dist/index.js",


### PR DESCRIPTION
## Summary

Merges the published `release/v0.9.0` branch back into `main`.

This brings back:
- SDK/package version bumps to `0.9.0`
- SDK publish workflow resume/token fallback fixes
- chart raster artifact handling for public package assembly
- SDK dependency adjustment so `@mog-sdk/sdk` does not depend on unpublished `@mog-sdk/chart-raster-wasm`

## Verification

- Published npm package set verified at `0.9.0`
- Final publish workflow succeeded: https://github.com/fundamental-research-labs/mog/actions/runs/27100711236
- Clean consumer install of `@mog-sdk/sdk@0.9.0` passed native/root and WASM subpath smoke tests
