### PR TITLE
Use published SDK WASM for VS Code publish

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -42,7 +42,6 @@ permissions:
 env:
   NODE_VERSION: '24.16.0'
   PNPM_VERSION: '11.5.0'
-  WASM_PACK_VERSION: '0.15.0'
 
 jobs:
   publish:
@@ -136,20 +135,16 @@ jobs:
           fi
           echo "Packaging ${EXTENSION_ID}"
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --version "$WASM_PACK_VERSION" --locked
-
-      - name: Install binaryen and brotli
-        run: sudo apt-get update && sudo apt-get install -y binaryen brotli
-
-      - name: Build WASM package assets
-        run: bash compute/wasm/build.sh --profile release
+      - name: Hydrate WASM package assets
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          TARBALL=$(npm pack "@mog-sdk/wasm@${VERSION}" --pack-destination "$RUNNER_TEMP")
+          mkdir -p "$RUNNER_TEMP/mog-sdk-wasm"
+          tar -xzf "$RUNNER_TEMP/$TARBALL" -C "$RUNNER_TEMP/mog-sdk-wasm"
+          cp "$RUNNER_TEMP"/mog-sdk-wasm/package/compute_core_wasm* compute/wasm/npm/
+          test -f compute/wasm/npm/compute_core_wasm.js
+          test -f compute/wasm/npm/compute_core_wasm_bg.wasm
 
       - run: pnpm --dir integrations/vscode/mog-xlsx-editor test
 


### PR DESCRIPTION
## Summary
- hydrate VS Code extension packaging from the version-matched @mog-sdk/wasm npm artifact
- remove source WASM toolchain setup from the VS Code publish workflow

## Verification
- ruby YAML parse check for .github/workflows/publish-vscode-extension.yml
- npm pack @mog-sdk/wasm@0.9.1 contains compute_core_wasm.js and compute_core_wasm_bg.wasm
- COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm@11.5.0 install --frozen-lockfile
- workflow hydrate snippet copied compute_core_wasm.js and compute_core_wasm_bg.wasm into compute/wasm/npm
- COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm@11.5.0 --dir integrations/vscode/mog-xlsx-editor typecheck
- COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm@11.5.0 --dir integrations/vscode/mog-xlsx-editor package