### PR TITLE
Fix VS Code Marketplace publisher

### DIFF
--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Check extension identity
         run: |
           EXTENSION_ID=$(node -p "const p=require('./integrations/vscode/mog-xlsx-editor/package.json'); p.publisher + '.' + p.name + '@' + p.version")
-          if [ "$EXTENSION_ID" != "mog.mog-xlsx-editor@${{ steps.version.outputs.version }}" ]; then
+          if [ "$EXTENSION_ID" != "FundamentalResearchLabs.mog-xlsx-editor@${{ steps.version.outputs.version }}" ]; then
             echo "::error::Unexpected VS Code extension identity ${EXTENSION_ID}"
             exit 1
           fi

--- a/integrations/vscode/mog-xlsx-editor/package.json
+++ b/integrations/vscode/mog-xlsx-editor/package.json
@@ -3,7 +3,7 @@
   "displayName": "Mog Spreadsheet",
   "description": "Open, inspect, edit, and save XLSX workbooks in VS Code with Mog's spreadsheet runtime.",
   "version": "0.9.1",
-  "publisher": "mog",
+  "publisher": "FundamentalResearchLabs",
   "icon": "resources/icon.png",
   "license": "Apache-2.0",
   "type": "module",

--- a/integrations/vscode/mog-xlsx-editor/tests/e2e/suite/index.ts
+++ b/integrations/vscode/mog-xlsx-editor/tests/e2e/suite/index.ts
@@ -29,8 +29,10 @@ type CdpClient = {
   close(): void;
 };
 
+const extensionId = 'FundamentalResearchLabs.mog-xlsx-editor';
+
 async function openFixtureCopy(name: string, destinationName = name): Promise<vscode.Uri> {
-  const extension = vscode.extensions.getExtension('mog.mog-xlsx-editor');
+  const extension = vscode.extensions.getExtension(extensionId);
   assert.ok(extension, 'extension should be registered in VS Code host');
   await extension.activate();
   const workspace = process.env.MOG_VSCODE_TEST_WORKSPACE;
@@ -240,7 +242,7 @@ async function findMogWebviewTarget(): Promise<CdpTarget> {
       if (
         target.type === 'iframe' &&
         target.url?.startsWith('vscode-webview://') &&
-        target.url.includes('extensionId=mog.mog-xlsx-editor') &&
+        target.url.includes(`extensionId=${extensionId}`) &&
         target.webSocketDebuggerUrl
       ) {
         return target;


### PR DESCRIPTION
Updates the VS Code extension publisher from `mog` to `FundamentalResearchLabs` so the 0.9.1 VSIX targets the company Marketplace publisher. Also updates the workflow identity guard and E2E extension ID checks to match the packaged extension identity.\n\nVerification:\n- `pnpm --dir integrations/vscode/mog-xlsx-editor test`\n- hydrated `@mog-sdk/wasm@0.9.1` assets using the workflow step\n- `pnpm --dir integrations/vscode/mog-xlsx-editor typecheck`\n- `pnpm --dir integrations/vscode/mog-xlsx-editor package`\n- inspected VSIX manifest: `Publisher="FundamentalResearchLabs"`, `Version="0.9.1"`