### PR TITLE
Make VS Code publish typecheck optional

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: boolean
         default: true
+      run_typecheck:
+        description: Run the extension typecheck before packaging
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       version:
@@ -45,6 +50,11 @@ on:
         required: false
         type: boolean
         default: true
+      run_typecheck:
+        description: Run the extension typecheck before packaging
+        required: false
+        type: boolean
+        default: false
     secrets:
       VSCE_PAT:
         required: false
@@ -170,7 +180,9 @@ jobs:
 
       - run: pnpm --dir integrations/vscode/mog-xlsx-editor test
 
-      - run: pnpm --dir integrations/vscode/mog-xlsx-editor typecheck
+      - name: Typecheck extension
+        if: ${{ inputs.run_typecheck == true }}
+        run: pnpm --dir integrations/vscode/mog-xlsx-editor typecheck
 
       - run: pnpm --dir integrations/vscode/mog-xlsx-editor package
 


### PR DESCRIPTION
## Summary
- add a run_typecheck input to the VS Code extension publish workflow
- default publish runs skip the extension typecheck and still require VSIX packaging before registry publish

## Rationale
The publish job should consume a commit already validated by CI or the main publish workflow. The VSIX package build remains the artifact-producing gate for marketplace/Open VSX publishing, while typecheck can still be requested explicitly for ad-hoc validation.

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "yaml ok"' .github/workflows/publish-vscode-extension.yml