### PR TITLE
Fix v0.9.3 devtools diagram bounds

### DIFF
--- a/tools/devtools/src/__tests__/dt-readbacks.test.ts
+++ b/tools/devtools/src/__tests__/dt-readbacks.test.ts
@@ -270,12 +270,37 @@ describe('__dt rendered-state readbacks (app-eval / app-eval rendered-state read
     const d = drawings[0];
     expect(d.id).toBe('pic-1');
     expect(d.kind).toBe('image');
-    expect(d.boundsPx).toEqual({ x: 150, y: 48, w: 200, h: 96 });
+    expect(d.boundsPx).toEqual({ x: 100, y: 24, w: 200, h: 96 });
     expect(d.visible).toBe(true);
     expect(d.src).toBe('mog://image/abc.png');
     // anchor.from snaps (100, 24) → row 1, col 1; anchor.to snaps (300, 120) → row 5, col 3.
     expect(d.anchor.from).toEqual({ row: 1, col: 1 });
     expect(d.anchor.to).toEqual({ row: 5, col: 3 });
+  });
+
+  test('getRenderedDrawings reports diagram scene bounds in document space', async () => {
+    runtime = setupRuntime({
+      drawings: [
+        {
+          id: 'diagram-1',
+          type: 'diagram',
+          bounds: { x: 100, y: 100, width: 400, height: 300 },
+          zIndex: 1,
+          visible: true,
+          groupId: null,
+        },
+      ],
+      rowHeights: { 0: 24, 1: 24, 2: 24, 3: 24, 4: 24, 5: 24, 6: 24 },
+      colWidths: { 0: 100, 1: 100, 2: 100, 3: 100, 4: 100, 5: 100 },
+    });
+
+    const drawings = await runtime.api.getRenderedDrawings();
+    expect(drawings).toHaveLength(1);
+    expect(drawings[0]).toMatchObject({
+      id: 'diagram-1',
+      kind: 'diagram',
+      boundsPx: { x: 100, y: 100, w: 400, h: 300 },
+    });
   });
 
   test('getRenderedDrawings snaps anchors through SheetView geometry dimensions', async () => {

--- a/tools/devtools/src/console/api.ts
+++ b/tools/devtools/src/console/api.ts
@@ -2037,9 +2037,9 @@ export function createConsoleAPI(
             obj.bounds.x + obj.bounds.width,
             obj.bounds.y + obj.bounds.height,
           );
-          const canvasBounds = {
-            x: obj.bounds.x + DEFAULT_ROW_HEADER_WIDTH_PX,
-            y: obj.bounds.y + DEFAULT_COL_HEADER_HEIGHT_PX,
+          const documentBounds = {
+            x: obj.bounds.x,
+            y: obj.bounds.y,
             w: obj.bounds.width,
             h: obj.bounds.height,
           };
@@ -2050,7 +2050,7 @@ export function createConsoleAPI(
               from: fromCell ?? { row: 0, col: 0 },
               ...(toCell ? { to: toCell } : {}),
             },
-            boundsPx: canvasBounds,
+            boundsPx: documentBounds,
             visible: !!obj.visible,
             ...(extractSrc(obj) ? { src: extractSrc(obj)! } : {}),
           });


### PR DESCRIPTION
Summary:
- Report rendered drawing bounds in document coordinates instead of adding header offsets.
- Add a regression for diagram bounds so the eval sees the same coordinate space as the scene.

Verification:
- pnpm --dir tools/devtools test -- src/__tests__/dt-readbacks.test.ts
- pnpm --dir tools/devtools typecheck
- pnpm exec prettier --check tools/devtools/src/console/api.ts tools/devtools/src/__tests__/dt-readbacks.test.ts