### PR TITLE
[fleet v0.9.3] Initialize form-control overlay scroll transform

### DIFF
--- a/apps/spreadsheet/src/components/canvas-overlays/form-controls/FormControlLayerContainer.tsx
+++ b/apps/spreadsheet/src/components/canvas-overlays/form-controls/FormControlLayerContainer.tsx
@@ -16,7 +16,7 @@
  * @module components/canvas-overlays/form-controls
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import type { FormControl } from '@mog-sdk/contracts/form-controls';
 
@@ -163,24 +163,28 @@ export function FormControlLayerContainer() {
   // SCROLL TRANSFORM - 60fps GPU-accelerated scrolling
   // ═══════════════════════════════════════════════════════════════════════════
 
-  useEffect(() => {
+  const syncScrollTransform = useCallback(() => {
     const viewport = getViewport();
-    if (!viewport || !isReady) return;
+    if (!viewport || !isReady || !overlayRef.current) return;
 
-    const syncScroll = () => {
-      const pos = viewport.getScrollPosition();
-      if (overlayRef.current) {
-        overlayRef.current.style.transform = `translate3d(${-pos.x}px, ${-pos.y}px, 0)`;
-      }
-    };
+    const pos = viewport.getScrollPosition();
+    overlayRef.current.style.transform = `translate3d(${-pos.x}px, ${-pos.y}px, 0)`;
+  }, [getViewport, isReady]);
 
-    syncScroll();
+  useLayoutEffect(() => {
+    syncScrollTransform();
+  }, [resolvedControls.length, syncScrollTransform]);
+
+  useEffect(() => {
+    if (!isReady) return;
+
+    syncScrollTransform();
 
     const inputCoordinator = coordinator.input.inputCoordinator;
-    const unsubscribe = inputCoordinator.onScrollChange(syncScroll);
+    const unsubscribe = inputCoordinator.onScrollChange(syncScrollTransform);
 
     return unsubscribe;
-  }, [getViewport, coordinator, isReady]);
+  }, [coordinator, isReady, syncScrollTransform]);
 
   // ═══════════════════════════════════════════════════════════════════════════
   // EARLY RETURNS - After all hooks have been called


### PR DESCRIPTION
## Summary
- Apply the current scroll transform when form-control overlays first mount on an already-scrolled sheet.
- Reuse the same transform callback for scroll subscriptions so checkbox overlays stay aligned with their anchor cells.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Workers grouped under this root cause: `23`, `24`, `25`, `26`
- Verified scenarios:
  - `kewpie-object-creation-insert-checkbox-dialog-apply-ok-collapsed-fiscal-columns` passed `5/5` after fix, with nearby checkbox checks passing `3/3`.
  - `kewpie-object-creation-insert-checkbox-far-right-latest-quarter-view-collapsed-fiscal-columns` passed `5/5` after fix; overlay delta became `{x:0,y:0}`.
  - `kewpie-object-creation-insert-checkbox-keyboard-shortcuts-collapsed-fiscal-columns` passed `7/7` after fix.
  - `kewpie-object-creation-insert-checkbox-real-click-ribbon-collapsed-fiscal-columns` passed `7/7` after fix.

## Notes
- Integrated from worker `24`, the cleanest patch in this duplicate group because it separates initial mount transform application from scroll subscription handling.