### PR TITLE
[fleet v0.9.3] Follow anchor cell for Name Box ranges

### DIFF
--- a/apps/spreadsheet/src/chrome/formula-bar/NameBoxDropdown.tsx
+++ b/apps/spreadsheet/src/chrome/formula-bar/NameBoxDropdown.tsx
@@ -437,7 +437,13 @@ export const NameBoxDropdown = memo(function NameBoxDropdown({
       ): void => {
         deps.commands.object.deselectAll();
         deps.commands.chart.deselectAll();
-        selectionCommands.setSelection([range], nextActiveCell);
+        const isSingleCell =
+          range.startRow === range.endRow && range.startCol === range.endCol;
+        selectionCommands.setSelection(
+          [range],
+          nextActiveCell,
+          isSingleCell ? undefined : null,
+        );
       };
 
       if (trimmedAddress.includes(':')) {

--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/page-navigation-emits.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/page-navigation-emits.test.ts
@@ -51,6 +51,31 @@ describe('page navigation emits', () => {
     actor.stop();
   });
 
+  it('follows the active cell for direct range selection when anchor is explicitly null', () => {
+    const actor = createActor(selectionMachine);
+    const emitted: SelectionEmitted[] = [];
+    const subscription = actor.on('userSelectionChanged', (event) => emitted.push(event));
+
+    actor.start();
+    actor.send({
+      type: 'SET_SELECTION',
+      ranges: [{ startRow: 2, startCol: 11, endRow: 7, endCol: 13 }],
+      activeCell: { row: 2, col: 11 },
+      anchor: null,
+      source: 'user',
+    });
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      activeCell: { row: 2, col: 11 },
+      followCell: { row: 2, col: 11 },
+    });
+    expect(emitted[0].scrollIntent).toBeUndefined();
+
+    subscription.unsubscribe();
+    actor.stop();
+  });
+
   it('annotates Ctrl+Home with a top-left origin scroll intent', () => {
     const actor = createActor(selectionMachine);
     const emitted: SelectionEmitted[] = [];


### PR DESCRIPTION
## Summary
- Treat direct multi-cell Name Box navigation as a direct jump by passing `anchor: null`.
- This keeps the active/start cell in view while preserving the selected range, so table filter overlays render for the leftmost header.
- Add selection-machine regression coverage for direct range selections with a null anchor.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Workers grouped under this root cause: `45`, `48`, `49`
- Verified scenarios:
  - `kewpie-object-creation-insert-table-dialog-apply-ok-collapsed-fiscal-columns` passed `6/6` after fix; filter button count became `3`.
  - `kewpie-insert-table-hidden-outline-collapsed-fiscal-columns` passed `4/4` after fix; filter button count became `3`.
  - `kewpie-object-creation-insert-table-keyboard-shortcuts-collapsed-fiscal-columns` passed `5/5` after fix; DOM overlays included columns `11`, `12`, and `13`.

## Notes
- Integrated from worker `48`, which encodes the root cause in selection semantics rather than adding a post-selection scroll call.