### PR TITLE
[fleet v0.9.3] Return to formula origin after error cancel

### DIFF
--- a/apps/spreadsheet/src/coordinator/__tests__/editor-transition-handlers.test.ts
+++ b/apps/spreadsheet/src/coordinator/__tests__/editor-transition-handlers.test.ts
@@ -1,0 +1,63 @@
+import { jest } from '@jest/globals';
+import type { StoreApi } from 'zustand';
+import { createActor } from 'xstate';
+
+import { sheetId as toSheetId, type SheetId } from '@mog-sdk/contracts/core';
+
+import type { UIState } from '../../ui-store';
+import { editorMachine } from '../../systems/grid-editing/machines/grid-editor-machine';
+import { EditorEvents } from '../../systems/grid-editing/machines/editor/events';
+import { wireReturnToOriginSheet } from '../editor-transition-handlers';
+
+function createUiStore(activeSheetId: string): StoreApi<UIState> {
+  let currentActiveSheetId = toSheetId(activeSheetId);
+  const setActiveSheet = jest.fn((sheetId: SheetId) => {
+    currentActiveSheetId = sheetId;
+  });
+  const getSheetViewState = jest.fn(() => null);
+  const saveSheetViewState = jest.fn();
+
+  const store = {
+    getState: () => ({
+      activeSheetId: currentActiveSheetId,
+      setActiveSheet,
+      getSheetViewState,
+      saveSheetViewState,
+    }),
+  };
+
+  return store as unknown as StoreApi<UIState>;
+}
+
+describe('wireReturnToOriginSheet', () => {
+  it('returns to the origin sheet when a cross-sheet formula is cancelled from validation error state', () => {
+    const actor = createActor(editorMachine);
+    actor.start();
+
+    const uiStore = createUiStore('sheet-2');
+    const cleanup = wireReturnToOriginSheet(actor, uiStore);
+
+    actor.send(
+      EditorEvents.startEditing(
+        { row: 0, col: 0 },
+        'sheet-1',
+        '=SUM(',
+        undefined,
+        'typing',
+        '=SUM('.length,
+      ),
+    );
+    expect(actor.getSnapshot().matches('formulaEditing')).toBe(true);
+
+    actor.send(EditorEvents.commit('none'));
+    actor.send(EditorEvents.validationError('expected a function argument'));
+    expect(actor.getSnapshot().matches('error')).toBe(true);
+
+    actor.send(EditorEvents.cancel());
+
+    expect(uiStore.getState().setActiveSheet).toHaveBeenCalledWith(toSheetId('sheet-1'));
+
+    cleanup();
+    actor.stop();
+  });
+});

--- a/apps/spreadsheet/src/coordinator/editor-transition-handlers.ts
+++ b/apps/spreadsheet/src/coordinator/editor-transition-handlers.ts
@@ -31,6 +31,7 @@ function wasEditingNowInactive(
   const wasEditing =
     prevState.matches('formulaEditing') ||
     prevState.matches('editing') ||
+    prevState.matches('error') ||
     prevState.matches('committing');
   return wasEditing && currentState.matches('inactive');
 }


### PR DESCRIPTION
## Summary
- Treat editor `error -> inactive` as an edit cancellation transition for cross-sheet formula editing.
- Return to the origin sheet when Escape cancels an incomplete formula that already reached validation error state.
- Add focused coordinator regression coverage.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `53`
- Scenario: `escape-during-cross-sheet-formula-returns-to-origin`
- Worker verification: focused regression test passed, production bundle built, scenario passed `8/8`.

## Notes
- This is separate from scroll-commit point-mode preservation in #61; it covers the Escape cancellation path from editor error state.