### PR TITLE
Fix VS Code publish identity check

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Check extension identity
         run: |
-          EXTENSION_ID=$(node -p "const p=require('./integrations/vscode/mog-xlsx-editor/package.json'); `${p.publisher}.${p.name}@${p.version}`")
+          EXTENSION_ID=$(node -p "const p=require('./integrations/vscode/mog-xlsx-editor/package.json'); p.publisher + '.' + p.name + '@' + p.version")
           if [ "$EXTENSION_ID" != "mog.mog-xlsx-editor@${{ steps.version.outputs.version }}" ]; then
             echo "::error::Unexpected VS Code extension identity ${EXTENSION_ID}"
             exit 1


### PR DESCRIPTION
## Summary
- avoid shell command substitution in the VS Code extension identity check
- keep the expected publisher/name/version contract unchanged

## Verification
- ruby YAML parse check for .github/workflows/publish-vscode-extension.yml
- node expression resolves to mog.mog-xlsx-editor@0.9.1