### PR TITLE
Fix v0.9.3 devtools merged cell readbacks

### DIFF
--- a/tools/devtools/src/__tests__/dt-readbacks.test.ts
+++ b/tools/devtools/src/__tests__/dt-readbacks.test.ts
@@ -116,10 +116,88 @@ function setupRuntime(opts: {
   colWidths: Record<number, number>;
   bridgeColPositions?: Record<number, number>;
   coordinateDocumentPixelToCell?: boolean;
+  viewportCells?: Record<
+    string,
+    {
+      displayText?: string | null;
+      valueType?: number;
+      numberValue?: number;
+      hasFormula?: boolean;
+      errorText?: string | null;
+    }
+  >;
+  bridgeCells?: Record<
+    string,
+    {
+      formatted?: string | null;
+      value?: unknown;
+      formula?: string;
+    }
+  >;
+  merges?: Array<{ startRow: number; startCol: number; endRow: number; endCol: number }>;
 }): RuntimeBundle {
   const g = globalThis as { window?: Record<string, unknown>; document?: unknown };
 
   const sceneGraph = makeSceneGraph(opts.drawings);
+  const viewportId = 'main:sheet-1';
+  const computeBridge: Record<string, unknown> = {};
+  if (opts.bridgeColPositions) {
+    computeBridge.getColPosition = async (_sheetId: string, col: number) =>
+      opts.bridgeColPositions?.[col] ?? 0;
+  }
+  if (opts.viewportCells) {
+    computeBridge.getPerViewportStates = () => new Map([[viewportId, {}]]);
+    computeBridge.getAccessorForViewport = (id: string) => {
+      if (id !== viewportId) return null;
+      let current:
+        | {
+            displayText?: string | null;
+            valueType?: number;
+            numberValue?: number;
+            hasFormula?: boolean;
+            errorText?: string | null;
+          }
+        | undefined;
+      return {
+        moveTo(row: number, col: number) {
+          current = opts.viewportCells?.[`${row},${col}`];
+          return current !== undefined;
+        },
+        get displayText() {
+          return current?.displayText ?? null;
+        },
+        get valueType() {
+          return current?.valueType ?? 0;
+        },
+        get numberValue() {
+          return current?.numberValue;
+        },
+        get hasFormula() {
+          return current?.hasFormula ?? false;
+        },
+        get errorText() {
+          return current?.errorText ?? null;
+        },
+      };
+    };
+  }
+  if (opts.bridgeCells || opts.merges) {
+    computeBridge.queryRange = async (
+      _sheetId: string,
+      startRow: number,
+      startCol: number,
+      _endRow: number,
+      _endCol: number,
+    ) => {
+      const cell = opts.bridgeCells?.[`${startRow},${startCol}`];
+      return {
+        cells: cell ? [{ row: startRow, col: startCol, ...cell }] : [],
+        merges: opts.merges ?? [],
+      };
+    };
+    computeBridge.getAllMergesInSheet = async () => opts.merges ?? [];
+  }
+
   // __SHELL__ is still consulted by other readbacks (workbook lookup
   // fallback, principal resolution) but the scene graph is now sourced
   // from SheetView's object-scene capability — see `getRenderedDrawings`
@@ -130,14 +208,12 @@ function setupRuntime(opts: {
       getDocument: (id: string) =>
         id === 'doc-1'
           ? {
-              context: opts.bridgeColPositions
-                ? {
-                    computeBridge: {
-                      getColPosition: async (_sheetId: string, col: number) =>
-                        opts.bridgeColPositions?.[col] ?? 0,
-                    },
-                  }
-                : {},
+              context:
+                Object.keys(computeBridge).length > 0
+                  ? {
+                      computeBridge,
+                    }
+                  : {},
             }
           : null,
     },
@@ -168,6 +244,17 @@ function setupRuntime(opts: {
           },
           getVisibleRange() {
             return renderer.getCoordinateSystem().getVisibleRange();
+          },
+          getMergeAnchor(row: number, col: number) {
+            return (
+              opts.merges?.find(
+                (merge) =>
+                  row >= merge.startRow &&
+                  row <= merge.endRow &&
+                  col >= merge.startCol &&
+                  col <= merge.endCol,
+              ) ?? null
+            );
           },
           getPositionDimensions() {
             return {
@@ -531,6 +618,65 @@ describe('__dt rendered-state readbacks (app-eval / app-eval rendered-state read
     } finally {
       delete (globalThis as any).document;
     }
+  });
+
+  test('getCellValue returns empty data for covered merged cells', () => {
+    runtime = setupRuntime({
+      drawings: [],
+      rowHeights: { 0: 24, 1: 24 },
+      colWidths: { 0: 100, 1: 100 },
+      viewportCells: {
+        '0,0': { displayText: 'Merged', valueType: 2 },
+        '1,1': { displayText: 'Merged', valueType: 2 },
+      },
+      merges: [{ startRow: 0, startCol: 0, endRow: 1, endCol: 1 }],
+    });
+
+    expect(runtime.api.getCellValue(0, 0)).toMatchObject({
+      row: 0,
+      col: 0,
+      displayText: 'Merged',
+      valueType: 2,
+    });
+    expect(runtime.api.getCellValue(1, 1)).toMatchObject({
+      row: 1,
+      col: 1,
+      displayText: null,
+      valueType: 0,
+      hasFormula: false,
+    });
+  });
+
+  test('getCellsViaBridge returns empty data for covered merged cells', async () => {
+    runtime = setupRuntime({
+      drawings: [],
+      rowHeights: { 0: 24, 1: 24 },
+      colWidths: { 0: 100, 1: 100 },
+      bridgeCells: {
+        '0,0': { formatted: 'Merged', value: 'Merged' },
+        '1,1': { formatted: 'Merged', value: 'Merged' },
+      },
+      merges: [{ startRow: 0, startCol: 0, endRow: 1, endCol: 1 }],
+    });
+
+    const cells = await runtime.api.getCellsViaBridge([
+      { row: 0, col: 0 },
+      { row: 1, col: 1 },
+    ]);
+
+    expect(cells['0,0']).toMatchObject({
+      row: 0,
+      col: 0,
+      displayText: 'Merged',
+      valueType: 2,
+    });
+    expect(cells['1,1']).toMatchObject({
+      row: 1,
+      col: 1,
+      displayText: null,
+      valueType: 0,
+      hasFormula: false,
+    });
   });
 
   test('getDisplayedFormatsForCells uses range prefetch for dense in-limit cells', async () => {

--- a/tools/devtools/src/console/viewport-inspector.ts
+++ b/tools/devtools/src/console/viewport-inspector.ts
@@ -427,6 +427,89 @@ function getActiveSheetId(): string | null {
   }
 }
 
+type NormalizedMergeRegion = {
+  startRow: number;
+  startCol: number;
+  endRow: number;
+  endCol: number;
+};
+
+function readNumericField(input: Record<string, unknown>, keys: readonly string[]): number | null {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function normalizeMergeRegion(region: unknown): NormalizedMergeRegion | null {
+  if (!region || typeof region !== 'object') return null;
+  const record = region as Record<string, unknown>;
+  const startRow = readNumericField(record, ['startRow', 'start_row', 'row', 'anchorRow']);
+  const startCol = readNumericField(record, ['startCol', 'start_col', 'col', 'anchorCol']);
+  const endRow = readNumericField(record, ['endRow', 'end_row']);
+  const endCol = readNumericField(record, ['endCol', 'end_col']);
+  if (startRow === null || startCol === null || endRow === null || endCol === null) return null;
+  return {
+    startRow: Math.min(startRow, endRow),
+    startCol: Math.min(startCol, endCol),
+    endRow: Math.max(startRow, endRow),
+    endCol: Math.max(startCol, endCol),
+  };
+}
+
+function isCoveredCell(row: number, col: number, region: NormalizedMergeRegion | null): boolean {
+  if (!region) return false;
+  const inside =
+    row >= region.startRow &&
+    row <= region.endRow &&
+    col >= region.startCol &&
+    col <= region.endCol;
+  return inside && (row !== region.startRow || col !== region.startCol);
+}
+
+function readRenderedMergeRegion(row: number, col: number): NormalizedMergeRegion | null {
+  try {
+    const coord = (window as any).__COORDINATOR__;
+    const geometry = coord?.renderer?.getGeometry?.();
+    return normalizeMergeRegion(geometry?.getMergeAnchor?.(row, col));
+  } catch {
+    return null;
+  }
+}
+
+async function readBridgeMergeRegions(
+  bridge: any,
+  sheetId: string,
+): Promise<NormalizedMergeRegion[]> {
+  if (typeof bridge?.getAllMergesInSheet !== 'function') return [];
+  try {
+    const regions = await bridge.getAllMergesInSheet(sheetId);
+    if (!Array.isArray(regions)) return [];
+    return regions
+      .map(normalizeMergeRegion)
+      .filter((region): region is NormalizedMergeRegion => Boolean(region));
+  } catch {
+    return [];
+  }
+}
+
+function emptyCellReadback(
+  row: number,
+  col: number,
+  viewportId: string,
+): import('../types').ProgrammaticCellValue {
+  return {
+    row,
+    col,
+    viewportId,
+    displayText: null,
+    valueType: 0,
+    hasFormula: false,
+    errorText: null,
+  };
+}
+
 /**
  * Read a batch of cells via the compute bridge — the same path
  * production code uses for out-of-viewport range queries
@@ -461,6 +544,7 @@ export async function readCellsViaBridge(
 
   const sheetId = getActiveSheetId();
   if (!sheetId) return out;
+  const mergeRegions = await readBridgeMergeRegions(bridge, sheetId);
 
   // Issue one queryRange per requested cell, in parallel. Each call is sparse
   // (the result array is empty when the cell holds no value), so even very
@@ -481,6 +565,11 @@ export async function readCellsViaBridge(
   );
 
   for (const { row, col, cell } of settled) {
+    if (mergeRegions.some((region) => isCoveredCell(row, col, region))) {
+      out[`${row},${col}`] = emptyCellReadback(row, col, '__bridge__');
+      continue;
+    }
+
     const formatted: string | null =
       typeof cell?.formatted === 'string' && cell.formatted !== '' ? cell.formatted : null;
     const formula: string | undefined =
@@ -690,6 +779,12 @@ export function readCellValue(
     if (!accessor) return null;
     const exists = accessor.moveTo?.(row, col);
     if (!exists) return null;
+    const mergeRegion =
+      readRenderedMergeRegion(row, col) ??
+      normalizeMergeRegion(
+        accessor.mergeBounds ?? accessor.mergeRegion ?? accessor.mergedRegion ?? null,
+      );
+    if (isCoveredCell(row, col, mergeRegion)) return emptyCellReadback(row, col, vpId);
     const displayText = hasLinkedUnlabeledCheckboxOverlay(row, col)
       ? ''
       : (accessor.displayText ?? null);


### PR DESCRIPTION
Summary:
- Normalize merge metadata and make covered merged cells read back as empty through viewport inspection.
- Apply the same covered-cell behavior to bridge-backed cell reads.

Verification:
- pnpm --dir tools/devtools test -- src/__tests__/dt-readbacks.test.ts
- pnpm --dir tools/devtools typecheck
- pnpm exec prettier --check tools/devtools/src/console/viewport-inspector.ts tools/devtools/src/__tests__/dt-readbacks.test.ts