### PR TITLE
Fix v0.9.3 devtools readbacks

### DIFF
--- a/tools/devtools/src/__tests__/dt-readbacks.test.ts
+++ b/tools/devtools/src/__tests__/dt-readbacks.test.ts
@@ -34,7 +34,15 @@ interface FakeSceneObject {
   visible: boolean;
   groupId: string | null;
   rotation?: number;
-  data?: { src?: string; chartId?: string; wordArt?: unknown };
+  data?: {
+    src?: string;
+    chartId?: string;
+    wordArt?: unknown;
+    textEffect?: unknown;
+    chartType?: string;
+    dataRange?: string;
+    sourceRange?: string;
+  };
 }
 
 function makeSceneGraph(objects: FakeSceneObject[]) {
@@ -116,10 +124,90 @@ function setupRuntime(opts: {
   colWidths: Record<number, number>;
   bridgeColPositions?: Record<number, number>;
   coordinateDocumentPixelToCell?: boolean;
+  renderedCellSizes?: Record<string, { width: number; height: number }>;
+  viewportCells?: Record<
+    string,
+    {
+      displayText?: string | null;
+      valueType?: number;
+      numberValue?: number;
+      hasFormula?: boolean;
+      errorText?: string | null;
+    }
+  >;
+  bridgeCells?: Record<
+    string,
+    {
+      formatted?: string | null;
+      value?: unknown;
+      formula?: string;
+    }
+  >;
+  merges?: Array<{ startRow: number; startCol: number; endRow: number; endCol: number }>;
+  charts?: Array<Record<string, unknown>>;
 }): RuntimeBundle {
   const g = globalThis as { window?: Record<string, unknown>; document?: unknown };
 
   const sceneGraph = makeSceneGraph(opts.drawings);
+  const viewportId = 'main:sheet-1';
+  const computeBridge: Record<string, unknown> = {};
+  if (opts.bridgeColPositions) {
+    computeBridge.getColPosition = async (_sheetId: string, col: number) =>
+      opts.bridgeColPositions?.[col] ?? 0;
+  }
+  if (opts.viewportCells) {
+    computeBridge.getPerViewportStates = () => new Map([[viewportId, {}]]);
+    computeBridge.getAccessorForViewport = (id: string) => {
+      if (id !== viewportId) return null;
+      let current:
+        | {
+            displayText?: string | null;
+            valueType?: number;
+            numberValue?: number;
+            hasFormula?: boolean;
+            errorText?: string | null;
+          }
+        | undefined;
+      return {
+        moveTo(row: number, col: number) {
+          current = opts.viewportCells?.[`${row},${col}`];
+          return current !== undefined;
+        },
+        get displayText() {
+          return current?.displayText ?? null;
+        },
+        get valueType() {
+          return current?.valueType ?? 0;
+        },
+        get numberValue() {
+          return current?.numberValue;
+        },
+        get hasFormula() {
+          return current?.hasFormula ?? false;
+        },
+        get errorText() {
+          return current?.errorText ?? null;
+        },
+      };
+    };
+  }
+  if (opts.bridgeCells || opts.merges) {
+    computeBridge.queryRange = async (
+      _sheetId: string,
+      startRow: number,
+      startCol: number,
+      _endRow: number,
+      _endCol: number,
+    ) => {
+      const cell = opts.bridgeCells?.[`${startRow},${startCol}`];
+      return {
+        cells: cell ? [{ row: startRow, col: startCol, ...cell }] : [],
+        merges: opts.merges ?? [],
+      };
+    };
+    computeBridge.getAllMergesInSheet = async () => opts.merges ?? [];
+  }
+
   // __SHELL__ is still consulted by other readbacks (workbook lookup
   // fallback, principal resolution) but the scene graph is now sourced
   // from SheetView's object-scene capability — see `getRenderedDrawings`
@@ -130,14 +218,12 @@ function setupRuntime(opts: {
       getDocument: (id: string) =>
         id === 'doc-1'
           ? {
-              context: opts.bridgeColPositions
-                ? {
-                    computeBridge: {
-                      getColPosition: async (_sheetId: string, col: number) =>
-                        opts.bridgeColPositions?.[col] ?? 0,
-                    },
-                  }
-                : {},
+              context:
+                Object.keys(computeBridge).length > 0
+                  ? {
+                      computeBridge,
+                    }
+                  : {},
             }
           : null,
     },
@@ -166,8 +252,27 @@ function setupRuntime(opts: {
             if (h == null || w == null) return null;
             return { x: 0, y: 0, width: w, height: h };
           },
+          getCellRenderedSize(cell: { row: number; col: number }) {
+            const explicit = opts.renderedCellSizes?.[`${cell.row},${cell.col}`];
+            if (explicit) return explicit;
+            const h = opts.rowHeights[cell.row];
+            const w = opts.colWidths[cell.col];
+            if (h == null || w == null) return null;
+            return { width: w, height: h };
+          },
           getVisibleRange() {
             return renderer.getCoordinateSystem().getVisibleRange();
+          },
+          getMergeAnchor(row: number, col: number) {
+            return (
+              opts.merges?.find(
+                (merge) =>
+                  row >= merge.startRow &&
+                  row <= merge.endRow &&
+                  col >= merge.startCol &&
+                  col <= merge.endCol,
+              ) ?? null
+            );
           },
           getPositionDimensions() {
             return {
@@ -205,6 +310,17 @@ function setupRuntime(opts: {
       activeSheet: {
         sheetId: 'sheet-1',
         getSheetId: () => 'sheet-1',
+        charts: {
+          get: async (id: string) =>
+            opts.charts?.find(
+              (chart) =>
+                chart.id === id ||
+                chart.chartId === id ||
+                chart.objectId === id ||
+                chart.name === id,
+            ) ?? null,
+          list: async () => opts.charts ?? [],
+        },
         layout: {
           // No documentPixelToCell here — force fallback to coordinator's
           // coordinate system.
@@ -270,12 +386,37 @@ describe('__dt rendered-state readbacks (app-eval / app-eval rendered-state read
     const d = drawings[0];
     expect(d.id).toBe('pic-1');
     expect(d.kind).toBe('image');
-    expect(d.boundsPx).toEqual({ x: 150, y: 48, w: 200, h: 96 });
+    expect(d.boundsPx).toEqual({ x: 100, y: 24, w: 200, h: 96 });
     expect(d.visible).toBe(true);
     expect(d.src).toBe('mog://image/abc.png');
     // anchor.from snaps (100, 24) → row 1, col 1; anchor.to snaps (300, 120) → row 5, col 3.
     expect(d.anchor.from).toEqual({ row: 1, col: 1 });
     expect(d.anchor.to).toEqual({ row: 5, col: 3 });
+  });
+
+  test('getRenderedDrawings reports diagram scene bounds in document space', async () => {
+    runtime = setupRuntime({
+      drawings: [
+        {
+          id: 'diagram-1',
+          type: 'diagram',
+          bounds: { x: 100, y: 100, width: 400, height: 300 },
+          zIndex: 1,
+          visible: true,
+          groupId: null,
+        },
+      ],
+      rowHeights: { 0: 24, 1: 24, 2: 24, 3: 24, 4: 24, 5: 24, 6: 24 },
+      colWidths: { 0: 100, 1: 100, 2: 100, 3: 100, 4: 100, 5: 100 },
+    });
+
+    const drawings = await runtime.api.getRenderedDrawings();
+    expect(drawings).toHaveLength(1);
+    expect(drawings[0]).toMatchObject({
+      id: 'diagram-1',
+      kind: 'diagram',
+      boundsPx: { x: 100, y: 100, w: 400, h: 300 },
+    });
   });
 
   test('getRenderedDrawings snaps anchors through SheetView geometry dimensions', async () => {
@@ -372,6 +513,50 @@ describe('__dt rendered-state readbacks (app-eval / app-eval rendered-state read
     expect(byId['legacy-text-effect-1']).toBe('wordArt');
     expect(byId['plain-textbox']).toBe('shape');
     expect(byId['smartart-1']).toBe('smartArt');
+  });
+
+  test('getRenderedDrawings enriches chart descriptors from the chart model', async () => {
+    runtime = setupRuntime({
+      drawings: [
+        {
+          id: 'chart-object-1',
+          type: 'chart',
+          bounds: { x: 256, y: 20, width: 512, height: 280 },
+          zIndex: 1,
+          visible: true,
+          groupId: null,
+          data: { chartId: 'chart-1' } as any,
+        },
+      ],
+      rowHeights: Object.fromEntries(Array.from({ length: 20 }, (_v, row) => [row, 20])),
+      colWidths: Object.fromEntries(Array.from({ length: 16 }, (_v, col) => [col, 64])),
+      coordinateDocumentPixelToCell: false,
+      charts: [
+        {
+          id: 'chart-1',
+          type: 'combo',
+          dataRange: 'Data!A2:C5',
+          anchorRow: 1,
+          anchorCol: 4,
+        },
+      ],
+    });
+
+    const drawings = await runtime.api.getRenderedDrawings();
+    expect(drawings).toHaveLength(1);
+    expect(drawings[0]).toMatchObject({
+      id: 'chart-object-1',
+      kind: 'chart',
+      chartType: 'combo',
+      dataRange: 'Data!A2:C5',
+      sourceRange: 'Data!A2:C5',
+      chartRange: 'E2:M16',
+      usedSyntheticAnchorFallback: false,
+      anchor: {
+        from: { row: 1, col: 4 },
+        to: { row: 15, col: 12 },
+      },
+    });
   });
 
   test('getRenderedDrawings includes visible DOM form-control overlays', async () => {
@@ -512,6 +697,21 @@ describe('__dt rendered-state readbacks (app-eval / app-eval rendered-state read
     expect(w).toBeNull();
   });
 
+  test('getRenderedCellSize reports intrinsic size when page bounds are not visible', async () => {
+    runtime = setupRuntime({
+      drawings: [],
+      rowHeights: {},
+      colWidths: {},
+      renderedCellSizes: { '0,255': { width: 64, height: 24 } },
+    });
+
+    await expect(runtime.api.getRenderedCellSize(null, 0, 255)).resolves.toEqual({
+      width: 64,
+      height: 24,
+    });
+    await expect(runtime.api.getRenderedColWidth(null, 255)).resolves.toBeNull();
+  });
+
   test('getCanvasSnapshot returns empty Uint8Array when no canvas exists', async () => {
     runtime = setupRuntime({
       drawings: [],
@@ -531,6 +731,65 @@ describe('__dt rendered-state readbacks (app-eval / app-eval rendered-state read
     } finally {
       delete (globalThis as any).document;
     }
+  });
+
+  test('getCellValue returns empty data for covered merged cells', () => {
+    runtime = setupRuntime({
+      drawings: [],
+      rowHeights: { 0: 24, 1: 24 },
+      colWidths: { 0: 100, 1: 100 },
+      viewportCells: {
+        '0,0': { displayText: 'Merged', valueType: 2 },
+        '1,1': { displayText: 'Merged', valueType: 2 },
+      },
+      merges: [{ startRow: 0, startCol: 0, endRow: 1, endCol: 1 }],
+    });
+
+    expect(runtime.api.getCellValue(0, 0)).toMatchObject({
+      row: 0,
+      col: 0,
+      displayText: 'Merged',
+      valueType: 2,
+    });
+    expect(runtime.api.getCellValue(1, 1)).toMatchObject({
+      row: 1,
+      col: 1,
+      displayText: null,
+      valueType: 0,
+      hasFormula: false,
+    });
+  });
+
+  test('getCellsViaBridge returns empty data for covered merged cells', async () => {
+    runtime = setupRuntime({
+      drawings: [],
+      rowHeights: { 0: 24, 1: 24 },
+      colWidths: { 0: 100, 1: 100 },
+      bridgeCells: {
+        '0,0': { formatted: 'Merged', value: 'Merged' },
+        '1,1': { formatted: 'Merged', value: 'Merged' },
+      },
+      merges: [{ startRow: 0, startCol: 0, endRow: 1, endCol: 1 }],
+    });
+
+    const cells = await runtime.api.getCellsViaBridge([
+      { row: 0, col: 0 },
+      { row: 1, col: 1 },
+    ]);
+
+    expect(cells['0,0']).toMatchObject({
+      row: 0,
+      col: 0,
+      displayText: 'Merged',
+      valueType: 2,
+    });
+    expect(cells['1,1']).toMatchObject({
+      row: 1,
+      col: 1,
+      displayText: null,
+      valueType: 0,
+      hasFormula: false,
+    });
   });
 
   test('getDisplayedFormatsForCells uses range prefetch for dense in-limit cells', async () => {

--- a/tools/devtools/src/console/api.ts
+++ b/tools/devtools/src/console/api.ts
@@ -39,6 +39,7 @@ import {
   readIconBucket,
   readResolvedNumberFormats,
 } from './viewport-inspector';
+import { completeDrawingAnchor, getChartReadback } from './drawing-readbacks';
 
 export function createConsoleAPI(
   store: EventStore,
@@ -577,6 +578,11 @@ export function createConsoleAPI(
     height: number;
   };
 
+  type RenderedCellSize = {
+    width: number;
+    height: number;
+  };
+
   function getRenderedCellBounds(row: number, col: number): RenderedCellBounds | null {
     try {
       const coordinator = (window as any).__COORDINATOR__;
@@ -601,6 +607,28 @@ export function createConsoleAPI(
     } catch {
       return null;
     }
+  }
+
+  function getRenderedCellSize(row: number, col: number): RenderedCellSize | null {
+    try {
+      const coordinator = (window as any).__COORDINATOR__;
+      const geometry = coordinator?.renderer?.getGeometry?.();
+      const size = geometry?.getCellRenderedSize?.({ row, col });
+      if (
+        size &&
+        Number.isFinite(size.width) &&
+        Number.isFinite(size.height) &&
+        size.width >= 0 &&
+        size.height >= 0
+      ) {
+        return { width: size.width, height: size.height };
+      }
+    } catch {
+      // fall through to visible page-bounds fallback
+    }
+
+    const bounds = getRenderedCellBounds(row, col);
+    return bounds ? { width: bounds.width, height: bounds.height } : null;
   }
 
   /**
@@ -2037,22 +2065,27 @@ export function createConsoleAPI(
             obj.bounds.x + obj.bounds.width,
             obj.bounds.y + obj.bounds.height,
           );
-          const canvasBounds = {
-            x: obj.bounds.x + DEFAULT_ROW_HEADER_WIDTH_PX,
-            y: obj.bounds.y + DEFAULT_COL_HEADER_HEIGHT_PX,
+          const fallbackAnchor = {
+            from: fromCell ?? { row: 0, col: 0 },
+            ...(toCell ? { to: toCell } : {}),
+          };
+          const modelAnchor = completeDrawingAnchor(model?.anchor, toCell);
+          const chartReadback = kind === 'chart' ? await getChartReadback(ws, obj, toCell) : null;
+          const { anchor: chartAnchor, ...chartFields } = chartReadback ?? {};
+          const documentBounds = {
+            x: obj.bounds.x,
+            y: obj.bounds.y,
             w: obj.bounds.width,
             h: obj.bounds.height,
           };
           out.push({
             id: obj.id,
             kind,
-            anchor: model?.anchor ?? {
-              from: fromCell ?? { row: 0, col: 0 },
-              ...(toCell ? { to: toCell } : {}),
-            },
-            boundsPx: canvasBounds,
+            anchor: chartAnchor ?? modelAnchor ?? fallbackAnchor,
+            boundsPx: documentBounds,
             visible: !!obj.visible,
             ...(extractSrc(obj) ? { src: extractSrc(obj)! } : {}),
+            ...chartFields,
           });
         }
 
@@ -2123,6 +2156,14 @@ export function createConsoleAPI(
 
     async getRenderedColWidth(_sheet: string | null, col: number): Promise<number | null> {
       return getRenderedCellBounds(0, col)?.width ?? null;
+    },
+
+    async getRenderedCellSize(
+      _sheet: string | null,
+      row: number,
+      col: number,
+    ): Promise<{ width: number; height: number } | null> {
+      return getRenderedCellSize(row, col);
     },
 
     getRenderedViewportStartRow(scope: string = 'main'): number | null {

--- a/tools/devtools/src/console/drawing-readbacks.ts
+++ b/tools/devtools/src/console/drawing-readbacks.ts
@@ -1,0 +1,169 @@
+import type { DrawingDescriptor } from '../types';
+
+type DrawingAnchorDescriptor = DrawingDescriptor['anchor'];
+type CellRef = { row: number; col: number };
+
+function getObjectChartId(obj: { id: string; data?: Record<string, unknown> }): string | null {
+  const chartId = obj.data?.chartId;
+  return typeof chartId === 'string' && chartId.length > 0 ? chartId : obj.id;
+}
+
+function readStringField(record: unknown, keys: readonly string[]): string | null {
+  if (!record || typeof record !== 'object') return null;
+  const source = record as Record<string, unknown>;
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return null;
+}
+
+function readNumberField(record: unknown, keys: readonly string[]): number | null {
+  if (!record || typeof record !== 'object') return null;
+  const source = record as Record<string, unknown>;
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function readCellRef(record: unknown): CellRef | null {
+  const row = readNumberField(record, ['row', 'startRow', 'anchorRow']);
+  const col = readNumberField(record, ['col', 'startCol', 'anchorCol']);
+  return row === null || col === null ? null : { row, col };
+}
+
+export function completeDrawingAnchor(
+  anchor: DrawingAnchorDescriptor | null | undefined,
+  fallbackToCell: CellRef | null,
+): DrawingAnchorDescriptor | null {
+  if (!anchor?.from) return null;
+  return {
+    from: anchor.from,
+    ...(anchor.to ? { to: anchor.to } : fallbackToCell ? { to: fallbackToCell } : {}),
+    ...(anchor.offsetPx ? { offsetPx: anchor.offsetPx } : {}),
+  };
+}
+
+async function getChartModel(ws: any, chartId: string | null): Promise<unknown | null> {
+  if (!chartId || !ws?.charts) return null;
+  try {
+    if (typeof ws.charts.get === 'function') {
+      const chart = await ws.charts.get(chartId);
+      if (chart) return chart;
+    }
+  } catch {
+    // fall through to list lookup
+  }
+  try {
+    if (typeof ws.charts.list === 'function') {
+      const charts = await ws.charts.list();
+      if (Array.isArray(charts)) {
+        return (
+          charts.find((chart) => {
+            if (!chart || typeof chart !== 'object') return false;
+            const record = chart as Record<string, unknown>;
+            return (
+              record.id === chartId ||
+              record.chartId === chartId ||
+              record.objectId === chartId ||
+              record.name === chartId
+            );
+          }) ?? null
+        );
+      }
+    }
+  } catch {
+    // best-effort
+  }
+  return null;
+}
+
+function cellRefToA1(cell: CellRef): string {
+  let n = Math.max(0, Math.floor(cell.col)) + 1;
+  let col = '';
+  while (n > 0) {
+    const rem = (n - 1) % 26;
+    col = String.fromCharCode(65 + rem) + col;
+    n = Math.floor((n - 1) / 26);
+  }
+  return `${col}${Math.max(0, Math.floor(cell.row)) + 1}`;
+}
+
+function anchorToRange(anchor: DrawingAnchorDescriptor | null): string | null {
+  if (!anchor?.from || !anchor.to) return null;
+  return `${cellRefToA1(anchor.from)}:${cellRefToA1(anchor.to)}`;
+}
+
+function getChartAnchor(
+  chart: unknown,
+  fallbackToCell: CellRef | null,
+): DrawingAnchorDescriptor | null {
+  if (!chart || typeof chart !== 'object') return null;
+  const record = chart as Record<string, unknown>;
+  const explicitAnchor = record.anchor;
+  if (explicitAnchor && typeof explicitAnchor === 'object') {
+    const anchor = explicitAnchor as { from?: unknown; to?: unknown };
+    const from = readCellRef(anchor.from);
+    if (from) {
+      const to = readCellRef(anchor.to);
+      return {
+        from,
+        ...(to ? { to } : {}),
+      };
+    }
+  }
+
+  const position = record.position;
+  if (position && typeof position === 'object') {
+    const pos = position as { from?: unknown; to?: unknown };
+    const from = readCellRef(pos.from);
+    if (from) {
+      const to = readCellRef(pos.to);
+      return {
+        from,
+        ...(to ? { to } : fallbackToCell ? { to: fallbackToCell } : {}),
+      };
+    }
+  }
+
+  const anchorRow = readNumberField(record, ['anchorRow', 'row', 'startRow']);
+  const anchorCol = readNumberField(record, ['anchorCol', 'col', 'startCol']);
+  if (anchorRow === null || anchorCol === null) return null;
+  return {
+    from: { row: anchorRow, col: anchorCol },
+    ...(fallbackToCell ? { to: fallbackToCell } : {}),
+  };
+}
+
+export async function getChartReadback(
+  ws: any,
+  obj: { id: string; data?: Record<string, unknown> },
+  fallbackToCell: CellRef | null,
+): Promise<Partial<DrawingDescriptor> | null> {
+  const chartId = getObjectChartId(obj);
+  const chart = await getChartModel(ws, chartId);
+  const chartType =
+    readStringField(chart, ['chartType', 'type', 'kind']) ??
+    readStringField(obj.data, ['chartType', 'type']);
+  const dataRange =
+    readStringField(chart, ['dataRange', 'sourceRange', 'range']) ??
+    readStringField(obj.data, ['dataRange', 'sourceRange', 'range']);
+  const sourceRange =
+    readStringField(chart, ['sourceRange', 'dataRange', 'range']) ??
+    readStringField(obj.data, ['sourceRange', 'dataRange', 'range']);
+  const chartAnchor = getChartAnchor(chart, fallbackToCell);
+  const chartRange =
+    readStringField(chart, ['chartRange', 'rangeAddress', 'anchorRange']) ??
+    anchorToRange(chartAnchor);
+
+  if (!chart && !chartType && !dataRange && !sourceRange) return null;
+  return {
+    ...(chartType ? { chartType } : {}),
+    ...(dataRange ? { dataRange } : {}),
+    ...(sourceRange ? { sourceRange } : {}),
+    ...(chartRange ? { chartRange } : {}),
+    ...(chartAnchor ? { anchor: chartAnchor, usedSyntheticAnchorFallback: false } : {}),
+  };
+}

--- a/tools/devtools/src/console/viewport-inspector.ts
+++ b/tools/devtools/src/console/viewport-inspector.ts
@@ -427,6 +427,89 @@ function getActiveSheetId(): string | null {
   }
 }
 
+type NormalizedMergeRegion = {
+  startRow: number;
+  startCol: number;
+  endRow: number;
+  endCol: number;
+};
+
+function readNumericField(input: Record<string, unknown>, keys: readonly string[]): number | null {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function normalizeMergeRegion(region: unknown): NormalizedMergeRegion | null {
+  if (!region || typeof region !== 'object') return null;
+  const record = region as Record<string, unknown>;
+  const startRow = readNumericField(record, ['startRow', 'start_row', 'row', 'anchorRow']);
+  const startCol = readNumericField(record, ['startCol', 'start_col', 'col', 'anchorCol']);
+  const endRow = readNumericField(record, ['endRow', 'end_row']);
+  const endCol = readNumericField(record, ['endCol', 'end_col']);
+  if (startRow === null || startCol === null || endRow === null || endCol === null) return null;
+  return {
+    startRow: Math.min(startRow, endRow),
+    startCol: Math.min(startCol, endCol),
+    endRow: Math.max(startRow, endRow),
+    endCol: Math.max(startCol, endCol),
+  };
+}
+
+function isCoveredCell(row: number, col: number, region: NormalizedMergeRegion | null): boolean {
+  if (!region) return false;
+  const inside =
+    row >= region.startRow &&
+    row <= region.endRow &&
+    col >= region.startCol &&
+    col <= region.endCol;
+  return inside && (row !== region.startRow || col !== region.startCol);
+}
+
+function readRenderedMergeRegion(row: number, col: number): NormalizedMergeRegion | null {
+  try {
+    const coord = (window as any).__COORDINATOR__;
+    const geometry = coord?.renderer?.getGeometry?.();
+    return normalizeMergeRegion(geometry?.getMergeAnchor?.(row, col));
+  } catch {
+    return null;
+  }
+}
+
+async function readBridgeMergeRegions(
+  bridge: any,
+  sheetId: string,
+): Promise<NormalizedMergeRegion[]> {
+  if (typeof bridge?.getAllMergesInSheet !== 'function') return [];
+  try {
+    const regions = await bridge.getAllMergesInSheet(sheetId);
+    if (!Array.isArray(regions)) return [];
+    return regions
+      .map(normalizeMergeRegion)
+      .filter((region): region is NormalizedMergeRegion => Boolean(region));
+  } catch {
+    return [];
+  }
+}
+
+function emptyCellReadback(
+  row: number,
+  col: number,
+  viewportId: string,
+): import('../types').ProgrammaticCellValue {
+  return {
+    row,
+    col,
+    viewportId,
+    displayText: null,
+    valueType: 0,
+    hasFormula: false,
+    errorText: null,
+  };
+}
+
 /**
  * Read a batch of cells via the compute bridge — the same path
  * production code uses for out-of-viewport range queries
@@ -461,6 +544,7 @@ export async function readCellsViaBridge(
 
   const sheetId = getActiveSheetId();
   if (!sheetId) return out;
+  const mergeRegions = await readBridgeMergeRegions(bridge, sheetId);
 
   // Issue one queryRange per requested cell, in parallel. Each call is sparse
   // (the result array is empty when the cell holds no value), so even very
@@ -481,6 +565,11 @@ export async function readCellsViaBridge(
   );
 
   for (const { row, col, cell } of settled) {
+    if (mergeRegions.some((region) => isCoveredCell(row, col, region))) {
+      out[`${row},${col}`] = emptyCellReadback(row, col, '__bridge__');
+      continue;
+    }
+
     const formatted: string | null =
       typeof cell?.formatted === 'string' && cell.formatted !== '' ? cell.formatted : null;
     const formula: string | undefined =
@@ -690,6 +779,12 @@ export function readCellValue(
     if (!accessor) return null;
     const exists = accessor.moveTo?.(row, col);
     if (!exists) return null;
+    const mergeRegion =
+      readRenderedMergeRegion(row, col) ??
+      normalizeMergeRegion(
+        accessor.mergeBounds ?? accessor.mergeRegion ?? accessor.mergedRegion ?? null,
+      );
+    if (isCoveredCell(row, col, mergeRegion)) return emptyCellReadback(row, col, vpId);
     const displayText = hasLinkedUnlabeledCheckboxOverlay(row, col)
       ? ''
       : (accessor.displayText ?? null);

--- a/tools/devtools/src/types.ts
+++ b/tools/devtools/src/types.ts
@@ -701,6 +701,17 @@ export interface DevToolsConsoleAPI {
   getRenderedColWidth(sheet: string | null, col: number): Promise<number | null>;
 
   /**
+   * Intrinsic rendered cell size in CSS pixels, independent of current viewport
+   * visibility when SheetView geometry can resolve it. Falls back to page
+   * bounds for older renderer adapters.
+   */
+  getRenderedCellSize(
+    sheet: string | null,
+    row: number,
+    col: number,
+  ): Promise<{ width: number; height: number } | null>;
+
+  /**
    * First row whose canvas geometry is currently resolvable for the given
    * renderer viewport scope. Unlike {@link getViewportStartRow}, this is not a
    * compute/prefetch bound; it is derived from the live grid renderer and is
@@ -1212,6 +1223,11 @@ export interface DrawingDescriptor {
   visible: boolean;
   /** For image/chart drawings, the source URL or chart id. Optional for shapes. */
   src?: string;
+  chartType?: string;
+  dataRange?: string;
+  sourceRange?: string;
+  chartRange?: string;
+  usedSyntheticAnchorFallback?: boolean;
 }
 
 export interface PixelRect {


### PR DESCRIPTION
## Summary
- Add `__dt.getRenderedCellSize()` for intrinsic rendered cell sizes independent of viewport clipping.
- Return drawing scene bounds in document space and enrich chart descriptors with chart metadata and completed anchors.
- Normalize covered merged-cell readbacks to empty values in both `getCellValue()` and `getCellsViaBridge()`.
- Extract chart descriptor enrichment into a focused devtools helper and expand readback regression coverage.

## Verification
- `pnpm --dir tools/devtools test -- src/__tests__/dt-readbacks.test.ts`
- `pnpm --dir tools/devtools typecheck`
- `pnpm exec prettier --check tools/devtools/src/console/api.ts tools/devtools/src/console/drawing-readbacks.ts tools/devtools/src/console/viewport-inspector.ts tools/devtools/src/types.ts tools/devtools/src/__tests__/dt-readbacks.test.ts`