### PR TITLE
[fleet v0.9.3] Stabilize note popover save flow

### DIFF
--- a/apps/spreadsheet/src/components/comments/CommentPopover.tsx
+++ b/apps/spreadsheet/src/components/comments/CommentPopover.tsx
@@ -621,7 +621,9 @@ export function CommentPopover() {
     <>
       <div className="px-3 py-2 border-b border-ss-border flex items-center justify-between shrink-0">
         <div className="flex items-center gap-2">
-          <span className="text-caption font-medium text-ss-text-secondary">Comment</span>
+          <span className="text-caption font-medium text-ss-text-secondary">
+            {isNoteBacked ? 'Note' : 'Comment'}
+          </span>
           {isResolved && (
             <span className="text-caption text-ss-success flex items-center gap-1">
               <CheckmarkCircleSvg style={{ width: 12, height: 12 }} />
@@ -630,7 +632,7 @@ export function CommentPopover() {
           )}
         </div>
         <div className="flex gap-1">
-          {comments.length > 0 && (
+          {comments.length > 0 && !isNoteBacked && (
             <button
               type="button"
               data-testid="resolve-thread"


### PR DESCRIPTION
Fleet-captured patch for metadata-note-add-edit-readback.

Base: origin/dev-v0.9.3
Fleet run: f1781071010832, worker 11

The detailed app-eval report is stored in the internal fleet report directory.