### PR TITLE
Fix v0.9.3 devtools chart readback

### DIFF
--- a/tools/devtools/src/__tests__/dt-readbacks.test.ts
+++ b/tools/devtools/src/__tests__/dt-readbacks.test.ts
@@ -34,7 +34,14 @@ interface FakeSceneObject {
   visible: boolean;
   groupId: string | null;
   rotation?: number;
-  data?: { src?: string; chartId?: string; wordArt?: unknown };
+  data?: {
+    src?: string;
+    chartId?: string;
+    wordArt?: unknown;
+    chartType?: string;
+    dataRange?: string;
+    sourceRange?: string;
+  };
 }
 
 function makeSceneGraph(objects: FakeSceneObject[]) {
@@ -116,6 +123,7 @@ function setupRuntime(opts: {
   colWidths: Record<number, number>;
   bridgeColPositions?: Record<number, number>;
   coordinateDocumentPixelToCell?: boolean;
+  charts?: Array<Record<string, unknown>>;
 }): RuntimeBundle {
   const g = globalThis as { window?: Record<string, unknown>; document?: unknown };
 
@@ -205,6 +213,17 @@ function setupRuntime(opts: {
       activeSheet: {
         sheetId: 'sheet-1',
         getSheetId: () => 'sheet-1',
+        charts: {
+          get: async (id: string) =>
+            opts.charts?.find(
+              (chart) =>
+                chart.id === id ||
+                chart.chartId === id ||
+                chart.objectId === id ||
+                chart.name === id,
+            ) ?? null,
+          list: async () => opts.charts ?? [],
+        },
         layout: {
           // No documentPixelToCell here — force fallback to coordinator's
           // coordinate system.
@@ -372,6 +391,50 @@ describe('__dt rendered-state readbacks (app-eval / app-eval rendered-state read
     expect(byId['legacy-text-effect-1']).toBe('wordArt');
     expect(byId['plain-textbox']).toBe('shape');
     expect(byId['smartart-1']).toBe('smartArt');
+  });
+
+  test('getRenderedDrawings enriches chart descriptors from the chart model', async () => {
+    runtime = setupRuntime({
+      drawings: [
+        {
+          id: 'chart-object-1',
+          type: 'chart',
+          bounds: { x: 256, y: 20, width: 512, height: 280 },
+          zIndex: 1,
+          visible: true,
+          groupId: null,
+          data: { chartId: 'chart-1' } as any,
+        },
+      ],
+      rowHeights: Object.fromEntries(Array.from({ length: 20 }, (_v, row) => [row, 20])),
+      colWidths: Object.fromEntries(Array.from({ length: 16 }, (_v, col) => [col, 64])),
+      coordinateDocumentPixelToCell: false,
+      charts: [
+        {
+          id: 'chart-1',
+          type: 'combo',
+          dataRange: 'Data!A2:C5',
+          anchorRow: 1,
+          anchorCol: 4,
+        },
+      ],
+    });
+
+    const drawings = await runtime.api.getRenderedDrawings();
+    expect(drawings).toHaveLength(1);
+    expect(drawings[0]).toMatchObject({
+      id: 'chart-object-1',
+      kind: 'chart',
+      chartType: 'combo',
+      dataRange: 'Data!A2:C5',
+      sourceRange: 'Data!A2:C5',
+      chartRange: 'E2:M16',
+      usedSyntheticAnchorFallback: false,
+      anchor: {
+        from: { row: 1, col: 4 },
+        to: { row: 15, col: 12 },
+      },
+    });
   });
 
   test('getRenderedDrawings includes visible DOM form-control overlays', async () => {

--- a/tools/devtools/src/console/api.ts
+++ b/tools/devtools/src/console/api.ts
@@ -39,6 +39,7 @@ import {
   readIconBucket,
   readResolvedNumberFormats,
 } from './viewport-inspector';
+import { completeDrawingAnchor, getChartReadback } from './drawing-readbacks';
 
 export function createConsoleAPI(
   store: EventStore,
@@ -2037,6 +2038,13 @@ export function createConsoleAPI(
             obj.bounds.x + obj.bounds.width,
             obj.bounds.y + obj.bounds.height,
           );
+          const fallbackAnchor = {
+            from: fromCell ?? { row: 0, col: 0 },
+            ...(toCell ? { to: toCell } : {}),
+          };
+          const modelAnchor = completeDrawingAnchor(model?.anchor, toCell);
+          const chartReadback = kind === 'chart' ? await getChartReadback(ws, obj, toCell) : null;
+          const { anchor: chartAnchor, ...chartFields } = chartReadback ?? {};
           const canvasBounds = {
             x: obj.bounds.x + DEFAULT_ROW_HEADER_WIDTH_PX,
             y: obj.bounds.y + DEFAULT_COL_HEADER_HEIGHT_PX,
@@ -2046,13 +2054,11 @@ export function createConsoleAPI(
           out.push({
             id: obj.id,
             kind,
-            anchor: model?.anchor ?? {
-              from: fromCell ?? { row: 0, col: 0 },
-              ...(toCell ? { to: toCell } : {}),
-            },
+            anchor: chartAnchor ?? modelAnchor ?? fallbackAnchor,
             boundsPx: canvasBounds,
             visible: !!obj.visible,
             ...(extractSrc(obj) ? { src: extractSrc(obj)! } : {}),
+            ...chartFields,
           });
         }
 

--- a/tools/devtools/src/console/drawing-readbacks.ts
+++ b/tools/devtools/src/console/drawing-readbacks.ts
@@ -1,0 +1,169 @@
+import type { DrawingDescriptor } from '../types';
+
+type DrawingAnchorDescriptor = DrawingDescriptor['anchor'];
+type CellRef = { row: number; col: number };
+
+function getObjectChartId(obj: { id: string; data?: Record<string, unknown> }): string | null {
+  const chartId = obj.data?.chartId;
+  return typeof chartId === 'string' && chartId.length > 0 ? chartId : obj.id;
+}
+
+function readStringField(record: unknown, keys: readonly string[]): string | null {
+  if (!record || typeof record !== 'object') return null;
+  const source = record as Record<string, unknown>;
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return null;
+}
+
+function readNumberField(record: unknown, keys: readonly string[]): number | null {
+  if (!record || typeof record !== 'object') return null;
+  const source = record as Record<string, unknown>;
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function readCellRef(record: unknown): CellRef | null {
+  const row = readNumberField(record, ['row', 'startRow', 'anchorRow']);
+  const col = readNumberField(record, ['col', 'startCol', 'anchorCol']);
+  return row === null || col === null ? null : { row, col };
+}
+
+export function completeDrawingAnchor(
+  anchor: DrawingAnchorDescriptor | null | undefined,
+  fallbackToCell: CellRef | null,
+): DrawingAnchorDescriptor | null {
+  if (!anchor?.from) return null;
+  return {
+    from: anchor.from,
+    ...(anchor.to ? { to: anchor.to } : fallbackToCell ? { to: fallbackToCell } : {}),
+    ...(anchor.offsetPx ? { offsetPx: anchor.offsetPx } : {}),
+  };
+}
+
+async function getChartModel(ws: any, chartId: string | null): Promise<unknown | null> {
+  if (!chartId || !ws?.charts) return null;
+  try {
+    if (typeof ws.charts.get === 'function') {
+      const chart = await ws.charts.get(chartId);
+      if (chart) return chart;
+    }
+  } catch {
+    // fall through to list lookup
+  }
+  try {
+    if (typeof ws.charts.list === 'function') {
+      const charts = await ws.charts.list();
+      if (Array.isArray(charts)) {
+        return (
+          charts.find((chart) => {
+            if (!chart || typeof chart !== 'object') return false;
+            const record = chart as Record<string, unknown>;
+            return (
+              record.id === chartId ||
+              record.chartId === chartId ||
+              record.objectId === chartId ||
+              record.name === chartId
+            );
+          }) ?? null
+        );
+      }
+    }
+  } catch {
+    // best-effort
+  }
+  return null;
+}
+
+function cellRefToA1(cell: CellRef): string {
+  let n = Math.max(0, Math.floor(cell.col)) + 1;
+  let col = '';
+  while (n > 0) {
+    const rem = (n - 1) % 26;
+    col = String.fromCharCode(65 + rem) + col;
+    n = Math.floor((n - 1) / 26);
+  }
+  return `${col}${Math.max(0, Math.floor(cell.row)) + 1}`;
+}
+
+function anchorToRange(anchor: DrawingAnchorDescriptor | null): string | null {
+  if (!anchor?.from || !anchor.to) return null;
+  return `${cellRefToA1(anchor.from)}:${cellRefToA1(anchor.to)}`;
+}
+
+function getChartAnchor(
+  chart: unknown,
+  fallbackToCell: CellRef | null,
+): DrawingAnchorDescriptor | null {
+  if (!chart || typeof chart !== 'object') return null;
+  const record = chart as Record<string, unknown>;
+  const explicitAnchor = record.anchor;
+  if (explicitAnchor && typeof explicitAnchor === 'object') {
+    const anchor = explicitAnchor as { from?: unknown; to?: unknown };
+    const from = readCellRef(anchor.from);
+    if (from) {
+      const to = readCellRef(anchor.to);
+      return {
+        from,
+        ...(to ? { to } : {}),
+      };
+    }
+  }
+
+  const position = record.position;
+  if (position && typeof position === 'object') {
+    const pos = position as { from?: unknown; to?: unknown };
+    const from = readCellRef(pos.from);
+    if (from) {
+      const to = readCellRef(pos.to);
+      return {
+        from,
+        ...(to ? { to } : fallbackToCell ? { to: fallbackToCell } : {}),
+      };
+    }
+  }
+
+  const anchorRow = readNumberField(record, ['anchorRow', 'row', 'startRow']);
+  const anchorCol = readNumberField(record, ['anchorCol', 'col', 'startCol']);
+  if (anchorRow === null || anchorCol === null) return null;
+  return {
+    from: { row: anchorRow, col: anchorCol },
+    ...(fallbackToCell ? { to: fallbackToCell } : {}),
+  };
+}
+
+export async function getChartReadback(
+  ws: any,
+  obj: { id: string; data?: Record<string, unknown> },
+  fallbackToCell: CellRef | null,
+): Promise<Partial<DrawingDescriptor> | null> {
+  const chartId = getObjectChartId(obj);
+  const chart = await getChartModel(ws, chartId);
+  const chartType =
+    readStringField(chart, ['chartType', 'type', 'kind']) ??
+    readStringField(obj.data, ['chartType', 'type']);
+  const dataRange =
+    readStringField(chart, ['dataRange', 'sourceRange', 'range']) ??
+    readStringField(obj.data, ['dataRange', 'sourceRange', 'range']);
+  const sourceRange =
+    readStringField(chart, ['sourceRange', 'dataRange', 'range']) ??
+    readStringField(obj.data, ['sourceRange', 'dataRange', 'range']);
+  const chartAnchor = getChartAnchor(chart, fallbackToCell);
+  const chartRange =
+    readStringField(chart, ['chartRange', 'rangeAddress', 'anchorRange']) ??
+    anchorToRange(chartAnchor);
+
+  if (!chart && !chartType && !dataRange && !sourceRange) return null;
+  return {
+    ...(chartType ? { chartType } : {}),
+    ...(dataRange ? { dataRange } : {}),
+    ...(sourceRange ? { sourceRange } : {}),
+    ...(chartRange ? { chartRange } : {}),
+    ...(chartAnchor ? { anchor: chartAnchor, usedSyntheticAnchorFallback: false } : {}),
+  };
+}

--- a/tools/devtools/src/types.ts
+++ b/tools/devtools/src/types.ts
@@ -1212,6 +1212,11 @@ export interface DrawingDescriptor {
   visible: boolean;
   /** For image/chart drawings, the source URL or chart id. Optional for shapes. */
   src?: string;
+  chartType?: string;
+  dataRange?: string;
+  sourceRange?: string;
+  chartRange?: string;
+  usedSyntheticAnchorFallback?: boolean;
 }
 
 export interface PixelRect {


### PR DESCRIPTION
Summary:
- Enrich rendered drawing chart descriptors from the sheet chart model.
- Fill partial chart anchors from scene metadata while preserving current bounds semantics in this isolated fix.

Verification:
- pnpm --dir tools/devtools test -- src/__tests__/dt-readbacks.test.ts
- pnpm --dir tools/devtools typecheck
- pnpm exec prettier --check tools/devtools/src/console/api.ts tools/devtools/src/console/drawing-readbacks.ts tools/devtools/src/types.ts tools/devtools/src/__tests__/dt-readbacks.test.ts