### PR TITLE
Fix v0.9.3 spreadsheet runtime eval issues

### DIFF
--- a/apps/spreadsheet/src/actions/handlers/clipboard.ts
+++ b/apps/spreadsheet/src/actions/handlers/clipboard.ts
@@ -51,6 +51,7 @@ import { blobToDataUrl } from '../../utils/blob-to-data-url';
 import { pasteChartFromClipboard } from './chart-clipboard';
 import { getUIStore, handled } from './handler-utils';
 import {
+  getActiveClipboardPaste,
   trackActiveClipboardPaste,
   waitForPendingClipboardPaste,
 } from '../../systems/grid-editing/coordination/pending-clipboard-paste';
@@ -727,7 +728,14 @@ function emitClipboardSettlement(
  * Announces "Pasted" for screen reader accessibility.
  *
  */
-export const PASTE: AsyncActionHandler = (deps) => runPaste(deps);
+export const PASTE: AsyncActionHandler = (deps) => {
+  if (isEditing(deps)) {
+    return runPaste(deps);
+  }
+  const pastePromise = runPaste(deps);
+  trackActiveClipboardPaste(pastePromise);
+  return pastePromise;
+};
 
 const runPaste: AsyncActionHandler = async (deps) => {
   // In edit mode, let native browser handle text paste at cursor
@@ -767,7 +775,6 @@ const runPaste: AsyncActionHandler = async (deps) => {
       });
     },
   });
-  trackActiveClipboardPaste(pastePromise);
   await pastePromise;
 
   // Accessibility announcement for paste operation
