### PR TITLE
Merge release/v0.9.1 back into main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "compute-core-pyo3"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bridge-pyo3",
  "bridge-types",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Command-line interface for operating Mog workbooks with the headless SDK",
   "type": "module",
   "bin": {

--- a/cli/scripts/package-skill.mjs
+++ b/cli/scripts/package-skill.mjs
@@ -15,7 +15,7 @@ const crcTable = makeCrc32Table();
 const packageVersion = releasePackageVersion();
 
 const skillSource = readFileSync(resolve(skillRoot, 'SKILL.md'), 'utf8');
-assertNoInstallVersionMismatch(skillSource, 'cli/skill/SKILL.md');
+assertNoPinnedInstallVersions(skillSource, 'cli/skill/SKILL.md');
 assertNoForbiddenInstallPaths(skillSource, 'cli/skill/SKILL.md');
 assertSkillRootContract();
 assertApiSpecSynced();
@@ -26,7 +26,7 @@ rmSync(zipPath, { force: true });
 const entries = [
   {
     name: 'SKILL.md',
-    data: Buffer.from(rewriteSkillInstallVersion(skillSource), 'utf8'),
+    data: Buffer.from(skillSource, 'utf8'),
   },
   {
     name: 'references/api-spec.json',
@@ -34,7 +34,7 @@ const entries = [
   },
 ];
 assertEntriesExactly(entries.map((entry) => entry.name));
-assertNoInstallVersionMismatch(entries[0].data.toString('utf8'), 'packaged SKILL.md');
+assertNoPinnedInstallVersions(entries[0].data.toString('utf8'), 'packaged SKILL.md');
 assertNoForbiddenInstallPaths(entries[0].data.toString('utf8'), 'packaged SKILL.md');
 assertPackagedApiSpecVersion(entries[1].data);
 
@@ -88,34 +88,21 @@ function assertApiSpecPackageVersion(spec, label) {
   }
 }
 
-function rewriteSkillInstallVersion(source) {
-  return source
-    .replace(/mog-cli-v[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9_.-]+)?/g, `mog-cli-v${packageVersion}`)
-    .replace(
-      /@mog\/cli@[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9_.-]+)?/g,
-      `@mog-sdk/cli@${packageVersion}`,
-    )
-    .replace(
-      /@mog-sdk\/cli@[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9_.-]+)?/g,
-      `@mog-sdk/cli@${packageVersion}`,
-    );
-}
-
-function assertNoInstallVersionMismatch(source, label) {
+function assertNoPinnedInstallVersions(source, label) {
   const patterns = [
-    /@mog-sdk\/cli@([0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9_.-]+)?)/g,
-    /@mog\/cli@([0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9_.-]+)?)/g,
-    /mog-cli-v([0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9_.-]+)?)/g,
+    /@mog-sdk\/cli@[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9_.-]+)?/g,
+    /@mog\/cli@[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9_.-]+)?/g,
+    /mog-cli-v[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9_.-]+)?/g,
   ];
-  const mismatches = [];
+  const pinned = [];
   for (const pattern of patterns) {
     for (const match of source.matchAll(pattern)) {
-      if (match[1] !== packageVersion) mismatches.push(match[0]);
+      pinned.push(match[0]);
     }
   }
-  if (mismatches.length > 0) {
+  if (pinned.length > 0) {
     throw new Error(
-      `${label} contains install version(s) that do not match @mog-sdk/cli@${packageVersion}: ${mismatches.join(', ')}`,
+      `${label} must not pin CLI install versions; found ${pinned.join(', ')}`,
     );
   }
 }

--- a/cli/skill/SKILL.md
+++ b/cli/skill/SKILL.md
@@ -20,7 +20,7 @@ If missing, install from npm with a user-local prefix:
 
 ```bash
 mkdir -p "$HOME/.mog/npm"
-npm install --prefix "$HOME/.mog/npm" @mog-sdk/cli@0.9.0
+npm install --prefix "$HOME/.mog/npm" @mog-sdk/cli
 export PATH="$HOME/.mog/npm/node_modules/.bin:$PATH"
 mog --help
 ```

--- a/compute/chart-render-wasm/npm/package.json
+++ b/compute/chart-render-wasm/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/chart-raster-wasm",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Mog chart raster backend for browsers, edge runtimes, and headless WASM hosts",
   "type": "module",
   "main": "compute_chart_render_wasm.js",

--- a/compute/napi/npm/darwin-arm64/package.json
+++ b/compute/napi/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/darwin-arm64",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "os": [
     "darwin"
   ],

--- a/compute/napi/npm/darwin-x64/package.json
+++ b/compute/napi/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/darwin-x64",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "os": [
     "darwin"
   ],

--- a/compute/napi/npm/linux-arm64-gnu/package.json
+++ b/compute/napi/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/linux-arm64-gnu",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "os": [
     "linux"
   ],

--- a/compute/napi/npm/linux-arm64-musl/package.json
+++ b/compute/napi/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/linux-arm64-musl",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "os": [
     "linux"
   ],

--- a/compute/napi/npm/linux-x64-gnu/package.json
+++ b/compute/napi/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/linux-x64-gnu",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "os": [
     "linux"
   ],

--- a/compute/napi/npm/linux-x64-musl/package.json
+++ b/compute/napi/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/linux-x64-musl",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "os": [
     "linux"
   ],

--- a/compute/napi/npm/win32-x64-msvc/package.json
+++ b/compute/napi/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/win32-x64-msvc",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "os": [
     "win32"
   ],

--- a/compute/pyo3/Cargo.toml
+++ b/compute/pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compute-core-pyo3"
-version = "0.9.0"
+version = "0.9.1"
 publish = false
 edition.workspace = true
 

--- a/compute/pyo3/pyproject.toml
+++ b/compute/pyo3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mog-sdk"
-version = "0.9.0"
+version = "0.9.1"
 description = "Mog spreadsheet engine — Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/compute/wasm/npm/package.json
+++ b/compute/wasm/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/wasm",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Mog compute engine for browsers — WASM build of compute-core with full formula, formatting, and XLSX support",
   "type": "module",
   "main": "compute_core_wasm.js",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/contracts",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "SEE LICENSE IN LICENSE",
   "repository": "https://github.com/fundamental-research-labs/mog",
   "private": false,

--- a/runtime/embed/package.json
+++ b/runtime/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/embed",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "SEE LICENSE IN LICENSE",
   "repository": "https://github.com/fundamental-research-labs/mog",
   "description": "Embeddable read-only Mog spreadsheet component",

--- a/runtime/sdk/package.json
+++ b/runtime/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/sdk",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Headless spreadsheet engine with native Node and WASM runtime bindings",
   "type": "module",
   "main": "dist/index.cjs",

--- a/runtime/spreadsheet-app/package.json
+++ b/runtime/spreadsheet-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/spreadsheet-app",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "SEE LICENSE IN LICENSE",
   "description": "Policy-driven full Mog spreadsheet app embed for trusted same-origin hosts",
   "type": "module",

--- a/views/sheet-view/package.json
+++ b/views/sheet-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/sheet-view",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "SEE LICENSE IN LICENSE",
   "files": [
     "dist/index.js",


### PR DESCRIPTION
Backmerge release/v0.9.1 into main.

Commits:
- 8d3e58f9 Bump SDK release metadata to v0.9.1
- b931200e Avoid pinned CLI install version in skill

Requested immediate merge.