### PR TITLE
Approve VSCE publish build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,8 +81,13 @@ overrides:
   react-icons: 5.5.0
 
 allowBuilds:
+  '@vscode/vsce-sign': true
   esbuild: true
+  keytar: true
   unrs-resolver: true
 
 onlyBuiltDependencies:
+  - '@vscode/vsce-sign'
   - esbuild
+  - keytar
+  - unrs-resolver


### PR DESCRIPTION
## Summary
- approve VSCE publish dependencies that run install scripts under pnpm's build approval policy
- keep the existing esbuild and unrs-resolver approvals explicit

## Verification
- COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm@11.5.0 install --frozen-lockfile