### PR TITLE
[fleet v0.9.3] Infer sparse table header rows

### DIFF
--- a/apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts
+++ b/apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts
@@ -48,6 +48,48 @@ describe('resolveDataCommandTarget', () => {
     expect(ws.getCurrentRegion).not.toHaveBeenCalled();
   });
 
+  test('explicit multi-row command selection infers headers with blank header cells', async () => {
+    const ws = makeWorksheet({
+      values: {
+        '2,11': 'FY11/25',
+        '2,12': 'FY11/25',
+        '2,13': 'FY11/28',
+        '2,14': null,
+        '2,15': '1Q',
+        '2,16': '2Q',
+        '6,15': 128319,
+        '6,16': 140667,
+      },
+    });
+    const range = { startRow: 2, startCol: 11, endRow: 20, endCol: 16 };
+
+    await expect(resolveDataCommandTarget(ws as Worksheet, range)).resolves.toEqual({
+      range,
+      hasHeaders: true,
+      wasExpanded: false,
+    });
+    expect(ws.getCurrentRegion).not.toHaveBeenCalled();
+  });
+
+  test('explicit multi-row command selection rejects numeric first-row cells as headers', async () => {
+    const ws = makeWorksheet({
+      values: {
+        '0,0': 'Name',
+        '0,1': 2026,
+        '1,0': 'Ada',
+        '1,1': 10,
+      },
+    });
+    const range = { startRow: 0, startCol: 0, endRow: 3, endCol: 1 };
+
+    await expect(resolveDataCommandTarget(ws as Worksheet, range)).resolves.toEqual({
+      range,
+      hasHeaders: false,
+      wasExpanded: false,
+    });
+    expect(ws.getCurrentRegion).not.toHaveBeenCalled();
+  });
+
   test('explicit multi-row command selection tolerates blank spacer rows before body values', async () => {
     const ws = makeWorksheet({
       values: {

--- a/apps/spreadsheet/src/actions/data-command-target.ts
+++ b/apps/spreadsheet/src/actions/data-command-target.ts
@@ -47,11 +47,17 @@ async function rangeLooksLikeHeaderTable(ws: Worksheet, range: CellRange): Promi
     Array.from({ length: width }, (_, i) => ws.getCell(range.startRow, range.startCol + i)),
   );
 
-  const firstRowAllText = firstRow.every((cell) => {
+  const firstRowHasTextHeader = firstRow.some((cell) => {
     const value = cell?.value;
     return typeof value === 'string' && value.trim().length > 0;
   });
-  if (!firstRowAllText) return false;
+  if (!firstRowHasTextHeader) return false;
+
+  const firstRowOnlyTextOrBlank = firstRow.every((cell) => {
+    const value = cell?.value;
+    return value == null || value === '' || typeof value === 'string';
+  });
+  if (!firstRowOnlyTextOrBlank) return false;
 
   const rowHasDataSignal = (row: Array<{ value?: unknown } | null | undefined>): boolean =>
     row.some((cell) => {


### PR DESCRIPTION
## Summary
- Treat sparse first rows as table headers when at least one nonblank first-row cell is text, all nonblank first-row cells are text, and body rows contain data.
- Preserve numeric-first-row rejection.
- Add focused resolver regression tests for blank header cells and numeric first-row cells.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Workers grouped under this root cause: `14`, `16`, `28`, `40`
- Verified scenarios:
  - `kewpie-format-presentation-format-as-table-far-right-latest-quarter-view-balance-sheet` passed `4/4` after fix.
  - `kewpie-format-presentation-format-as-table-hidden-outline-precondition-collapsed-fiscal-columns` passed `3/3` after fix.
  - `kewpie-format-presentation-format-as-table-real-click-ribbon-collapsed-fiscal-columns` passed `4/4` after fix.
  - `kewpie-format-presentation-format-as-table-dialog-apply-ok-balance-sheet` passed `6/6` after fix.

## Notes
- Integrated from worker `16`, which covers blank header cells plus numeric first-row rejection in the shared data-target resolver.
- This is separate from the quick-sort blank-leading-row fix PR.