### PR TITLE
[fleet v0.9.3] Preserve formula point-mode on scroll

### DIFF
--- a/apps/spreadsheet/src/systems/grid-editing/coordination/scroll-commit-coordination.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/coordination/scroll-commit-coordination.ts
@@ -36,9 +36,10 @@ export interface ScrollCommitCoordinationResult {
 /**
  * Set up scroll-commit coordination.
  *
- * When the grid scrolls while the editor is active, commit the current edit
- * with direction 'none' (no cursor movement). This matches Excel behavior
- * where scrolling commits the edit and closes the editor.
+ * When the grid scrolls while a regular editor is active, commit the current
+ * edit with direction 'none' (no cursor movement). Formula point-mode edits
+ * stay open because sheet switches restore scroll position while the user is
+ * building cross-sheet references.
  *
  * Uses a cached subscription to editor state instead of polling getSnapshot().
  *
@@ -55,18 +56,17 @@ export function setupScrollCommitCoordination(
   const { editorActor, onScrollChange } = config;
 
   // M6 fix: Cache editing state via subscription instead of polling getSnapshot()
-  let isEditing = false;
+  let shouldCommitOnScroll = false;
   const editorSubscription = editorActor.subscribe((state) => {
-    isEditing =
-      state.matches('editing') ||
-      state.matches('formulaEditing') ||
-      state.matches('richTextEditing');
+    shouldCommitOnScroll = state.matches('editing') || state.matches('richTextEditing');
   });
 
   const handleScroll = (): void => {
-    // Only commit if actively editing text, formula, or rich text.
+    // Only commit if actively editing text or rich text.
+    // Formula point-mode is excluded because cross-sheet navigation restores
+    // scroll and must not validate/commit an incomplete formula.
     // imeComposing, validating, committing, inactive, etc. are all excluded.
-    if (!isEditing) return;
+    if (!shouldCommitOnScroll) return;
 
     editorActor.send({ type: 'COMMIT', direction: 'none' });
   };

--- a/apps/spreadsheet/src/systems/grid-editing/testing/__tests__/scroll-commit.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/testing/__tests__/scroll-commit.test.ts
@@ -58,7 +58,7 @@ describe('setupScrollCommitCoordination', () => {
     expect(sent).toEqual([{ type: 'COMMIT', direction: 'none' }]);
   });
 
-  it('commits edit on scroll while formula editing', () => {
+  it('does not commit formula point-mode on scroll', () => {
     const { actor, sent } = createMockEditorActor(['formulaEditing']);
     let scrollCallback: (() => void) | null = null;
 
@@ -74,7 +74,7 @@ describe('setupScrollCommitCoordination', () => {
 
     scrollCallback!();
 
-    expect(sent).toEqual([{ type: 'COMMIT', direction: 'none' }]);
+    expect(sent).toEqual([]);
   });
 
   it('commits edit on scroll while rich text editing', () => {


### PR DESCRIPTION
## Summary
- Prevent scroll-commit coordination from committing formula point-mode edits.
- Keep regular text and rich-text edit scroll commit behavior unchanged.
- Update the scroll coordination unit test to lock the cross-sheet formula contract.

## Fleet evidence
- Baseline app-eval run: f1781139319947
- Debugger fanout run: f1781141191822
- Canary debugger run: f1781140263037
- Canary report: mog-internal/plans/app-eval-debug-reports-v093-20260610-180928/canary/f1781140263037/worker-0.md
- Canary scenario: cross-sheet-formula-bar-stays-active
- Canary diagnosis: sheet-switch scroll restoration called scroll callbacks and sent COMMIT while the editor was in formula point-mode, validating the incomplete formula and preventing cross-sheet reference insertion.

## Verification
- pnpm --filter @mog/app-spreadsheet test -- src/systems/grid-editing/testing/__tests__/scroll-commit.test.ts
- pnpm typecheck:prepare
- pnpm --filter @mog/platform-memory typecheck
- pnpm --filter @mog/kernel-host-internal typecheck
- pnpm --filter @mog/app-spreadsheet typecheck
- npx tsx dev/app-eval/cli.ts run --url http://localhost:3002 --name cross-sheet-formula-bar-stays-active --json-output /tmp/app-eval-cross-sheet-scroll-commit-fix.json --output /tmp/app-eval-cross-sheet-scroll-commit-fix
- npx tsx dev/app-eval/cli.ts run --url http://localhost:3002 --names-file /tmp/app-eval-cross-sheet-failing-names.txt --json-output /tmp/app-eval-cross-sheet-cluster-fix.json --output /tmp/app-eval-cross-sheet-cluster-fix

The extracted 16-scenario cross-sheet failure cluster passed 16/16 against this branch.