### PR TITLE
[fleet v0.9.3] Select imported hidden outline group context

### DIFF
--- a/apps/spreadsheet/src/actions/handlers/__tests__/workbook-grouping.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/workbook-grouping.test.ts
@@ -385,6 +385,32 @@ describe('Workbook SHOW_DETAIL/HIDE_DETAIL summary selections', () => {
     expect(layout.unhideColumns).toHaveBeenCalledWith(15, 26);
   });
 
+  it('expands an imported hidden column group from its visible leading sibling group', async () => {
+    const range: CellRange = { startRow: 12, startCol: 11, endRow: 12, endCol: 11 };
+    const { deps, outline, layout } = createMockDeps([range], {
+      rowGroups: [],
+      columnGroups: [
+        { id: 'cols-l', start: 11, end: 11, level: 1, collapsed: false },
+        {
+          id: 'kewpie-fiscal-cols',
+          start: 15,
+          end: 26,
+          level: 1,
+          collapsed: true,
+          hidden: true,
+        },
+      ],
+    });
+
+    const result = await SHOW_DETAIL(deps);
+
+    expect(result.handled).toBe(true);
+    expect(outline.toggleCollapsed).toHaveBeenCalledTimes(1);
+    expect(outline.toggleCollapsed).toHaveBeenCalledWith('kewpie-fiscal-cols');
+    expect(layout.unhideColumns).toHaveBeenCalledTimes(1);
+    expect(layout.unhideColumns).toHaveBeenCalledWith(15, 26);
+  });
+
   it('expands a collapsed column group when the selection overlaps hidden detail columns', async () => {
     const range: CellRange = { startRow: 2, startCol: 11, endRow: 20, endCol: 27 };
     const { deps, outline } = createMockDeps([range], {
@@ -514,5 +540,29 @@ describe('Workbook SHOW_DETAIL/HIDE_DETAIL summary selections', () => {
     expect(layout.hideColumns).toHaveBeenCalledWith([
       15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
     ]);
+  });
+
+  it('collapses an imported hidden column group instead of its visible leading sibling group', async () => {
+    const range: CellRange = { startRow: 12, startCol: 11, endRow: 12, endCol: 11 };
+    const { deps, outline, layout } = createMockDeps([range], {
+      rowGroups: [],
+      columnGroups: [
+        { id: 'cols-l', start: 11, end: 11, level: 1, collapsed: false },
+        {
+          id: 'kewpie-fiscal-cols',
+          start: 15,
+          end: 26,
+          level: 1,
+          collapsed: false,
+        },
+      ],
+    });
+
+    const result = await HIDE_DETAIL(deps);
+
+    expect(result.handled).toBe(true);
+    expect(outline.toggleCollapsed).toHaveBeenCalledTimes(1);
+    expect(outline.toggleCollapsed).toHaveBeenCalledWith('kewpie-fiscal-cols');
+    expect(layout.hideColumns).not.toHaveBeenCalled();
   });
 });

--- a/apps/spreadsheet/src/actions/handlers/workbook.ts
+++ b/apps/spreadsheet/src/actions/handlers/workbook.ts
@@ -242,6 +242,7 @@ function selectionMatchesRowGroupForDetail(
   bounds: SelectionBounds,
   settings: OutlineSummarySettings,
   groups: readonly GroupRecord[] = [group],
+  includeVisibleSiblingGroupContext = false,
 ): boolean {
   if (rangesOverlap(group.start, group.end, bounds.startRow, bounds.endRow)) {
     return true;
@@ -265,6 +266,7 @@ function selectionMatchesRowGroupForDetail(
     bounds.startRow,
     bounds.endRow,
     settings.summaryRowsBelow,
+    isImportedHiddenGroup(group) || includeVisibleSiblingGroupContext,
   );
 }
 
@@ -273,6 +275,7 @@ function selectionMatchesColumnGroupForDetail(
   bounds: SelectionBounds,
   settings: OutlineSummarySettings,
   groups: readonly GroupRecord[] = [group],
+  includeVisibleSiblingGroupContext = false,
 ): boolean {
   if (rangesOverlap(group.start, group.end, bounds.startCol, bounds.endCol)) {
     return true;
@@ -296,6 +299,7 @@ function selectionMatchesColumnGroupForDetail(
     bounds.startCol,
     bounds.endCol,
     settings.summaryColumnsRight,
+    isImportedHiddenGroup(group) || includeVisibleSiblingGroupContext,
   );
 }
 
@@ -325,6 +329,7 @@ function selectionMatchesAdjacentOutlineContext(
   selectionStart: number,
   selectionEnd: number,
   summaryAfter: boolean,
+  includeVisibleSiblingGroup = false,
 ): boolean {
   const sameLevelGroups = groups
     .filter((candidate) => candidate.level === group.level)
@@ -335,16 +340,34 @@ function selectionMatchesAdjacentOutlineContext(
   if (summaryAfter) {
     const previous = sameLevelGroups[groupIndex - 1];
     if (!previous) return false;
-    return selectionStart >= previous.end + 1 && selectionEnd < group.start;
+    const includePreviousGroup = includeVisibleSiblingGroup && isVisibleSingletonGroup(previous);
+    const contextStart = includePreviousGroup ? previous.start : previous.end + 1;
+    return selectionStart >= contextStart && selectionEnd < group.start;
   }
 
   const next = sameLevelGroups[groupIndex + 1];
   if (!next) return false;
-  return selectionStart > group.end && selectionEnd <= next.start - 1;
+  const includeNextGroup = includeVisibleSiblingGroup && isVisibleSingletonGroup(next);
+  const contextEnd = includeNextGroup ? next.end : next.start - 1;
+  return selectionStart > group.end && selectionEnd <= contextEnd;
+}
+
+function isVisibleSingletonGroup(group: GroupRecord): boolean {
+  return !group.collapsed && group.hidden !== true && group.start === group.end;
 }
 
 function isImportedHiddenGroup(group: GroupRecord): boolean {
   return group.collapsedOnMember === true || group.hidden === true;
+}
+
+function compareDetailGroupCollapsePriority(a: GroupRecord, b: GroupRecord): number {
+  const levelDelta = b.level - a.level;
+  if (levelDelta !== 0) return levelDelta;
+
+  const importedDelta = Number(isImportedHiddenGroup(b)) - Number(isImportedHiddenGroup(a));
+  if (importedDelta !== 0) return importedDelta;
+
+  return b.end - b.start - (a.end - a.start);
 }
 
 function detailIndexes(group: GroupRecord): number[] {
@@ -629,9 +652,10 @@ export const HIDE_DETAIL: AsyncActionHandler = async (deps) => {
   // Find the innermost expanded row group containing the selection.
   const rowGroupsContaining = rowGroups
     .filter(
-      (g) => !g.collapsed && selectionMatchesRowGroupForDetail(g, bounds, settings, rowGroups),
+      (g) =>
+        !g.collapsed && selectionMatchesRowGroupForDetail(g, bounds, settings, rowGroups, true),
     )
-    .sort((a, b) => b.level - a.level);
+    .sort(compareDetailGroupCollapsePriority);
 
   let toggled = false;
   if (rowGroupsContaining.length > 0) {
@@ -647,9 +671,10 @@ export const HIDE_DETAIL: AsyncActionHandler = async (deps) => {
   const colGroupsContaining = columnGroups
     .filter(
       (g) =>
-        !g.collapsed && selectionMatchesColumnGroupForDetail(g, bounds, settings, columnGroups),
+        !g.collapsed &&
+        selectionMatchesColumnGroupForDetail(g, bounds, settings, columnGroups, true),
     )
-    .sort((a, b) => b.level - a.level);
+    .sort(compareDetailGroupCollapsePriority);
 
   if (colGroupsContaining.length > 0) {
     const group = colGroupsContaining[0];


### PR DESCRIPTION
## Summary
- Allow Show/Hide Detail to use a visible singleton sibling outline group as context for an adjacent imported hidden group.
- Prioritize the wider imported hidden group over the visible singleton carrier when collapsing after expansion.
- Add focused grouping regression coverage for the imported Kewpie fiscal-column outline shape.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Workers grouped under this root cause: `47`, `51`, `56`, `60`, `79`, `80`
- Verified scenarios:
  - `kewpie-outline-hidden-detail-expand-collapse-existing-group-far-right-latest-quarter-view-collapsed-fiscal-columns` passed `4/4` after fix.
  - `kewpie-outline-hidden-detail-show-detail-then-filter-dialog-apply-ok-collapsed-fiscal-columns` passed `4/4` after fix.
  - `kewpie-outline-hidden-detail-hide-detail-then-chart-dialog-apply-ok-collapsed-fiscal-columns` passed `6/6` after fix.
  - `kewpie-outline-hidden-detail-hide-detail-then-chart-real-click-ribbon-collapsed-fiscal-columns` passed `6/6` after fix.
  - `kewpie-collapse-edit-expand-ribbon-collapsed-fiscal-columns` passed `8/8` after fix.
  - `kewpie-multi-step-analyst-flow-review-hidden-detail-and-summarize-dialog-apply-ok-collapsed-fiscal-columns` passed `7/7` after fix.

## Notes
- Integrated from worker `47`, which was the most complete patch in this duplicate group.
- This PR is separate from cross-sheet formula fixes (#61) and visible-row sort option forwarding (#62).
- Full reports are stored under `plans/app-eval-debug-reports-v093-20260610-180928/debug/worker-*.md` in `mog-internal`.