### PR TITLE
Prepare spreadsheet app assets for VS Code publish

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -42,6 +42,7 @@ permissions:
 env:
   NODE_VERSION: '24.16.0'
   PNPM_VERSION: '11.5.0'
+  WASM_PACK_VERSION: '0.15.0'
 
 jobs:
   publish:
@@ -134,6 +135,21 @@ jobs:
             exit 1
           fi
           echo "Packaging ${EXTENSION_ID}"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --version "$WASM_PACK_VERSION" --locked
+
+      - name: Install binaryen and brotli
+        run: sudo apt-get update && sudo apt-get install -y binaryen brotli
+
+      - name: Build WASM package assets
+        run: bash compute/wasm/build.sh --profile release
 
       - run: pnpm --dir integrations/vscode/mog-xlsx-editor test
 

--- a/runtime/spreadsheet-app/package.json
+++ b/runtime/spreadsheet-app/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup --no-dts && node scripts/build-types.mjs && vite build --config vite.css.config.ts && node scripts/finalize-assets.mjs && node scripts/check-boundary.mjs --require-dist",
+    "build": "pnpm --filter @mog/icons ensure-generated && tsup --no-dts && node scripts/build-types.mjs && vite build --config vite.css.config.ts && node scripts/finalize-assets.mjs && node scripts/check-boundary.mjs --require-dist",
     "build:dev": "tsup --no-dts",
     "test": "node scripts/generate-workbook-facade-matrix.mjs --check && node scripts/check-boundary.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",


### PR DESCRIPTION
## Summary
- make @mog-sdk/spreadsheet-app build generate @mog/icons sources before bundling
- build release @mog-sdk/wasm assets in the VS Code extension publish workflow before typecheck/package

## Verification
- ruby YAML parse check for .github/workflows/publish-vscode-extension.yml
- COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm@11.5.0 install --frozen-lockfile
- bash compute/wasm/build.sh --profile dev
- COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm@11.5.0 --dir integrations/vscode/mog-xlsx-editor typecheck
- COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm@11.5.0 --dir integrations/vscode/mog-xlsx-editor package