### PR TITLE
[fleet v0.9.3] Choose Ungroup direction from Data ribbon

### DIFF
--- a/apps/spreadsheet/src/chrome/toolbar/tabs/DataRibbon.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/tabs/DataRibbon.tsx
@@ -249,8 +249,16 @@ export function DataRibbon({
   onImportJson,
   onImportFromWeb,
 }: DataRibbonProps) {
-  const { groupRows, groupColumns, canGroup, canUngroup, canShowDetail, canHideDetail } =
-    useGroupingActions();
+  const {
+    groupRows,
+    groupColumns,
+    ungroupRows,
+    ungroupColumns,
+    canGroup,
+    canUngroup,
+    canShowDetail,
+    canHideDetail,
+  } = useGroupingActions();
   const { canClearFilters, canReapplyFilters } = useFilterActions();
 
   // Get dispatch for action handling
@@ -442,13 +450,24 @@ export function DataRibbon({
     setIsGroupDropdownOpen(false);
     groupColumns();
   }, [groupColumns]);
+  const [isUngroupDropdownOpen, setIsUngroupDropdownOpen] = useState(false);
   const handleUngroupClick = useCallback(() => {
-    window.setTimeout(() => dispatch('UNGROUP'), 0);
-  }, [dispatch]);
+    if (!canUngroup) return;
+    setIsUngroupDropdownOpen((open) => !open);
+  }, [canUngroup]);
+  const handleUngroupRows = useCallback(() => {
+    setIsUngroupDropdownOpen(false);
+    ungroupRows();
+  }, [ungroupRows]);
+  const handleUngroupColumns = useCallback(() => {
+    setIsUngroupDropdownOpen(false);
+    ungroupColumns();
+  }, [ungroupColumns]);
 
   useEffect(() => {
     if (!canGroup) setIsGroupDropdownOpen(false);
-  }, [canGroup]);
+    if (!canUngroup) setIsUngroupDropdownOpen(false);
+  }, [canGroup, canUngroup]);
 
   // ===========================================================================
   // KeyTip Registration (display-only — keytip overlay reads `key`,
@@ -928,18 +947,48 @@ export function DataRibbon({
               </div>
             </RibbonDropdownPanel>
           </div>
-          <RibbonButton
-            id="data-ungroup"
-            layout="vertical"
-            height="full"
-            width="narrow"
-            icon={<UngroupIcon />}
-            label="Ungroup"
-            onClick={handleUngroupClick}
-            disabled={!canUngroup}
-            title="Ungroup selected rows (Alt+Shift+Left)"
-            aria-label="Ungroup"
-          />
+          <div className="relative">
+            <RibbonButton
+              id="data-ungroup"
+              layout="vertical"
+              height="full"
+              width="narrow"
+              icon={<UngroupIcon />}
+              label="Ungroup"
+              onClick={handleUngroupClick}
+              disabled={!canUngroup}
+              isOpen={isUngroupDropdownOpen}
+              title="Ungroup selected rows or columns"
+              aria-label="Ungroup"
+              aria-expanded={isUngroupDropdownOpen}
+              aria-haspopup="menu"
+            />
+            <RibbonDropdownPanel
+              open={isUngroupDropdownOpen}
+              onClose={() => setIsUngroupDropdownOpen(false)}
+            >
+              <div
+                className="bg-ss-surface rounded shadow-ss-md border border-ss-border min-w-[120px] py-1"
+                role="menu"
+                aria-label="Ungroup rows or columns"
+              >
+                <RibbonDropdownItem
+                  dataValue="rows"
+                  icon={<UngroupIcon />}
+                  onClick={handleUngroupRows}
+                >
+                  Rows
+                </RibbonDropdownItem>
+                <RibbonDropdownItem
+                  dataValue="columns"
+                  icon={<UngroupIcon />}
+                  onClick={handleUngroupColumns}
+                >
+                  Columns
+                </RibbonDropdownItem>
+              </div>
+            </RibbonDropdownPanel>
+          </div>
           <RibbonButton
             id="data-show-detail"
             layout="vertical"

--- a/apps/spreadsheet/src/chrome/toolbar/tabs/__tests__/DataRibbon-outline-dispatch.test.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/tabs/__tests__/DataRibbon-outline-dispatch.test.ts
@@ -1,21 +1,22 @@
 import { readFileSync } from 'node:fs';
 
 describe('DataRibbon outline wiring', () => {
-  test('group opens a row/column chooser while remaining outline buttons dispatch unified handlers', () => {
+  test('group and ungroup open row/column choosers while detail buttons dispatch unified handlers', () => {
     const source = readFileSync(new URL('../DataRibbon.tsx', import.meta.url), 'utf8');
 
     expect(source).toContain('onClick={handleGroupClick}');
     expect(source).toContain('onClick={handleGroupRows}');
     expect(source).toContain('onClick={handleGroupColumns}');
     expect(source).toContain('onClick={handleUngroupClick}');
+    expect(source).toContain('onClick={handleUngroupRows}');
+    expect(source).toContain('onClick={handleUngroupColumns}');
     expect(source).toContain('Rows');
     expect(source).toContain('Columns');
     expect(source).not.toContain("onClick={() => dispatch('GROUP')}");
-    expect(source).toContain("dispatch('UNGROUP')");
+    expect(source).not.toContain("dispatch('UNGROUP')");
     expect(source).toContain("onClick={() => dispatch('SHOW_DETAIL')}");
     expect(source).toContain("onClick={() => dispatch('HIDE_DETAIL')}");
 
-    expect(source).not.toContain('onClick={ungroupRows}');
     expect(source).not.toContain('onClick={showDetail}');
     expect(source).not.toContain('onClick={hideDetail}');
   });


### PR DESCRIPTION
## Summary
- Make Data > Ungroup mirror Data > Group by requiring an explicit Rows/Columns choice.
- Route ribbon clicks to `ungroupRows()` / `ungroupColumns()` instead of bare `UNGROUP`, avoiding row-first inference for rectangular fiscal-column selections.
- Update DataRibbon outline dispatch coverage.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `66`
- Scenario: `kewpie-outline-hidden-detail-group-new-detail-block-undo-redo-invariant-collapsed-fiscal-columns`
- Worker verification: focused DataRibbon test passed, production bundle built, scenario passed `8/8`; `levelsAfterUngroup` became `{col12:1,col13:0,col14:0}`.

## Notes
- This is a standalone Data ribbon routing fix, separate from the workbook outline context fix in #63.