### PR TITLE
[fleet v0.9.3] Trim blank leading rows for data commands

### DIFF
--- a/apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts
+++ b/apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts
@@ -67,6 +67,23 @@ describe('resolveDataCommandTarget', () => {
     expect(ws.getCurrentRegion).not.toHaveBeenCalled();
   });
 
+  test('explicit multi-row command selection trims a blank leading title row over body values', async () => {
+    const ws = makeWorksheet({
+      values: {
+        '458,6': 167726,
+        '459,6': 57825,
+      },
+    });
+    const range = { startRow: 457, startCol: 6, endRow: 479, endCol: 6 };
+
+    await expect(resolveDataCommandTarget(ws as Worksheet, range)).resolves.toEqual({
+      range: { startRow: 458, startCol: 6, endRow: 479, endCol: 6 },
+      hasHeaders: false,
+      wasExpanded: false,
+    });
+    expect(ws.getCurrentRegion).not.toHaveBeenCalled();
+  });
+
   test('explicit multi-row dialog target infers headers from first row without expanding', async () => {
     const ws = makeWorksheet({
       values: {
@@ -81,6 +98,22 @@ describe('resolveDataCommandTarget', () => {
     await expect(resolveDataDialogTarget(ws as Worksheet, range)).resolves.toEqual({
       range,
       hasHeaders: true,
+      wasExpanded: false,
+    });
+    expect(ws.getCurrentRegion).not.toHaveBeenCalled();
+  });
+
+  test('explicit multi-row dialog target preserves a blank leading row', async () => {
+    const ws = makeWorksheet({
+      values: {
+        '458,6': 167726,
+      },
+    });
+    const range = { startRow: 457, startCol: 6, endRow: 479, endCol: 6 };
+
+    await expect(resolveDataDialogTarget(ws as Worksheet, range)).resolves.toEqual({
+      range,
+      hasHeaders: false,
       wasExpanded: false,
     });
     expect(ws.getCurrentRegion).not.toHaveBeenCalled();

--- a/apps/spreadsheet/src/actions/data-command-target.ts
+++ b/apps/spreadsheet/src/actions/data-command-target.ts
@@ -10,6 +10,7 @@ export interface DataCommandTarget {
 interface ResolveDataTargetOptions {
   readonly allowEmptySingleCell: boolean;
   readonly inferHeadersForExplicitMultiRow: boolean;
+  readonly trimBlankLeadingCommandRow: boolean;
 }
 
 const HEADER_BODY_SCAN_ROW_LIMIT = 100;
@@ -39,13 +40,40 @@ export function getRelativeCommandColumn(
   return activeCell.col - range.startCol;
 }
 
+function cellHasNonBlankValue(cell: { value?: unknown } | null | undefined): boolean {
+  const value = cell?.value;
+  if (value == null || value === '') return false;
+  if (typeof value !== 'string') return true;
+  return value.trim() !== '';
+}
+
+function rowHasDataSignal(row: Array<{ value?: unknown } | null | undefined>): boolean {
+  return row.some((cell) => {
+    const value = cell?.value;
+    if (value == null || value === '') return false;
+    if (typeof value !== 'string') return true;
+    return value.trim() !== '' && Number.isFinite(Number(value));
+  });
+}
+
+function rowHasNonBlankValue(row: Array<{ value?: unknown } | null | undefined>): boolean {
+  return row.some(cellHasNonBlankValue);
+}
+
+async function readRangeRow(
+  ws: Worksheet,
+  row: number,
+  startCol: number,
+  width: number,
+): Promise<Array<{ value?: unknown } | null | undefined>> {
+  return Promise.all(Array.from({ length: width }, (_, i) => ws.getCell(row, startCol + i)));
+}
+
 async function rangeLooksLikeHeaderTable(ws: Worksheet, range: CellRange): Promise<boolean> {
   if (range.startRow >= range.endRow) return false;
 
   const width = range.endCol - range.startCol + 1;
-  const firstRow = await Promise.all(
-    Array.from({ length: width }, (_, i) => ws.getCell(range.startRow, range.startCol + i)),
-  );
+  const firstRow = await readRangeRow(ws, range.startRow, range.startCol, width);
 
   const firstRowAllText = firstRow.every((cell) => {
     const value = cell?.value;
@@ -53,23 +81,31 @@ async function rangeLooksLikeHeaderTable(ws: Worksheet, range: CellRange): Promi
   });
   if (!firstRowAllText) return false;
 
-  const rowHasDataSignal = (row: Array<{ value?: unknown } | null | undefined>): boolean =>
-    row.some((cell) => {
-      const value = cell?.value;
-      if (value == null || value === '') return false;
-      if (typeof value !== 'string') return true;
-      return value.trim() !== '' && Number.isFinite(Number(value));
-    });
-
   const scanEndRow = Math.min(range.endRow, range.startRow + HEADER_BODY_SCAN_ROW_LIMIT);
   for (let row = range.startRow + 1; row <= scanEndRow; row++) {
-    const bodyRow = await Promise.all(
-      Array.from({ length: width }, (_, i) => ws.getCell(row, range.startCol + i)),
-    );
+    const bodyRow = await readRangeRow(ws, row, range.startCol, width);
     if (rowHasDataSignal(bodyRow)) return true;
   }
 
   return false;
+}
+
+async function trimBlankLeadingCommandRow(ws: Worksheet, range: CellRange): Promise<CellRange> {
+  if (range.startRow >= range.endRow) return range;
+
+  const width = range.endCol - range.startCol + 1;
+  const firstRow = await readRangeRow(ws, range.startRow, range.startCol, width);
+  if (rowHasNonBlankValue(firstRow)) return range;
+
+  const scanEndRow = Math.min(range.endRow, range.startRow + HEADER_BODY_SCAN_ROW_LIMIT);
+  for (let row = range.startRow + 1; row <= scanEndRow; row++) {
+    const bodyRow = await readRangeRow(ws, row, range.startCol, width);
+    if (rowHasNonBlankValue(bodyRow)) {
+      return { ...range, startRow: range.startRow + 1 };
+    }
+  }
+
+  return range;
 }
 
 export async function resolveDataCommandTarget(
@@ -79,6 +115,7 @@ export async function resolveDataCommandTarget(
   return resolveDataTarget(ws, userRange, {
     allowEmptySingleCell: false,
     inferHeadersForExplicitMultiRow: true,
+    trimBlankLeadingCommandRow: true,
   });
 }
 
@@ -91,10 +128,13 @@ async function resolveDataTarget(
   const isMultiRow = range.startRow !== range.endRow;
 
   if (isMultiRow) {
+    const commandRange = options.trimBlankLeadingCommandRow
+      ? await trimBlankLeadingCommandRow(ws, range)
+      : range;
     return {
-      range,
+      range: commandRange,
       hasHeaders: options.inferHeadersForExplicitMultiRow
-        ? await rangeLooksLikeHeaderTable(ws, range)
+        ? await rangeLooksLikeHeaderTable(ws, commandRange)
         : false,
       wasExpanded: false,
     };
@@ -139,6 +179,7 @@ export async function resolveDataDialogTarget(
   const target = await resolveDataTarget(ws, userRange, {
     allowEmptySingleCell: true,
     inferHeadersForExplicitMultiRow: true,
+    trimBlankLeadingCommandRow: false,
   });
   return (
     target ?? {


### PR DESCRIPTION
## Summary
- For explicit multi-row mutating data commands, trim a completely blank leading selected row when later rows contain data.
- Keep dialog target resolution faithful to the user-selected range, so range-editing dialogs do not silently rewrite the selection.
- Reuse row-reading helpers for command target/header inference.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `10`
- Scenario: `kewpie-data-tools-sort-ascending-with-header-keyboard-shortcuts-balance-sheet`
- Worker verification: scenario passed `4/4` after fix.

## Notes
- This PR intentionally stays separate from sparse table-header inference even though both fixes live in `data-command-target.ts`; they are distinct root causes.