@@ -817,6 +824,14 @@ export const CLEAR_CLIPBOARD: ActionHandler = (deps) => {
   // routed through the selection actor; the UIStore
   // mode slice fields were retired.
   deps.commands.selection.exitAllModes();
+
+  const activePaste = getActiveClipboardPaste();
+  if (activePaste) {
+    void activePaste.finally(() => {
+      deps.commands.clipboard.clear();
+    });
+    return handled();
+  }
 
   // Otherwise, clear the clipboard as normal
   deps.commands.clipboard.clear();

--- a/apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx
@@ -38,7 +38,7 @@
  *
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useStore } from 'zustand';
 import {
   useActiveSheetId,
@@ -48,7 +48,12 @@ import {
 } from '../../../internal-api';
 
 import { Tooltip } from '@mog/shell';
-import type { BorderPresetMode, BorderStyle, CellBorders } from '@mog-sdk/contracts/core';
+import type {
+  BorderPresetMode,
+  BorderStyle,
+  CellBorders,
+  CellFormat,
+} from '@mog-sdk/contracts/core';
 import { FONT_COLLAPSE_CONFIG } from '@mog-sdk/contracts/ribbon';
 import { BorderPicker } from '../../../components/pickers/BorderPicker';
 import { ColorPicker } from '../../../components/pickers/ColorPicker';
@@ -83,6 +88,7 @@ import {
 import { RibbonVisibilityItem } from '../visibility/RibbonVisibilityContext';
 // Note: DropdownArrowIcon is still used for the font picker dropdown
 import { DEFAULT_FONT_FAMILY, DEFAULT_FONT_SIZE } from '../primitives/ToolbarStyles';
+import { getCommonSelectionFontColor } from './font-color-selection';
 
 // =============================================================================
 // Helpers
@@ -180,6 +186,7 @@ export const FontGroup = React.memo(function FontGroup() {
   const fontSize = useUIStore((s) => s.activeCellFormat?.fontSize ?? DEFAULT_FONT_SIZE);
   const fontColor = useUIStore((s) => s.activeCellFormat?.fontColor);
   const backgroundColor = useUIStore((s) => s.activeCellFormat?.backgroundColor);
+  const toolbarRanges = useUIStore((s) => s.toolbarRanges);
 
   // ===========================================================================
   // Collapse Support
@@ -264,6 +271,24 @@ export const FontGroup = React.memo(function FontGroup() {
   const [recentFontColors, setRecentFontColors] = useState(() => getRecentColors('font'));
   const [recentFillColors, setRecentFillColors] = useState(() => getRecentColors('fill'));
   const [recentBorderColors, setRecentBorderColors] = useState(() => getRecentColors('border'));
+  const fontColorPickerValue = useMemo(() => {
+    if (!fontColorOpen) return fontColor;
+    return getCommonSelectionFontColor({
+      ranges: toolbarRanges,
+      activeCellFontColor: fontColor,
+      getCellFormat: (row, col) => {
+        if (!activeSheetId) return undefined;
+        try {
+          const format = coordinator.workbook
+            ?.getSheetById(activeSheetId)
+            ?.viewport.getCellData(row, col)?.format;
+          return (format as CellFormat | undefined) ?? undefined;
+        } catch {
+          return undefined;
+        }
+      },
+    });
+  }, [activeSheetId, coordinator, fontColor, fontColorOpen, toolbarRanges]);
 
   // Handler to apply font color and track in recents.
   const handleFontColorChange = useCallback(
@@ -633,7 +658,7 @@ export const FontGroup = React.memo(function FontGroup() {
             <RibbonDropdownPanel open={fontColorOpen} onClose={() => setFontColorOpen(false)}>
               <div data-testid="ribbon-dropdown-menu-font-color">
                 <ColorPicker
-                  value={fontColor}
+                  value={fontColorPickerValue}
                   onChange={(color) => {
                     handleFontColorChange(color);
                     setFontColorOpen(false);

--- a/apps/spreadsheet/src/chrome/toolbar/groups/font-color-selection.test.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/font-color-selection.test.ts
@@ -1,0 +1,51 @@
+import { getCommonSelectionFontColor, normalizeEffectiveFontColor } from './font-color-selection';
+
+describe('font color selection', () => {
+  it('treats missing font color as effective black', () => {
+    expect(normalizeEffectiveFontColor(undefined)).toBe('#000000');
+    expect(normalizeEffectiveFontColor(null)).toBe('#000000');
+  });
+
+  it('returns black for a uniform default-black selection', () => {
+    const color = getCommonSelectionFontColor({
+      ranges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }],
+      activeCellFontColor: undefined,
+      getCellFormat: () => undefined,
+    });
+
+    expect(color).toBe('#000000');
+  });
+
+  it('returns undefined for a mixed black and red selection', () => {
+    const color = getCommonSelectionFontColor({
+      ranges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }],
+      activeCellFontColor: '#000000',
+      getCellFormat: (_row, col) => (col === 0 ? undefined : { fontColor: '#FF0000' }),
+    });
+
+    expect(color).toBeUndefined();
+  });
+
+  it('normalizes equivalent hex values before comparing', () => {
+    const color = getCommonSelectionFontColor({
+      ranges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }],
+      activeCellFontColor: '#000',
+      getCellFormat: (_row, col) => (col === 0 ? { fontColor: '#000' } : { fontColor: '#000000' }),
+    });
+
+    expect(color).toBe('#000000');
+  });
+
+  it('falls back to the active cell color for large selections', () => {
+    const color = getCommonSelectionFontColor({
+      ranges: [{ startRow: 0, startCol: 0, endRow: 99, endCol: 99 }],
+      activeCellFontColor: '#123456',
+      getCellFormat: () => {
+        throw new Error('large selections should not be scanned cell-by-cell');
+      },
+      maxCells: 10,
+    });
+
+    expect(color).toBe('#123456');
+  });
+});

--- a/apps/spreadsheet/src/chrome/toolbar/groups/font-color-selection.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/font-color-selection.ts
@@ -1,0 +1,74 @@
+import type { CellFormat, CellRange } from '@mog-sdk/contracts/core';
+
+const DEFAULT_FONT_COLOR = '#000000';
+const MAX_SELECTION_COLOR_SCAN_CELLS = 512;
+
+function normalizeHexColor(color: string): string {
+  const trimmed = color.trim();
+  const shortHex = trimmed.match(/^#([0-9a-f]{3})$/i);
+  if (shortHex) {
+    return `#${shortHex[1]
+      .split('')
+      .map((part) => part + part)
+      .join('')
+      .toUpperCase()}`;
+  }
+  const longHex = trimmed.match(/^#([0-9a-f]{6})$/i);
+  if (longHex) return `#${longHex[1].toUpperCase()}`;
+  return trimmed.toLowerCase();
+}
+
+export function normalizeEffectiveFontColor(color: string | null | undefined): string {
+  return color ? normalizeHexColor(color) : DEFAULT_FONT_COLOR;
+}
+
+function normalizedRange(range: CellRange): {
+  startRow: number;
+  endRow: number;
+  startCol: number;
+  endCol: number;
+} {
+  return {
+    startRow: Math.min(range.startRow, range.endRow),
+    endRow: Math.max(range.startRow, range.endRow),
+    startCol: Math.min(range.startCol, range.endCol),
+    endCol: Math.max(range.startCol, range.endCol),
+  };
+}
+
+export function getCommonSelectionFontColor(args: {
+  ranges: readonly CellRange[];
+  activeCellFontColor: string | null | undefined;
+  getCellFormat: (row: number, col: number) => CellFormat | null | undefined;
+  maxCells?: number;
+}): string | undefined {
+  const maxCells = args.maxCells ?? MAX_SELECTION_COLOR_SCAN_CELLS;
+  if (args.ranges.length === 0) return normalizeEffectiveFontColor(args.activeCellFontColor);
+
+  let cellCount = 0;
+  for (const range of args.ranges) {
+    const normalized = normalizedRange(range);
+    cellCount +=
+      (normalized.endRow - normalized.startRow + 1) * (normalized.endCol - normalized.startCol + 1);
+    if (cellCount > maxCells) {
+      return normalizeEffectiveFontColor(args.activeCellFontColor);
+    }
+  }
+
+  let commonColor: string | null = null;
+  for (const range of args.ranges) {
+    const normalized = normalizedRange(range);
+    for (let row = normalized.startRow; row <= normalized.endRow; row++) {
+      for (let col = normalized.startCol; col <= normalized.endCol; col++) {
+        const color = normalizeEffectiveFontColor(args.getCellFormat(row, col)?.fontColor);
+        if (commonColor === null) {
+          commonColor = color;
+        } else if (color !== commonColor) {
+          return undefined;
+        }
+      }
+    }
+  }
+
+  return commonColor ?? normalizeEffectiveFontColor(args.activeCellFontColor);
+}

--- a/apps/spreadsheet/src/systems/grid-editing/coordination/pending-clipboard-paste.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/coordination/pending-clipboard-paste.ts
@@ -46,3 +46,7 @@ export async function waitForActiveClipboardPaste(): Promise<void> {
   await Promise.resolve();
   await globalPendingClipboardPaste().__MOG_ACTIVE_CLIPBOARD_PASTE__;
 }
+
+export function getActiveClipboardPaste(): Promise<unknown> | undefined {
+  return globalPendingClipboardPaste().__MOG_ACTIVE_CLIPBOARD_PASTE__;
+}

--- a/apps/spreadsheet/src/systems/renderer/execution/__tests__/cell-scroll.test.ts
+++ b/apps/spreadsheet/src/systems/renderer/execution/__tests__/cell-scroll.test.ts
@@ -1,0 +1,94 @@
+import type { ISheetViewGeometry } from '@mog-sdk/sheet-view';
+
+import { resolveCellLevelScrollPosition } from '../cell-scroll';
+
+function createGeometry(
+  overrides: Partial<Pick<ISheetViewGeometry, 'getDimensions'>> = {},
+): Pick<ISheetViewGeometry, 'getDimensions'> {
+  return {
+    getDimensions(anchor) {
+      const row = 'row' in anchor ? anchor.row : anchor.startRow;
+      const col = 'col' in anchor ? anchor.col : anchor.startCol;
+      return [
+        {
+          row,
+          top: row * 20,
+          height: 20,
+          hidden: false,
+        },
+        {
+          col,
+          left: col * 80,
+          width: 80,
+          hidden: false,
+        },
+      ];
+    },
+    ...overrides,
+  };
+}
+
+describe('resolveCellLevelScrollPosition', () => {
+  it('uses direct cell positions when panes are not frozen', () => {
+    const position = resolveCellLevelScrollPosition({
+      geometry: createGeometry(),
+      topRow: 10,
+      leftCol: 3,
+      frozenPanes: { rows: 0, cols: 0 },
+    });
+
+    expect(position).toEqual({ x: 240, y: 200 });
+  });
+
+  it('subtracts frozen row and column boundaries', () => {
+    const position = resolveCellLevelScrollPosition({
+      geometry: createGeometry(),
+      topRow: 10,
+      leftCol: 3,
+      frozenPanes: { rows: 2, cols: 1 },
+    });
+
+    expect(position).toEqual({ x: 160, y: 160 });
+  });
+
+  it('uses the viewport frozen pane state when no explicit panes are provided', () => {
+    const position = resolveCellLevelScrollPosition({
+      geometry: createGeometry(),
+      viewport: {
+        getFrozenPanes: () => ({ rows: 2, cols: 1 }),
+      },
+      topRow: 5,
+      leftCol: 4,
+    });
+
+    expect(position).toEqual({ x: 240, y: 60 });
+  });
+
+  it('clamps cell positions inside frozen panes to the scroll origin', () => {
+    const position = resolveCellLevelScrollPosition({
+      geometry: createGeometry(),
+      topRow: 1,
+      leftCol: 0,
+      frozenPanes: { rows: 3, cols: 2 },
+    });
+
+    expect(position).toEqual({ x: 0, y: 0 });
+  });
+
+  it('returns null when geometry cannot resolve the target cell', () => {
+    const position = resolveCellLevelScrollPosition({
+      geometry: createGeometry({
+        getDimensions(anchor) {
+          const row = 'row' in anchor ? anchor.row : anchor.startRow;
+          if (row === 7) return [];
+          return createGeometry().getDimensions(anchor);
+        },
+      }),
+      topRow: 7,
+      leftCol: 3,
+      frozenPanes: { rows: 2, cols: 1 },
+    });
+
+    expect(position).toBeNull();
+  });
+});

--- a/apps/spreadsheet/src/systems/renderer/execution/cell-scroll.ts
+++ b/apps/spreadsheet/src/systems/renderer/execution/cell-scroll.ts
@@ -1,0 +1,86 @@
+import type { ISheetViewGeometry, ISheetViewViewport } from '@mog-sdk/sheet-view';
+import type { Point } from '@mog-sdk/contracts/viewport';
+
+type FrozenPaneLike = {
+  readonly rows?: number | null;
+  readonly cols?: number | null;
+};
+
+type NormalizedFrozenPanes = {
+  readonly rows: number;
+  readonly cols: number;
+};
+
+type DimensionPosition = 'top' | 'left';
+
+export interface CellLevelScrollPositionArgs {
+  readonly geometry: Pick<ISheetViewGeometry, 'getDimensions'>;
+  readonly viewport?: Pick<ISheetViewViewport, 'getFrozenPanes'> | null;
+  readonly topRow: number;
+  readonly leftCol: number;
+  readonly frozenPanes?: FrozenPaneLike | null;
+}
+
+function normalizeIndex(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function normalizeFrozenPaneCount(value: number | null | undefined): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value as number)) : 0;
+}
+
+function hasDimensionPosition(
+  candidate: unknown,
+  key: DimensionPosition,
+): candidate is Partial<Record<DimensionPosition, number>> {
+  return (
+    typeof candidate === 'object' &&
+    candidate !== null &&
+    key in candidate &&
+    typeof (candidate as Record<string, unknown>)[key] === 'number'
+  );
+}
+
+function getDimensionPosition(
+  geometry: Pick<ISheetViewGeometry, 'getDimensions'>,
+  row: number,
+  col: number,
+  key: DimensionPosition,
+): number | null {
+  const dimension = geometry
+    .getDimensions({ row, col })
+    .find((candidate) => hasDimensionPosition(candidate, key));
+
+  if (!dimension) return null;
+  const position = (dimension as Partial<Record<DimensionPosition, number>>)[key];
+  return typeof position === 'number' && Number.isFinite(position) ? position : null;
+}
+
+function resolveFrozenPanes(args: CellLevelScrollPositionArgs): NormalizedFrozenPanes {
+  const frozenPanes = args.frozenPanes ?? args.viewport?.getFrozenPanes() ?? { rows: 0, cols: 0 };
+  return {
+    rows: normalizeFrozenPaneCount(frozenPanes.rows),
+    cols: normalizeFrozenPaneCount(frozenPanes.cols),
+  };
+}
+
+export function resolveCellLevelScrollPosition(args: CellLevelScrollPositionArgs): Point | null {
+  const topRow = normalizeIndex(args.topRow);
+  const leftCol = normalizeIndex(args.leftCol);
+  const frozenPanes = resolveFrozenPanes(args);
+
+  const rowTop = getDimensionPosition(args.geometry, topRow, 0, 'top');
+  const colLeft = getDimensionPosition(args.geometry, 0, leftCol, 'left');
+  if (rowTop === null || colLeft === null) return null;
+
+  const frozenRowTop =
+    frozenPanes.rows > 0 ? getDimensionPosition(args.geometry, frozenPanes.rows, 0, 'top') : 0;
+  const frozenColLeft =
+    frozenPanes.cols > 0 ? getDimensionPosition(args.geometry, 0, frozenPanes.cols, 'left') : 0;
+  if (frozenRowTop === null || frozenColLeft === null) return null;
+
+  return {
+    x: Math.max(0, colLeft - frozenColLeft),
+    y: Math.max(0, rowTop - frozenRowTop),
+  };
+}

--- a/apps/spreadsheet/src/systems/renderer/execution/renderer-execution.ts
+++ b/apps/spreadsheet/src/systems/renderer/execution/renderer-execution.ts
@@ -41,6 +41,7 @@ import type {
 } from '@mog-sdk/contracts/viewport';
 
 import type { RendererActor } from '../machines/grid-renderer-machine';
+import { resolveCellLevelScrollPosition } from './cell-scroll';
 
 const INTERNAL_GRID_RENDERER_KEY = '__mogInternalGridRenderer';
 
@@ -183,19 +184,16 @@ export function setupRendererExecution(config: RendererExecutionConfig): Rendere
     }
 
     // Fall back to the workbook-persisted cell top-left for first visits after
-    // load, matching the initial sheet path.
-    const rowDims = sheetView.geometry.getDimensions({ row: topRow, col: 0 });
-    const colDims = sheetView.geometry.getDimensions({ row: 0, col: leftCol });
-    const rowDim = rowDims.find((d: any) => 'top' in d);
-    const colDim = colDims.find((d: any) => 'left' in d);
-    if (rowDim && 'top' in rowDim && colDim && 'left' in colDim) {
-      scroll = {
-        x: colDim.left,
-        y: rowDim.top,
-      };
-    }
-
-    return scroll;
+    // load, matching the initial sheet path. Frozen panes pin rows/columns in
+    // place, so scrollable pixels start after the frozen boundary.
+    return (
+      resolveCellLevelScrollPosition({
+        geometry: sheetView.geometry,
+        viewport: sheetView.viewport,
+        topRow,
+        leftCol,
+      }) ?? scroll
+    );
   }
 
   // ===========================================================================

--- a/apps/spreadsheet/src/systems/renderer/render-system.ts
+++ b/apps/spreadsheet/src/systems/renderer/render-system.ts
@@ -71,6 +71,7 @@ import {
   setupRendererExecution,
   type RendererExecutionResult,
 } from './execution/renderer-execution';
+import { resolveCellLevelScrollPosition } from './execution/cell-scroll';
 import {
   PageBreakCoordinator,
   type PageBreakHitResult,
@@ -456,17 +457,18 @@ export class RenderSystem implements IRenderSystem {
     if (this.disposed || !this.started) return;
     if (topRow === 0 && leftCol === 0) return;
 
-    // Use geometry capability to convert cell-level scroll to pixels.
+    // Use SheetView capabilities to convert cell-level scroll to pixels.
     const geometry = this.getGeometry();
+    const viewport = this.getViewport();
     if (!geometry) return;
 
-    const rowDims = geometry.getDimensions({ row: topRow, col: 0 });
-    const colDims = geometry.getDimensions({ row: 0, col: leftCol });
-    const rowDim = rowDims.find((d: any) => 'top' in d);
-    const colDim = colDims.find((d: any) => 'left' in d);
-    if (!rowDim || !('top' in rowDim) || !colDim || !('left' in colDim)) return;
-
-    const pixelPos: Point = { x: colDim.left, y: rowDim.top };
+    const pixelPos = resolveCellLevelScrollPosition({
+      geometry,
+      viewport,
+      topRow,
+      leftCol,
+    });
+    if (!pixelPos) return;
 
     this.rendererExecution?.setScrollPosition(pixelPos);
 

--- a/canvas/grid-renderer/src/__tests__/text-clipping-contract.test.ts
+++ b/canvas/grid-renderer/src/__tests__/text-clipping-contract.test.ts
@@ -140,8 +140,8 @@ describe('cell text clipping contract', () => {
       width: expect.any(Number),
       height: 18,
     });
-    expect(clips[0].x).toBeLessThan(-999_000);
-    expect(clips[0].width).toBeGreaterThan(2_000_000);
+    expect(clips[0].x).toBe(-15_960);
+    expect(clips[0].width).toBe(32_240);
     expect(paints.find((op) => op.kind === 'fillText')?.clips).toContainEqual(clips[0]);
   });
 
@@ -226,8 +226,8 @@ describe('cell text clipping contract', () => {
     expect(clips).toHaveLength(1);
     expect(clips[0].y).toBe(60);
     expect(clips[0].height).toBe(18);
-    expect(clips[0].x).toBeLessThan(-999_000);
-    expect(clips[0].width).toBeGreaterThan(2_000_000);
+    expect(clips[0].x).toBe(-15_960);
+    expect(clips[0].width).toBe(32_080);
     expect(paints.find((op) => op.kind === 'fillText')?.clips).toContainEqual(clips[0]);
   });
 });

--- a/canvas/grid-renderer/src/cells/text.ts
+++ b/canvas/grid-renderer/src/cells/text.ts
@@ -78,7 +78,7 @@ export interface OverflowResult {
  */
 const fontStringCache = new Map<string, string>();
 const MAX_FONT_CACHE_SIZE = 5000;
-const VERTICAL_CLIP_HORIZONTAL_MARGIN = 1_000_000;
+const VERTICAL_CLIP_HORIZONTAL_MARGIN = 16_000;
 
 /**
  * Clip text paint to the row's vertical interior while leaving horizontal


### PR DESCRIPTION
## Summary
- Bound normal text clipping to a finite overflow margin to avoid huge clip rectangles.
- Make the font color picker treat missing selected-cell font color as effective black and show mixed state only for real mixed colors.
- Keep async paste completion from being cancelled by Escape/Clear by deferring clipboard clear until the active paste settles.
- Restore cell-level scroll positions through one helper that accounts for frozen panes.

## Verification
- `NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning" pnpm --filter @mog/app-spreadsheet exec jest --runTestsByPath src/chrome/toolbar/groups/font-color-selection.test.ts src/systems/renderer/execution/__tests__/cell-scroll.test.ts`
- `NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning" pnpm --filter @mog/grid-renderer exec jest --runTestsByPath src/__tests__/text-clipping-contract.test.ts`
- `pnpm --filter @mog/app-spreadsheet typecheck`
- `pnpm --filter @mog/grid-renderer typecheck`
- `pnpm exec prettier --check ...touched files...`

## Notes
- Attempted root `pnpm typecheck`; it failed outside this change on missing declaration packages: `@mog/platform-memory`, `@mog/kernel-host-internal`, `@mog-sdk/sdk/node`, and `@mog-sdk/chart-raster-wasm`. The changed package typechecks pass.