### PR TITLE
Fix v0.9.3 frozen pane scroll restore

### DIFF
--- a/apps/spreadsheet/src/systems/renderer/execution/__tests__/cell-scroll.test.ts
+++ b/apps/spreadsheet/src/systems/renderer/execution/__tests__/cell-scroll.test.ts
@@ -1,0 +1,94 @@
+import type { ISheetViewGeometry } from '@mog-sdk/sheet-view';
+
+import { resolveCellLevelScrollPosition } from '../cell-scroll';
+
+function createGeometry(
+  overrides: Partial<Pick<ISheetViewGeometry, 'getDimensions'>> = {},
+): Pick<ISheetViewGeometry, 'getDimensions'> {
+  return {
+    getDimensions(anchor) {
+      const row = 'row' in anchor ? anchor.row : anchor.startRow;
+      const col = 'col' in anchor ? anchor.col : anchor.startCol;
+      return [
+        {
+          row,
+          top: row * 20,
+          height: 20,
+          hidden: false,
+        },
+        {
+          col,
+          left: col * 80,
+          width: 80,
+          hidden: false,
+        },
+      ];
+    },
+    ...overrides,
+  };
+}
+
+describe('resolveCellLevelScrollPosition', () => {
+  it('uses direct cell positions when panes are not frozen', () => {
+    const position = resolveCellLevelScrollPosition({
+      geometry: createGeometry(),
+      topRow: 10,
+      leftCol: 3,
+      frozenPanes: { rows: 0, cols: 0 },
+    });
+
+    expect(position).toEqual({ x: 240, y: 200 });
+  });
+
+  it('subtracts frozen row and column boundaries', () => {
+    const position = resolveCellLevelScrollPosition({
+      geometry: createGeometry(),
+      topRow: 10,
+      leftCol: 3,
+      frozenPanes: { rows: 2, cols: 1 },
+    });
+
+    expect(position).toEqual({ x: 160, y: 160 });
+  });
+
+  it('uses the viewport frozen pane state when no explicit panes are provided', () => {
+    const position = resolveCellLevelScrollPosition({
+      geometry: createGeometry(),
+      viewport: {
+        getFrozenPanes: () => ({ rows: 2, cols: 1 }),
+      },
+      topRow: 5,
+      leftCol: 4,
+    });
+
+    expect(position).toEqual({ x: 240, y: 60 });
+  });
+
+  it('clamps cell positions inside frozen panes to the scroll origin', () => {
+    const position = resolveCellLevelScrollPosition({
+      geometry: createGeometry(),
+      topRow: 1,
+      leftCol: 0,
+      frozenPanes: { rows: 3, cols: 2 },
+    });
+
+    expect(position).toEqual({ x: 0, y: 0 });
+  });
+
+  it('returns null when geometry cannot resolve the target cell', () => {
+    const position = resolveCellLevelScrollPosition({
+      geometry: createGeometry({
+        getDimensions(anchor) {
+          const row = 'row' in anchor ? anchor.row : anchor.startRow;
+          if (row === 7) return [];
+          return createGeometry().getDimensions(anchor);
+        },
+      }),
+      topRow: 7,
+      leftCol: 3,
+      frozenPanes: { rows: 2, cols: 1 },
+    });
+
+    expect(position).toBeNull();
+  });
+});

--- a/apps/spreadsheet/src/systems/renderer/execution/cell-scroll.ts
+++ b/apps/spreadsheet/src/systems/renderer/execution/cell-scroll.ts
@@ -1,0 +1,86 @@
+import type { ISheetViewGeometry, ISheetViewViewport } from '@mog-sdk/sheet-view';
+import type { Point } from '@mog-sdk/contracts/viewport';
+
+type FrozenPaneLike = {
+  readonly rows?: number | null;
+  readonly cols?: number | null;
+};
+
+type NormalizedFrozenPanes = {
+  readonly rows: number;
+  readonly cols: number;
+};
+
+type DimensionPosition = 'top' | 'left';
+
+export interface CellLevelScrollPositionArgs {
+  readonly geometry: Pick<ISheetViewGeometry, 'getDimensions'>;
+  readonly viewport?: Pick<ISheetViewViewport, 'getFrozenPanes'> | null;
+  readonly topRow: number;
+  readonly leftCol: number;
+  readonly frozenPanes?: FrozenPaneLike | null;
+}
+
+function normalizeIndex(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function normalizeFrozenPaneCount(value: number | null | undefined): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value as number)) : 0;
+}
+
+function hasDimensionPosition(
+  candidate: unknown,
+  key: DimensionPosition,
+): candidate is Partial<Record<DimensionPosition, number>> {
+  return (
+    typeof candidate === 'object' &&
+    candidate !== null &&
+    key in candidate &&
+    typeof (candidate as Record<string, unknown>)[key] === 'number'
+  );
+}
+
+function getDimensionPosition(
+  geometry: Pick<ISheetViewGeometry, 'getDimensions'>,
+  row: number,
+  col: number,
+  key: DimensionPosition,
+): number | null {
+  const dimension = geometry
+    .getDimensions({ row, col })
+    .find((candidate) => hasDimensionPosition(candidate, key));
+
+  if (!dimension) return null;
+  const position = (dimension as Partial<Record<DimensionPosition, number>>)[key];
+  return typeof position === 'number' && Number.isFinite(position) ? position : null;
+}
+
+function resolveFrozenPanes(args: CellLevelScrollPositionArgs): NormalizedFrozenPanes {
+  const frozenPanes = args.frozenPanes ?? args.viewport?.getFrozenPanes() ?? { rows: 0, cols: 0 };
+  return {
+    rows: normalizeFrozenPaneCount(frozenPanes.rows),
+    cols: normalizeFrozenPaneCount(frozenPanes.cols),
+  };
+}
+
+export function resolveCellLevelScrollPosition(args: CellLevelScrollPositionArgs): Point | null {
+  const topRow = normalizeIndex(args.topRow);
+  const leftCol = normalizeIndex(args.leftCol);
+  const frozenPanes = resolveFrozenPanes(args);
+
+  const rowTop = getDimensionPosition(args.geometry, topRow, 0, 'top');
+  const colLeft = getDimensionPosition(args.geometry, 0, leftCol, 'left');
+  if (rowTop === null || colLeft === null) return null;
+
+  const frozenRowTop =
+    frozenPanes.rows > 0 ? getDimensionPosition(args.geometry, frozenPanes.rows, 0, 'top') : 0;
+  const frozenColLeft =
+    frozenPanes.cols > 0 ? getDimensionPosition(args.geometry, 0, frozenPanes.cols, 'left') : 0;
+  if (frozenRowTop === null || frozenColLeft === null) return null;
+
+  return {
+    x: Math.max(0, colLeft - frozenColLeft),
+    y: Math.max(0, rowTop - frozenRowTop),
+  };
+}

