### PR TITLE
Fix fleet-discovered app-eval production regressions

### DIFF
--- a/apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts
+++ b/apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts
@@ -29,7 +29,7 @@ describe('resolveDataCommandTarget', () => {
     expect(ws.getCurrentRegion).not.toHaveBeenCalled();
   });
 
-  test('explicit multi-row command selection does not infer headers from first row', async () => {
+  test('explicit multi-row command selection infers headers from first row', async () => {
     const ws = makeWorksheet({
       values: {
         '0,0': 'Name',
@@ -42,7 +42,26 @@ describe('resolveDataCommandTarget', () => {
 
     await expect(resolveDataCommandTarget(ws as Worksheet, range)).resolves.toEqual({
       range,
-      hasHeaders: false,
+      hasHeaders: true,
+      wasExpanded: false,
+    });
+    expect(ws.getCurrentRegion).not.toHaveBeenCalled();
+  });
+
+  test('explicit multi-row command selection tolerates blank spacer rows before body values', async () => {
+    const ws = makeWorksheet({
+      values: {
+        '2,27': '1Q',
+        '3,27': '',
+        '4,27': null,
+        '5,27': 100536,
+      },
+    });
+    const range = { startRow: 2, startCol: 27, endRow: 20, endCol: 27 };
+
+    await expect(resolveDataCommandTarget(ws as Worksheet, range)).resolves.toEqual({
+      range,
+      hasHeaders: true,
       wasExpanded: false,
     });
     expect(ws.getCurrentRegion).not.toHaveBeenCalled();

--- a/apps/spreadsheet/src/actions/__tests__/dispatch-symmetry-b.test.ts
+++ b/apps/spreadsheet/src/actions/__tests__/dispatch-symmetry-b.test.ts
@@ -68,6 +68,7 @@ const EDITING_GROUP_ACTIONS: ActionType[] = [
 /** CellsGroup actions: insert/delete + dimension + visibility. */
 const CELLS_GROUP_ACTIONS: ActionType[] = [
   'INSERT_CELLS_SHIFT_DOWN',
+  'INSERT_CUT_CELLS_SHIFT_DOWN',
   'OPEN_INSERT_CELLS_DIALOG',
   'INSERT_ROW_ABOVE',
   'INSERT_COLUMN_LEFT',

--- a/apps/spreadsheet/src/actions/data-command-target.ts
+++ b/apps/spreadsheet/src/actions/data-command-target.ts
@@ -12,6 +12,8 @@ interface ResolveDataTargetOptions {
   readonly inferHeadersForExplicitMultiRow: boolean;
 }
 
+const HEADER_BODY_SCAN_ROW_LIMIT = 100;
+
 export function normalizeCommandRange(range: CellRange): CellRange {
   return {
     startRow: range.startRow,
@@ -44,22 +46,30 @@ async function rangeLooksLikeHeaderTable(ws: Worksheet, range: CellRange): Promi
   const firstRow = await Promise.all(
     Array.from({ length: width }, (_, i) => ws.getCell(range.startRow, range.startCol + i)),
   );
-  const secondRow = await Promise.all(
-    Array.from({ length: width }, (_, i) => ws.getCell(range.startRow + 1, range.startCol + i)),
-  );
 
   const firstRowAllText = firstRow.every((cell) => {
     const value = cell?.value;
     return typeof value === 'string' && value.trim().length > 0;
   });
-  const secondRowHasDataSignal = secondRow.some((cell) => {
-    const value = cell?.value;
-    if (value == null || value === '') return false;
-    if (typeof value !== 'string') return true;
-    return value.trim() !== '' && Number.isFinite(Number(value));
-  });
+  if (!firstRowAllText) return false;
 
-  return firstRowAllText && secondRowHasDataSignal;
+  const rowHasDataSignal = (row: Array<{ value?: unknown } | null | undefined>): boolean =>
+    row.some((cell) => {
+      const value = cell?.value;
+      if (value == null || value === '') return false;
+      if (typeof value !== 'string') return true;
+      return value.trim() !== '' && Number.isFinite(Number(value));
+    });
+
+  const scanEndRow = Math.min(range.endRow, range.startRow + HEADER_BODY_SCAN_ROW_LIMIT);
+  for (let row = range.startRow + 1; row <= scanEndRow; row++) {
+    const bodyRow = await Promise.all(
+      Array.from({ length: width }, (_, i) => ws.getCell(row, range.startCol + i)),
+    );
+    if (rowHasDataSignal(bodyRow)) return true;
+  }
+
+  return false;
 }
 
 export async function resolveDataCommandTarget(
@@ -68,7 +78,7 @@ export async function resolveDataCommandTarget(
 ): Promise<DataCommandTarget | null> {
   return resolveDataTarget(ws, userRange, {
     allowEmptySingleCell: false,
-    inferHeadersForExplicitMultiRow: false,
+    inferHeadersForExplicitMultiRow: true,
   });
 }
 

--- a/apps/spreadsheet/src/actions/dispatcher.ts
+++ b/apps/spreadsheet/src/actions/dispatcher.ts
@@ -486,6 +486,7 @@ export const HANDLER_MAP: Record<ActionType, AnyActionHandler> = {
   // Insert/Delete cells with shift
   INSERT_CELLS: StructureHandlers.INSERT_CELLS,
   INSERT_CELLS_SHIFT_DOWN: StructureHandlers.INSERT_CELLS_SHIFT_DOWN,
+  INSERT_CUT_CELLS_SHIFT_DOWN: StructureHandlers.INSERT_CUT_CELLS_SHIFT_DOWN,
   DELETE_CELLS: StructureHandlers.DELETE_CELLS,
   HIDE_ROW: StructureHandlers.HIDE_ROW,
   UNHIDE_ROW: StructureHandlers.UNHIDE_ROW,

--- a/apps/spreadsheet/src/actions/handlers/__tests__/charts.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/charts.test.ts
@@ -185,6 +185,7 @@ function createMockDeps(overrides?: Partial<ActionDependencies>): ActionDependen
       getResolvedFormulaRanges: () => [],
       getActiveFormulaRange: () => null,
       getCommitType: () => null,
+      getEditStartSelectionRanges: () => null,
       isInactive: () => true,
       isEditing: () => false,
       isFormulaEditing: () => false,
@@ -1207,6 +1208,7 @@ describe('Chart Handlers - Context Menu Actions', () => {
  */
 function createDepsWithSelection(opts: {
   ranges: Array<{ startRow: number; startCol: number; endRow: number; endCol: number }>;
+  editStartRanges?: Array<{ startRow: number; startCol: number; endRow: number; endCol: number }>;
   expandedRegion?: { startRow: number; startCol: number; endRow: number; endCol: number };
   insertChartWizardOpenSpy?: jest.Mock;
 }): ActionDependencies {
@@ -1214,6 +1216,7 @@ function createDepsWithSelection(opts: {
 
   // Override selection.getDataBoundedRanges
   (deps.accessors.selection as any).getDataBoundedRanges = () => opts.ranges;
+  (deps.accessors.editor as any).getEditStartSelectionRanges = () => opts.editStartRanges ?? null;
 
   // Wire getCurrentRegion to return the configured expanded block (or echo input)
   const ws = (deps.workbook as any).activeSheet;
@@ -1284,6 +1287,22 @@ describe('Chart Handlers - Current-Region Auto-Expansion', () => {
       expect(addedConfig.dataRange).toBe('A1:D6');
     });
 
+    it('uses edit-start multi-cell selection when active selection collapsed during enter-mode', async () => {
+      const deps = createDepsWithSelection({
+        ranges: [{ startRow: 2, startCol: 12, endRow: 2, endCol: 12 }],
+        editStartRanges: [{ startRow: 2, startCol: 12, endRow: 20, endCol: 13 }],
+        expandedRegion: { startRow: 0, startCol: 11, endRow: 2, endCol: 13 },
+      });
+
+      const result = await ChartHandlers.CREATE_EMBEDDED_CHART(deps);
+      expect(result.handled).toBe(true);
+
+      const ws = (deps.workbook as any).activeSheet;
+      expect(ws.getCurrentRegion).not.toHaveBeenCalled();
+      const addedConfig = ws.charts.add.mock.calls[0][0];
+      expect(addedConfig.dataRange).toBe('M3:N21');
+    });
+
     it('expands single-row header selection (A1:D1) to the full data block', async () => {
       // A single-row selection treated as a header row should expand down to
       // the contiguous data region.
@@ -1350,6 +1369,20 @@ describe('Chart Handlers - Current-Region Auto-Expansion', () => {
       expect(openSpy).toHaveBeenCalledWith('A1:C5');
     });
 
+    it('opens wizard from edit-start multi-cell selection when active selection collapsed', async () => {
+      const openSpy = jest.fn();
+      const deps = createDepsWithSelection({
+        ranges: [{ startRow: 2, startCol: 12, endRow: 2, endCol: 12 }],
+        editStartRanges: [{ startRow: 2, startCol: 12, endRow: 20, endCol: 13 }],
+        expandedRegion: { startRow: 0, startCol: 11, endRow: 2, endCol: 13 },
+        insertChartWizardOpenSpy: openSpy,
+      });
+
+      const result = await ChartHandlers.OPEN_INSERT_CHART_WIZARD_DIALOG(deps);
+      expect(result.handled).toBe(true);
+      expect(openSpy).toHaveBeenCalledWith('M3:N21');
+    });
+
     it('opens wizard with empty initialDataRange when no selection', async () => {
       const openSpy = jest.fn();
       const deps = createDepsWithSelection({
@@ -1373,6 +1406,19 @@ describe('Chart Handlers - Current-Region Auto-Expansion', () => {
       const result = await ChartHandlers.OPEN_INSERT_CHART_WIZARD_DIALOG(deps);
       expect(result.handled).toBe(true);
       expect(openSpy).toHaveBeenCalledWith('A1:D10');
+    });
+
+    it('does not shrink a wider single-row chart selection to a narrower current region', async () => {
+      const openSpy = jest.fn();
+      const deps = createDepsWithSelection({
+        ranges: [{ startRow: 20, startCol: 11, endRow: 20, endCol: 27 }],
+        expandedRegion: { startRow: 20, startCol: 11, endRow: 20, endCol: 13 },
+        insertChartWizardOpenSpy: openSpy,
+      });
+
+      const result = await ChartHandlers.OPEN_INSERT_CHART_WIZARD_DIALOG(deps);
+      expect(result.handled).toBe(true);
+      expect(openSpy).toHaveBeenCalledWith('L21:AB21');
     });
   });
 });

--- a/apps/spreadsheet/src/actions/handlers/__tests__/object-picture.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/object-picture.test.ts
@@ -32,6 +32,7 @@ function createMockDeps(picture: PictureOverrides = {}): {
   comboBoxAdd: jest.Mock;
   setCell: jest.Mock;
   setFormat: jest.Mock;
+  getCell: jest.Mock;
   pictureUpdate: jest.Mock;
   canDoStructureOp: jest.Mock;
   uiState: {
@@ -46,6 +47,7 @@ function createMockDeps(picture: PictureOverrides = {}): {
   const textBoxAdd = jest.fn(async () => ({ id: 'textbox-new-1' }));
   const checkboxAdd = jest.fn(async () => ({ id: 'checkbox-new-1' }));
   const comboBoxAdd = jest.fn(async () => ({ id: 'combobox-new-1' }));
+  const getCell = jest.fn(async () => ({ value: null, displayText: null, formula: null }));
   const setCell = jest.fn(async () => undefined);
   const setFormat = jest.fn(async () => undefined);
   const pictureUpdate = jest.fn(async () => undefined);
@@ -82,6 +84,7 @@ function createMockDeps(picture: PictureOverrides = {}): {
       formats: {
         set: setFormat,
       },
+      getCell,
       setCell,
       protection: {
         canDoStructureOp,
@@ -133,6 +136,7 @@ function createMockDeps(picture: PictureOverrides = {}): {
     comboBoxAdd,
     setCell,
     setFormat,
+    getCell,
     pictureUpdate,
     canDoStructureOp,
     uiState,
@@ -226,7 +230,7 @@ describe('object picture handlers', () => {
 
   describe('form control insertion', () => {
     it('inserts a checkbox form control through the worksheet API', async () => {
-      const { deps, checkboxAdd, setCell, setFormat, canDoStructureOp } = createMockDeps();
+      const { deps, checkboxAdd, getCell, setCell, setFormat, canDoStructureOp } = createMockDeps();
 
       const result = await ObjectHandlers.INSERT_FORM_CONTROL_CHECKBOX(deps);
 
@@ -238,9 +242,31 @@ describe('object picture handlers', () => {
         width: 16,
         height: 16,
       });
+      expect(getCell).toHaveBeenCalledWith(0, 0);
       expect(setCell).toHaveBeenCalledWith(0, 0, false);
       expect(setFormat).toHaveBeenCalledWith(0, 0, { numberFormat: ';;;' });
       expect(canDoStructureOp).toHaveBeenCalledWith('editObject');
+    });
+
+    it('does not overwrite a populated cell when inserting a checkbox form control', async () => {
+      const { deps, checkboxAdd, getCell, setCell, setFormat } = createMockDeps();
+      getCell.mockResolvedValueOnce({
+        value: 34500,
+        displayText: '34,500 ',
+        formula: '',
+      });
+
+      const result = await ObjectHandlers.INSERT_FORM_CONTROL_CHECKBOX(deps);
+
+      expect(result.handled).toBe(true);
+      expect(checkboxAdd).toHaveBeenCalledWith({
+        anchor: { row: 0, col: 0 },
+        linkedCell: { row: 0, col: 0 },
+        width: 16,
+        height: 16,
+      });
+      expect(setCell).not.toHaveBeenCalled();
+      expect(setFormat).not.toHaveBeenCalled();
     });
 
     it('inserts a combo box form control through the worksheet API', async () => {

--- a/apps/spreadsheet/src/actions/handlers/__tests__/sort.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/sort.test.ts
@@ -7,7 +7,7 @@
  * selection to the contiguous data block before running Sort, and the sort
  * key is the *active cell's* column within the resolved range (clicking C3
  * in A1:D10 sorts by C, not A). Multi-row selections pass through unchanged
- * and never infer headers unless a dialog/user option says so.
+ * but still infer headers when the selected first row has a header signal.
  *
  */
 
@@ -206,7 +206,7 @@ describe('SORT_ASCENDING — current-region auto-expansion', () => {
     });
   });
 
-  test('explicit A2:A6 mixed data selection is headerless even when first item is text', async () => {
+  test('explicit A2:A6 mixed data selection preserves a detected header row', async () => {
     const setup = makeMockDeps({
       selectionRanges: [{ startRow: 1, startCol: 0, endRow: 5, endCol: 0 }],
       activeCell: { row: 1, col: 0 },
@@ -224,7 +224,7 @@ describe('SORT_ASCENDING — current-region auto-expansion', () => {
     expect(rangeArg).toEqual({ startRow: 1, startCol: 0, endRow: 5, endCol: 0 });
     expect(optionsArg).toEqual({
       columns: [{ column: 0, direction: 'asc' }],
-      hasHeaders: false,
+      hasHeaders: true,
     });
   });
 

--- a/apps/spreadsheet/src/actions/handlers/__tests__/structure-autofit.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/structure-autofit.test.ts
@@ -11,6 +11,7 @@ import {
 const autoFitRows = jest.fn(async () => undefined);
 const autoFitColumns = jest.fn(async () => undefined);
 const getTextMeasurementService = jest.fn(() => ({ measure: jest.fn() }));
+const pasteHandler = jest.fn(async () => ({ handled: true }));
 
 jest.unstable_mockModule('../../../systems/grid-editing/features/autofit', () => ({
   autoFitRows,
@@ -19,6 +20,10 @@ jest.unstable_mockModule('../../../systems/grid-editing/features/autofit', () =>
 
 jest.unstable_mockModule('@mog/grid-renderer', () => ({
   getTextMeasurementService,
+}));
+
+jest.unstable_mockModule('../clipboard-paste', () => ({
+  PASTE: pasteHandler,
 }));
 
 const StructureHandlers = await import('../structure');
@@ -62,6 +67,7 @@ function createDeps(
   const workbook = {
     getSheetById: jest.fn(() => worksheet),
     activeSheet: worksheet,
+    batch: jest.fn(async (_label: string, fn: (wb: unknown) => Promise<unknown>) => fn(workbook)),
   };
 
   return {
@@ -71,6 +77,11 @@ function createDeps(
       selection: {
         getActiveCell: jest.fn(() => options.activeCell ?? { row: 4, col: 3 }),
         getRanges: jest.fn(() => options.ranges ?? []),
+      },
+      clipboard: {
+        hasCut: jest.fn(() => true),
+        getIsCut: jest.fn(() => true),
+        isExternalClipboard: jest.fn(() => false),
       },
     },
     commands: {
@@ -94,6 +105,7 @@ describe('Structure autofit handlers', () => {
     autoFitRows.mockClear();
     autoFitColumns.mockClear();
     getTextMeasurementService.mockClear();
+    pasteHandler.mockClear();
   });
 
   it('AUTO_FIT_COLUMN_WIDTH targets the active column when no selection ranges are available', async () => {
@@ -186,6 +198,30 @@ describe('Structure autofit handlers', () => {
 
     const worksheet = deps.workbook.activeSheet as any;
     expect(worksheet.structure.insertCellsWithShift).toHaveBeenCalledWith(4, 3, 4, 3, 'down');
+  });
+
+  it('INSERT_CUT_CELLS_SHIFT_DOWN inserts the active-cell slot and awaits paste', async () => {
+    const deps = createDeps({ activeCell: { row: 4, col: 3 }, ranges: [] });
+
+    const result = await StructureHandlers.INSERT_CUT_CELLS_SHIFT_DOWN(deps);
+
+    const worksheet = deps.workbook.activeSheet as any;
+    expect(result.handled).toBe(true);
+    expect(deps.workbook.batch).toHaveBeenCalledWith('Insert Cut Cells', expect.any(Function));
+    expect(worksheet.structure.insertCellsWithShift).toHaveBeenCalledWith(4, 3, 4, 3, 'down');
+    expect(pasteHandler).toHaveBeenCalledWith(deps);
+  });
+
+  it('INSERT_CUT_CELLS_SHIFT_DOWN is disabled without an active cut clipboard', async () => {
+    const deps = createDeps({ activeCell: { row: 4, col: 3 }, ranges: [] });
+    (deps.accessors.clipboard.hasCut as jest.Mock).mockReturnValue(false);
+
+    const result = await StructureHandlers.INSERT_CUT_CELLS_SHIFT_DOWN(deps);
+
+    const worksheet = deps.workbook.activeSheet as any;
+    expect(result.handled).toBe(false);
+    expect(worksheet.structure.insertCellsWithShift).not.toHaveBeenCalled();
+    expect(pasteHandler).not.toHaveBeenCalled();
   });
 
   it('visibility and explicit sizing actions target the active row or column when ranges are empty', async () => {

--- a/apps/spreadsheet/src/actions/handlers/__tests__/workbook-grouping.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/workbook-grouping.test.ts
@@ -16,15 +16,29 @@ interface MockSetup {
     getState: jest.Mock;
     getSettings: jest.Mock;
   };
+  layout: {
+    hideRows: jest.Mock;
+    hideColumns: jest.Mock;
+    unhideRows: jest.Mock;
+    unhideColumns: jest.Mock;
+  };
   workbook: {
     setPendingUndoDescription: jest.Mock;
   };
+}
+
+interface MockSelectionOptions {
+  activeCell?: { row: number; col: number };
+  anchor?: { row: number; col: number } | null;
+  anchorCol?: number | null;
+  anchorRow?: number | null;
 }
 
 function createMockDeps(
   ranges: CellRange[],
   outlineState = { rowGroups: [], columnGroups: [] },
   outlineSettings = { summaryRowsBelow: true, summaryColumnsRight: true },
+  selectionOptions: MockSelectionOptions = {},
 ): MockSetup {
   const activeSheetId = sheetId('sheet1');
   const outline = {
@@ -36,7 +50,13 @@ function createMockDeps(
     getState: jest.fn().mockResolvedValue(outlineState),
     getSettings: jest.fn().mockResolvedValue(outlineSettings),
   };
-  const worksheet = { outline };
+  const layout = {
+    hideRows: jest.fn().mockResolvedValue(undefined),
+    hideColumns: jest.fn().mockResolvedValue(undefined),
+    unhideRows: jest.fn().mockResolvedValue(undefined),
+    unhideColumns: jest.fn().mockResolvedValue(undefined),
+  };
+  const worksheet = { outline, layout };
   const workbook = {
     getActiveSheetId: jest.fn().mockReturnValue(activeSheetId),
     getSheetById: jest.fn().mockReturnValue(worksheet),
@@ -48,11 +68,15 @@ function createMockDeps(
     accessors: {
       selection: {
         getRanges: jest.fn().mockReturnValue(ranges),
+        getActiveCell: jest.fn().mockReturnValue(selectionOptions.activeCell ?? { row: 0, col: 0 }),
+        getAnchor: jest.fn().mockReturnValue(selectionOptions.anchor ?? null),
+        getAnchorCol: jest.fn().mockReturnValue(selectionOptions.anchorCol ?? null),
+        getAnchorRow: jest.fn().mockReturnValue(selectionOptions.anchorRow ?? null),
       },
     },
   } as unknown as ActionDependencies;
 
-  return { deps, outline, workbook };
+  return { deps, outline, layout, workbook };
 }
 
 function fullColumnRange(startCol: number, endCol: number): CellRange {
@@ -117,6 +141,38 @@ describe('Workbook GROUP/UNGROUP axis inference', () => {
     expect(workbook.setPendingUndoDescription).toHaveBeenCalledWith('Ungroup rows 2-4');
   });
 
+  it('ungroups the containing row group for a single full-row selection', async () => {
+    const { deps, outline, workbook } = createMockDeps([fullRowRange(3, 3)], {
+      rowGroups: [{ id: 'rows-2-4', start: 1, end: 3, level: 1, collapsed: false }],
+      columnGroups: [],
+    });
+
+    const result = await UNGROUP(deps);
+
+    expect(result.handled).toBe(true);
+    expect(outline.getState).toHaveBeenCalledTimes(1);
+    expect(outline.ungroupRows).toHaveBeenCalledTimes(1);
+    expect(outline.ungroupRows).toHaveBeenCalledWith(1, 3);
+    expect(outline.ungroupColumns).not.toHaveBeenCalled();
+    expect(workbook.setPendingUndoDescription).toHaveBeenCalledWith('Ungroup rows 2-4');
+  });
+
+  it('ungroups the containing column group for a single full-column selection', async () => {
+    const { deps, outline, workbook } = createMockDeps([fullColumnRange(4, 4)], {
+      rowGroups: [],
+      columnGroups: [{ id: 'cols-3-5', start: 2, end: 4, level: 1, collapsed: false }],
+    });
+
+    const result = await UNGROUP(deps);
+
+    expect(result.handled).toBe(true);
+    expect(outline.getState).toHaveBeenCalledTimes(1);
+    expect(outline.ungroupColumns).toHaveBeenCalledTimes(1);
+    expect(outline.ungroupColumns).toHaveBeenCalledWith(2, 4);
+    expect(outline.ungroupRows).not.toHaveBeenCalled();
+    expect(workbook.setPendingUndoDescription).toHaveBeenCalledWith('Ungroup columns 3-5');
+  });
+
   it('routes full-row selections to row grouping', async () => {
     const { deps, outline, workbook } = createMockDeps([fullRowRange(3, 5)]);
 
@@ -127,6 +183,41 @@ describe('Workbook GROUP/UNGROUP axis inference', () => {
     expect(outline.groupRows).toHaveBeenCalledWith(3, 5);
     expect(outline.groupColumns).not.toHaveBeenCalled();
     expect(workbook.setPendingUndoDescription).toHaveBeenCalledWith('Group rows 4-6');
+  });
+
+  it('recovers a collapsed full-row GROUP selection from the preserved anchor', async () => {
+    const { deps, outline, workbook } = createMockDeps(
+      [fullRowRange(5, 5)],
+      { rowGroups: [], columnGroups: [] },
+      { summaryRowsBelow: true, summaryColumnsRight: true },
+      { activeCell: { row: 5, col: 0 }, anchor: { row: 3, col: 0 } },
+    );
+
+    const result = await GROUP(deps);
+
+    expect(result.handled).toBe(true);
+    expect(outline.groupRows).toHaveBeenCalledTimes(1);
+    expect(outline.groupRows).toHaveBeenCalledWith(3, 5);
+    expect(workbook.setPendingUndoDescription).toHaveBeenCalledWith('Group rows 4-6');
+  });
+
+  it('recovers a collapsed full-row UNGROUP selection from the preserved anchor', async () => {
+    const { deps, outline, workbook } = createMockDeps(
+      [fullRowRange(5, 5)],
+      {
+        rowGroups: [{ id: 'rows-4-6', start: 3, end: 5, level: 1, collapsed: false }],
+        columnGroups: [],
+      },
+      { summaryRowsBelow: true, summaryColumnsRight: true },
+      { activeCell: { row: 5, col: 0 }, anchor: { row: 3, col: 0 } },
+    );
+
+    const result = await UNGROUP(deps);
+
+    expect(result.handled).toBe(true);
+    expect(outline.ungroupRows).toHaveBeenCalledTimes(1);
+    expect(outline.ungroupRows).toHaveBeenCalledWith(3, 5);
+    expect(workbook.setPendingUndoDescription).toHaveBeenCalledWith('Ungroup rows 4-6');
   });
 
   it('keeps ordinary 2D selections on the existing row-first route', async () => {
@@ -229,6 +320,119 @@ describe('Workbook SHOW_DETAIL/HIDE_DETAIL summary selections', () => {
     expect(outline.toggleCollapsed).toHaveBeenCalledWith('cols-b-d');
   });
 
+  it('expands a collapsed column group from the visible leading outline context', async () => {
+    const range: CellRange = { startRow: 20, startCol: 13, endRow: 20, endCol: 13 };
+    const { deps, outline } = createMockDeps([range], {
+      rowGroups: [],
+      columnGroups: [
+        { id: 'cols-l', start: 11, end: 11, level: 1, collapsed: false },
+        { id: 'cols-p-aa', start: 15, end: 26, level: 1, collapsed: true },
+      ],
+    });
+
+    const result = await SHOW_DETAIL(deps);
+
+    expect(result.handled).toBe(true);
+    expect(outline.toggleCollapsed).toHaveBeenCalledTimes(1);
+    expect(outline.toggleCollapsed).toHaveBeenCalledWith('cols-p-aa');
+  });
+
+  it('expands an imported collapsed-on-member column group from the adjacent column on the left', async () => {
+    const range: CellRange = { startRow: 12, startCol: 14, endRow: 12, endCol: 14 };
+    const { deps, outline } = createMockDeps([range], {
+      rowGroups: [],
+      columnGroups: [
+        {
+          id: 'kewpie-fiscal-cols',
+          start: 15,
+          end: 26,
+          level: 1,
+          collapsed: true,
+          collapsedOnMember: true,
+        },
+      ],
+    });
+
+    const result = await SHOW_DETAIL(deps);
+
+    expect(result.handled).toBe(true);
+    expect(outline.toggleCollapsed).toHaveBeenCalledTimes(1);
+    expect(outline.toggleCollapsed).toHaveBeenCalledWith('kewpie-fiscal-cols');
+  });
+
+  it('expands an imported hidden column group from the adjacent column on the left', async () => {
+    const range: CellRange = { startRow: 12, startCol: 14, endRow: 12, endCol: 14 };
+    const { deps, outline, layout } = createMockDeps([range], {
+      rowGroups: [],
+      columnGroups: [
+        {
+          id: 'kewpie-fiscal-cols',
+          start: 15,
+          end: 26,
+          level: 1,
+          collapsed: true,
+          hidden: true,
+        },
+      ],
+    });
+
+    const result = await SHOW_DETAIL(deps);
+
+    expect(result.handled).toBe(true);
+    expect(outline.toggleCollapsed).toHaveBeenCalledTimes(1);
+    expect(outline.toggleCollapsed).toHaveBeenCalledWith('kewpie-fiscal-cols');
+    expect(layout.unhideColumns).toHaveBeenCalledTimes(1);
+    expect(layout.unhideColumns).toHaveBeenCalledWith(15, 26);
+  });
+
+  it('expands a collapsed column group when the selection overlaps hidden detail columns', async () => {
+    const range: CellRange = { startRow: 2, startCol: 11, endRow: 20, endCol: 27 };
+    const { deps, outline } = createMockDeps([range], {
+      rowGroups: [],
+      columnGroups: [{ id: 'cols-p-aa', start: 15, end: 26, level: 1, collapsed: true }],
+    });
+
+    const result = await SHOW_DETAIL(deps);
+
+    expect(result.handled).toBe(true);
+    expect(outline.toggleCollapsed).toHaveBeenCalledTimes(1);
+    expect(outline.toggleCollapsed).toHaveBeenCalledWith('cols-p-aa');
+  });
+
+  it('does not expand an ordinary collapsed column group from the opposite summary edge', async () => {
+    const range: CellRange = { startRow: 12, startCol: 14, endRow: 12, endCol: 14 };
+    const { deps, outline } = createMockDeps([range], {
+      rowGroups: [],
+      columnGroups: [
+        {
+          id: 'ordinary-fiscal-cols',
+          start: 15,
+          end: 26,
+          level: 1,
+          collapsed: true,
+        },
+      ],
+    });
+
+    const result = await SHOW_DETAIL(deps);
+
+    expect(result.handled).toBe(false);
+    expect(outline.toggleCollapsed).not.toHaveBeenCalled();
+  });
+
+  it('does not expand a distant collapsed column group without an outline context', async () => {
+    const range: CellRange = { startRow: 0, startCol: 2, endRow: 0, endCol: 2 };
+    const { deps, outline } = createMockDeps([range], {
+      rowGroups: [],
+      columnGroups: [{ id: 'cols-p-aa', start: 15, end: 26, level: 1, collapsed: true }],
+    });
+
+    const result = await SHOW_DETAIL(deps);
+
+    expect(result.handled).toBe(false);
+    expect(outline.toggleCollapsed).not.toHaveBeenCalled();
+  });
+
   it('collapses the innermost expanded row group from its adjacent summary row', async () => {
     const range: CellRange = { startRow: 4, startCol: 0, endRow: 4, endCol: 0 };
     const { deps, outline } = createMockDeps([range], {
@@ -244,5 +448,71 @@ describe('Workbook SHOW_DETAIL/HIDE_DETAIL summary selections', () => {
     expect(result.handled).toBe(true);
     expect(outline.toggleCollapsed).toHaveBeenCalledTimes(1);
     expect(outline.toggleCollapsed).toHaveBeenCalledWith('inner');
+  });
+
+  it('collapses an expanded column group from the visible leading outline context', async () => {
+    const range: CellRange = { startRow: 12, startCol: 14, endRow: 12, endCol: 14 };
+    const { deps, outline } = createMockDeps([range], {
+      rowGroups: [],
+      columnGroups: [
+        { id: 'cols-l', start: 11, end: 11, level: 1, collapsed: false },
+        { id: 'cols-p-aa', start: 15, end: 26, level: 1, collapsed: false },
+      ],
+    });
+
+    const result = await HIDE_DETAIL(deps);
+
+    expect(result.handled).toBe(true);
+    expect(outline.toggleCollapsed).toHaveBeenCalledTimes(1);
+    expect(outline.toggleCollapsed).toHaveBeenCalledWith('cols-p-aa');
+  });
+
+  it('collapses an imported expanded column group from the adjacent column on the left', async () => {
+    const range: CellRange = { startRow: 12, startCol: 14, endRow: 12, endCol: 14 };
+    const { deps, outline } = createMockDeps([range], {
+      rowGroups: [],
+      columnGroups: [
+        {
+          id: 'kewpie-fiscal-cols',
+          start: 15,
+          end: 26,
+          level: 1,
+          collapsed: false,
+          collapsedOnMember: true,
+        },
+      ],
+    });
+
+    const result = await HIDE_DETAIL(deps);
+
+    expect(result.handled).toBe(true);
+    expect(outline.toggleCollapsed).toHaveBeenCalledTimes(1);
+    expect(outline.toggleCollapsed).toHaveBeenCalledWith('kewpie-fiscal-cols');
+  });
+
+  it('collapses an imported hidden column group from the adjacent column on the left', async () => {
+    const range: CellRange = { startRow: 12, startCol: 14, endRow: 12, endCol: 14 };
+    const { deps, outline, layout } = createMockDeps([range], {
+      rowGroups: [],
+      columnGroups: [
+        {
+          id: 'kewpie-fiscal-cols',
+          start: 15,
+          end: 26,
+          level: 1,
+          collapsed: false,
+          hidden: true,
+        },
+      ],
+    });
+
+    const result = await HIDE_DETAIL(deps);
+
+    expect(result.handled).toBe(true);
+    expect(outline.toggleCollapsed).not.toHaveBeenCalled();
+    expect(layout.hideColumns).toHaveBeenCalledTimes(1);
+    expect(layout.hideColumns).toHaveBeenCalledWith([
+      15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+    ]);
   });
 });

--- a/apps/spreadsheet/src/actions/handlers/charts.ts
+++ b/apps/spreadsheet/src/actions/handlers/charts.ts
@@ -54,6 +54,13 @@ interface ChartPosition {
   anchorCol: number;
 }
 
+type ChartSourceRange = {
+  startRow: number;
+  startCol: number;
+  endRow: number;
+  endCol: number;
+};
+
 /**
  * Type guard to check if coordinator exposes renderer capabilities.
  */
@@ -84,6 +91,19 @@ function getChartIdFromPayloadOrSelectedObject(
   return payload?.chartId ?? deps.accessors.object.getFirstSelectedId();
 }
 
+function isMultiCellRange(range: ChartSourceRange): boolean {
+  return range.startRow !== range.endRow || range.startCol !== range.endCol;
+}
+
+function getChartSourceRanges(deps: ActionDependencies, sheetId: SheetId): ChartSourceRange[] {
+  const editStartRanges = deps.accessors.editor.getEditStartSelectionRanges?.();
+  if (editStartRanges?.some(isMultiCellRange)) {
+    return editStartRanges;
+  }
+
+  return deps.accessors.selection.getDataBoundedRanges(sheetId);
+}
+
 /**
  * Get smart chart position that ensures visibility.
  *
@@ -95,7 +115,7 @@ function getChartIdFromPayloadOrSelectedObject(
  */
 async function getSmartChartPosition(
   deps: ActionDependencies,
-  sourceRange: { startRow: number; startCol: number; endRow: number; endCol: number } | null,
+  sourceRange: ChartSourceRange | null,
   defaultPosition: ChartPosition,
   _sheetId: SheetId,
 ): Promise<ChartPosition> {
@@ -813,7 +833,7 @@ export const CREATE_CHART_SHEET: AsyncActionHandler = async (deps): Promise<Acti
   const ws = deps.workbook.activeSheet;
 
   // Get selection for data range (bounded to actual data extent)
-  const ranges = deps.accessors.selection.getDataBoundedRanges(sheetId);
+  const ranges = getChartSourceRanges(deps, sheetId);
 
   // Create a new sheet for the chart via unified Workbook API
   let newWs;
@@ -870,7 +890,7 @@ export const CREATE_EMBEDDED_CHART: AsyncActionHandler = async (
   const ws = deps.workbook.activeSheet;
 
   // Get selection for data range (bounded to actual data extent)
-  const ranges = deps.accessors.selection.getDataBoundedRanges(sheetId);
+  const ranges = getChartSourceRanges(deps, sheetId);
 
   // Default chart configuration
   const chartType = payload?.type || 'column';
@@ -986,7 +1006,7 @@ export const OPEN_INSERT_CHART_WIZARD_DIALOG: AsyncActionHandler = async (
 
   // Try to get the current selection to pre-populate the data range (bounded to actual data extent)
   let initialDataRange = '';
-  const ranges = deps.accessors.selection.getDataBoundedRanges(sheetId);
+  const ranges = getChartSourceRanges(deps, sheetId);
   if (ranges && ranges.length > 0) {
     // Excel parity: expand single-cell / single-row selections to the
     // surrounding data region before seeding the wizard.
@@ -1040,7 +1060,7 @@ export const INSERT_CHART_FROM_WIZARD: AsyncActionHandler = async (deps): Promis
   const ws = deps.workbook.activeSheet;
 
   // Get current selection for chart placement (bounded to actual data extent)
-  const ranges = deps.accessors.selection.getDataBoundedRanges(sheetId);
+  const ranges = getChartSourceRanges(deps, sheetId);
 
   // Default position when no selection
   const DEFAULT_POSITION = { anchorRow: 2, anchorCol: 2 };

--- a/apps/spreadsheet/src/actions/handlers/expand-to-data-region.ts
+++ b/apps/spreadsheet/src/actions/handlers/expand-to-data-region.ts
@@ -8,7 +8,8 @@
  *
  * Behavior (matches Excel):
  * - Single cell → expand via `ws.getCurrentRegion`
- * - Single row → expand via `ws.getCurrentRegion` (treated as header row)
+ * - Single row → expand via `ws.getCurrentRegion` (treated as header row),
+ *   preserving any explicit rows/columns the user already selected
  * - Multi-row range → return as-is (user explicitly chose the range)
  * - Empty cell (no adjacent data) → return `null`
  *
@@ -37,5 +38,10 @@ export async function expandToDataRegion(
   if (expanded.startRow === expanded.endRow && expanded.startCol === expanded.endCol) {
     return null;
   }
-  return expanded;
+  return {
+    startRow: Math.min(expanded.startRow, range.startRow),
+    startCol: Math.min(expanded.startCol, range.startCol),
+    endRow: Math.max(expanded.endRow, range.endRow),
+    endCol: Math.max(expanded.endCol, range.endCol),
+  };
 }

--- a/apps/spreadsheet/src/actions/handlers/object.ts
+++ b/apps/spreadsheet/src/actions/handlers/object.ts
@@ -170,6 +170,25 @@ function getSelectedCellPosition(deps: ActionDependencies): { row: number; col: 
   return { row: 0, col: 0 };
 }
 
+function isBlankCellForCheckboxInitialization(cell: unknown): boolean {
+  if (cell == null) return true;
+  if (typeof cell !== 'object') return false;
+
+  const data = cell as {
+    value?: unknown;
+    formula?: unknown;
+    displayText?: unknown;
+  };
+
+  const hasValue = data.value !== undefined && data.value !== null && data.value !== '';
+  const hasFormula =
+    typeof data.formula === 'string' ? data.formula.length > 0 : data.formula != null;
+  const hasDisplayText =
+    typeof data.displayText === 'string' ? data.displayText.length > 0 : data.displayText != null;
+
+  return !hasValue && !hasFormula && !hasDisplayText;
+}
+
 // =============================================================================
 // Object Deletion/Selection Actions
 // These actions route to chart actor when a chart is selected.
@@ -849,10 +868,14 @@ export const INSERT_FORM_CONTROL_CHECKBOX: AsyncActionHandler = async (
       width: DEFAULT_CHECKBOX_WIDTH,
       height: DEFAULT_CHECKBOX_HEIGHT,
     });
-    await ws.setCell(position.row, position.col, false);
-    await ws.formats.set(position.row, position.col, {
-      numberFormat: CHECKBOX_LINKED_CELL_HIDDEN_FORMAT,
-    });
+
+    const targetCell = await ws.getCell(position.row, position.col);
+    if (isBlankCellForCheckboxInitialization(targetCell)) {
+      await ws.setCell(position.row, position.col, false);
+      await ws.formats.set(position.row, position.col, {
+        numberFormat: CHECKBOX_LINKED_CELL_HIDDEN_FORMAT,
+      });
+    }
     return handled();
   } catch (err) {
     if (isProtectionRejection(err)) {

--- a/apps/spreadsheet/src/actions/handlers/structure.ts
+++ b/apps/spreadsheet/src/actions/handlers/structure.ts
@@ -50,6 +50,7 @@ import {
   getAutofitColumnsForSelection,
   getAutofitRowsForSelection,
 } from '../../systems/grid-editing/features/autofit/selection-targets';
+import { PASTE } from './clipboard-paste';
 
 // =============================================================================
 // Type Helpers
@@ -657,6 +658,45 @@ export const INSERT_CELLS_SHIFT_DOWN: AsyncActionHandler = async (deps) => {
       range.endCol,
       'down',
     ),
+  );
+};
+
+/**
+ * Insert cells for an active cut range, then paste the cut data into the
+ * inserted destination. Mirrors Excel's Home > Insert > Insert Cut Cells route.
+ */
+export const INSERT_CUT_CELLS_SHIFT_DOWN: AsyncActionHandler = async (deps) => {
+  const clipboard = deps.accessors.clipboard;
+  if (!clipboard.hasCut() || !clipboard.getIsCut() || clipboard.isExternalClipboard()) {
+    return notHandled('disabled');
+  }
+
+  const { activeCell, ranges } = getSelectionContext(deps);
+  const range = getRangesOrActiveCell(ranges, activeCell)[0];
+
+  return withProtectionFeedback(deps, () =>
+    deps.workbook.batch('Insert Cut Cells', async () => {
+      const ws = deps.workbook.activeSheet;
+
+      if (range.isFullRow) {
+        await INSERT_ROW_ABOVE(deps);
+      } else if (range.isFullColumn) {
+        await INSERT_COLUMN_LEFT(deps);
+      } else {
+        await ws.structure.insertCellsWithShift(
+          range.startRow,
+          range.startCol,
+          range.endRow,
+          range.endCol,
+          'down',
+        );
+      }
+
+      const pasteResult = await PASTE(deps);
+      if (!pasteResult.handled) {
+        throw new Error(pasteResult.error ?? pasteResult.reason ?? 'Insert Cut Cells paste failed');
+      }
+    }),
   );
 };
 

--- a/apps/spreadsheet/src/actions/handlers/workbook.ts
+++ b/apps/spreadsheet/src/actions/handlers/workbook.ts
@@ -20,7 +20,12 @@
  *
  */
 
-import type { ActionHandler, ActionResult, AsyncActionHandler } from '@mog-sdk/contracts/actions';
+import type {
+  ActionDependencies,
+  ActionHandler,
+  ActionResult,
+  AsyncActionHandler,
+} from '@mog-sdk/contracts/actions';
 import { MAX_COLS, MAX_ROWS, type CellRange, type SheetId } from '@mog-sdk/contracts/core';
 
 import { handled, notHandled } from './handler-utils';
@@ -37,6 +42,14 @@ interface SelectionBounds {
 }
 
 type GroupingAxis = 'rows' | 'columns';
+
+interface GroupingSelectionSnapshot {
+  ranges: readonly CellRange[];
+  activeCell: { row: number; col: number };
+  anchor: { row: number; col: number } | null;
+  anchorCol: number | null;
+  anchorRow: number | null;
+}
 
 /**
  * Compute bounding box of all selected ranges. Mirrors
@@ -120,6 +133,64 @@ function inferSpanAxis(bounds: SelectionBounds): GroupingAxis | null {
   return null;
 }
 
+function isSingleFullRowRange(range: CellRange): boolean {
+  return range.startRow === range.endRow && hasFullRowIntent(range);
+}
+
+function isSingleFullColumnRange(range: CellRange): boolean {
+  return range.startCol === range.endCol && hasFullColumnIntent(range);
+}
+
+function getGroupingCommandRanges(snapshot: GroupingSelectionSnapshot): readonly CellRange[] {
+  if (snapshot.ranges.length !== 1) return snapshot.ranges;
+
+  const range = snapshot.ranges[0];
+  if (isSingleFullRowRange(range)) {
+    const anchorRow = snapshot.anchorRow ?? snapshot.anchor?.row ?? null;
+    if (anchorRow !== null && anchorRow !== range.startRow) {
+      return [
+        {
+          ...range,
+          startRow: Math.min(anchorRow, snapshot.activeCell.row, range.startRow, range.endRow),
+          endRow: Math.max(anchorRow, snapshot.activeCell.row, range.startRow, range.endRow),
+          startCol: 0,
+          endCol: MAX_COLS - 1,
+          isFullRow: true,
+        },
+      ];
+    }
+  }
+
+  if (isSingleFullColumnRange(range)) {
+    const anchorCol = snapshot.anchorCol ?? snapshot.anchor?.col ?? null;
+    if (anchorCol !== null && anchorCol !== range.startCol) {
+      return [
+        {
+          ...range,
+          startRow: 0,
+          endRow: MAX_ROWS - 1,
+          startCol: Math.min(anchorCol, snapshot.activeCell.col, range.startCol, range.endCol),
+          endCol: Math.max(anchorCol, snapshot.activeCell.col, range.startCol, range.endCol),
+          isFullColumn: true,
+        },
+      ];
+    }
+  }
+
+  return snapshot.ranges;
+}
+
+function getGroupingCommandRangesFromDeps(deps: ActionDependencies): readonly CellRange[] {
+  const selection = deps.accessors.selection;
+  return getGroupingCommandRanges({
+    ranges: selection.getRanges(),
+    activeCell: selection.getActiveCell(),
+    anchor: selection.getAnchor(),
+    anchorCol: selection.getAnchorCol(),
+    anchorRow: selection.getAnchorRow(),
+  });
+}
+
 function findInnermostContainingGroup(
   groups: GroupRecord[],
   start: number,
@@ -162,28 +233,70 @@ function summaryIndex(group: GroupRecord, summaryAfter: boolean): number | null 
   return index >= 0 ? index : null;
 }
 
+function selectionContainsIndex(start: number, end: number, index: number): boolean {
+  return start <= index && end >= index;
+}
+
 function selectionMatchesRowGroupForDetail(
   group: GroupRecord,
   bounds: SelectionBounds,
   settings: OutlineSummarySettings,
+  groups: readonly GroupRecord[] = [group],
 ): boolean {
-  if (group.start <= bounds.startRow && group.end >= bounds.endRow) {
+  if (rangesOverlap(group.start, group.end, bounds.startRow, bounds.endRow)) {
     return true;
   }
   const summary = summaryIndex(group, settings.summaryRowsBelow);
-  return summary !== null && bounds.startRow === summary && bounds.endRow === summary;
+  if (summary !== null && bounds.startRow <= summary && bounds.endRow >= summary) {
+    return true;
+  }
+  const importedMemberSummary = isImportedHiddenGroup(group)
+    ? summaryIndex(group, !settings.summaryRowsBelow)
+    : null;
+  if (
+    importedMemberSummary !== null &&
+    selectionContainsIndex(bounds.startRow, bounds.endRow, importedMemberSummary)
+  ) {
+    return true;
+  }
+  return selectionMatchesAdjacentOutlineContext(
+    group,
+    groups,
+    bounds.startRow,
+    bounds.endRow,
+    settings.summaryRowsBelow,
+  );
 }
 
 function selectionMatchesColumnGroupForDetail(
   group: GroupRecord,
   bounds: SelectionBounds,
   settings: OutlineSummarySettings,
+  groups: readonly GroupRecord[] = [group],
 ): boolean {
-  if (group.start <= bounds.startCol && group.end >= bounds.endCol) {
+  if (rangesOverlap(group.start, group.end, bounds.startCol, bounds.endCol)) {
     return true;
   }
   const summary = summaryIndex(group, settings.summaryColumnsRight);
-  return summary !== null && bounds.startCol === summary && bounds.endCol === summary;
+  if (summary !== null && bounds.startCol <= summary && bounds.endCol >= summary) {
+    return true;
+  }
+  const importedMemberSummary = isImportedHiddenGroup(group)
+    ? summaryIndex(group, !settings.summaryColumnsRight)
+    : null;
+  if (
+    importedMemberSummary !== null &&
+    selectionContainsIndex(bounds.startCol, bounds.endCol, importedMemberSummary)
+  ) {
+    return true;
+  }
+  return selectionMatchesAdjacentOutlineContext(
+    group,
+    groups,
+    bounds.startCol,
+    bounds.endCol,
+    settings.summaryColumnsRight,
+  );
 }
 
 /** Minimal shape of `GroupDefinition` used by the show/hide detail iterators. */
@@ -193,6 +306,76 @@ interface GroupRecord {
   end: number;
   level: number;
   collapsed: boolean;
+  hidden?: boolean;
+  collapsedOnMember?: boolean;
+}
+
+function rangesOverlap(
+  leftStart: number,
+  leftEnd: number,
+  rightStart: number,
+  rightEnd: number,
+): boolean {
+  return leftStart <= rightEnd && rightStart <= leftEnd;
+}
+
+function selectionMatchesAdjacentOutlineContext(
+  group: GroupRecord,
+  groups: readonly GroupRecord[],
+  selectionStart: number,
+  selectionEnd: number,
+  summaryAfter: boolean,
+): boolean {
+  const sameLevelGroups = groups
+    .filter((candidate) => candidate.level === group.level)
+    .sort((a, b) => a.start - b.start || a.end - b.end);
+  const groupIndex = sameLevelGroups.findIndex((candidate) => candidate.id === group.id);
+  if (groupIndex === -1) return false;
+
+  if (summaryAfter) {
+    const previous = sameLevelGroups[groupIndex - 1];
+    if (!previous) return false;
+    return selectionStart >= previous.end + 1 && selectionEnd < group.start;
+  }
+
+  const next = sameLevelGroups[groupIndex + 1];
+  if (!next) return false;
+  return selectionStart > group.end && selectionEnd <= next.start - 1;
+}
+
+function isImportedHiddenGroup(group: GroupRecord): boolean {
+  return group.collapsedOnMember === true || group.hidden === true;
+}
+
+function detailIndexes(group: GroupRecord): number[] {
+  return Array.from(
+    { length: group.end - group.start + 1 },
+    (_value, index) => group.start + index,
+  );
+}
+
+async function setImportedDetailVisibility(
+  ws: import('@mog-sdk/contracts/api').WorksheetWithInternals,
+  group: GroupRecord,
+  axis: GroupingAxis,
+  visible: boolean,
+): Promise<void> {
+  if (group.hidden !== true) return;
+
+  if (axis === 'rows') {
+    if (visible) {
+      await ws.layout.unhideRows(group.start, group.end);
+    } else {
+      await ws.layout.hideRows(detailIndexes(group));
+    }
+    return;
+  }
+
+  if (visible) {
+    await ws.layout.unhideColumns(group.start, group.end);
+  } else {
+    await ws.layout.hideColumns(detailIndexes(group));
+  }
 }
 
 // =============================================================================
@@ -276,10 +459,9 @@ export const DELETE_SHEET: AsyncActionHandler = async (deps) => {
 // Grouping Actions
 //
 // Ported from apps/spreadsheet/src/hooks/data/use-grouping-actions.ts:269-443.
-// Selection bounds come from `deps.accessors.selection.getRanges()` (the
-// same selection accessor every other handler uses), NOT
-// `coordinator.grid.getSelectionSnapshot`; keeping `coordinator?: unknown`
-// untouched preserves the current handler contract.
+// Selection bounds come from actor accessors at action time. Header selections
+// can visually collapse while focus moves through ribbon popovers, so grouping
+// commands recover row/column spans from the preserved selection anchor.
 // =============================================================================
 
 /**
@@ -290,7 +472,7 @@ export const DELETE_SHEET: AsyncActionHandler = async (deps) => {
  */
 export const GROUP: AsyncActionHandler = async (deps) => {
   const { workbook: wb } = deps;
-  const ranges = deps.accessors.selection.getRanges();
+  const ranges = getGroupingCommandRangesFromDeps(deps);
   const bounds = computeSelectionBounds(ranges);
   if (!bounds) return notHandled('disabled');
 
@@ -319,7 +501,7 @@ export const GROUP: AsyncActionHandler = async (deps) => {
  */
 export const UNGROUP: AsyncActionHandler = async (deps) => {
   const { workbook: wb } = deps;
-  const ranges = deps.accessors.selection.getRanges();
+  const ranges = getGroupingCommandRangesFromDeps(deps);
   const bounds = computeSelectionBounds(ranges);
   if (!bounds) return notHandled('disabled');
 
@@ -327,11 +509,39 @@ export const UNGROUP: AsyncActionHandler = async (deps) => {
 
   const ws = wb.getSheetById(wb.getActiveSheetId());
   if (axis === 'rows') {
+    if (bounds.startRow === bounds.endRow) {
+      const state = await ws.outline.getState();
+      const rowGroup = findInnermostContainingGroup(
+        state.rowGroups as GroupRecord[],
+        bounds.startRow,
+        bounds.endRow,
+      );
+      if (rowGroup) {
+        wb.setPendingUndoDescription(`Ungroup rows ${rowGroup.start + 1}-${rowGroup.end + 1}`);
+        await ws.outline.ungroupRows(rowGroup.start, rowGroup.end);
+        return handled();
+      }
+    }
     wb.setPendingUndoDescription(`Ungroup rows ${bounds.startRow + 1}-${bounds.endRow + 1}`);
     await ws.outline.ungroupRows(bounds.startRow, bounds.endRow);
     return handled();
   }
   if (axis === 'columns') {
+    if (bounds.startCol === bounds.endCol) {
+      const state = await ws.outline.getState();
+      const columnGroup = findInnermostContainingGroup(
+        state.columnGroups as GroupRecord[],
+        bounds.startCol,
+        bounds.endCol,
+      );
+      if (columnGroup) {
+        wb.setPendingUndoDescription(
+          `Ungroup columns ${columnGroup.start + 1}-${columnGroup.end + 1}`,
+        );
+        await ws.outline.ungroupColumns(columnGroup.start, columnGroup.end);
+        return handled();
+      }
+    }
     wb.setPendingUndoDescription(`Ungroup columns ${bounds.startCol + 1}-${bounds.endCol + 1}`);
     await ws.outline.ungroupColumns(bounds.startCol, bounds.endCol);
     return handled();
@@ -370,7 +580,7 @@ export const UNGROUP: AsyncActionHandler = async (deps) => {
  */
 export const SHOW_DETAIL: AsyncActionHandler = async (deps) => {
   const { workbook: wb } = deps;
-  const bounds = computeSelectionBounds(deps.accessors.selection.getRanges());
+  const bounds = computeSelectionBounds(getGroupingCommandRangesFromDeps(deps));
   if (!bounds) return notHandled('disabled');
 
   const ws = wb.getSheetById(wb.getActiveSheetId());
@@ -381,14 +591,19 @@ export const SHOW_DETAIL: AsyncActionHandler = async (deps) => {
 
   let toggled = false;
   for (const group of rowGroups) {
-    if (group.collapsed && selectionMatchesRowGroupForDetail(group, bounds, settings)) {
+    if (group.collapsed && selectionMatchesRowGroupForDetail(group, bounds, settings, rowGroups)) {
       await ws.outline.toggleCollapsed(group.id);
+      await setImportedDetailVisibility(ws, group, 'rows', true);
       toggled = true;
     }
   }
   for (const group of columnGroups) {
-    if (group.collapsed && selectionMatchesColumnGroupForDetail(group, bounds, settings)) {
+    if (
+      group.collapsed &&
+      selectionMatchesColumnGroupForDetail(group, bounds, settings, columnGroups)
+    ) {
       await ws.outline.toggleCollapsed(group.id);
+      await setImportedDetailVisibility(ws, group, 'columns', true);
       toggled = true;
     }
   }
@@ -402,7 +617,7 @@ export const SHOW_DETAIL: AsyncActionHandler = async (deps) => {
  */
 export const HIDE_DETAIL: AsyncActionHandler = async (deps) => {
   const { workbook: wb } = deps;
-  const bounds = computeSelectionBounds(deps.accessors.selection.getRanges());
+  const bounds = computeSelectionBounds(getGroupingCommandRangesFromDeps(deps));
   if (!bounds) return notHandled('disabled');
 
   const ws = wb.getSheetById(wb.getActiveSheetId());
@@ -413,21 +628,36 @@ export const HIDE_DETAIL: AsyncActionHandler = async (deps) => {
 
   // Find the innermost expanded row group containing the selection.
   const rowGroupsContaining = rowGroups
-    .filter((g) => !g.collapsed && selectionMatchesRowGroupForDetail(g, bounds, settings))
+    .filter(
+      (g) => !g.collapsed && selectionMatchesRowGroupForDetail(g, bounds, settings, rowGroups),
+    )
     .sort((a, b) => b.level - a.level);
 
   let toggled = false;
   if (rowGroupsContaining.length > 0) {
-    await ws.outline.toggleCollapsed(rowGroupsContaining[0].id);
+    const group = rowGroupsContaining[0];
+    if (group.hidden === true) {
+      await setImportedDetailVisibility(ws, group, 'rows', false);
+    } else {
+      await ws.outline.toggleCollapsed(group.id);
+    }
     toggled = true;
   }
 
   const colGroupsContaining = columnGroups
-    .filter((g) => !g.collapsed && selectionMatchesColumnGroupForDetail(g, bounds, settings))
+    .filter(
+      (g) =>
+        !g.collapsed && selectionMatchesColumnGroupForDetail(g, bounds, settings, columnGroups),
+    )
     .sort((a, b) => b.level - a.level);
 
   if (colGroupsContaining.length > 0) {
-    await ws.outline.toggleCollapsed(colGroupsContaining[0].id);
+    const group = colGroupsContaining[0];
+    if (group.hidden === true) {
+      await setImportedDetailVisibility(ws, group, 'columns', false);
+    } else {
+      await ws.outline.toggleCollapsed(group.id);
+    }
     toggled = true;
   }
 

--- a/apps/spreadsheet/src/actions/type-guards.ts
+++ b/apps/spreadsheet/src/actions/type-guards.ts
@@ -296,6 +296,7 @@ export function isStructureAction(action: string): action is StructureActionType
     'DELETE_COLUMNS',
     'INSERT_CELLS',
     'INSERT_CELLS_SHIFT_DOWN',
+    'INSERT_CUT_CELLS_SHIFT_DOWN',
     'DELETE_CELLS',
     'HIDE_ROW',
     'UNHIDE_ROW',

--- a/apps/spreadsheet/src/chrome/formula-bar/NameBoxDropdown.tsx
+++ b/apps/spreadsheet/src/chrome/formula-bar/NameBoxDropdown.tsx
@@ -431,13 +431,22 @@ export const NameBoxDropdown = memo(function NameBoxDropdown({
         }
       };
 
+      const setCellSelection = (
+        range: CellRange,
+        nextActiveCell: { row: number; col: number },
+      ): void => {
+        deps.commands.object.deselectAll();
+        deps.commands.chart.deselectAll();
+        selectionCommands.setSelection([range], nextActiveCell);
+      };
+
       if (trimmedAddress.includes(':')) {
         const parsedRange = parseCellRange(trimmedAddress);
         if (parsedRange) {
           if (parsedRange.sheetName) {
             await activateSheetByName(parsedRange.sheetName);
           }
-          selectionCommands.setSelection([rangeFromParsedCellRange(parsedRange)], {
+          setCellSelection(rangeFromParsedCellRange(parsedRange), {
             row: parsedRange.startRow,
             col: parsedRange.startCol,
           });
@@ -460,7 +469,7 @@ export const NameBoxDropdown = memo(function NameBoxDropdown({
         if (parsedRange.sheetName) {
           await activateSheetByName(parsedRange.sheetName);
         }
-        selectionCommands.setSelection([rangeFromParsedCellRange(parsedRange)], {
+        setCellSelection(rangeFromParsedCellRange(parsedRange), {
           row: parsedRange.startRow,
           col: parsedRange.startCol,
         });
@@ -501,15 +510,13 @@ export const NameBoxDropdown = memo(function NameBoxDropdown({
         if (parsed) {
           // Switch to table's sheet if different
           await activateSheetByName(matchingTable.sheetName);
-          selectionCommands.setSelection(
-            [
-              {
-                startRow: parsed.row,
-                startCol: parsed.col,
-                endRow: parsed.row,
-                endCol: parsed.col,
-              },
-            ],
+          setCellSelection(
+            {
+              startRow: parsed.row,
+              startCol: parsed.col,
+              endRow: parsed.row,
+              endCol: parsed.col,
+            },
             { row: parsed.row, col: parsed.col },
           );
         }
@@ -547,7 +554,7 @@ export const NameBoxDropdown = memo(function NameBoxDropdown({
 
         // Set selection to the range (or single cell when start === end);
         // the viewport-follow coordinator scrolls into view via the SET_SELECTION emit.
-        selectionCommands.setSelection([rangeFromParsedCellRange(parsed)], {
+        setCellSelection(rangeFromParsedCellRange(parsed), {
           row: parsed.startRow,
           col: parsed.startCol,
         });
@@ -599,6 +606,8 @@ export const NameBoxDropdown = memo(function NameBoxDropdown({
       openDefineNameDialog,
       wb,
       refreshNamedRanges,
+      deps.commands.object,
+      deps.commands.chart,
     ],
   );
 

--- a/apps/spreadsheet/src/chrome/toolbar/groups/CellsGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/CellsGroup.tsx
@@ -17,16 +17,20 @@
  */
 
 import React, { useCallback, useEffect } from 'react';
+import { useSelector } from '@xstate/react';
 import {
   dispatch,
   useActionDependencies,
   useActiveSheetId,
+  useCoordinator,
   useFeatureGate,
   useUIStore,
 } from '../../../internal-api';
 
 import { Tooltip } from '@mog/shell';
+import type { ClipboardState } from '@mog-sdk/contracts/actors';
 import { CELLS_COLLAPSE_CONFIG } from '@mog-sdk/contracts/ribbon';
+import { clipboardSelectors } from '../../../selectors';
 import { useDispatch } from '../../../hooks/toolbar/use-action-dependencies';
 import { useSheetProtectionPermissions } from '../../../hooks/structure/use-sheet-protection';
 import { useWorkbookStructureProtection } from '../../../hooks/structure/use-workbook-protection';
@@ -79,9 +83,17 @@ export const CellsGroup = React.memo(function CellsGroup() {
 
   const deps = useActionDependencies();
   const dispatchAction = useDispatch();
+  const coordinator = useCoordinator();
   const activeSheetId = useActiveSheetId();
   const sheetPermissions = useSheetProtectionPermissions(activeSheetId);
   const workbookStructureLocked = useWorkbookStructureProtection();
+  const hasCutCells = useSelector(coordinator.grid.access.actors.clipboard, (state) => {
+    const clipboardState = state as ClipboardState;
+    return (
+      clipboardSelectors.hasCut(clipboardState) &&
+      clipboardSelectors.cutSource(clipboardState) !== null
+    );
+  });
 
   // ===========================================================================
   // Local State (dropdown visibility)
@@ -170,7 +182,11 @@ export const CellsGroup = React.memo(function CellsGroup() {
                     aria-label="Insert"
                     onClick={(e) => {
                       e.stopPropagation();
-                      dispatchAction('INSERT_CELLS_SHIFT_DOWN');
+                      if (hasCutCells) {
+                        setTimeout(() => dispatchAction('INSERT_CUT_CELLS_SHIFT_DOWN'), 0);
+                      } else {
+                        dispatchAction('INSERT_CELLS_SHIFT_DOWN');
+                      }
                     }}
                   >
                     <span className="flex items-center justify-center w-4 h-4">
@@ -200,11 +216,18 @@ export const CellsGroup = React.memo(function CellsGroup() {
             menuLabel="Insert options"
           >
             <RibbonDropdownItem
-              dataValue="insert-cells"
+              dataValue={hasCutCells ? 'insert-cut-cells' : 'insert-cells'}
               icon={<InsertCellsIcon />}
-              onClick={() => dispatchAction('OPEN_INSERT_CELLS_DIALOG')}
+              onClick={() => {
+                if (hasCutCells) {
+                  setInsertDropdownOpen(false);
+                  setTimeout(() => dispatchAction('INSERT_CUT_CELLS_SHIFT_DOWN'), 0);
+                } else {
+                  dispatchAction('OPEN_INSERT_CELLS_DIALOG');
+                }
+              }}
             >
-              Insert Cells...
+              {hasCutCells ? 'Insert Cut Cells' : 'Insert Cells...'}
             </RibbonDropdownItem>
             <RibbonDropdownItem
               dataValue="insert-rows"

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/TabbedToolbar.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/TabbedToolbar.tsx
@@ -150,6 +150,10 @@ export interface TabbedToolbarProps extends Partial<ToolbarProps> {
   showFormulaBar?: boolean;
   /** Called when formula bar toggle is clicked */
   onToggleFormulaBar?: () => void;
+  /** Whether the status bar is shown */
+  showStatusBar?: boolean;
+  /** Called when status bar toggle is clicked */
+  onToggleStatusBar?: () => void;
   // Scrollbar visibility (Issue 7: View Options)
   /** Whether horizontal scrollbar is shown */
   showHorizontalScrollbar?: boolean;
@@ -275,6 +279,8 @@ export const TabbedToolbar = React.memo(function TabbedToolbar({
   onToggleHeadings,
   showFormulaBar,
   onToggleFormulaBar,
+  showStatusBar,
+  onToggleStatusBar,
   // Scrollbar visibility (Issue 7: View Options)
   showHorizontalScrollbar,
   onToggleHorizontalScrollbar,
@@ -521,6 +527,8 @@ export const TabbedToolbar = React.memo(function TabbedToolbar({
                     onToggleHeadings={onToggleHeadings}
                     showFormulaBar={showFormulaBar}
                     onToggleFormulaBar={onToggleFormulaBar}
+                    showStatusBar={showStatusBar}
+                    onToggleStatusBar={onToggleStatusBar}
                     // Scrollbar visibility (Issue 7: View Options)
                     showHorizontalScrollbar={showHorizontalScrollbar}
                     onToggleHorizontalScrollbar={onToggleHorizontalScrollbar}

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarContainer.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarContainer.tsx
@@ -97,6 +97,8 @@ export const ToolbarContainer = React.memo(function ToolbarContainer({
   const closeUndoDropdown = useUIStore((s) => s.closeUndoDropdown);
   const formulaBarVisible = useUIStore((s) => s.formulaBarVisible);
   const toggleFormulaBarVisible = useUIStore((s) => s.toggleFormulaBarVisible);
+  const statusBarVisible = useUIStore((s) => s.statusBarVisible);
+  const toggleStatusBarVisible = useUIStore((s) => s.toggleStatusBarVisible);
   const pageBreakPreviewMode = useUIStore((s) => s.pageBreakPreviewMode);
   const togglePageBreakPreviewMode = useUIStore((s) => s.togglePageBreakPreviewMode);
   const { setZoom } = useRendererActions();
@@ -408,6 +410,8 @@ export const ToolbarContainer = React.memo(function ToolbarContainer({
       onToggleHeadings={toggleHeadings}
       showFormulaBar={formulaBarVisible}
       onToggleFormulaBar={toggleFormulaBarVisible}
+      showStatusBar={statusBarVisible}
+      onToggleStatusBar={toggleStatusBarVisible}
       // Scrollbar visibility (Issue 7: View Options)
       showHorizontalScrollbar={workbookSettings.showHorizontalScrollbar}
       onToggleHorizontalScrollbar={handleToggleHorizontalScrollbar}

--- a/apps/spreadsheet/src/chrome/toolbar/tabs/DataRibbon.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/tabs/DataRibbon.tsx
@@ -442,6 +442,9 @@ export function DataRibbon({
     setIsGroupDropdownOpen(false);
     groupColumns();
   }, [groupColumns]);
+  const handleUngroupClick = useCallback(() => {
+    window.setTimeout(() => dispatch('UNGROUP'), 0);
+  }, [dispatch]);
 
   useEffect(() => {
     if (!canGroup) setIsGroupDropdownOpen(false);
@@ -932,7 +935,7 @@ export function DataRibbon({
             width="narrow"
             icon={<UngroupIcon />}
             label="Ungroup"
-            onClick={() => dispatch('UNGROUP')}
+            onClick={handleUngroupClick}
             disabled={!canUngroup}
             title="Ungroup selected rows (Alt+Shift+Left)"
             aria-label="Ungroup"

--- a/apps/spreadsheet/src/chrome/toolbar/tabs/ViewRibbon.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/tabs/ViewRibbon.tsx
@@ -3,7 +3,7 @@
  *
  * View tab content matching Excel 365 group order:
  * 1. Workbook Views - Normal, Page Break Preview, Page Layout, Custom Views
- * 2. Show - Ruler, Gridlines, Formula Bar, Headings
+ * 2. Show - Status Bar, Gridlines, Formula Bar, Headings
  * 3. Zoom - Zoom Out, dropdown, 100%, Zoom In, Zoom to Selection
  * 4. Window - New Window, Arrange All, Freeze Panes, Split, Hide, Unhide, Switch Windows
  * 5. Settings - CUSTOM (not in Excel, our addition for workbook/sheet settings)
@@ -160,30 +160,6 @@ function CustomViewsIcon() {
         strokeWidth="1.2"
         fill="none"
       />
-    </svg>
-  );
-}
-
-/** Ruler icon */
-function RulerIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect
-        x="1"
-        y="6"
-        width="14"
-        height="4"
-        rx="0.5"
-        stroke="currentColor"
-        strokeWidth="1.2"
-        fill="none"
-      />
-      <line x1="3" y1="6" x2="3" y2="8" stroke="currentColor" strokeWidth="1" />
-      <line x1="5" y1="6" x2="5" y2="7" stroke="currentColor" strokeWidth="1" />
-      <line x1="7" y1="6" x2="7" y2="8" stroke="currentColor" strokeWidth="1" />
-      <line x1="9" y1="6" x2="9" y2="7" stroke="currentColor" strokeWidth="1" />
-      <line x1="11" y1="6" x2="11" y2="8" stroke="currentColor" strokeWidth="1" />
-      <line x1="13" y1="6" x2="13" y2="7" stroke="currentColor" strokeWidth="1" />
     </svg>
   );
 }
@@ -363,6 +339,10 @@ interface ViewRibbonProps {
   showFormulaBar?: boolean;
   /** Called when formula bar toggle is clicked */
   onToggleFormulaBar?: () => void;
+  /** Whether the status bar is shown */
+  showStatusBar?: boolean;
+  /** Called when status bar toggle is clicked */
+  onToggleStatusBar?: () => void;
   // Scrollbar visibility (Issue 7: View Options)
   /** Whether horizontal scrollbar is shown */
   showHorizontalScrollbar?: boolean;
@@ -427,6 +407,8 @@ export function ViewRibbon({
   // V1: Formula Bar visibility
   showFormulaBar = true,
   onToggleFormulaBar,
+  showStatusBar = true,
+  onToggleStatusBar,
   // Scrollbar visibility (Issue 7: View Options)
   showHorizontalScrollbar = true,
   onToggleHorizontalScrollbar,
@@ -645,18 +627,26 @@ export function ViewRibbon({
             height: 'var(--ribbon-content-height)',
           }}
         >
-          {/* Row 1: Ruler | Headings */}
-          <RibbonVisibilityItem item="ruler">
+          {/* Row 1: Status Bar | Headings */}
+          <RibbonVisibilityItem item="statusBar">
             <label
-              className="flex items-center gap-1 whitespace-nowrap cursor-pointer opacity-50 min-w-0"
+              data-testid="panel-status-bar-reopen"
+              data-action="open-panel-status-bar"
+              className={`flex items-center gap-1 whitespace-nowrap cursor-pointer min-w-0 ${!onToggleStatusBar ? 'opacity-50' : ''}`}
               style={{ height: 'var(--ribbon-button-height-third)' }}
-              title="Ruler (coming soon)"
             >
               <span className="w-4 h-4 flex-shrink-0 flex items-center justify-center">
-                <RulerIcon />
+                <span className="text-ribbon-compact" aria-hidden="true">
+                  =
+                </span>
               </span>
-              <Checkbox disabled aria-label="Ruler" />
-              <span className="text-ribbon-compact text-ss-text-secondary">Ruler</span>
+              <Checkbox
+                checked={showStatusBar}
+                onChange={() => onToggleStatusBar?.()}
+                disabled={!onToggleStatusBar}
+                aria-label="Status Bar"
+              />
+              <span className="text-ribbon-compact text-ss-text-secondary">Status Bar</span>
             </label>
           </RibbonVisibilityItem>
           <RibbonVisibilityItem item="headings">
@@ -695,6 +685,7 @@ export function ViewRibbon({
               <span className="text-ribbon-compact text-ss-text-secondary">Gridlines</span>
             </label>
           </RibbonVisibilityItem>
+
           {/* Chrome-symmetry: Formula Bar reopen lives here. The label
  carries the contract testid + data-action; the Checkbox
  inherits the label click target so a single click toggles
@@ -737,6 +728,7 @@ export function ViewRibbon({
               <span className="text-ribbon-compact text-ss-text-secondary">H-Scroll</span>
             </label>
           </RibbonVisibilityItem>
+
           <RibbonVisibilityItem item="verticalScrollbar">
             <label
               className={`flex items-center gap-1 whitespace-nowrap cursor-pointer min-w-0 ${!onToggleVerticalScrollbar ? 'opacity-50' : ''}`}

--- a/apps/spreadsheet/src/chrome/toolbar/tabs/__tests__/DataRibbon-outline-dispatch.test.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/tabs/__tests__/DataRibbon-outline-dispatch.test.ts
@@ -7,10 +7,11 @@ describe('DataRibbon outline wiring', () => {
     expect(source).toContain('onClick={handleGroupClick}');
     expect(source).toContain('onClick={handleGroupRows}');
     expect(source).toContain('onClick={handleGroupColumns}');
+    expect(source).toContain('onClick={handleUngroupClick}');
     expect(source).toContain('Rows');
     expect(source).toContain('Columns');
     expect(source).not.toContain("onClick={() => dispatch('GROUP')}");
-    expect(source).toContain("onClick={() => dispatch('UNGROUP')}");
+    expect(source).toContain("dispatch('UNGROUP')");
     expect(source).toContain("onClick={() => dispatch('SHOW_DETAIL')}");
     expect(source).toContain("onClick={() => dispatch('HIDE_DETAIL')}");
 

--- a/apps/spreadsheet/src/components/canvas-overlays/form-controls/CheckboxOverlayControl.tsx
+++ b/apps/spreadsheet/src/components/canvas-overlays/form-controls/CheckboxOverlayControl.tsx
@@ -31,6 +31,8 @@ export interface CheckboxOverlayControlProps {
   height: number;
   /** Callback to write a value to the linked cell */
   onCellValueChange: (controlId: string, value: unknown) => void;
+  /** Linked cell position for DOM readbacks and app-eval probes. */
+  linkedCellPosition?: { row: number; col: number };
 }
 
 // =============================================================================
@@ -65,6 +67,7 @@ export const CheckboxOverlayControl = memo(function CheckboxOverlayControl({
   width,
   height,
   onCellValueChange,
+  linkedCellPosition,
 }: CheckboxOverlayControlProps) {
   const checked = isChecked(cellValue);
   const hasLabel = Boolean(control.label);
@@ -100,6 +103,8 @@ export const CheckboxOverlayControl = memo(function CheckboxOverlayControl({
       }}
       data-no-grid-pointer="true"
       data-testid={`form-control-checkbox-${control.id}`}
+      data-form-control-linked-row={linkedCellPosition?.row}
+      data-form-control-linked-col={linkedCellPosition?.col}
     >
       <input
         type="checkbox"

--- a/apps/spreadsheet/src/components/canvas-overlays/form-controls/FormControlLayer.test.tsx
+++ b/apps/spreadsheet/src/components/canvas-overlays/form-controls/FormControlLayer.test.tsx
@@ -2,12 +2,16 @@ import { jest } from '@jest/globals';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 
-import type { ScrollBarControl, SpinnerControl } from '@mog-sdk/contracts/form-controls';
+import type {
+  CheckboxControl,
+  ScrollBarControl,
+  SpinnerControl,
+} from '@mog-sdk/contracts/form-controls';
 
 import { FormControlLayer, type ResolvedFormControl } from './FormControlLayer';
 
 function resolved(
-  control: ScrollBarControl | SpinnerControl,
+  control: CheckboxControl | ScrollBarControl | SpinnerControl,
   cellValue: unknown,
 ): ResolvedFormControl {
   return {
@@ -22,6 +26,33 @@ function resolved(
 }
 
 describe('FormControlLayer numeric controls', () => {
+  it('exposes checkbox linked-cell coordinates on the visible checkbox overlay', () => {
+    const control: CheckboxControl = {
+      id: 'check-1',
+      type: 'checkbox',
+      sheetId: 'sheet-1' as never,
+      anchor: { cellId: 'cell-a1' as never, xOffset: 0, yOffset: 0 },
+      width: 16,
+      height: 16,
+      enabled: true,
+      zIndex: 3,
+      linkedCellId: 'cell-a1' as never,
+    };
+
+    render(
+      <FormControlLayer controls={[resolved(control, false)]} onCellValueChange={jest.fn()} />,
+    );
+
+    expect(screen.getByTestId('form-control-checkbox-check-1')).toHaveAttribute(
+      'data-form-control-linked-row',
+      '3',
+    );
+    expect(screen.getByTestId('form-control-checkbox-check-1')).toHaveAttribute(
+      'data-form-control-linked-col',
+      '7',
+    );
+  });
+
   it('renders scroll bars as DOM form-control overlays and writes numeric values', () => {
     const onCellValueChange = jest.fn();
     const control: ScrollBarControl = {

--- a/apps/spreadsheet/src/components/canvas-overlays/form-controls/FormControlLayer.tsx
+++ b/apps/spreadsheet/src/components/canvas-overlays/form-controls/FormControlLayer.tsx
@@ -88,6 +88,7 @@ const ControlRenderer = memo(
             width={width}
             height={height}
             onCellValueChange={onCellValueChange}
+            linkedCellPosition={linkedCellPosition}
           />
         );
         break;

--- a/apps/spreadsheet/src/components/comments/CommentPopover.tsx
+++ b/apps/spreadsheet/src/components/comments/CommentPopover.tsx
@@ -632,7 +632,7 @@ export function CommentPopover() {
           )}
         </div>
         <div className="flex gap-1">
-          {comments.length > 0 && !isNoteBacked && (
+          {comments.length > 0 && (
             <button
               type="button"
               data-testid="resolve-thread"

--- a/apps/spreadsheet/src/components/context-menu/CellContextMenu.tsx
+++ b/apps/spreadsheet/src/components/context-menu/CellContextMenu.tsx
@@ -297,14 +297,14 @@ export function CellContextMenu({ target, targetRow, targetCol, onClose }: CellC
           onClick: actions.insertColumnLeft,
         });
       } else {
-        // Cell range selection: "Insert..." (opens dialog)
+        // Cell range selection: "Insert..." or "Insert Cut Cells" when a cut is active.
         items.push({
           id: 'insert',
-          label: 'Insert...',
+          label: actions.hasCutClipboard ? 'Insert Cut Cells' : 'Insert...',
           icon: <InsertCellsIcon />,
           disabled: !actions.isContiguousSelection,
           dividerAfter: true,
-          onClick: actions.insertCells,
+          onClick: actions.hasCutClipboard ? actions.insertCutCells : actions.insertCells,
         });
       }
     }

--- a/apps/spreadsheet/src/dialogs/insert/InsertCellsDialog.test.tsx
+++ b/apps/spreadsheet/src/dialogs/insert/InsertCellsDialog.test.tsx
@@ -1,0 +1,140 @@
+import { jest } from '@jest/globals';
+
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const dispatchMock = jest.fn();
+const closeInsertCellsDialog = jest.fn();
+const deps = { workbook: {} };
+
+jest.unstable_mockModule('@mog/shell', () => ({
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    variant?: string;
+    ref?: React.Ref<HTMLButtonElement>;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  Dialog: ({
+    children,
+    open,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    onClose?: () => void;
+    dialogId?: string;
+    width?: number;
+    initialFocusRef?: React.RefObject<HTMLButtonElement>;
+    onEnterKeyDown?: () => void;
+  }) =>
+    open === false ? null : (
+      <div role="dialog" aria-modal="true">
+        {children}
+      </div>
+    ),
+  DialogBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <footer>{children}</footer>,
+  DialogHeader: ({ children, onClose }: { children: React.ReactNode; onClose?: () => void }) => (
+    <header>
+      {children}
+      <button type="button" aria-label="Close" onClick={onClose}>
+        Close
+      </button>
+    </header>
+  ),
+  RadioGroup: ({
+    name,
+    value,
+    onChange,
+    options,
+  }: {
+    name: string;
+    value: string;
+    onChange: (value: string) => void;
+    options: Array<{ value: string; label: string }>;
+    orientation?: string;
+    'aria-label'?: string;
+  }) => (
+    <div role="radiogroup">
+      {options.map((option) => (
+        <label key={option.value}>
+          <input
+            type="radio"
+            name={name}
+            checked={value === option.value}
+            onChange={() => onChange(option.value)}
+          />
+          {option.label}
+        </label>
+      ))}
+    </div>
+  ),
+}));
+
+jest.unstable_mockModule('../../internal-api', () => ({
+  dispatch: dispatchMock,
+  useUIStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      insertCellsDialog: {
+        isOpen: true,
+        mode: 'delete',
+        direction: 'up',
+        range: { startRow: 17, startCol: 27, endRow: 17, endCol: 27 },
+      },
+      closeInsertCellsDialog,
+    }),
+}));
+
+jest.unstable_mockModule('../../hooks/toolbar/use-action-dependencies', () => ({
+  useActionDependencies: () => deps,
+}));
+
+const { InsertCellsDialog } = await import('./InsertCellsDialog');
+
+describe('InsertCellsDialog', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    dispatchMock.mockClear();
+    closeInsertCellsDialog.mockClear();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('closes before dispatching the OK action on a later macrotask', async () => {
+    render(<InsertCellsDialog />);
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByLabelText(/Entire row/i));
+    fireEvent.click(within(dialog).getByRole('button', { name: /^OK$/ }));
+
+    expect(closeInsertCellsDialog).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).not.toHaveBeenCalled();
+    const pendingAction = (
+      window as typeof window & { __MOG_PENDING_DIALOG_ACTION__?: Promise<void> }
+    ).__MOG_PENDING_DIALOG_ACTION__;
+    expect(pendingAction).toBeInstanceOf(Promise);
+
+    jest.advanceTimersByTime(99);
+    expect(dispatchMock).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    await pendingAction;
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith('DELETE_ROWS', deps);
+    expect(
+      (window as typeof window & { __MOG_PENDING_DIALOG_ACTION__?: Promise<void> })
+        .__MOG_PENDING_DIALOG_ACTION__,
+    ).toBeUndefined();
+  });
+});

--- a/apps/spreadsheet/src/dialogs/insert/InsertCellsDialog.tsx
+++ b/apps/spreadsheet/src/dialogs/insert/InsertCellsDialog.tsx
@@ -42,6 +42,37 @@ const DELETE_OPTIONS: ShiftOption[] = [
   { value: 'column', label: 'Entire column' },
 ];
 
+const APPLY_AFTER_CLOSE_DELAY_MS = 100;
+
+type DialogActionWindow = typeof window & {
+  __MOG_PENDING_DIALOG_ACTION__?: Promise<void>;
+};
+
+function scheduleDialogAction(action: () => unknown): void {
+  const global = window as DialogActionWindow;
+  const pending = new Promise<void>((resolve, reject) => {
+    window.setTimeout(() => {
+      Promise.resolve()
+        .then(action)
+        .then(
+          () => {
+            if (global.__MOG_PENDING_DIALOG_ACTION__ === pending) {
+              delete global.__MOG_PENDING_DIALOG_ACTION__;
+            }
+            resolve();
+          },
+          (error) => {
+            if (global.__MOG_PENDING_DIALOG_ACTION__ === pending) {
+              delete global.__MOG_PENDING_DIALOG_ACTION__;
+            }
+            reject(error);
+          },
+        );
+    }, APPLY_AFTER_CLOSE_DELAY_MS);
+  });
+  global.__MOG_PENDING_DIALOG_ACTION__ = pending;
+}
+
 // =============================================================================
 // Component
 // =============================================================================
@@ -78,33 +109,42 @@ export function InsertCellsDialog() {
       return;
     }
 
-    // If user selected entire row/column, delegate to row/column actions
-    if (selectedOption === 'row') {
-      if (mode === 'insert') {
-        dispatch('INSERT_ROW_ABOVE', deps);
+    const action = () => {
+      // If user selected entire row/column, delegate to row/column actions
+      if (selectedOption === 'row') {
+        if (mode === 'insert') {
+          return dispatch('INSERT_ROW_ABOVE', deps);
+        } else {
+          return dispatch('DELETE_ROWS', deps);
+        }
+      } else if (selectedOption === 'column') {
+        if (mode === 'insert') {
+          return dispatch('INSERT_COLUMN_LEFT', deps);
+        } else {
+          return dispatch('DELETE_COLUMNS', deps);
+        }
       } else {
-        dispatch('DELETE_ROWS', deps);
+        // Shift cells in specified direction
+        if (mode === 'insert') {
+          if (deps.accessors.clipboard.hasCut()) {
+            return deps.commands.clipboard.paste({ row: range.startRow, col: range.startCol });
+          }
+
+          // Insert cells - shift existing cells right or down
+          const direction = selectedOption === 'right' ? 'right' : 'down';
+          return dispatch('INSERT_CELLS', deps, { range, direction });
+        } else {
+          // Delete cells - shift remaining cells left or up
+          const direction = selectedOption === 'left' ? 'left' : 'up';
+          return dispatch('DELETE_CELLS', deps, { range, direction });
+        }
       }
-    } else if (selectedOption === 'column') {
-      if (mode === 'insert') {
-        dispatch('INSERT_COLUMN_LEFT', deps);
-      } else {
-        dispatch('DELETE_COLUMNS', deps);
-      }
-    } else {
-      // Shift cells in specified direction
-      if (mode === 'insert') {
-        // Insert cells - shift existing cells right or down
-        const direction = selectedOption === 'right' ? 'right' : 'down';
-        dispatch('INSERT_CELLS', deps, { range, direction });
-      } else {
-        // Delete cells - shift remaining cells left or up
-        const direction = selectedOption === 'left' ? 'left' : 'up';
-        dispatch('DELETE_CELLS', deps, { range, direction });
-      }
-    }
+    };
 
     closeDialog();
+    // Structural mutations can synchronously monopolize the main thread; let the
+    // click/close sequence complete before starting the apply work.
+    scheduleDialogAction(action);
   }, [selectedOption, mode, range, deps, closeDialog]);
 
   // Handle Cancel button click

--- a/apps/spreadsheet/src/hooks/data/use-grouping-actions.ts
+++ b/apps/spreadsheet/src/hooks/data/use-grouping-actions.ts
@@ -23,7 +23,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import type { CellRange } from '@mog-sdk/contracts/core';
+import { MAX_COLS, MAX_ROWS, type CellRange } from '@mog-sdk/contracts/core';
 import type { GroupDefinition, SheetGroupingConfig } from '@mog-sdk/contracts/grouping';
 
 import { useActiveSheetId, useWorkbook } from '../../infra/context';
@@ -39,6 +39,16 @@ interface SelectionBounds {
   endRow: number;
   startCol: number;
   endCol: number;
+}
+
+type GroupingAxis = 'rows' | 'columns';
+
+interface GroupingSelectionSnapshot {
+  ranges: readonly CellRange[];
+  activeCell: { row: number; col: number };
+  anchor?: { row: number; col: number } | null;
+  anchorCol?: number | null;
+  anchorRow?: number | null;
 }
 
 // =============================================================================
@@ -65,6 +75,59 @@ function computeSelectionBounds(ranges: readonly CellRange[]): SelectionBounds |
   }
 
   return { startRow, endRow, startCol, endCol };
+}
+
+function isSingleFullRowRange(range: CellRange): boolean {
+  return (
+    range.startRow === range.endRow &&
+    (range.isFullRow === true || (range.startCol === 0 && range.endCol === MAX_COLS - 1))
+  );
+}
+
+function isSingleFullColumnRange(range: CellRange): boolean {
+  return (
+    range.startCol === range.endCol &&
+    (range.isFullColumn === true || (range.startRow === 0 && range.endRow === MAX_ROWS - 1))
+  );
+}
+
+function getGroupingCommandRanges(snapshot: GroupingSelectionSnapshot): readonly CellRange[] {
+  if (snapshot.ranges.length !== 1) return snapshot.ranges;
+
+  const range = snapshot.ranges[0];
+  if (isSingleFullRowRange(range)) {
+    const anchorRow = snapshot.anchorRow ?? snapshot.anchor?.row ?? null;
+    if (anchorRow !== null && anchorRow !== range.startRow) {
+      return [
+        {
+          ...range,
+          startRow: Math.min(anchorRow, snapshot.activeCell.row, range.startRow, range.endRow),
+          endRow: Math.max(anchorRow, snapshot.activeCell.row, range.startRow, range.endRow),
+          startCol: 0,
+          endCol: MAX_COLS - 1,
+          isFullRow: true,
+        },
+      ];
+    }
+  }
+
+  if (isSingleFullColumnRange(range)) {
+    const anchorCol = snapshot.anchorCol ?? snapshot.anchor?.col ?? null;
+    if (anchorCol !== null && anchorCol !== range.startCol) {
+      return [
+        {
+          ...range,
+          startRow: 0,
+          endRow: MAX_ROWS - 1,
+          startCol: Math.min(anchorCol, snapshot.activeCell.col, range.startCol, range.endCol),
+          endCol: Math.max(anchorCol, snapshot.activeCell.col, range.startCol, range.endCol),
+          isFullColumn: true,
+        },
+      ];
+    }
+  }
+
+  return snapshot.ranges;
 }
 
 interface OutlineSummarySettings {
@@ -103,8 +166,12 @@ function summaryIndex(
   return index >= 0 ? index : null;
 }
 
+function selectionContainsIndex(start: number, end: number, index: number): boolean {
+  return start <= index && end >= index;
+}
+
 function selectionMatchesRowGroupForDetail(
-  group: Pick<GroupDefinition, 'start' | 'end'>,
+  group: Pick<GroupDefinition, 'start' | 'end' | 'hidden' | 'collapsedOnMember'>,
   bounds: SelectionBounds,
   settings: OutlineSummarySettings,
 ): boolean {
@@ -112,11 +179,20 @@ function selectionMatchesRowGroupForDetail(
     return true;
   }
   const summary = summaryIndex(group, settings.summaryRowsBelow);
-  return summary !== null && bounds.startRow === summary && bounds.endRow === summary;
+  if (summary !== null && bounds.startRow === summary && bounds.endRow === summary) {
+    return true;
+  }
+  const importedMemberSummary = isImportedHiddenGroup(group)
+    ? summaryIndex(group, !settings.summaryRowsBelow)
+    : null;
+  return (
+    importedMemberSummary !== null &&
+    selectionContainsIndex(bounds.startRow, bounds.endRow, importedMemberSummary)
+  );
 }
 
 function selectionMatchesColumnGroupForDetail(
-  group: Pick<GroupDefinition, 'start' | 'end'>,
+  group: Pick<GroupDefinition, 'start' | 'end' | 'hidden' | 'collapsedOnMember'>,
   bounds: SelectionBounds,
   settings: OutlineSummarySettings,
 ): boolean {
@@ -124,7 +200,53 @@ function selectionMatchesColumnGroupForDetail(
     return true;
   }
   const summary = summaryIndex(group, settings.summaryColumnsRight);
-  return summary !== null && bounds.startCol === summary && bounds.endCol === summary;
+  if (summary !== null && bounds.startCol === summary && bounds.endCol === summary) {
+    return true;
+  }
+  const importedMemberSummary = isImportedHiddenGroup(group)
+    ? summaryIndex(group, !settings.summaryColumnsRight)
+    : null;
+  return (
+    importedMemberSummary !== null &&
+    selectionContainsIndex(bounds.startCol, bounds.endCol, importedMemberSummary)
+  );
+}
+
+function isImportedHiddenGroup(
+  group: Pick<GroupDefinition, 'hidden' | 'collapsedOnMember'>,
+): boolean {
+  return group.collapsedOnMember === true || group.hidden === true;
+}
+
+function detailIndexes(group: Pick<GroupDefinition, 'start' | 'end'>): number[] {
+  return Array.from(
+    { length: group.end - group.start + 1 },
+    (_value, index) => group.start + index,
+  );
+}
+
+async function setImportedDetailVisibility(
+  ws: import('@mog-sdk/contracts/api').WorksheetWithInternals,
+  group: GroupDefinition,
+  axis: GroupingAxis,
+  visible: boolean,
+): Promise<void> {
+  if (group.hidden !== true) return;
+
+  if (axis === 'rows') {
+    if (visible) {
+      await ws.layout.unhideRows(group.start, group.end);
+    } else {
+      await ws.layout.hideRows(detailIndexes(group));
+    }
+    return;
+  }
+
+  if (visible) {
+    await ws.layout.unhideColumns(group.start, group.end);
+  } else {
+    await ws.layout.hideColumns(detailIndexes(group));
+  }
 }
 
 // =============================================================================
@@ -273,7 +395,7 @@ export function useGroupingActions(): UseGroupingActionsReturn {
   // ==========================================================================
   const getSelectionBoundsOnDemand = useCallback((): SelectionBounds | null => {
     const snapshot = coordinator.grid.getSelectionSnapshot();
-    return computeSelectionBounds(snapshot.ranges);
+    return computeSelectionBounds(getGroupingCommandRanges(snapshot));
   }, [coordinator]);
 
   // ==========================================================================
@@ -456,12 +578,14 @@ export function useGroupingActions(): UseGroupingActionsReturn {
         if (group.collapsed && selectionMatchesRowGroupForDetail(group, bounds, settings)) {
           // Toggle to expand (collapsed -> expanded)
           await ws.outline.toggleCollapsed(group.id);
+          await setImportedDetailVisibility(ws, group, 'rows', true);
         }
       }
 
       for (const group of currentColumnGroups) {
         if (group.collapsed && selectionMatchesColumnGroupForDetail(group, bounds, settings)) {
           await ws.outline.toggleCollapsed(group.id);
+          await setImportedDetailVisibility(ws, group, 'columns', true);
         }
       }
     })();
@@ -488,7 +612,12 @@ export function useGroupingActions(): UseGroupingActionsReturn {
 
       if (rowGroupsContaining.length > 0) {
         // Toggle to collapse (expanded -> collapsed)
-        await ws.outline.toggleCollapsed(rowGroupsContaining[0].id);
+        const group = rowGroupsContaining[0];
+        if (group.hidden === true) {
+          await setImportedDetailVisibility(ws, group, 'rows', false);
+        } else {
+          await ws.outline.toggleCollapsed(group.id);
+        }
       }
 
       const colGroupsContaining = currentColumnGroups
@@ -499,7 +628,12 @@ export function useGroupingActions(): UseGroupingActionsReturn {
         .sort((a: GroupDefinition, b: GroupDefinition) => b.level - a.level);
 
       if (colGroupsContaining.length > 0) {
-        await ws.outline.toggleCollapsed(colGroupsContaining[0].id);
+        const group = colGroupsContaining[0];
+        if (group.hidden === true) {
+          await setImportedDetailVisibility(ws, group, 'columns', false);
+        } else {
+          await ws.outline.toggleCollapsed(group.id);
+        }
       }
     })();
   }, [wb, activeSheetId, getSelectionBoundsOnDemand]);

--- a/apps/spreadsheet/src/hooks/editing/use-clipboard.ts
+++ b/apps/spreadsheet/src/hooks/editing/use-clipboard.ts
@@ -98,6 +98,7 @@ function isOurClipboardData(
   clipboardState: ClipboardState,
   clipboardData: ClipboardData | null,
   systemText: string,
+  hasExternalSystemPayload = normalizeClipboardSignature(systemText) !== '',
 ): boolean {
   const internalSignature = clipboardData?.textSignature
     ? normalizeClipboardSignature(clipboardData.textSignature)
@@ -109,7 +110,8 @@ function isOurClipboardData(
     clipboardState.context.isStale !== true;
 
   return (
-    (internalSignature === systemSignature && systemSignature !== '') || hasFreshInternalClipboard
+    (internalSignature === systemSignature && systemSignature !== '') ||
+    (!hasExternalSystemPayload && hasFreshInternalClipboard)
   );
 }
 
@@ -1197,8 +1199,14 @@ export function useClipboardEvents(options: UseClipboardEventsOptions): UseClipb
         const activeCell = selectionSnapshot.activeCell;
         const targetRange = cloneRange(selectionSnapshot.ranges[0]);
 
-        // Get system clipboard text for signature comparison
+        // Get system clipboard payload for signature comparison
         const systemText = event.clipboardData?.getData('text/plain') ?? '';
+        const html = event.clipboardData?.getData('text/html') ?? '';
+        const files = event.clipboardData?.files;
+        const hasExternalSystemPayload =
+          normalizeClipboardSignature(systemText) !== '' ||
+          html !== '' ||
+          Boolean(files && Array.from(files).some((file) => file.type.startsWith('image/')));
 
         // Actor Access Layer: Point-in-time read (similar to action handler pattern)
         // This is inside an event handler callback, not a reactive subscription.
@@ -1209,7 +1217,12 @@ export function useClipboardEvents(options: UseClipboardEventsOptions): UseClipb
         // Compare system clipboard with our text signature to detect external copies
         // - If they match: user is pasting our copy → use rich internal data (formulas, formats)
         // - If they differ: user copied from another app → parse external clipboard
-        const isOurClipboard = isOurClipboardData(clipboardState, clipboardData, systemText);
+        const isOurClipboard = isOurClipboardData(
+          clipboardState,
+          clipboardData,
+          systemText,
+          hasExternalSystemPayload,
+        );
 
         if (clipboardData && isOurClipboard) {
           // System clipboard matches what we wrote - use rich internal data
@@ -1244,7 +1257,6 @@ export function useClipboardEvents(options: UseClipboardEventsOptions): UseClipb
         // System clipboard differs from our signature - user copied from external app
         // Use the text we already retrieved for signature comparison
         let text = systemText;
-        const html = event.clipboardData?.getData('text/html');
 
         // If no text from event, try navigator.clipboard
         if (!text) {
@@ -1281,7 +1293,6 @@ export function useClipboardEvents(options: UseClipboardEventsOptions): UseClipb
         // Image-only paste: clipboardData has image files but no cell text/HTML.
         // Routing priority matches unifiedPaste (text/HTML wins when both present).
         if (!text && !html) {
-          const files = event.clipboardData?.files;
           if (files && files.length > 0) {
             const imageFile = Array.from(files).find((f) => f.type.startsWith('image/'));
             if (imageFile) {

--- a/apps/spreadsheet/src/hooks/toolbar/use-context-menu-actions.ts
+++ b/apps/spreadsheet/src/hooks/toolbar/use-context-menu-actions.ts
@@ -113,6 +113,8 @@ export interface UseContextMenuActionsReturn {
 
   // Insert Cells Dialog
   insertCells: () => void;
+  insertCutCells: () => void;
+  hasCutClipboard: boolean;
 
   // Delete actions
   deleteRows: () => void;
@@ -538,6 +540,14 @@ export function useContextMenuActions(
       dispatch('OPEN_INSERT_CELLS_DIALOG', actionDeps);
     });
   }, [actionDeps, closeContextMenu]);
+
+  const insertCutCells = useCallback(() => {
+    selectResolvedContextCell();
+    closeContextMenu();
+    setTimeout(() => {
+      dispatch('INSERT_CUT_CELLS_SHIFT_DOWN', actionDeps);
+    }, 0);
+  }, [actionDeps, closeContextMenu, selectResolvedContextCell]);
 
   // ==========================================================================
   // Delete Actions
@@ -1422,6 +1432,8 @@ export function useContextMenuActions(
 
       // Insert Cells Dialog
       insertCells,
+      insertCutCells,
+      hasCutClipboard: clipboard.hasCut,
 
       // Delete
       deleteRows,
@@ -1580,6 +1592,8 @@ export function useContextMenuActions(
       insertColumnLeft,
       insertColumnRight,
       insertCells,
+      insertCutCells,
+      clipboard.hasCut,
       deleteRows,
       deleteColumns,
       deleteCells,

--- a/apps/spreadsheet/src/systems/grid-editing/coordination/__tests__/selection-context-coordination.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/coordination/__tests__/selection-context-coordination.test.ts
@@ -103,6 +103,38 @@ describe('Selection Context Coordination', () => {
       objectInteractionActor.stop();
       chartActor.stop();
     });
+
+    it('clears object selection when a user SET_SELECTION replaces the idle cell range', async () => {
+      const { selectionActor, objectInteractionActor, chartActor } = createTestActors();
+      const { cleanup } = setupCoordination({
+        selectionActor,
+        objectInteractionActor,
+      });
+
+      objectInteractionActor.send({
+        type: 'SELECT_OBJECT',
+        objectId: 'obj1',
+        shiftKey: false,
+        ctrlKey: false,
+      });
+      await waitForProcessing();
+      expect(objectInteractionActor.getSnapshot().matches('selected')).toBe(true);
+
+      selectionActor.send({
+        type: 'SET_SELECTION',
+        ranges: [{ startRow: 2, startCol: 11, endRow: 20, endCol: 27 }],
+        activeCell: { row: 2, col: 11 },
+      });
+      await waitForProcessing();
+
+      expect(objectInteractionActor.getSnapshot().matches('idle')).toBe(true);
+      expect(objectInteractionActor.getSnapshot().context.selectedIds).toEqual([]);
+
+      cleanup();
+      selectionActor.stop();
+      objectInteractionActor.stop();
+      chartActor.stop();
+    });
   });
 
   describe('Object selection clears other contexts', () => {

--- a/apps/spreadsheet/src/systems/grid-editing/coordination/selection-context-coordination.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/coordination/selection-context-coordination.ts
@@ -147,7 +147,20 @@ export function setupSelectionContextCoordination(
     prevSelectionActive = isActive;
   });
 
-  // 2. Object interaction machine subscription (handles all floating objects including charts)
+  // 2. User selection emit subscription. SET_SELECTION can replace the current
+  // cell range while the selection machine stays idle, so state-transition
+  // checks above do not see a new active-selection transition.
+  const unsubUserSelection = selectionActor.on('userSelectionChanged', () => {
+    if (!hasObjectSelection(objectInteractionActor.getSnapshot())) return;
+
+    activeContext = 'cells';
+    objectInteractionActor.send({
+      type: 'EXTERNAL_SELECTION_ACTIVE',
+      context: 'cells',
+    });
+  });
+
+  // 3. Object interaction machine subscription (handles all floating objects including charts)
   const unsubObjects = objectInteractionActor.subscribe((state: ObjectInteractionState_) => {
     const isSelected = hasObjectSelection(state);
 
@@ -175,6 +188,7 @@ export function setupSelectionContextCoordination(
   return {
     cleanup: () => {
       unsubSelection.unsubscribe();
+      unsubUserSelection.unsubscribe();
       unsubObjects.unsubscribe();
     },
     getActiveContext: () => activeContext,

--- a/apps/spreadsheet/src/systems/grid-editing/features/find-replace/find-replace-coordination.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/features/find-replace/find-replace-coordination.ts
@@ -48,6 +48,8 @@ interface CachedCellData extends Omit<IdentifiedCellData, 'cellId'> {
   cellId: CellId;
   /** Alias: the value field used for search matching (same as `value`) */
   displayValue: CellValue | null;
+  /** Whether this cell is hidden by its row or column. */
+  isHidden: boolean;
 }
 
 /**
@@ -333,12 +335,16 @@ export class FindReplaceCoordinator {
 
       // Use unified Worksheet API -- returns cells with CellId, value, formula, display string
       const ws = workbook.getSheetById(sheetId);
-      const identifiedCells = await ws.getRangeWithIdentity(
-        dataBounds.minRow,
-        dataBounds.minCol,
-        dataBounds.maxRow,
-        dataBounds.maxCol,
-      );
+      const [identifiedCells, hiddenRows, hiddenCols] = await Promise.all([
+        ws.getRangeWithIdentity(
+          dataBounds.minRow,
+          dataBounds.minCol,
+          dataBounds.maxRow,
+          dataBounds.maxCol,
+        ),
+        ws.layout.getHiddenRowsBitmap(),
+        ws.layout.getHiddenColumnsBitmap(),
+      ]);
 
       const cells: CachedCellData[] = [];
       const cellIndex = new Map<CellId, CachedCellData>();
@@ -348,6 +354,7 @@ export class FindReplaceCoordinator {
           ...ic,
           cellId: toCellId(ic.cellId),
           displayValue: ic.value,
+          isHidden: hiddenRows.has(ic.row) || hiddenCols.has(ic.col),
         };
         cells.push(cached);
         cellIndex.set(cached.cellId, cached);
@@ -379,11 +386,21 @@ export class FindReplaceCoordinator {
 
       const isReplacementQuery =
         this.lastExecutedQuery.trim() !== '' && this.lastExecutedQuery !== query;
-      const initialCurrentIndex = isReplacementQuery && results.length > 0 ? -1 : undefined;
+      const activeCellBeforeSearch = this.getActiveCell();
+      const firstResultPosition = results[0] ? this.getCachedResultPosition(results[0]) : null;
+      const activeWasFirstResult =
+        firstResultPosition !== null &&
+        firstResultPosition.sheet === activeSheetId &&
+        activeCellBeforeSearch?.row === firstResultPosition.row &&
+        activeCellBeforeSearch?.col === firstResultPosition.col;
+      const initialCurrentIndex =
+        results.length === 0 ? undefined : isReplacementQuery || !activeWasFirstResult ? -1 : 0;
 
       // Send results to machine. Replacement searches keep results highlighted
       // but leave navigation unselected so the first explicit Enter lands on
-      // the first result instead of skipping to the second.
+      // the first result instead of skipping to the second. Fresh searches do
+      // the same when live search moves the active cell to a different first
+      // result; if the active cell was already the first result, Enter advances.
       this.deps.findReplaceActor.send({
         type: 'SEARCH_COMPLETE',
         results,
@@ -391,8 +408,10 @@ export class FindReplaceCoordinator {
       });
       this.lastExecutedQuery = query;
 
-      // If there are results, navigate to the first one
-      if (results.length > 0 && initialCurrentIndex !== -1) {
+      // If there are results for a fresh query, live-search to the first one.
+      // Keep currentIndex at -1 when this is a new jump so the first Enter
+      // confirms that result instead of skipping past it.
+      if (results.length > 0 && !isReplacementQuery && !activeWasFirstResult) {
         await this.navigateToResult(results[0]);
       }
 
@@ -412,10 +431,8 @@ export class FindReplaceCoordinator {
     if (!this.deps) return;
 
     // Resolve from cache first (O(1)), fallback to deps
-    const cached = this.searchCache?.sheets.get(result.sheetId)?.cellIndex.get(result.cellId);
-    const position = cached
-      ? { row: cached.row, col: cached.col, sheet: result.sheetId }
-      : await this.deps.resolveCellPosition(result.cellId);
+    const position =
+      this.getCachedResultPosition(result) ?? (await this.deps.resolveCellPosition(result.cellId));
     if (!position) {
       console.warn('[FindReplaceCoordinator] Could not resolve position for', result.cellId);
       return;
@@ -631,6 +648,21 @@ export class FindReplaceCoordinator {
     const regex = new RegExp(escapeRegExp(query), 'gi');
     return currentValue.replace(regex, replacement);
   }
+
+  private getCachedResultPosition(
+    result: SearchResult,
+  ): { row: number; col: number; sheet: SheetId } | null {
+    const cached = this.searchCache?.sheets.get(result.sheetId)?.cellIndex.get(result.cellId);
+    return cached ? { row: cached.row, col: cached.col, sheet: result.sheetId } : null;
+  }
+
+  private getActiveCell(): { row: number; col: number } | null {
+    try {
+      return this.deps?.selectionActor.getSnapshot().context.activeCell ?? null;
+    } catch {
+      return null;
+    }
+  }
 }
 
 // =============================================================================
@@ -651,7 +683,7 @@ function createSearchProviderFromCache(cache: SearchCache): SearchDataProvider {
       if (!sheetData) return [];
 
       // Copy and sort by direction
-      const sorted = [...sheetData.cells];
+      const sorted = sheetData.cells.filter((cell) => !cell.isHidden);
       if (direction === 'byRow') {
         sorted.sort((a, b) => (a.row !== b.row ? a.row - b.row : a.col - b.col));
       } else {

--- a/apps/spreadsheet/src/systems/grid-editing/grid-editing-system.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/grid-editing-system.ts
@@ -2049,6 +2049,11 @@ export class GridEditingSystem implements IGridEditingSystem {
     });
     this.cleanupFns.push(() => selSub.unsubscribe());
 
+    const userSelectionSub = this.selectionActor.on('userSelectionChanged', () => {
+      for (const cb of this.selectionActiveCallbacks) cb();
+    });
+    this.cleanupFns.push(() => userSelectionSub.unsubscribe());
+
     // Editor state change subscription
     const editorSub = this.editorActor.subscribe((state) => {
       // Notify generic state change

--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/extend-selection.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/extend-selection.test.ts
@@ -410,6 +410,34 @@ describe('extendSelection - Shift+Arrow bug tests', () => {
       expect(result.activeCell).toEqual({ row: 4, col: 1 });
     });
 
+    it('repeated Shift+Right extends by worksheet coordinates across hidden columns', () => {
+      let context: SelectionContext = {
+        ...initialSelectionContext,
+        activeCell: { row: 16, col: 12 }, // M17
+        pendingRange: { startRow: 16, startCol: 12, endRow: 16, endCol: 12 },
+        anchor: null,
+        isColHidden: (col) => col >= 15 && col <= 26, // P:AA
+      };
+
+      for (let col = 12; col < 27; col += 1) {
+        const result = callExtendSelection(context, {
+          type: 'KEY_ARROW',
+          direction: 'right',
+          shiftKey: true,
+        });
+        context = { ...context, ...result };
+      }
+
+      expect(context.pendingRange).toEqual({
+        startRow: 16,
+        startCol: 12,
+        endRow: 16,
+        endCol: 27,
+      });
+      expect(context.anchor).toEqual({ row: 16, col: 12 });
+      expect(context.activeCell).toEqual({ row: 16, col: 12 });
+    });
+
     it('preserves a full-column selection when extending right from Ctrl+Space', () => {
       const context: SelectionContext = {
         ...initialSelectionContext,

--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/merged-navigation.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/merged-navigation.test.ts
@@ -497,7 +497,7 @@ describe('Hidden Cell Skipping - Machine Level', () => {
     expect(result.activeCell).toEqual(cell(12, 27)); // AB13
   });
 
-  it('extendSelection skips hidden cells when extending', () => {
+  it('extendSelection includes hidden cells when extending range geometry', () => {
     const isRowHidden = (row: number) => row === 2; // Row 3 is hidden
 
     const context = createContext({
@@ -513,9 +513,10 @@ describe('Hidden Cell Skipping - Machine Level', () => {
       shiftKey: true,
     });
 
-    // Should skip row 2 (hidden), extend to row 3
+    // Shift+Arrow extends the worksheet-coordinate range by one row. Hidden
+    // rows remain selected instead of being treated as one visible step.
     expect(result.anchor).toEqual(cell(1, 0)); // A2 (anchor)
-    expect(result.pendingRange).toEqual(range(1, 0, 3, 0)); // A2:A4
+    expect(result.pendingRange).toEqual(range(1, 0, 2, 0)); // A2:A3
   });
 });
 

--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/selection-modes.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/selection-modes.test.ts
@@ -243,14 +243,14 @@ describe('selection-mode lifecycle', () => {
     }
   });
 
-  it('8. mouse_shift_click_moves_active_cell_to_clicked_edge_and_keeps_anchor', () => {
+  it('8. mouse_shift_click_keeps_active_cell_at_anchor', () => {
     const actor = startActorAt(0, 0);
 
     actor.send({ type: 'MOUSE_DOWN', cell: cell(2, 2), shiftKey: true, ctrlKey: false });
 
     let after = actor.getSnapshot().context;
     expect(after.anchor).toEqual(cell(0, 0));
-    expect(after.activeCell).toEqual(cell(2, 2));
+    expect(after.activeCell).toEqual(cell(0, 0));
     expect(after.pendingRange).toEqual(rng(0, 0, 2, 2));
 
     actor.send({ type: 'MOUSE_UP' });
@@ -258,7 +258,7 @@ describe('selection-mode lifecycle', () => {
 
     after = actor.getSnapshot().context;
     expect(after.anchor).toEqual(cell(0, 0));
-    expect(after.activeCell).toEqual(cell(0, 1));
+    expect(after.activeCell).toEqual(cell(0, 0));
     expect(after.pendingRange).toEqual(rng(0, 0, 0, 1));
     actor.stop();
   });

--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/keyboard-actions.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/keyboard-actions.ts
@@ -35,6 +35,7 @@ import {
   createFullColumnRangeSpan,
   createFullRowRangeSpan,
   getMovingEdge,
+  moveCell,
   moveCellSkipHidden,
   normalizeRange,
   rangeFromAnchorAndCell,
@@ -173,16 +174,12 @@ const extendSelection = assign(
       const movingEdge = getMovingEdge(context.pendingRange, anchorCell);
       const targetRow =
         event.direction === 'up' || event.direction === 'down'
-          ? moveCellSkipHidden(
-              movingEdge,
-              event.direction,
-              1,
-              context.isRowHidden,
-              context.isColHidden,
-            ).row
+          ? moveCell(movingEdge, event.direction, 1).row
           : movingEdge.row;
       const activeCell =
-        context.modes.extend && !event.shiftKey ? { row: targetRow, col: anchorCell.col } : anchorCell;
+        context.modes.extend && !event.shiftKey
+          ? { row: targetRow, col: anchorCell.col }
+          : anchorCell;
 
       return {
         pendingRange: createFullRowRangeSpan(anchorCell.row, targetRow),
@@ -199,16 +196,12 @@ const extendSelection = assign(
       const movingEdge = getMovingEdge(context.pendingRange, anchorCell);
       const targetCol =
         event.direction === 'left' || event.direction === 'right'
-          ? moveCellSkipHidden(
-              movingEdge,
-              event.direction,
-              1,
-              context.isRowHidden,
-              context.isColHidden,
-            ).col
+          ? moveCell(movingEdge, event.direction, 1).col
           : movingEdge.col;
       const activeCell =
-        context.modes.extend && !event.shiftKey ? { row: anchorCell.row, col: targetCol } : anchorCell;
+        context.modes.extend && !event.shiftKey
+          ? { row: anchorCell.row, col: targetCol }
+          : anchorCell;
 
       return {
         pendingRange: createFullColumnRangeSpan(anchorCell.col, targetCol),
@@ -223,14 +216,10 @@ const extendSelection = assign(
     // Get the "moving edge" - the corner opposite the anchor that should move
     // For first extend (single cell), the moving edge is the activeCell itself
     const movingEdge = getMovingEdge(context.pendingRange, anchor);
-    // Move the moving edge in the arrow direction
-    const stepped = moveCellSkipHidden(
-      movingEdge,
-      event.direction,
-      1,
-      context.isRowHidden,
-      context.isColHidden,
-    );
+    // Shift+Arrow changes range geometry by worksheet coordinates. Hidden
+    // rows/columns remain part of the selected rectangle; plain navigation
+    // uses moveCellSkipHidden separately.
+    const stepped = moveCell(movingEdge, event.direction, 1);
     // extend past a merge boundary so the moving edge doesn't
     // sit on the merge interior — matches the same machine-internal escape
     // used by `moveActiveCell`.

--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/mouse-actions.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/mouse-actions.ts
@@ -53,17 +53,14 @@ const setAnchorAndSelect = assign(
 
 /**
  * Extend selection to clicked cell (shift+click).
- * Mouse Shift+click keeps the original anchor for subsequent Shift+clicks,
- * while the clicked cell becomes the active edge.
+ * Mouse Shift+click keeps the original anchor active, matching keyboard
+ * extend and drag selection behavior. The moving edge lives in range geometry.
  */
 const extendToCell = assign(
   ({ context, event }: { context: SelectionContext; event: SelectionEvent }) => {
     if (event.type !== 'MOUSE_DOWN') return {};
     const anchor = context.anchor ?? context.activeCell;
-    return {
-      ...buildExtendUpdate(anchor, event.cell),
-      activeCell: event.cell,
-    };
+    return buildExtendUpdate(anchor, event.cell);
   },
 );
 

--- a/apps/spreadsheet/src/systems/grid-editing/testing/__tests__/find-replace-wiring.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/testing/__tests__/find-replace-wiring.test.ts
@@ -36,7 +36,10 @@ import { setupFindReplaceCoordination } from '../../features/find-replace/find-r
 function createMockWorkbook(
   sheetId: SheetId,
   cells: Array<{ row: number; col: number; value: string; cellId: string }>,
+  options: { hiddenRows?: number[]; hiddenCols?: number[] } = {},
 ): WorkbookInternal {
+  const hiddenRows = new Set(options.hiddenRows ?? []);
+  const hiddenCols = new Set(options.hiddenCols ?? []);
   const mockWorksheet = {
     getSheetId: () => sheetId,
     getUsedRange: async () =>
@@ -68,8 +71,8 @@ function createMockWorkbook(
       return cells.find((c) => c.row === row && c.col === col)?.value ?? '';
     }),
     layout: {
-      getHiddenRowsBitmap: jest.fn().mockResolvedValue(new Set<number>()),
-      getHiddenColumnsBitmap: jest.fn().mockResolvedValue(new Set<number>()),
+      getHiddenRowsBitmap: jest.fn().mockResolvedValue(hiddenRows),
+      getHiddenColumnsBitmap: jest.fn().mockResolvedValue(hiddenCols),
     },
     structure: {
       getMergedRegions: jest.fn().mockResolvedValue([]),
@@ -158,6 +161,10 @@ async function waitForFindReplace(
   throw new Error(
     `Timed out waiting for find/replace condition. Current context: ${JSON.stringify(finalSnap.context)}`,
   );
+}
+
+function getActiveCell(system: GridEditingSystem): { row: number; col: number } {
+  return system.access.actors.selection.getSnapshot().context.activeCell;
 }
 
 // =============================================================================
@@ -339,7 +346,80 @@ describe('Find-Replace Wiring (Bug #28)', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Test 5: Without coordination wired, search hangs (documents the dep)
+  // Test 5: Hidden rows/columns are skipped by search navigation
+  // ---------------------------------------------------------------------------
+
+  it('skips hidden-column matches and keeps Enter on the first visible live-search result', async () => {
+    const mockWorkbook = createMockWorkbook(
+      sheetId('sheet-1'),
+      [
+        { row: 2, col: 15, value: '1Q', cellId: 'hidden-p3' },
+        { row: 2, col: 19, value: '1Q', cellId: 'hidden-t3' },
+        { row: 2, col: 23, value: '1Q', cellId: 'hidden-x3' },
+        { row: 2, col: 27, value: '1Q', cellId: 'visible-ab3' },
+        { row: 2, col: 31, value: '1Q', cellId: 'visible-af3' },
+      ],
+      { hiddenCols: [15, 19, 23] },
+    );
+
+    system = new GridEditingSystem({
+      initialSheetId: 'sheet-1',
+      workbook: mockWorkbook,
+    });
+    system.start();
+
+    cleanupFindReplace = wireFindReplace(system, mockWorkbook, 'sheet-1');
+
+    system.access.actors.selection.send({
+      type: 'SET_SELECTION',
+      ranges: [{ startRow: 20, startCol: 15, endRow: 20, endCol: 15 }],
+      activeCell: { row: 20, col: 15 },
+    });
+
+    const actor = system.access.actors.findReplace;
+
+    actor.send({ type: 'OPEN' });
+    actor.send({ type: 'SET_QUERY', query: '1Q' });
+    actor.send({ type: 'SEARCH' });
+
+    await waitForFindReplace(
+      system,
+      (snap) =>
+        snap.matches('hasResults' as any) &&
+        snap.context.results.length === 2 &&
+        getActiveCell(system).row === 2 &&
+        getActiveCell(system).col === 27,
+    );
+
+    expect(actor.getSnapshot().context.results.map((result) => result.cellId)).toEqual([
+      'visible-ab3',
+      'visible-af3',
+    ]);
+    expect(actor.getSnapshot().context.currentIndex).toBe(-1);
+
+    actor.send({ type: 'FIND_NEXT' });
+
+    await waitForFindReplace(
+      system,
+      (snap) =>
+        snap.context.currentIndex === 0 &&
+        getActiveCell(system).row === 2 &&
+        getActiveCell(system).col === 27,
+    );
+
+    actor.send({ type: 'FIND_NEXT' });
+
+    await waitForFindReplace(
+      system,
+      (snap) =>
+        snap.context.currentIndex === 1 &&
+        getActiveCell(system).row === 2 &&
+        getActiveCell(system).col === 31,
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 6: Without coordination wired, search hangs (documents the dep)
   // ---------------------------------------------------------------------------
 
   it('without coordination wired, search stays in searching', async () => {

--- a/apps/spreadsheet/src/systems/input/coordination/input-coordination.ts
+++ b/apps/spreadsheet/src/systems/input/coordination/input-coordination.ts
@@ -1022,12 +1022,13 @@ export class InputCoordinator {
   }
 
   /**
-   * Reset the internal scroll position without triggering any side effects.
+   * Reset the internal scroll position without writing back to the renderer.
    *
    * Use this when an external system (e.g., renderer-execution) has already
    * set the scroll position and the physics engine needs to sync to it.
-   * This avoids re-triggering the save path (onScrollPositionChanged) or
-   * firing scroll callbacks that would create a feedback loop.
+   * This avoids re-triggering the save path (onScrollPositionChanged) while
+   * still publishing the adopted position to scroll subscribers such as the
+   * scrollbar bounds bridge.
    *
    * Specifically used during sheet switch: renderer-execution restores scroll
    * via renderer.setScroll(), then calls this to sync the physics engine.
@@ -1038,9 +1039,16 @@ export class InputCoordinator {
   resetScrollPosition(x: number, y: number): void {
     this.assertNotDisposed();
     this.stopAllAnimations();
+    const bounds = this.scrollPhysics.getBounds();
+    const maxX = Math.max(bounds.maxX, x);
+    const maxY = Math.max(bounds.maxY, y);
+    if (maxX !== bounds.maxX || maxY !== bounds.maxY) {
+      this.scrollPhysics.setBounds(bounds.minX, maxX, bounds.minY, maxY);
+    }
     this.scrollPhysics.setPosition(x, y);
-    // Intentionally does NOT call applyScrollPosition(), notifyScrollCallbacks(),
-    // or requestRender() — the caller has already applied the position externally.
+    this.notifyScrollCallbacks();
+    // Intentionally does NOT call applyScrollPosition() or requestRender() —
+    // the caller has already applied the position externally.
   }
 
   /**

--- a/apps/spreadsheet/src/systems/input/testing/__tests__/scroll-architecture-redesign.test.ts
+++ b/apps/spreadsheet/src/systems/input/testing/__tests__/scroll-architecture-redesign.test.ts
@@ -140,6 +140,24 @@ describe('setScrollPosition callback', () => {
     expect(positions).toHaveLength(0);
   });
 
+  it('resetScrollPosition adopts renderer-owned positions beyond current dynamic bounds', () => {
+    const positions: Array<{ x: number; y: number }> = [];
+    const scrollStates: Array<{ x: number; y: number }> = [];
+    coordinator.setDependencies(
+      createMinimalDeps({
+        setScrollPosition: (pos) => positions.push({ x: pos.x, y: pos.y }),
+      }),
+    );
+    coordinator.onScrollChange((state) => scrollStates.push({ x: state.x, y: state.y }));
+
+    coordinator.setContentScrollBounds(2000, 2000);
+    coordinator.resetScrollPosition(601, 6270);
+
+    expect(coordinator.getScrollState()).toMatchObject({ x: 601, y: 6270 });
+    expect(positions).toHaveLength(0);
+    expect(scrollStates).toEqual([{ x: 601, y: 6270 }]);
+  });
+
   it('works when setScrollPosition is not provided (optional)', () => {
     coordinator.setDependencies(createMinimalDeps());
 

--- a/apps/spreadsheet/src/systems/renderer/execution/__tests__/page-scroll.test.ts
+++ b/apps/spreadsheet/src/systems/renderer/execution/__tests__/page-scroll.test.ts
@@ -1,0 +1,77 @@
+import { resolvePageScrollPosition } from '../page-scroll';
+
+function makeDimensions(options: { colWidth?: number; rowHeight?: number } = {}) {
+  const colWidth = options.colWidth ?? 69;
+  const rowHeight = options.rowHeight ?? 20;
+  return {
+    totalRows: 1_000,
+    totalCols: 1_000,
+    getRowTop: (row: number) => row * rowHeight,
+    getColLeft: (col: number) => col * colWidth,
+  };
+}
+
+describe('resolvePageScrollPosition', () => {
+  it('keeps single-viewport horizontal page scroll behavior unchanged', () => {
+    const next = resolvePageScrollPosition({
+      axis: 'horizontal',
+      direction: 'next',
+      visibleRange: { startRow: 0, startCol: 9, endRow: 36, endCol: 37 },
+      dimensions: makeDimensions(),
+      current: { x: 621, y: 0 },
+      layout: {
+        viewports: [
+          {
+            id: 'main',
+            viewportOrigin: { x: 0, y: 0 },
+          },
+        ],
+        primaryViewportId: 'main',
+      } as any,
+    });
+
+    expect(next).toEqual({ x: 38 * 69, y: 0 });
+  });
+
+  it('subtracts frozen viewport origin from horizontal page scroll targets', () => {
+    const next = resolvePageScrollPosition({
+      axis: 'horizontal',
+      direction: 'next',
+      visibleRange: { startRow: 451, startCol: 9, endRow: 487, endCol: 37 },
+      dimensions: makeDimensions(),
+      current: { x: 621, y: 6270 },
+      layout: {
+        viewports: [
+          {
+            id: 'main',
+            viewportOrigin: { x: 207, y: 60 },
+          },
+        ],
+        primaryViewportId: 'main',
+      } as any,
+    });
+
+    expect(next).toEqual({ x: 38 * 69 - 207, y: 6270 });
+  });
+
+  it('subtracts frozen viewport origin from vertical page scroll targets', () => {
+    const next = resolvePageScrollPosition({
+      axis: 'vertical',
+      direction: 'previous',
+      visibleRange: { startRow: 451, startCol: 9, endRow: 487, endCol: 37 },
+      dimensions: makeDimensions(),
+      current: { x: 621, y: 6270 },
+      layout: {
+        viewports: [
+          {
+            id: 'main',
+            viewportOrigin: { x: 207, y: 60 },
+          },
+        ],
+        primaryViewportId: 'main',
+      } as any,
+    });
+
+    expect(next).toEqual({ x: 621, y: (451 - 37) * 20 - 60 });
+  });
+});

--- a/apps/spreadsheet/src/systems/renderer/execution/page-scroll.ts
+++ b/apps/spreadsheet/src/systems/renderer/execution/page-scroll.ts
@@ -1,0 +1,78 @@
+import type { Point, ViewportLayout } from '@mog-sdk/contracts/viewport';
+
+type PageScrollAxis = 'horizontal' | 'vertical';
+type PageScrollDirection = 'previous' | 'next';
+
+interface VisibleRange {
+  startRow: number;
+  startCol: number;
+  endRow: number;
+  endCol: number;
+}
+
+interface PositionDimensions {
+  totalRows: number;
+  totalCols: number;
+  getRowTop(row: number): number;
+  getColLeft(col: number): number;
+}
+
+interface ResolvePageScrollPositionOptions {
+  axis: PageScrollAxis;
+  direction: PageScrollDirection;
+  visibleRange: VisibleRange;
+  dimensions: PositionDimensions;
+  current: Point;
+  layout: ViewportLayout | null;
+}
+
+function getPrimaryViewportOrigin(layout: ViewportLayout | null): Point {
+  const primaryViewport =
+    layout?.viewports.find((viewport) => viewport.id === layout.primaryViewportId) ??
+    layout?.viewports.find((viewport) => viewport.id === 'main') ??
+    layout?.viewports.find((viewport) => viewport.id.startsWith('main:')) ??
+    layout?.viewports[0];
+
+  return primaryViewport?.viewportOrigin ?? { x: 0, y: 0 };
+}
+
+/**
+ * Page navigation chooses a target row/column in document coordinates. Convert
+ * that target to the canonical scroll offset for the active viewport, whose
+ * document origin may start after frozen rows/columns.
+ */
+export function resolvePageScrollPosition({
+  axis,
+  direction,
+  visibleRange,
+  dimensions,
+  current,
+  layout,
+}: ResolvePageScrollPositionOptions): Point {
+  const viewportOrigin = getPrimaryViewportOrigin(layout);
+  let next = { x: current.x, y: current.y };
+
+  if (axis === 'horizontal') {
+    const visibleCols = Math.max(1, visibleRange.endCol - visibleRange.startCol + 1);
+    const targetStartCol =
+      direction === 'previous'
+        ? Math.max(0, visibleRange.startCol - visibleCols)
+        : Math.min(dimensions.totalCols - 1, visibleRange.startCol + visibleCols);
+    next = {
+      ...next,
+      x: Math.max(0, dimensions.getColLeft(targetStartCol) - viewportOrigin.x),
+    };
+  } else {
+    const visibleRows = Math.max(1, visibleRange.endRow - visibleRange.startRow + 1);
+    const targetStartRow =
+      direction === 'previous'
+        ? Math.max(0, visibleRange.startRow - visibleRows)
+        : Math.min(dimensions.totalRows - 1, visibleRange.startRow + visibleRows);
+    next = {
+      ...next,
+      y: Math.max(0, dimensions.getRowTop(targetStartRow) - viewportOrigin.y),
+    };
+  }
+
+  return next;
+}

--- a/apps/spreadsheet/src/systems/renderer/render-system.ts
+++ b/apps/spreadsheet/src/systems/renderer/render-system.ts
@@ -72,6 +72,7 @@ import {
   type RendererExecutionResult,
 } from './execution/renderer-execution';
 import { resolveCellLevelScrollPosition } from './execution/cell-scroll';
+import { resolvePageScrollPosition } from './execution/page-scroll';
 import {
   PageBreakCoordinator,
   type PageBreakHitResult,
@@ -953,23 +954,15 @@ export class RenderSystem implements IRenderSystem {
     const visibleRange = viewport.getSnapshot().visibleRange;
     const dimensions = geometry.getPositionDimensions();
     const current = viewport.getScrollPosition();
-    let next = { x: current.x, y: current.y };
-
-    if (axis === 'horizontal') {
-      const visibleCols = Math.max(1, visibleRange.endCol - visibleRange.startCol + 1);
-      const targetStartCol =
-        direction === 'previous'
-          ? Math.max(0, visibleRange.startCol - visibleCols)
-          : Math.min(dimensions.totalCols - 1, visibleRange.startCol + visibleCols);
-      next = { ...next, x: dimensions.getColLeft(targetStartCol) };
-    } else {
-      const visibleRows = Math.max(1, visibleRange.endRow - visibleRange.startRow + 1);
-      const targetStartRow =
-        direction === 'previous'
-          ? Math.max(0, visibleRange.startRow - visibleRows)
-          : Math.min(dimensions.totalRows - 1, visibleRange.startRow + visibleRows);
-      next = { ...next, y: dimensions.getRowTop(targetStartRow) };
-    }
+    const layout = this.rendererExecution?.getViewportLayout() ?? null;
+    const next = resolvePageScrollPosition({
+      axis,
+      direction,
+      visibleRange,
+      dimensions,
+      current,
+      layout,
+    });
 
     const clamped = viewport.clampScrollPosition(next);
     this.rendererExecution?.setScrollPosition(clamped);

--- a/apps/spreadsheet/src/systems/testing-foundation/__tests__/integration/selection-object-exclusivity.test.ts
+++ b/apps/spreadsheet/src/systems/testing-foundation/__tests__/integration/selection-object-exclusivity.test.ts
@@ -62,6 +62,19 @@ describe('Selection-Object mutual exclusion', () => {
     expect(objSnap.selectedIds).toEqual([]);
   });
 
+  test('programmatic user setSelection deselects objects', () => {
+    sim.objects!.handleObjectMouseDown('obj-1', 'body', { x: 150, y: 150 }, false, false);
+    sim.objects!.handleObjectMouseUp({ x: 150, y: 150 });
+    expect(sim.objects!.getObjectInteractionSnapshot().selectedIds).toContain('obj-1');
+
+    sim.grid.access.commands.selection.setSelection(
+      [{ startRow: 2, startCol: 11, endRow: 20, endCol: 27 }],
+      { row: 2, col: 11 },
+    );
+
+    expect(sim.objects!.getObjectInteractionSnapshot().selectedIds).toEqual([]);
+  });
+
   test('objects.onObjectSelectionActive deselects grid via notifyExternalSelectionActive', () => {
     // Trigger a grid selection first
     sim.grid.access.commands.selection.mouseDown({ row: 0, col: 0 }, false, false);

--- a/canvas/engine/src/__tests__/dirty-rect-accumulator.test.ts
+++ b/canvas/engine/src/__tests__/dirty-rect-accumulator.test.ts
@@ -106,6 +106,14 @@ describe('DirtyRectAccumulator', () => {
     expect(union.height).toBe(5);
   });
 
+  it('large rects hints coalesce without spreading the array into the call stack', () => {
+    const bounds = Array.from({ length: 200_000 }, (_, i) => rect(i, i % 7, 1, 2));
+
+    expect(() => acc.add({ type: 'rects', bounds })).not.toThrow();
+    expect(acc.isFull()).toBe(false);
+    expect(acc.getRects()).toEqual([rect(0, 0, 200_000, 8)]);
+  });
+
   // ---------------------------------------------------------------------------
   // Area threshold promotes to full
   // ---------------------------------------------------------------------------

--- a/canvas/engine/src/core/dirty-rect-accumulator.ts
+++ b/canvas/engine/src/core/dirty-rect-accumulator.ts
@@ -41,7 +41,13 @@ export class DirtyRectAccumulator {
     if (hint.type === 'rect') {
       this._rects.push(hint.bounds);
     } else if (hint.type === 'rects') {
-      this._rects.push(...hint.bounds);
+      if (this._rects.length + hint.bounds.length > DirtyRectAccumulator.COALESCE_THRESHOLD) {
+        this.mergeRectsIntoBoundingUnion(hint.bounds);
+      } else {
+        for (const bounds of hint.bounds) {
+          this._rects.push(bounds);
+        }
+      }
     }
 
     if (this._rects.length > DirtyRectAccumulator.COALESCE_THRESHOLD) {
@@ -106,6 +112,37 @@ export class DirtyRectAccumulator {
     }
 
     // Replace all rects with the bounding union (stays in doc-space)
+    this._rects.length = 0;
+    this._rects.push({
+      x: minX,
+      y: minY,
+      width: maxX - minX,
+      height: maxY - minY,
+    } as DocSpaceRect);
+  }
+
+  private mergeRectsIntoBoundingUnion(rects: readonly DocSpaceRect[]): void {
+    if (rects.length === 0) return;
+
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
+
+    for (const r of this._rects) {
+      minX = Math.min(minX, r.x);
+      minY = Math.min(minY, r.y);
+      maxX = Math.max(maxX, r.x + r.width);
+      maxY = Math.max(maxY, r.y + r.height);
+    }
+
+    for (const r of rects) {
+      minX = Math.min(minX, r.x);
+      minY = Math.min(minY, r.y);
+      maxX = Math.max(maxX, r.x + r.width);
+      maxY = Math.max(maxY, r.y + r.height);
+    }
+
     this._rects.length = 0;
     this._rects.push({
       x: minX,

--- a/canvas/grid-canvas/src/renderer/__tests__/grid-render-scheduler.test.ts
+++ b/canvas/grid-canvas/src/renderer/__tests__/grid-render-scheduler.test.ts
@@ -1,0 +1,45 @@
+import { jest } from '@jest/globals';
+
+import type { CanvasEngine, DirtyCellExpander } from '@mog/canvas-engine';
+import type { ViewportPositionIndex } from '@mog/grid-renderer';
+
+import { GridRenderScheduler } from '../grid-render-scheduler';
+
+function createEngine(): CanvasEngine {
+  return {
+    markDirty: jest.fn(),
+    requestFrame: jest.fn(),
+  } as unknown as CanvasEngine;
+}
+
+function createPositionIndex(): ViewportPositionIndex {
+  return {
+    getColLeft: jest.fn((col: number) => col * 64),
+    getRowTop: jest.fn((row: number) => row * 20),
+    getColWidth: jest.fn(() => 64),
+    getRowHeight: jest.fn(() => 20),
+  } as unknown as ViewportPositionIndex;
+}
+
+describe('GridRenderScheduler', () => {
+  it('falls back to full cell-layer dirty for very large cell batches', () => {
+    const engine = createEngine();
+    const scheduler = new GridRenderScheduler(engine);
+    const expander: DirtyCellExpander = {
+      expandDirtyCells: jest.fn((cells) => cells),
+    };
+    const cells = Array.from({ length: 10_001 }, (_value, index) => ({
+      row: Math.floor(index / 100),
+      col: index % 100,
+    }));
+
+    scheduler.setPositionIndex(createPositionIndex());
+    scheduler.setCellExpander(expander);
+    scheduler.markCellsDirty(cells);
+
+    expect(expander.expandDirtyCells).not.toHaveBeenCalled();
+    expect(engine.markDirty).toHaveBeenCalledTimes(1);
+    expect(engine.markDirty).toHaveBeenCalledWith('cells');
+    expect(engine.requestFrame).toHaveBeenCalledTimes(1);
+  });
+});

--- a/canvas/grid-canvas/src/renderer/grid-render-scheduler.ts
+++ b/canvas/grid-canvas/src/renderer/grid-render-scheduler.ts
@@ -27,6 +27,13 @@ import type { ViewportPositionIndex } from '@mog/grid-renderer';
 /** Layer IDs that need invalidation for cell content/format changes */
 const CELL_LAYERS: readonly LayerName[] = ['cells'];
 
+/**
+ * Large structural edits can emit hundreds of thousands of cell patches.
+ * Resolving each to a precise dirty rect blocks the main thread longer than a
+ * full repaint and the accumulator coalesces large rect sets anyway.
+ */
+const MAX_PRECISE_DIRTY_CELLS = 10_000;
+
 /** Layer IDs for geometry changes (row/col dimensions) */
 const GEOMETRY_LAYERS: readonly LayerName[] = [
   'cells',
@@ -62,18 +69,31 @@ export class GridRenderScheduler implements RenderScheduler {
     this._cellExpander = expander;
   }
 
+  private markCellLayersFullDirty(): void {
+    for (const layerId of CELL_LAYERS) {
+      this.engine.markDirty(layerId);
+    }
+    this.engine.requestFrame();
+  }
+
   markCellsDirty(cells?: { row: number; col: number }[]): void {
     if (!cells || cells.length === 0 || !this._positionIndex) {
       // No cells specified or no position index — fall back to full dirty
-      for (const layerId of CELL_LAYERS) {
-        this.engine.markDirty(layerId);
-      }
-      this.engine.requestFrame();
+      this.markCellLayersFullDirty();
+      return;
+    }
+
+    if (cells.length > MAX_PRECISE_DIRTY_CELLS) {
+      this.markCellLayersFullDirty();
       return;
     }
 
     // Step 1: dependency expansion (render-derived)
     const expandedCells = this._cellExpander ? this._cellExpander.expandDirtyCells(cells) : cells;
+    if (expandedCells.length > MAX_PRECISE_DIRTY_CELLS) {
+      this.markCellLayersFullDirty();
+      return;
+    }
 
     // Step 2: coordinate resolution (data-derived)
     const pi = this._positionIndex;

--- a/canvas/grid-renderer/src/coordinates/__tests__/is-cell-visible.test.ts
+++ b/canvas/grid-renderer/src/coordinates/__tests__/is-cell-visible.test.ts
@@ -80,6 +80,57 @@ describe('CoordinateSystem.isCellVisible — viewport-follow contract', () => {
       expect(visible).toBe(scrollTo === null);
       expect(visible).toBe(false);
     });
+
+    it('frozen-row cells can still request horizontal scrolling', () => {
+      coords.setFrozenPanes({ rows: 3, cols: 1 });
+      coords.setViewport({
+        scrollTop: 250,
+        scrollLeft: 50 * DEFAULT_COL_WIDTH,
+        width: 800,
+        height: 600,
+      });
+
+      const cell = { row: 2, col: 10 };
+      const scrollTo = coords.getScrollToCell(TEST_SHEET_ID, cell);
+
+      expect(coords.isCellVisible(TEST_SHEET_ID, cell)).toBe(false);
+      expect(scrollTo).not.toBeNull();
+      expect(scrollTo?.top).toBe(250);
+      expect(scrollTo?.left).toBeLessThan(50 * DEFAULT_COL_WIDTH);
+    });
+
+    it('frozen-column cells can still request vertical scrolling', () => {
+      coords.setFrozenPanes({ rows: 3, cols: 1 });
+      coords.setViewport({
+        scrollTop: 50 * DEFAULT_ROW_HEIGHT,
+        scrollLeft: 250,
+        width: 800,
+        height: 600,
+      });
+
+      const cell = { row: 10, col: 0 };
+      const scrollTo = coords.getScrollToCell(TEST_SHEET_ID, cell);
+
+      expect(coords.isCellVisible(TEST_SHEET_ID, cell)).toBe(false);
+      expect(scrollTo).not.toBeNull();
+      expect(scrollTo?.top).toBeLessThan(50 * DEFAULT_ROW_HEIGHT);
+      expect(scrollTo?.left).toBe(250);
+    });
+
+    it('cells in both frozen axes need no scroll target', () => {
+      coords.setFrozenPanes({ rows: 3, cols: 1 });
+      coords.setViewport({
+        scrollTop: 50 * DEFAULT_ROW_HEIGHT,
+        scrollLeft: 50 * DEFAULT_COL_WIDTH,
+        width: 800,
+        height: 600,
+      });
+
+      const cell = { row: 2, col: 0 };
+
+      expect(coords.isCellVisible(TEST_SHEET_ID, cell)).toBe(true);
+      expect(coords.getScrollToCell(TEST_SHEET_ID, cell)).toBeNull();
+    });
   });
 
   describe('visibility reads live scroll state', () => {

--- a/canvas/grid-renderer/src/coordinates/coordinate-system.ts
+++ b/canvas/grid-renderer/src/coordinates/coordinate-system.ts
@@ -190,7 +190,7 @@ export class CoordinateSystemImpl implements CoordinateSystem {
     if (cached === undefined) {
       const pi = this.positionIndex;
       cached = pi
-        ? pi.getRowTop(this.frozenPanes.rows)
+        ? (pi.getRowTop(this.frozenPanes.rows) ?? this.frozenPanes.rows * DEFAULT_ROW_HEIGHT)
         : this.frozenPanes.rows * DEFAULT_ROW_HEIGHT;
       this.frozenRowsHeightCache.set(sheetId, cached);
     }
@@ -208,7 +208,7 @@ export class CoordinateSystemImpl implements CoordinateSystem {
     if (cached === undefined) {
       const pi = this.positionIndex;
       cached = pi
-        ? pi.getColLeft(this.frozenPanes.cols)
+        ? (pi.getColLeft(this.frozenPanes.cols) ?? this.frozenPanes.cols * DEFAULT_COL_WIDTH)
         : this.frozenPanes.cols * DEFAULT_COL_WIDTH;
       this.frozenColsWidthCache.set(sheetId, cached);
     }
@@ -1031,8 +1031,12 @@ export class CoordinateSystemImpl implements CoordinateSystem {
     const frozenRowsHeight = this.getFrozenRowsHeight(sheetId);
     const frozenColsWidth = this.getFrozenColsWidth(sheetId);
 
-    // If cell is frozen, it's always visible
-    if (this.isCellFrozen(sheetId, cell)) return null;
+    const isFrozenRow = cell.row < this.frozenPanes.rows;
+    const isFrozenCol = cell.col < this.frozenPanes.cols;
+
+    // A cell in both frozen axes is always visible. A cell in only one
+    // frozen axis can still need scrolling along the other axis.
+    if (isFrozenRow && isFrozenCol) return null;
 
     const cellRect = this.cellToDocument(sheetId, cell);
 
@@ -1057,18 +1061,24 @@ export class CoordinateSystemImpl implements CoordinateSystem {
     let newScrollTop = this.viewport.scrollTop;
     let newScrollLeft = this.viewport.scrollLeft;
 
-    // Check vertical
-    if (cellTop < visibleTop) {
-      newScrollTop = Math.max(0, cellTop - padding);
-    } else if (cellBottom > visibleBottom) {
-      newScrollTop = cellBottom - scrollableHeight + padding;
+    // Check vertical. Frozen rows are already fixed vertically, but may
+    // still require horizontal scrolling.
+    if (!isFrozenRow) {
+      if (cellTop < visibleTop) {
+        newScrollTop = Math.max(0, cellTop - padding);
+      } else if (cellBottom > visibleBottom) {
+        newScrollTop = cellBottom - scrollableHeight + padding;
+      }
     }
 
-    // Check horizontal
-    if (cellLeft < visibleLeft) {
-      newScrollLeft = Math.max(0, cellLeft - padding);
-    } else if (cellRight > visibleRight) {
-      newScrollLeft = cellRight - scrollableWidth + padding;
+    // Check horizontal. Frozen columns are already fixed horizontally, but
+    // may still require vertical scrolling.
+    if (!isFrozenCol) {
+      if (cellLeft < visibleLeft) {
+        newScrollLeft = Math.max(0, cellLeft - padding);
+      } else if (cellRight > visibleRight) {
+        newScrollLeft = cellRight - scrollableWidth + padding;
+      }
     }
 
     // Clamp to bounds

--- a/compute/core/src/storage/engine/services/features/grouping.rs
+++ b/compute/core/src/storage/engine/services/features/grouping.rs
@@ -1,14 +1,58 @@
 use crate::snapshot::{Axis, ChangeKind, GroupingChange, MutationResult};
 use crate::storage::engine::stores::EngineStores;
-use crate::storage::sheet::{dimensions, grouping};
+use crate::storage::sheet::{dimensions, get_meta_for_export, grouping};
 use cell_types::SheetId;
+use compute_document::undo::ORIGIN_USER_EDIT;
+use domain_types::yrs_schema;
 use value_types::ComputeError;
+use yrs::{Origin, Transact};
 
 fn group_bounds(groups: &[grouping::GroupDefinition]) -> Option<(u32, u32)> {
     groups.iter().fold(None, |acc, group| match acc {
         Some((start, end)) => Some((start.min(group.start), end.max(group.end))),
         None => Some((group.start, group.end)),
     })
+}
+
+fn unhide_expanded_column_group(
+    stores: &mut EngineStores,
+    sheet_id: &SheetId,
+    start: u32,
+    end: u32,
+) {
+    clear_expanded_column_group_collapsed_markers(stores, sheet_id, start, end);
+
+    let cols: Vec<u32> = (start..=end).collect();
+    dimensions::unhide_columns(
+        stores.storage.doc(),
+        stores.storage.sheets(),
+        sheet_id,
+        &cols,
+    );
+}
+
+fn clear_expanded_column_group_collapsed_markers(
+    stores: &mut EngineStores,
+    sheet_id: &SheetId,
+    start: u32,
+    end: u32,
+) {
+    let mut txn = stores
+        .storage
+        .doc()
+        .transact_mut_with(Origin::from(ORIGIN_USER_EDIT));
+    let Some(meta) = get_meta_for_export(&txn, stores.storage.sheets(), sheet_id) else {
+        return;
+    };
+
+    let mut collapsed_cols =
+        yrs_schema::helpers::read_json_vec::<_, u32>(&meta, &txn, "colCollapsed");
+    let marker_end = end.saturating_add(1);
+    let original_len = collapsed_cols.len();
+    collapsed_cols.retain(|col| *col < start || *col > marker_end);
+    if collapsed_cols.len() != original_len {
+        yrs_schema::helpers::write_json_vec(&meta, &mut txn, "colCollapsed", &collapsed_cols);
+    }
 }
 
 fn row_containing_group_bounds(
@@ -314,7 +358,12 @@ pub(in crate::storage::engine) fn set_group_collapsed(
     if let Some((axis, start, end)) = affected {
         match axis {
             grouping::GroupAxis::Row => sync_row_layout_range(stores, sheet_id, start, end),
-            grouping::GroupAxis::Column => sync_column_layout_range(stores, sheet_id, start, end),
+            grouping::GroupAxis::Column => {
+                if !collapsed {
+                    unhide_expanded_column_group(stores, sheet_id, start, end);
+                }
+                sync_column_layout_range(stores, sheet_id, start, end);
+            }
         }
     }
     let mut result = MutationResult::empty();
@@ -353,7 +402,12 @@ pub(in crate::storage::engine) fn toggle_group_collapsed(
     if let Some((axis, start, end)) = affected {
         match axis {
             grouping::GroupAxis::Row => sync_row_layout_range(stores, sheet_id, start, end),
-            grouping::GroupAxis::Column => sync_column_layout_range(stores, sheet_id, start, end),
+            grouping::GroupAxis::Column => {
+                if matches!(toggled, Some(false)) {
+                    unhide_expanded_column_group(stores, sheet_id, start, end);
+                }
+                sync_column_layout_range(stores, sheet_id, start, end);
+            }
         }
     }
     let mut result = MutationResult::empty();
@@ -381,6 +435,7 @@ pub(in crate::storage::engine) fn expand_all_groups(
         sync_row_layout_range(stores, sheet_id, start, end);
     }
     if let Some((start, end)) = col_bounds {
+        unhide_expanded_column_group(stores, sheet_id, start, end);
         sync_column_layout_range(stores, sheet_id, start, end);
     }
     let mut result = MutationResult::empty();
@@ -641,7 +696,12 @@ pub(in crate::storage::engine) fn set_level_collapsed(
     if let Some((start, end)) = affected {
         match group_axis {
             grouping::GroupAxis::Row => sync_row_layout_range(stores, sheet_id, start, end),
-            grouping::GroupAxis::Column => sync_column_layout_range(stores, sheet_id, start, end),
+            grouping::GroupAxis::Column => {
+                if !collapsed {
+                    unhide_expanded_column_group(stores, sheet_id, start, end);
+                }
+                sync_column_layout_range(stores, sheet_id, start, end);
+            }
         }
     }
     Ok(MutationResult::empty())

--- a/compute/core/src/storage/engine/services/queries/dimensions.rs
+++ b/compute/core/src/storage/engine/services/queries/dimensions.rs
@@ -9,7 +9,10 @@ pub(in crate::storage::engine) fn is_row_hidden_query(
     sheet_id: &SheetId,
     row: u32,
 ) -> bool {
-    sheet_dimensions::is_row_hidden(stores.storage.doc(), stores.storage.sheets(), sheet_id, row)
+    let doc = stores.storage.doc();
+    let sheets = stores.storage.sheets();
+    sheet_dimensions::is_row_hidden(doc, sheets, sheet_id, row)
+        || !sheet_grouping::is_row_visible_by_groups(doc, sheets, sheet_id, row)
 }
 
 pub(in crate::storage::engine) fn is_col_hidden_query(
@@ -17,7 +20,10 @@ pub(in crate::storage::engine) fn is_col_hidden_query(
     sheet_id: &SheetId,
     col: u32,
 ) -> bool {
-    sheet_dimensions::is_column_hidden(stores.storage.doc(), stores.storage.sheets(), sheet_id, col)
+    let doc = stores.storage.doc();
+    let sheets = stores.storage.sheets();
+    sheet_dimensions::is_column_hidden(doc, sheets, sheet_id, col)
+        || !sheet_grouping::is_column_visible_by_groups(doc, sheets, sheet_id, col)
 }
 
 pub(in crate::storage::engine) fn get_hidden_rows(

--- a/compute/core/src/storage/engine/services/queries/mod.rs
+++ b/compute/core/src/storage/engine/services/queries/mod.rs
@@ -19,8 +19,8 @@ use crate::snapshot::{
 use crate::storage::cells::values as cell_values;
 use crate::storage::infra::cell_iter;
 use crate::storage::sheet::{
-    dimensions as sheet_dimensions, merges, order, print, properties, protection, settings, view,
-    visibility,
+    dimensions as sheet_dimensions, grouping as sheet_grouping, merges, order, print, properties,
+    protection, settings, view, visibility,
 };
 use crate::storage::workbook::named_ranges as workbook_named_ranges;
 use crate::storage::workbook::settings as workbook_settings;

--- a/compute/core/src/storage/engine/tests/test_outline_visibility.rs
+++ b/compute/core/src/storage/engine/tests/test_outline_visibility.rs
@@ -11,6 +11,7 @@
 use super::super::*;
 use super::helpers::*;
 use compute_wire::constants::{CELL_STRIDE, DIM_STRIDE, MERGE_STRIDE, VIEWPORT_HEADER_SIZE};
+use domain_types::{ColDimension, OutlineGroup, ParseOutput, SheetData, SheetDimensions};
 
 #[derive(serde::Deserialize)]
 struct GroupDefId {
@@ -172,6 +173,107 @@ fn collapsed_outline_column_group_returns_zero_col_width() {
         engine.get_col_width_query(&sid, 7) > 0.0,
         "col 7 (outside group) should keep its width"
     );
+}
+
+#[test]
+fn imported_hidden_outline_columns_expand_to_visible_columns() {
+    let mut col_widths: Vec<ColDimension> = (3..=6)
+        .map(|col| ColDimension {
+            col,
+            width: 8.43,
+            width_present: Some(true),
+            hidden: true,
+            hidden_attr: Some(true),
+            ..Default::default()
+        })
+        .collect();
+    col_widths.push(ColDimension {
+        col: 7,
+        width: 8.43,
+        width_present: Some(true),
+        collapsed: true,
+        collapsed_attr: Some(true),
+        ..Default::default()
+    });
+
+    let input = ParseOutput {
+        sheets: vec![SheetData {
+            name: "Imported".to_string(),
+            rows: 20,
+            cols: 12,
+            dimensions: SheetDimensions {
+                col_widths,
+                ..Default::default()
+            },
+            outline_groups: vec![OutlineGroup {
+                is_row: false,
+                start: 3,
+                end: 6,
+                level: 1,
+                collapsed: true,
+                hidden: true,
+                collapsed_on_member: false,
+            }],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let mut engine = engine_from_parse_output_normal(&input);
+    let sid = *engine.mirror().sheet_ids().next().expect("sheet id");
+
+    assert_eq!(engine.get_col_width_query(&sid, 3), 0.0);
+    assert!(
+        engine.is_col_hidden_query(&sid, 3),
+        "imported collapsed outline columns should report hidden before expansion"
+    );
+    let exported_before_expand = engine
+        .export_to_parse_output()
+        .expect("export before expand")
+        .parse_output;
+    assert!(
+        exported_before_expand.sheets[0]
+            .dimensions
+            .col_widths
+            .iter()
+            .any(|col| col.col == 7 && col.collapsed),
+        "imported collapsed summary column marker should be present before expansion"
+    );
+
+    let group_id = engine
+        .get_groups(&sid, "column")
+        .first()
+        .expect("column group")
+        .id
+        .clone();
+    engine
+        .set_group_collapsed(&sid, &group_id, false)
+        .expect("expand group");
+
+    assert!(engine.get_col_width_query(&sid, 3) > 0.0);
+    assert!(!engine.is_col_hidden_query(&sid, 3));
+    let group = engine
+        .get_group_in_sheet(&sid, &group_id)
+        .expect("expanded group");
+    assert!(!group.collapsed);
+    assert!(!group.hidden);
+    let exported_after_expand = engine
+        .export_to_parse_output()
+        .expect("export after expand")
+        .parse_output;
+    assert!(
+        !exported_after_expand.sheets[0]
+            .dimensions
+            .col_widths
+            .iter()
+            .any(|col| col.col == 7 && col.collapsed),
+        "expanded outline export must not keep the stale collapsed summary column marker"
+    );
+
+    engine
+        .set_group_collapsed(&sid, &group_id, true)
+        .expect("collapse group");
+    assert_eq!(engine.get_col_width_query(&sid, 3), 0.0);
+    assert!(engine.is_col_hidden_query(&sid, 3));
 }
 
 #[test]

--- a/compute/core/src/storage/sheet/grouping/collapse.rs
+++ b/compute/core/src/storage/sheet/grouping/collapse.rs
@@ -19,10 +19,14 @@ pub fn set_group_collapsed(
         .chain(config.column_groups.iter_mut())
         .find(|g| g.id == group_id);
     if let Some(group) = found {
-        if group.collapsed == collapsed {
+        let clear_imported_hidden = !collapsed && group.hidden;
+        if group.collapsed == collapsed && !clear_imported_hidden {
             return;
         }
         group.collapsed = collapsed;
+        if clear_imported_hidden {
+            group.hidden = false;
+        }
         set_sheet_grouping_config(doc, sheets, sheet_id, &config);
     }
 }

--- a/compute/core/src/storage/sheet/grouping/collapse_tests.rs
+++ b/compute/core/src/storage/sheet/grouping/collapse_tests.rs
@@ -34,6 +34,44 @@ fn test_toggle_collapsed() {
 }
 
 #[test]
+fn test_expanding_imported_hidden_group_clears_hidden_flag() {
+    let (s, id) = storage_with_sheet();
+    let mut config = get_sheet_grouping_config(s.doc(), &s.sheets_ref(), &id);
+    config.column_groups.push(GroupDefinition {
+        id: "imported-hidden-column-group".to_string(),
+        sheet_id: id.to_uuid_string(),
+        axis: GroupAxis::Column,
+        start: 2,
+        end: 5,
+        level: 1,
+        collapsed: true,
+        parent_id: None,
+        hidden: true,
+        collapsed_on_member: false,
+    });
+    set_sheet_grouping_config(s.doc(), &s.sheets_ref(), &id, &config);
+
+    set_group_collapsed(
+        s.doc(),
+        &s.sheets_ref(),
+        &id,
+        "imported-hidden-column-group",
+        false,
+    );
+
+    let group = get_group_in_sheet(
+        s.doc(),
+        &s.sheets_ref(),
+        &id,
+        "imported-hidden-column-group",
+    )
+    .unwrap();
+    assert!(!group.collapsed);
+    assert!(!group.hidden);
+    assert!(is_column_visible_by_groups(s.doc(), &s.sheets_ref(), &id, 3));
+}
+
+#[test]
 fn test_set_level_collapsed() {
     let (s, id) = storage_with_sheet();
     group_rows(s.doc(), &s.sheets_ref(), &id, 1, 10).unwrap();

--- a/contracts/src/ribbon/collapse-configs.ts
+++ b/contracts/src/ribbon/collapse-configs.ts
@@ -570,15 +570,18 @@ export const WORKBOOK_VIEWS_COLLAPSE_CONFIG: GroupCollapseConfig = {
 
 /**
  * Show group (View tab) collapse configuration.
- * Priority 4 - gridlines, headings, formula bar.
+ * Priority 4 - gridlines, headings, formula bar, status bar.
+ * Keep the checkbox grid mounted through desktop dense/minimal levels so
+ * View > Show controls remain directly reachable instead of hiding behind a
+ * collapsed group menu.
  */
 export const SHOW_COLLAPSE_CONFIG: GroupCollapseConfig = {
   priority: 4,
   levels: {
     0: 'full',
     1: 'compact',
-    2: 'dropdown',
-    3: 'dropdown',
+    2: 'compact',
+    3: 'compact',
     4: 'hidden',
   },
 };

--- a/contracts/src/ribbon/visibility-config.ts
+++ b/contracts/src/ribbon/visibility-config.ts
@@ -311,6 +311,7 @@ export const RIBBON_VISIBILITY_SCHEMA = {
       ruler: true,
       gridlines: true,
       formulaBar: true,
+      statusBar: true,
       headings: true,
       horizontalScrollbar: true,
       verticalScrollbar: true,

--- a/kernel/src/api/workbook/__tests__/viewport-region.test.ts
+++ b/kernel/src/api/workbook/__tests__/viewport-region.test.ts
@@ -78,4 +78,29 @@ describe('ViewportRegionImpl async cleanup ordering', () => {
 
     expect(bridge.updateViewportVisibleWindow).toHaveBeenCalledWith('vp-1', 'sheet-1', nextBounds);
   });
+
+  it('collapses degenerate frozen-corner bounds before registering or refreshing', async () => {
+    const bridge = createBridge();
+    const region = new ViewportRegionImpl(
+      'sheet-1' as any,
+      { startRow: 0, startCol: 0, endRow: 1, endCol: -1 },
+      bridge,
+      'frozen-corner:sheet-1',
+    );
+
+    await region.refresh('none');
+
+    const normalizedBounds = { startRow: 0, startCol: 0, endRow: 1, endCol: 0 };
+    expect(bridge.registerViewportRegion).toHaveBeenCalledWith(
+      'frozen-corner:sheet-1',
+      'sheet-1',
+      normalizedBounds,
+    );
+    expect(bridge.refreshViewportForRegion).toHaveBeenCalledWith(
+      'frozen-corner:sheet-1',
+      'sheet-1',
+      normalizedBounds,
+      'none',
+    );
+  });
 });

--- a/kernel/src/api/workbook/viewport.ts
+++ b/kernel/src/api/workbook/viewport.ts
@@ -17,7 +17,10 @@ import type { SheetId } from '@mog-sdk/contracts/core';
 import type { RenderScheduler } from '@mog-sdk/contracts/rendering';
 import { DisposableBase, type DisposableStore } from '@mog/spreadsheet-utils/disposable';
 import type { ComputeBridge } from '../../bridges/compute/compute-bridge';
-import type { ViewportScrollBehavior } from '../../bridges/wire/viewport-prefetch';
+import {
+  normalizeViewportBounds,
+  type ViewportScrollBehavior,
+} from '../../bridges/wire/viewport-prefetch';
 
 type ViewportBounds = WorkbookViewportBounds;
 
@@ -55,12 +58,12 @@ export class ViewportRegionImpl extends DisposableBase implements ViewportRegion
     this.id = viewportId ?? `vp-${++regionCounter}`;
     this.sheetId = sheetId;
     this.computeBridge = computeBridge;
-    this.bounds = bounds;
+    this.bounds = normalizeViewportBounds(bounds);
 
     // Register with the Rust engine. Refresh/dispose are ordered against this
     // promise so a newly-created region cannot fetch before Rust knows its
     // viewport ID, and disposal cannot reorder unregister before register.
-    this.registration = this.computeBridge.registerViewportRegion(this.id, sheetId, bounds);
+    this.registration = this.computeBridge.registerViewportRegion(this.id, sheetId, this.bounds);
     this.registrationSucceeded = this.registration.then(
       () => true,
       (err) => {
@@ -90,8 +93,8 @@ export class ViewportRegionImpl extends DisposableBase implements ViewportRegion
    */
   updateBounds(bounds: ViewportBounds): void {
     this.throwIfDisposed();
-    this.bounds = bounds;
-    this.computeBridge.updateViewportVisibleWindow(this.id, this.sheetId, bounds);
+    this.bounds = normalizeViewportBounds(bounds);
+    this.computeBridge.updateViewportVisibleWindow(this.id, this.sheetId, this.bounds);
   }
 
   async refresh(scrollBehavior?: unknown): Promise<void> {

--- a/kernel/src/bridges/compute/__tests__/compute-core-lifecycle-cleanup.test.ts
+++ b/kernel/src/bridges/compute/__tests__/compute-core-lifecycle-cleanup.test.ts
@@ -90,6 +90,30 @@ describe('ComputeCore document-scoped cleanup lifecycle', () => {
     await core.destroy();
   });
 
+  it('normalizes degenerate viewport bounds before registering with Rust', async () => {
+    const transport = {
+      call: jest.fn(() => Promise.resolve(undefined)),
+    };
+    const core = createStartedCore(transport as BridgeTransport);
+
+    await core.registerViewportRegion('frozen-corner:sheet-1', 'sheet-1' as any, {
+      startRow: 0,
+      startCol: 0,
+      endRow: 1,
+      endCol: -1,
+    });
+
+    expect(transport.call).toHaveBeenCalledWith('compute_register_viewport', {
+      docId: 'test-doc',
+      viewportId: 'frozen-corner:sheet-1',
+      sheetId: 'sheet-1',
+      startRow: 0,
+      startCol: 0,
+      endRow: 1,
+      endCol: 0,
+    });
+  });
+
   it('viewport release operations no-op during DESTROYING', async () => {
     const destroyDeferred = deferred<void>();
     const transport = {

--- a/kernel/src/bridges/compute/__tests__/viewport-fetch-manager.test.ts
+++ b/kernel/src/bridges/compute/__tests__/viewport-fetch-manager.test.ts
@@ -270,6 +270,53 @@ describe('ViewportFetchManager', () => {
       expect(args.endCol).toBeGreaterThanOrEqual(bounds.endCol);
     });
 
+    it('does not send negative degenerate frozen-corner bounds to Rust', async () => {
+      const transport = makeMockTransport();
+      const { manager } = createManager(transport);
+
+      await manager.refresh(
+        'frozen-corner:sheet-1',
+        'sheet-1',
+        {
+          startRow: 0,
+          startCol: 0,
+          endRow: 1,
+          endCol: -1,
+        },
+        'none',
+      );
+
+      const registerCall = transport.call.mock.calls.find(
+        ([cmd]: [string]) => cmd === 'compute_register_viewport',
+      );
+      expect(registerCall).toBeDefined();
+      const [, registerArgs] = registerCall!;
+      expect(registerArgs).toEqual(
+        expect.objectContaining({
+          viewportId: 'frozen-corner:sheet-1',
+          sheetId: 'sheet-1',
+          startRow: 0,
+          startCol: 0,
+          endRow: 1,
+          endCol: 0,
+        }),
+      );
+
+      const fetchCall = transport.call.mock.calls.find(
+        ([cmd]: [string]) => cmd === 'compute_get_viewport_binary',
+      );
+      expect(fetchCall).toBeDefined();
+      const [, fetchArgs] = fetchCall!;
+      expect(fetchArgs).toEqual(
+        expect.objectContaining({
+          startRow: 0,
+          startCol: 0,
+          endRow: 2,
+          endCol: 1,
+        }),
+      );
+    });
+
     it('re-registers compute viewport on prefetch hit without fetching', async () => {
       const transport = makeMockTransport();
       const { manager } = createManager(transport);
@@ -514,6 +561,55 @@ describe('ViewportFetchManager', () => {
       expect(state.lastVisibleBounds).toEqual(expectedVisibleBounds);
       expect(state.prefetchDirtyState.dirtyRegion).toBeNull();
       expect(state.prefetchDirtyState.staleCells.size).toBe(0);
+    });
+
+    it('normalizes zero-column buffer bounds before force-refresh registration', async () => {
+      const transport = {
+        call: jest.fn(async (cmd: string) => {
+          if (cmd === 'compute_get_viewport_binary') {
+            return makeBuffer(0, 0, 2, 0);
+          }
+          return undefined;
+        }) as any,
+      } as BridgeTransport & { call: jest.Mock };
+      const { manager } = createManager(transport);
+
+      await manager.refresh(
+        'frozen-corner:sheet-1',
+        'sheet-1',
+        {
+          startRow: 0,
+          startCol: 0,
+          endRow: 1,
+          endCol: -1,
+        },
+        'none',
+      );
+      transport.call.mockClear();
+
+      await manager.forceRefreshAllViewports();
+
+      const registerCall = transport.call.mock.calls.find(
+        ([cmd]: [string]) => cmd === 'compute_register_viewport',
+      );
+      expect(registerCall).toBeDefined();
+      const [, registerArgs] = registerCall!;
+      expect(registerArgs).toEqual(
+        expect.objectContaining({
+          viewportId: 'frozen-corner:sheet-1',
+          sheetId: 'sheet-1',
+          startRow: 0,
+          startCol: 0,
+          endRow: 1,
+          endCol: 0,
+        }),
+      );
+      expect(manager.getPerViewportStates().get('frozen-corner:sheet-1')!.prefetchBounds).toEqual({
+        startRow: 0,
+        startCol: 0,
+        endRow: 1,
+        endCol: 0,
+      });
     });
 
     it('fetches registered viewports that have a visible window but no buffer yet', async () => {

--- a/kernel/src/bridges/compute/compute-core.ts
+++ b/kernel/src/bridges/compute/compute-core.ts
@@ -33,7 +33,11 @@ import type { ReadonlyBinaryViewportBuffer } from '../wire/viewport-coordinator'
 import type { CellMetadataCache } from '../wire/cell-metadata-cache';
 import type { RangeMetadataCache } from '../wire/range-metadata-cache';
 import { ViewportCoordinatorRegistry } from '../wire/viewport-coordinator-registry';
-import type { ViewportPrefetchState, ViewportScrollBehavior } from '../wire/viewport-prefetch';
+import {
+  normalizeViewportBounds,
+  type ViewportPrefetchState,
+  type ViewportScrollBehavior,
+} from '../wire/viewport-prefetch';
 
 import { ViewportFetchManager } from './viewport-fetch-manager';
 import {
@@ -1284,7 +1288,12 @@ export class ComputeCore {
     scrollBehavior: ViewportScrollBehavior = 'free',
   ): Promise<void> {
     this.ensureInitialized();
-    return this.fetchManager!.refresh(viewportId, sheetId, bounds, scrollBehavior);
+    return this.fetchManager!.refresh(
+      viewportId,
+      sheetId,
+      normalizeViewportBounds(bounds),
+      scrollBehavior,
+    );
   }
 
   /**
@@ -1297,7 +1306,7 @@ export class ComputeCore {
     bounds: { startRow: number; startCol: number; endRow: number; endCol: number },
   ): void {
     if (!this.isInitialized) return;
-    this.fetchManager?.updateVisibleWindow(viewportId, sheetId, bounds);
+    this.fetchManager?.updateVisibleWindow(viewportId, sheetId, normalizeViewportBounds(bounds));
   }
 
   /**
@@ -1371,14 +1380,15 @@ export class ComputeCore {
     bounds: { startRow: number; startCol: number; endRow: number; endCol: number },
   ): Promise<void> {
     this.ensureInitialized();
+    const normalizedBounds = normalizeViewportBounds(bounds);
     await this.transport.call<void>('compute_register_viewport', {
       docId: this.docId,
       viewportId,
       sheetId,
-      startRow: bounds.startRow,
-      startCol: bounds.startCol,
-      endRow: bounds.endRow,
-      endCol: bounds.endCol,
+      startRow: normalizedBounds.startRow,
+      startCol: normalizedBounds.startCol,
+      endRow: normalizedBounds.endRow,
+      endCol: normalizedBounds.endCol,
     });
   }
 
@@ -1390,13 +1400,14 @@ export class ComputeCore {
     bounds: { startRow: number; startCol: number; endRow: number; endCol: number },
   ): Promise<void> {
     this.ensureInitialized();
+    const normalizedBounds = normalizeViewportBounds(bounds);
     await this.transport.call<void>('compute_update_viewport_bounds', {
       docId: this.docId,
       viewportId,
-      startRow: bounds.startRow,
-      startCol: bounds.startCol,
-      endRow: bounds.endRow,
-      endCol: bounds.endCol,
+      startRow: normalizedBounds.startRow,
+      startCol: normalizedBounds.startCol,
+      endRow: normalizedBounds.endRow,
+      endCol: normalizedBounds.endCol,
     });
   }
 

--- a/kernel/src/bridges/compute/viewport-fetch-manager.ts
+++ b/kernel/src/bridges/compute/viewport-fetch-manager.ts
@@ -42,6 +42,7 @@ import {
   computePrefetchBounds,
   getPrefetchConfigForViewport,
   isWithinPrefetch,
+  normalizeViewportBounds,
 } from '../wire/viewport-prefetch';
 
 // ---------------------------------------------------------------------------
@@ -189,12 +190,12 @@ export class ViewportFetchManager {
   }
 
   private stripSheetId(bounds: ViewportBounds): PrefetchBounds {
-    return {
+    return normalizeViewportBounds({
       startRow: bounds.startRow,
       startCol: bounds.startCol,
       endRow: bounds.endRow,
       endCol: bounds.endCol,
-    };
+    });
   }
 
   private setVisibleWindow(viewportId: string, sheetId: string, bounds: PrefetchBounds): number {

--- a/kernel/src/bridges/wire/viewport-prefetch.ts
+++ b/kernel/src/bridges/wire/viewport-prefetch.ts
@@ -146,6 +146,33 @@ export function canSkipRefetch(
 // ---------------------------------------------------------------------------
 
 /**
+ * Normalize viewport bounds before they cross the Rust bridge.
+ *
+ * Some pane layouts legitimately produce a degenerate visible range, e.g. a
+ * frozen-corner viewport with no frozen columns has `endCol: -1`. The Rust ABI
+ * takes unsigned coordinates, so negative ends must be collapsed before IPC
+ * instead of wrapping to `u32::MAX`.
+ */
+export function normalizeViewportBounds(
+  bounds: PrefetchBounds,
+  sheetDimensions: { maxRow: number; maxCol: number } = { maxRow: 1048576, maxCol: 16384 },
+): PrefetchBounds {
+  const maxRow = Math.max(0, sheetDimensions.maxRow);
+  const maxCol = Math.max(0, sheetDimensions.maxCol);
+  const startRow = Math.min(maxRow, Math.max(0, bounds.startRow));
+  const startCol = Math.min(maxCol, Math.max(0, bounds.startCol));
+  const endRow = Math.min(maxRow, Math.max(startRow, bounds.endRow));
+  const endCol = Math.min(maxCol, Math.max(startCol, bounds.endCol));
+
+  return {
+    startRow,
+    startCol,
+    endRow,
+    endCol,
+  };
+}
+
+/**
  * Compute oversized prefetch bounds around the visible area.
  * Clamps to [0, sheetDimensions.maxRow/maxCol].
  */
@@ -157,12 +184,15 @@ export function computePrefetchBounds(
     overscanCols: DEFAULT_OVERSCAN_COLS,
   },
 ): PrefetchBounds {
-  return {
-    startRow: Math.max(0, visibleBounds.startRow - config.overscanRows),
-    startCol: Math.max(0, visibleBounds.startCol - config.overscanCols),
-    endRow: Math.min(sheetDimensions.maxRow, visibleBounds.endRow + config.overscanRows),
-    endCol: Math.min(sheetDimensions.maxCol, visibleBounds.endCol + config.overscanCols),
-  };
+  return normalizeViewportBounds(
+    {
+      startRow: visibleBounds.startRow - config.overscanRows,
+      startCol: visibleBounds.startCol - config.overscanCols,
+      endRow: visibleBounds.endRow + config.overscanRows,
+      endCol: visibleBounds.endCol + config.overscanCols,
+    },
+    sheetDimensions,
+  );
 }
 
 /**

--- a/tools/devtools/src/__tests__/dt-readbacks.test.ts
+++ b/tools/devtools/src/__tests__/dt-readbacks.test.ts
@@ -759,6 +759,78 @@ describe('__dt rendered-state readbacks (app-eval / app-eval rendered-state read
     });
   });
 
+  test('getCellValue preserves populated linked-cell display under an unlabeled checkbox overlay', () => {
+    runtime = setupRuntime({
+      drawings: [],
+      rowHeights: { 20: 24 },
+      colWidths: { 12: 100 },
+      viewportCells: {
+        '20,12': {
+          displayText: '34,500',
+          valueType: 1,
+          numberValue: 34500,
+          hasFormula: false,
+        },
+      },
+    });
+
+    const fakeDocument: any = {
+      querySelector: (selector: string) =>
+        selector ===
+        '[data-form-control-type="checkbox"][data-form-control-linked-row="20"][data-form-control-linked-col="12"]'
+          ? {
+              querySelector: (childSelector: string) =>
+                childSelector === '[data-testid^="form-control-checkbox-"]'
+                  ? { textContent: '' }
+                  : null,
+            }
+          : null,
+    };
+    (globalThis as any).document = fakeDocument;
+    (globalThis as any).window.document = fakeDocument;
+
+    const cell = runtime.api.getCellValue(20, 12);
+
+    expect(cell?.displayText).toBe('34,500');
+    expect(cell?.valueType).toBe(1);
+    expect(cell?.numberValue).toBe(34500);
+  });
+
+  test('getCellValue masks boolean linked-cell display under an unlabeled checkbox overlay', () => {
+    runtime = setupRuntime({
+      drawings: [],
+      rowHeights: { 0: 24 },
+      colWidths: { 0: 100 },
+      viewportCells: {
+        '0,0': {
+          displayText: 'FALSE',
+          valueType: 3,
+          hasFormula: false,
+        },
+      },
+    });
+
+    const fakeDocument: any = {
+      querySelector: (selector: string) =>
+        selector ===
+        '[data-form-control-type="checkbox"][data-form-control-linked-row="0"][data-form-control-linked-col="0"]'
+          ? {
+              querySelector: (childSelector: string) =>
+                childSelector === '[data-testid^="form-control-checkbox-"]'
+                  ? { textContent: '' }
+                  : null,
+            }
+          : null,
+    };
+    (globalThis as any).document = fakeDocument;
+    (globalThis as any).window.document = fakeDocument;
+
+    const cell = runtime.api.getCellValue(0, 0);
+
+    expect(cell?.displayText).toBe('');
+    expect(cell?.valueType).toBe(3);
+  });
+
   test('getCellsViaBridge returns empty data for covered merged cells', async () => {
     runtime = setupRuntime({
       drawings: [],

--- a/tools/devtools/src/console/viewport-inspector.ts
+++ b/tools/devtools/src/console/viewport-inspector.ts
@@ -745,7 +745,11 @@ export async function readDisplayedFormatsViaBridge(
   return out;
 }
 
-function hasLinkedUnlabeledCheckboxOverlay(row: number, col: number): boolean {
+function shouldMaskLinkedUnlabeledCheckboxDisplay(
+  row: number,
+  col: number,
+  cell: { valueType?: unknown; displayText?: unknown },
+): boolean {
   if (typeof document === 'undefined') return false;
 
   const selector = [
@@ -759,7 +763,12 @@ function hasLinkedUnlabeledCheckboxOverlay(row: number, col: number): boolean {
   const overlay = wrapper.querySelector<HTMLElement>('[data-testid^="form-control-checkbox-"]');
   if (!overlay) return false;
 
-  return (overlay.textContent ?? '').trim().length === 0;
+  if ((overlay.textContent ?? '').trim().length > 0) return false;
+
+  if (cell.valueType === 3) return true;
+  const displayText =
+    typeof cell.displayText === 'string' ? cell.displayText.trim().toUpperCase() : '';
+  return displayText === 'TRUE' || displayText === 'FALSE';
 }
 
 /**
@@ -785,7 +794,7 @@ export function readCellValue(
         accessor.mergeBounds ?? accessor.mergeRegion ?? accessor.mergedRegion ?? null,
       );
     if (isCoveredCell(row, col, mergeRegion)) return emptyCellReadback(row, col, vpId);
-    const displayText = hasLinkedUnlabeledCheckboxOverlay(row, col)
+    const displayText = shouldMaskLinkedUnlabeledCheckboxDisplay(row, col, accessor)
       ? ''
       : (accessor.displayText ?? null);
     return {

--- a/types/editor/src/actions/action-types.ts
+++ b/types/editor/src/actions/action-types.ts
@@ -510,6 +510,7 @@ export type StructureActionType =
   // Insert/delete cells with shift (not entire rows/columns)
   | 'INSERT_CELLS'
   | 'INSERT_CELLS_SHIFT_DOWN'
+  | 'INSERT_CUT_CELLS_SHIFT_DOWN'
   | 'DELETE_CELLS'
   | 'HIDE_ROW'
   | 'UNHIDE_ROW'


### PR DESCRIPTION
## Summary

Fleet debugger sweep for app-eval failures on the cloud.

- Baseline app-eval run: `f1781124981000` (`1700/1887 FAIL`)
- Debugger fanout run: `f1781126623383` (`194/194 succeeded`)
- Local artifacts: `/Users/guangyuyang/Code/mog-all/mog-internal/plans/app-eval-debug-reports-20260610-140513`

This integrates the production-side fixes from the successful fleet patches:

- selection and viewport-follow fixes for hidden/frozen geometry
- status/view ribbon recovery and collapsed toolbar panel affordances
- data command target/header inference, chart source preservation, comments, checkbox/form control readback, system clipboard paste
- insert/delete/cut-cells dialog deferral and dirty-rect batch safety
- grouping/outline import visibility and full row/column selection recovery
- viewport bounds normalization, horizontal scroll sync, page-scroll execution

## Verification

- Cloud fleet debugger fanout: `f1781126623383` collected successfully, `194/194 succeeded`
- `pnpm --filter @mog/app-spreadsheet test -- ... --runInBand`: 18 suites passed, 368 passed, 2 todo
- `pnpm --filter @mog/grid-renderer test -- coordinates/__tests__/is-cell-visible.test.ts`: passed
- `pnpm --filter @mog/canvas-engine test -- dirty-rect-accumulator.test.ts`: passed
- `pnpm --filter @mog/grid-canvas test -- grid-render-scheduler.test.ts`: passed
- `pnpm --filter @mog-sdk/kernel test -- viewport-region.test.ts compute-core-lifecycle-cleanup.test.ts viewport-fetch-manager.test.ts`: passed
- `cargo test -p compute-core imported_hidden_outline_columns_expand_to_visible_columns`: passed
- `cargo test -p compute-core test_expanding_imported_hidden_group_clears_hidden_flag`: passed
- `cargo clippy -p compute-core`: passed with existing warnings
- `pnpm --filter @mog/grid-renderer typecheck`: passed
- `git diff --check`: passed

Typecheck note:

- Root `pnpm typecheck` currently fails before touched packages because `@mog-sdk/contracts` cannot resolve generated `@mog/types-*` workspace modules.
- `pnpm --filter @mog/app-spreadsheet typecheck` is blocked by existing unresolved shared imports/contracts (`@mog/platform-memory`, `@mog/kernel-host-internal`, `MutationResult`). The patch-specific grouping type error found during verification was fixed and no longer appears.
