### PR TITLE
[fleet v0.9.3] Extend hidden selection to next visible column

### DIFF
--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/extend-selection.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/extend-selection.test.ts
@@ -410,6 +410,33 @@ describe('extendSelection - Shift+Arrow bug tests', () => {
       expect(result.activeCell).toEqual({ row: 4, col: 1 });
     });
 
+    it('first Shift+Right from a hidden single-cell target jumps to the next visible column', () => {
+      const context: SelectionContext = {
+        ...initialSelectionContext,
+        activeCell: { row: 12, col: 15 }, // P13
+        pendingRange: { startRow: 12, startCol: 15, endRow: 12, endCol: 15 },
+        anchor: null,
+        isColHidden: (col) => col >= 15 && col <= 26, // P:AA
+      };
+
+      const event: SelectionEvent = {
+        type: 'KEY_ARROW',
+        direction: 'right',
+        shiftKey: true,
+      };
+
+      const result = callExtendSelection(context, event);
+
+      expect(result.pendingRange).toEqual({
+        startRow: 12,
+        startCol: 15,
+        endRow: 12,
+        endCol: 27,
+      });
+      expect(result.anchor).toEqual({ row: 12, col: 15 });
+      expect(result.activeCell).toEqual({ row: 12, col: 15 });
+    });
+
     it('repeated Shift+Right extends by worksheet coordinates across hidden columns', () => {
       let context: SelectionContext = {
         ...initialSelectionContext,

--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/keyboard-actions.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/keyboard-actions.ts
@@ -216,10 +216,28 @@ const extendSelection = assign(
     // Get the "moving edge" - the corner opposite the anchor that should move
     // For first extend (single cell), the moving edge is the activeCell itself
     const movingEdge = getMovingEdge(context.pendingRange, anchor);
-    // Shift+Arrow changes range geometry by worksheet coordinates. Hidden
-    // rows/columns remain part of the selected rectangle; plain navigation
-    // uses moveCellSkipHidden separately.
-    const stepped = moveCell(movingEdge, event.direction, 1);
+    const isSingleCellRange =
+      normalizedRange.startRow === normalizedRange.endRow &&
+      normalizedRange.startCol === normalizedRange.endCol;
+    const hiddenAnchorOnMovingAxis =
+      event.direction === 'left' || event.direction === 'right'
+        ? (context.isColHidden?.(anchor.col) ?? false)
+        : (context.isRowHidden?.(anchor.row) ?? false);
+
+    // Shift+Arrow normally changes range geometry by worksheet coordinates so
+    // hidden rows/columns remain inside the selected rectangle. A hidden single
+    // cell reached via Name Box is the exception: the first extend should land
+    // on the next visible edge while still selecting the hidden span.
+    const stepped =
+      isSingleCellRange && hiddenAnchorOnMovingAxis
+        ? moveCellSkipHidden(
+            movingEdge,
+            event.direction,
+            1,
+            context.isRowHidden,
+            context.isColHidden,
+          )
+        : moveCell(movingEdge, event.direction, 1);
     // extend past a merge boundary so the moving edge doesn't
     // sit on the merge interior — matches the same machine-internal escape
     // used by `moveActiveCell`.


### PR DESCRIPTION
## Summary
- When the first Shift+Right starts from a hidden single-cell Name Box target, jump the extension edge to the next visible column while keeping the hidden span selected.
- Preserve normal repeated Shift+Arrow behavior for visible anchors.
- Add focused selection-machine regression coverage.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `37`
- Scenario: `kewpie-selection-keyboard-shift-extend-right-undo-redo-invariant-collapsed-fiscal-columns`
- Worker verification: focused test passed (`27/27`), assigned scenario passed `5/5`, sibling visible-anchor smoke scenario passed `3/3`.

## Notes
- This is a narrow keyboard-selection fix, independent of the Name Box direct-range viewport fix in #67.