### PR TITLE
Fix v0.9.3 text clipping readback

### DIFF
--- a/canvas/grid-renderer/src/__tests__/text-clipping-contract.test.ts
+++ b/canvas/grid-renderer/src/__tests__/text-clipping-contract.test.ts
@@ -140,8 +140,8 @@ describe('cell text clipping contract', () => {
       width: expect.any(Number),
       height: 18,
     });
-    expect(clips[0].x).toBeLessThan(-999_000);
-    expect(clips[0].width).toBeGreaterThan(2_000_000);
+    expect(clips[0].x).toBe(-15_960);
+    expect(clips[0].width).toBe(32_240);
     expect(paints.find((op) => op.kind === 'fillText')?.clips).toContainEqual(clips[0]);
   });
 
@@ -226,8 +226,8 @@ describe('cell text clipping contract', () => {
     expect(clips).toHaveLength(1);
     expect(clips[0].y).toBe(60);
     expect(clips[0].height).toBe(18);
-    expect(clips[0].x).toBeLessThan(-999_000);
-    expect(clips[0].width).toBeGreaterThan(2_000_000);
+    expect(clips[0].x).toBe(-15_960);
+    expect(clips[0].width).toBe(32_080);
     expect(paints.find((op) => op.kind === 'fillText')?.clips).toContainEqual(clips[0]);
   });
 });

--- a/canvas/grid-renderer/src/cells/text.ts
+++ b/canvas/grid-renderer/src/cells/text.ts
@@ -78,7 +78,7 @@ export interface OverflowResult {
  */
 const fontStringCache = new Map<string, string>();
 const MAX_FONT_CACHE_SIZE = 5000;
-const VERTICAL_CLIP_HORIZONTAL_MARGIN = 1_000_000;
+const VERTICAL_CLIP_HORIZONTAL_MARGIN = 16_000;
 
 /**
  * Clip text paint to the row's vertical interior while leaving horizontal


### PR DESCRIPTION
Summary:
- Bound vertical text clipping to a realistic horizontal margin so readbacks do not report million-pixel spill rectangles.
- Update the clipping contract test to lock the bounded geometry.

Verification:
- NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning" pnpm --filter @mog/grid-renderer exec jest --runTestsByPath src/__tests__/text-clipping-contract.test.ts
- pnpm exec tsc -b tools/devtools infra/env infra/culture spreadsheet-utils canvas/engine && pnpm --filter @mog/grid-renderer typecheck
- pnpm exec prettier --check canvas/grid-renderer/src/cells/text.ts canvas/grid-renderer/src/__tests__/text-clipping-contract.test.ts