### PR TITLE
[fleet v0.9.3] Await system clipboard write settlement

### DIFF
--- a/apps/spreadsheet/src/actions/handlers/clipboard.ts
+++ b/apps/spreadsheet/src/actions/handlers/clipboard.ts
@@ -546,9 +546,18 @@ export const COPY: ActionHandler = (deps) => {
     rejectData = rej;
   });
   const settlementId = ++clipboardSettlementSequence;
+  let settledTsv = '';
 
   // SYNCHRONOUS: Reserve clipboard slot within user activation window.
   const clipboardWritePromise = writeToSystemClipboard(dataPromise);
+  const clipboardSettlementPromise = clipboardWritePromise
+    .then(() => {
+      emitClipboardSettlement('copy', settlementId, settledTsv, true);
+    })
+    .catch((clipErr) => {
+      console.warn('System clipboard write failed (copy):', clipErr);
+      emitClipboardSettlement('copy', settlementId, settledTsv, false, clipErr);
+    });
 
   // ASYNC: Bridge work runs in background via .then/.catch chain.
   // Handler returns handled() synchronously below.
@@ -560,6 +569,7 @@ export const COPY: ActionHandler = (deps) => {
 
       // Store text signature for external clipboard detection
       data.textSignature = tsv;
+      settledTsv = tsv;
 
       // Resolve the deferred promise — clipboard now receives the data.
       resolveData({ tsv, html });
@@ -569,16 +579,6 @@ export const COPY: ActionHandler = (deps) => {
       // system clipboard write fails (e.g., headless browsers, Playwright).
       copyCutDeps.commands.copy(mutableRanges, data);
 
-      // Await the clipboard write — best-effort, failure is non-fatal.
-      void clipboardWritePromise
-        .then(() => {
-          emitClipboardSettlement('copy', settlementId, tsv, true);
-        })
-        .catch((clipErr) => {
-          console.warn('System clipboard write failed (copy):', clipErr);
-          emitClipboardSettlement('copy', settlementId, tsv, false, clipErr);
-        });
-
       // Accessibility announcement for copy operation
       getUIStore(deps).getState().announce('Copied to clipboard', 'polite');
     })
@@ -587,7 +587,9 @@ export const COPY: ActionHandler = (deps) => {
       rejectData(err);
       console.error('Copy failed:', err);
     });
-  trackPendingClipboardCapture(capturePromise);
+  trackPendingClipboardCapture(
+    Promise.all([capturePromise, clipboardSettlementPromise]).then(() => undefined),
+  );
 
   return handled();
 };
@@ -638,9 +640,18 @@ export const CUT: ActionHandler = (deps) => {
     rejectData = rej;
   });
   const settlementId = ++clipboardSettlementSequence;
+  let settledTsv = '';
 
   // SYNCHRONOUS: Reserve clipboard slot within user activation window.
   const clipboardWritePromise = writeToSystemClipboard(dataPromise);
+  const clipboardSettlementPromise = clipboardWritePromise
+    .then(() => {
+      emitClipboardSettlement('cut', settlementId, settledTsv, true);
+    })
+    .catch((clipErr) => {
+      console.warn('System clipboard write failed (cut):', clipErr);
+      emitClipboardSettlement('cut', settlementId, settledTsv, false, clipErr);
+    });
 
   // ASYNC: Bridge work runs in background via .then/.catch chain.
   // Handler returns handled() synchronously below.
@@ -652,6 +663,7 @@ export const CUT: ActionHandler = (deps) => {
 
       // Store text signature for external clipboard detection
       data.textSignature = tsv;
+      settledTsv = tsv;
 
       // Resolve the deferred promise — clipboard now receives the data.
       resolveData({ tsv, html });
@@ -661,16 +673,6 @@ export const CUT: ActionHandler = (deps) => {
       // system clipboard write fails (e.g., headless browsers, Playwright).
       copyCutDeps.commands.cut(mutableRanges, data);
 
-      // Await the clipboard write — best-effort, failure is non-fatal.
-      void clipboardWritePromise
-        .then(() => {
-          emitClipboardSettlement('cut', settlementId, tsv, true);
-        })
-        .catch((clipErr) => {
-          console.warn('System clipboard write failed (cut):', clipErr);
-          emitClipboardSettlement('cut', settlementId, tsv, false, clipErr);
-        });
-
       // Accessibility announcement for cut operation
       getUIStore(deps).getState().announce('Cut to clipboard', 'polite');
     })
@@ -678,7 +680,9 @@ export const CUT: ActionHandler = (deps) => {
       rejectData(err);
       console.error('Cut failed:', err);
     });
-  trackPendingClipboardCapture(capturePromise);
+  trackPendingClipboardCapture(
+    Promise.all([capturePromise, clipboardSettlementPromise]).then(() => undefined),
+  );
 
   return handled();
 };

--- a/apps/spreadsheet/src/systems/grid-editing/coordination/pending-clipboard-capture.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/coordination/pending-clipboard-capture.ts
@@ -1,16 +1,21 @@
-let pendingClipboardCapture: Promise<void> | null = null;
+type PendingClipboardCaptureGlobal = typeof globalThis & {
+  __MOG_PENDING_CLIPBOARD_CAPTURE__?: Promise<unknown>;
+};
+
+const globalPendingClipboardCapture = () => globalThis as PendingClipboardCaptureGlobal;
 
 export function trackPendingClipboardCapture(promise: Promise<void>): void {
-  let tracked: Promise<void>;
-  tracked = promise.finally(() => {
-    if (pendingClipboardCapture === tracked) {
-      pendingClipboardCapture = null;
+  const global = globalPendingClipboardCapture();
+  const tracked = promise.catch(() => undefined);
+  global.__MOG_PENDING_CLIPBOARD_CAPTURE__ = tracked;
+  void tracked.finally(() => {
+    if (global.__MOG_PENDING_CLIPBOARD_CAPTURE__ === tracked) {
+      delete global.__MOG_PENDING_CLIPBOARD_CAPTURE__;
     }
   });
-  pendingClipboardCapture = tracked;
 }
 
 export async function waitForPendingClipboardCapture(): Promise<void> {
-  if (!pendingClipboardCapture) return;
-  await pendingClipboardCapture.catch(() => undefined);
+  await Promise.resolve();
+  await globalPendingClipboardCapture().__MOG_PENDING_CLIPBOARD_CAPTURE__;
 }


### PR DESCRIPTION
Fleet-captured patch for copy-paste-system-clipboard.

Base: origin/dev-v0.9.3
Fleet run: f1781071010832, worker 14

The detailed app-eval report is stored in the internal fleet report directory.