### PR TITLE
Fix v0.9.3 devtools cell size readback

### DIFF
--- a/tools/devtools/src/__tests__/dt-readbacks.test.ts
+++ b/tools/devtools/src/__tests__/dt-readbacks.test.ts
@@ -116,6 +116,7 @@ function setupRuntime(opts: {
   colWidths: Record<number, number>;
   bridgeColPositions?: Record<number, number>;
   coordinateDocumentPixelToCell?: boolean;
+  renderedCellSizes?: Record<string, { width: number; height: number }>;
 }): RuntimeBundle {
   const g = globalThis as { window?: Record<string, unknown>; document?: unknown };
 
@@ -165,6 +166,14 @@ function setupRuntime(opts: {
             const w = opts.colWidths[cell.col];
             if (h == null || w == null) return null;
             return { x: 0, y: 0, width: w, height: h };
+          },
+          getCellRenderedSize(cell: { row: number; col: number }) {
+            const explicit = opts.renderedCellSizes?.[`${cell.row},${cell.col}`];
+            if (explicit) return explicit;
+            const h = opts.rowHeights[cell.row];
+            const w = opts.colWidths[cell.col];
+            if (h == null || w == null) return null;
+            return { width: w, height: h };
           },
           getVisibleRange() {
             return renderer.getCoordinateSystem().getVisibleRange();
@@ -510,6 +519,21 @@ describe('__dt rendered-state readbacks (app-eval / app-eval rendered-state read
     });
     const w = await runtime.api.getRenderedColWidth(null, 999);
     expect(w).toBeNull();
+  });
+
+  test('getRenderedCellSize reports intrinsic size when page bounds are not visible', async () => {
+    runtime = setupRuntime({
+      drawings: [],
+      rowHeights: {},
+      colWidths: {},
+      renderedCellSizes: { '0,255': { width: 64, height: 24 } },
+    });
+
+    await expect(runtime.api.getRenderedCellSize(null, 0, 255)).resolves.toEqual({
+      width: 64,
+      height: 24,
+    });
+    await expect(runtime.api.getRenderedColWidth(null, 255)).resolves.toBeNull();
   });
 
   test('getCanvasSnapshot returns empty Uint8Array when no canvas exists', async () => {

--- a/tools/devtools/src/console/api.ts
+++ b/tools/devtools/src/console/api.ts
@@ -577,6 +577,11 @@ export function createConsoleAPI(
     height: number;
   };
 
+  type RenderedCellSize = {
+    width: number;
+    height: number;
+  };
+
   function getRenderedCellBounds(row: number, col: number): RenderedCellBounds | null {
     try {
       const coordinator = (window as any).__COORDINATOR__;
@@ -601,6 +606,28 @@ export function createConsoleAPI(
     } catch {
       return null;
     }
+  }
+
+  function getRenderedCellSize(row: number, col: number): RenderedCellSize | null {
+    try {
+      const coordinator = (window as any).__COORDINATOR__;
+      const geometry = coordinator?.renderer?.getGeometry?.();
+      const size = geometry?.getCellRenderedSize?.({ row, col });
+      if (
+        size &&
+        Number.isFinite(size.width) &&
+        Number.isFinite(size.height) &&
+        size.width >= 0 &&
+        size.height >= 0
+      ) {
+        return { width: size.width, height: size.height };
+      }
+    } catch {
+      // fall through to visible page-bounds fallback
+    }
+
+    const bounds = getRenderedCellBounds(row, col);
+    return bounds ? { width: bounds.width, height: bounds.height } : null;
   }
 
   /**
@@ -2123,6 +2150,14 @@ export function createConsoleAPI(
 
     async getRenderedColWidth(_sheet: string | null, col: number): Promise<number | null> {
       return getRenderedCellBounds(0, col)?.width ?? null;
+    },
+
+    async getRenderedCellSize(
+      _sheet: string | null,
+      row: number,
+      col: number,
+    ): Promise<{ width: number; height: number } | null> {
+      return getRenderedCellSize(row, col);
     },
 
     getRenderedViewportStartRow(scope: string = 'main'): number | null {

--- a/tools/devtools/src/types.ts
+++ b/tools/devtools/src/types.ts
@@ -701,6 +701,17 @@ export interface DevToolsConsoleAPI {
   getRenderedColWidth(sheet: string | null, col: number): Promise<number | null>;
 
   /**
+   * Intrinsic rendered cell size in CSS pixels, independent of current viewport
+   * visibility when SheetView geometry can resolve it. Falls back to page
+   * bounds for older renderer adapters.
+   */
+  getRenderedCellSize(
+    sheet: string | null,
+    row: number,
+    col: number,
+  ): Promise<{ width: number; height: number } | null>;
+
+  /**
    * First row whose canvas geometry is currently resolvable for the given
    * renderer viewport scope. Unlike {@link getViewportStartRow}, this is not a
    * compute/prefetch bound; it is derived from the live grid renderer and is


### PR DESCRIPTION
Summary:
- Add __dt.getRenderedCellSize so evals can read intrinsic rendered cell dimensions even when page bounds are not visible.
- Extend the devtools test fixture and API type surface for the new readback.

Verification:
- pnpm --dir tools/devtools test -- src/__tests__/dt-readbacks.test.ts
- pnpm --dir tools/devtools typecheck
- pnpm exec prettier --check tools/devtools/src/console/api.ts tools/devtools/src/types.ts tools/devtools/src/__tests__/dt-readbacks.test.ts