--- a/apps/spreadsheet/src/systems/renderer/execution/renderer-execution.ts
+++ b/apps/spreadsheet/src/systems/renderer/execution/renderer-execution.ts
@@ -41,6 +41,7 @@ import type {
 } from '@mog-sdk/contracts/viewport';
 
 import type { RendererActor } from '../machines/grid-renderer-machine';
+import { resolveCellLevelScrollPosition } from './cell-scroll';
 
 const INTERNAL_GRID_RENDERER_KEY = '__mogInternalGridRenderer';
 
@@ -183,19 +184,16 @@ export function setupRendererExecution(config: RendererExecutionConfig): Rendere
     }
 
     // Fall back to the workbook-persisted cell top-left for first visits after
-    // load, matching the initial sheet path.
-    const rowDims = sheetView.geometry.getDimensions({ row: topRow, col: 0 });
-    const colDims = sheetView.geometry.getDimensions({ row: 0, col: leftCol });
-    const rowDim = rowDims.find((d: any) => 'top' in d);
-    const colDim = colDims.find((d: any) => 'left' in d);
-    if (rowDim && 'top' in rowDim && colDim && 'left' in colDim) {
-      scroll = {
-        x: colDim.left,
-        y: rowDim.top,
-      };
-    }
-
-    return scroll;
+    // load, matching the initial sheet path. Frozen panes pin rows/columns in
+    // place, so scrollable pixels start after the frozen boundary.
+    return (
+      resolveCellLevelScrollPosition({
+        geometry: sheetView.geometry,
+        viewport: sheetView.viewport,
+        topRow,
+        leftCol,
+      }) ?? scroll
+    );
   }
 
   // ===========================================================================

--- a/apps/spreadsheet/src/systems/renderer/render-system.ts
+++ b/apps/spreadsheet/src/systems/renderer/render-system.ts
@@ -71,6 +71,7 @@ import {
   setupRendererExecution,
   type RendererExecutionResult,
 } from './execution/renderer-execution';
+import { resolveCellLevelScrollPosition } from './execution/cell-scroll';
 import {
   PageBreakCoordinator,
   type PageBreakHitResult,
@@ -456,17 +457,18 @@ export class RenderSystem implements IRenderSystem {
     if (this.disposed || !this.started) return;
     if (topRow === 0 && leftCol === 0) return;
 
-    // Use geometry capability to convert cell-level scroll to pixels.
+    // Use SheetView capabilities to convert cell-level scroll to pixels.
     const geometry = this.getGeometry();
+    const viewport = this.getViewport();
     if (!geometry) return;
 
-    const rowDims = geometry.getDimensions({ row: topRow, col: 0 });
-    const colDims = geometry.getDimensions({ row: 0, col: leftCol });
-    const rowDim = rowDims.find((d: any) => 'top' in d);
-    const colDim = colDims.find((d: any) => 'left' in d);
-    if (!rowDim || !('top' in rowDim) || !colDim || !('left' in colDim)) return;
-
-    const pixelPos: Point = { x: colDim.left, y: rowDim.top };
+    const pixelPos = resolveCellLevelScrollPosition({
+      geometry,
+      viewport,
+      topRow,
+      leftCol,
+    });
+    if (!pixelPos) return;
 
     this.rendererExecution?.setScrollPosition(pixelPos);
 


### PR DESCRIPTION
Summary:
- Resolve restored cell-level scroll positions through frozen pane boundaries instead of applying raw cell offsets.
- Reuse the helper for initial restore, sheet switch restore, and render-system scroll application.

Verification:
- NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning" pnpm --filter @mog/app-spreadsheet exec jest --runTestsByPath src/systems/renderer/execution/__tests__/cell-scroll.test.ts
- pnpm --filter @mog/platform-memory typecheck && pnpm --filter @mog/kernel-host-internal typecheck
- pnpm --filter @mog/app-spreadsheet typecheck
- pnpm exec prettier --check apps/spreadsheet/src/systems/renderer/execution/cell-scroll.ts apps/spreadsheet/src/systems/renderer/execution/__tests__/cell-scroll.test.ts apps/spreadsheet/src/systems/renderer/execution/renderer-execution.ts apps/spreadsheet/src/systems/renderer/render-system.ts