### PR TITLE
Fix v0.9.3 font color selection readback

### DIFF
--- a/apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx
@@ -38,7 +38,7 @@
  *
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useStore } from 'zustand';
 import {
   useActiveSheetId,
@@ -48,7 +48,12 @@ import {
 } from '../../../internal-api';
 
 import { Tooltip } from '@mog/shell';
-import type { BorderPresetMode, BorderStyle, CellBorders } from '@mog-sdk/contracts/core';
+import type {
+  BorderPresetMode,
+  BorderStyle,
+  CellBorders,
+  CellFormat,
+} from '@mog-sdk/contracts/core';
 import { FONT_COLLAPSE_CONFIG } from '@mog-sdk/contracts/ribbon';
 import { BorderPicker } from '../../../components/pickers/BorderPicker';
 import { ColorPicker } from '../../../components/pickers/ColorPicker';
@@ -83,6 +88,7 @@ import {
 import { RibbonVisibilityItem } from '../visibility/RibbonVisibilityContext';
 // Note: DropdownArrowIcon is still used for the font picker dropdown
 import { DEFAULT_FONT_FAMILY, DEFAULT_FONT_SIZE } from '../primitives/ToolbarStyles';
+import { getCommonSelectionFontColor } from './font-color-selection';
 
 // =============================================================================
 // Helpers
@@ -180,6 +186,7 @@ export const FontGroup = React.memo(function FontGroup() {
   const fontSize = useUIStore((s) => s.activeCellFormat?.fontSize ?? DEFAULT_FONT_SIZE);
   const fontColor = useUIStore((s) => s.activeCellFormat?.fontColor);
   const backgroundColor = useUIStore((s) => s.activeCellFormat?.backgroundColor);
+  const toolbarRanges = useUIStore((s) => s.toolbarRanges);
 
   // ===========================================================================
   // Collapse Support
@@ -264,6 +271,24 @@ export const FontGroup = React.memo(function FontGroup() {
   const [recentFontColors, setRecentFontColors] = useState(() => getRecentColors('font'));
   const [recentFillColors, setRecentFillColors] = useState(() => getRecentColors('fill'));
   const [recentBorderColors, setRecentBorderColors] = useState(() => getRecentColors('border'));
+  const fontColorPickerValue = useMemo(() => {
+    if (!fontColorOpen) return fontColor;
+    return getCommonSelectionFontColor({
+      ranges: toolbarRanges,
+      activeCellFontColor: fontColor,
+      getCellFormat: (row, col) => {
+        if (!activeSheetId) return undefined;
+        try {
+          const format = coordinator.workbook
+            ?.getSheetById(activeSheetId)
+            ?.viewport.getCellData(row, col)?.format;
+          return (format as CellFormat | undefined) ?? undefined;
+        } catch {
+          return undefined;
+        }
+      },
+    });
+  }, [activeSheetId, coordinator, fontColor, fontColorOpen, toolbarRanges]);
 
   // Handler to apply font color and track in recents.
   const handleFontColorChange = useCallback(
@@ -633,7 +658,7 @@ export const FontGroup = React.memo(function FontGroup() {
             <RibbonDropdownPanel open={fontColorOpen} onClose={() => setFontColorOpen(false)}>
               <div data-testid="ribbon-dropdown-menu-font-color">
                 <ColorPicker
-                  value={fontColor}
+                  value={fontColorPickerValue}
                   onChange={(color) => {
                     handleFontColorChange(color);
                     setFontColorOpen(false);

--- a/apps/spreadsheet/src/chrome/toolbar/groups/font-color-selection.test.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/font-color-selection.test.ts
@@ -1,0 +1,51 @@
+import { getCommonSelectionFontColor, normalizeEffectiveFontColor } from './font-color-selection';
+
+describe('font color selection', () => {
+  it('treats missing font color as effective black', () => {
+    expect(normalizeEffectiveFontColor(undefined)).toBe('#000000');
+    expect(normalizeEffectiveFontColor(null)).toBe('#000000');
+  });
+
+  it('returns black for a uniform default-black selection', () => {
+    const color = getCommonSelectionFontColor({
+      ranges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }],
+      activeCellFontColor: undefined,
+      getCellFormat: () => undefined,
+    });
+
+    expect(color).toBe('#000000');
+  });
+
+  it('returns undefined for a mixed black and red selection', () => {
+    const color = getCommonSelectionFontColor({
+      ranges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }],
+      activeCellFontColor: '#000000',
+      getCellFormat: (_row, col) => (col === 0 ? undefined : { fontColor: '#FF0000' }),
+    });
+
+    expect(color).toBeUndefined();
+  });
+
+  it('normalizes equivalent hex values before comparing', () => {
+    const color = getCommonSelectionFontColor({
+      ranges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }],
+      activeCellFontColor: '#000',
+      getCellFormat: (_row, col) => (col === 0 ? { fontColor: '#000' } : { fontColor: '#000000' }),
+    });
+
+    expect(color).toBe('#000000');
+  });
+
+  it('falls back to the active cell color for large selections', () => {
+    const color = getCommonSelectionFontColor({
+      ranges: [{ startRow: 0, startCol: 0, endRow: 99, endCol: 99 }],
+      activeCellFontColor: '#123456',
+      getCellFormat: () => {
+        throw new Error('large selections should not be scanned cell-by-cell');
+      },
+      maxCells: 10,
+    });
+
+    expect(color).toBe('#123456');
+  });
+});

--- a/apps/spreadsheet/src/chrome/toolbar/groups/font-color-selection.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/font-color-selection.ts
@@ -1,0 +1,74 @@
+import type { CellFormat, CellRange } from '@mog-sdk/contracts/core';
+
+const DEFAULT_FONT_COLOR = '#000000';
+const MAX_SELECTION_COLOR_SCAN_CELLS = 512;
+
+function normalizeHexColor(color: string): string {
+  const trimmed = color.trim();
+  const shortHex = trimmed.match(/^#([0-9a-f]{3})$/i);
+  if (shortHex) {
+    return `#${shortHex[1]
+      .split('')
+      .map((part) => part + part)
+      .join('')
+      .toUpperCase()}`;
+  }
+  const longHex = trimmed.match(/^#([0-9a-f]{6})$/i);
+  if (longHex) return `#${longHex[1].toUpperCase()}`;
+  return trimmed.toLowerCase();
+}
+
+export function normalizeEffectiveFontColor(color: string | null | undefined): string {
+  return color ? normalizeHexColor(color) : DEFAULT_FONT_COLOR;
+}
+
+function normalizedRange(range: CellRange): {
+  startRow: number;
+  endRow: number;
+  startCol: number;
+  endCol: number;
+} {
+  return {
+    startRow: Math.min(range.startRow, range.endRow),
+    endRow: Math.max(range.startRow, range.endRow),
+    startCol: Math.min(range.startCol, range.endCol),
+    endCol: Math.max(range.startCol, range.endCol),
+  };
+}
+
+export function getCommonSelectionFontColor(args: {
+  ranges: readonly CellRange[];
+  activeCellFontColor: string | null | undefined;
+  getCellFormat: (row: number, col: number) => CellFormat | null | undefined;
+  maxCells?: number;
+}): string | undefined {
+  const maxCells = args.maxCells ?? MAX_SELECTION_COLOR_SCAN_CELLS;
+  if (args.ranges.length === 0) return normalizeEffectiveFontColor(args.activeCellFontColor);
+
+  let cellCount = 0;
+  for (const range of args.ranges) {
+    const normalized = normalizedRange(range);
+    cellCount +=
+      (normalized.endRow - normalized.startRow + 1) * (normalized.endCol - normalized.startCol + 1);
+    if (cellCount > maxCells) {
+      return normalizeEffectiveFontColor(args.activeCellFontColor);
+    }
+  }
+
+  let commonColor: string | null = null;
+  for (const range of args.ranges) {
+    const normalized = normalizedRange(range);
+    for (let row = normalized.startRow; row <= normalized.endRow; row++) {
+      for (let col = normalized.startCol; col <= normalized.endCol; col++) {
+        const color = normalizeEffectiveFontColor(args.getCellFormat(row, col)?.fontColor);
+        if (commonColor === null) {
+          commonColor = color;
+        } else if (color !== commonColor) {
+          return undefined;
+        }
+      }
+    }
+  }
+
+  return commonColor ?? normalizeEffectiveFontColor(args.activeCellFontColor);
+}


### PR DESCRIPTION
Summary:
- Normalize missing cell font color to the effective default black when toolbar selection state is computed.
- Add focused tests for default, explicit, and mixed font color selections.

Verification:
- NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning" pnpm --filter @mog/app-spreadsheet exec jest --runTestsByPath src/chrome/toolbar/groups/font-color-selection.test.ts
- pnpm --filter @mog/platform-memory typecheck && pnpm --filter @mog/kernel-host-internal typecheck
- pnpm --filter @mog/app-spreadsheet typecheck
- pnpm exec prettier --check apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx apps/spreadsheet/src/chrome/toolbar/groups/font-color-selection.ts apps/spreadsheet/src/chrome/toolbar/groups/font-color-selection.test.ts