### PR TITLE
[fleet v0.9.3] Keep explicit quick-sort ranges headerless

### DIFF
--- a/apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts
+++ b/apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts
@@ -29,7 +29,7 @@ describe('resolveDataCommandTarget', () => {
     expect(ws.getCurrentRegion).not.toHaveBeenCalled();
   });
 
-  test('explicit multi-row command selection infers headers from first row', async () => {
+  test('explicit multi-row command selection is treated as headerless even when first row looks like headers', async () => {
     const ws = makeWorksheet({
       values: {
         '0,0': 'Name',
@@ -42,13 +42,13 @@ describe('resolveDataCommandTarget', () => {
 
     await expect(resolveDataCommandTarget(ws as Worksheet, range)).resolves.toEqual({
       range,
-      hasHeaders: true,
+      hasHeaders: false,
       wasExpanded: false,
     });
     expect(ws.getCurrentRegion).not.toHaveBeenCalled();
   });
 
-  test('explicit multi-row command selection tolerates blank spacer rows before body values', async () => {
+  test('explicit multi-row command selection does not infer headers from later body values', async () => {
     const ws = makeWorksheet({
       values: {
         '2,27': '1Q',
@@ -61,7 +61,7 @@ describe('resolveDataCommandTarget', () => {
 
     await expect(resolveDataCommandTarget(ws as Worksheet, range)).resolves.toEqual({
       range,
-      hasHeaders: true,
+      hasHeaders: false,
       wasExpanded: false,
     });
     expect(ws.getCurrentRegion).not.toHaveBeenCalled();

--- a/apps/spreadsheet/src/actions/data-command-target.ts
+++ b/apps/spreadsheet/src/actions/data-command-target.ts
@@ -78,7 +78,7 @@ export async function resolveDataCommandTarget(
 ): Promise<DataCommandTarget | null> {
   return resolveDataTarget(ws, userRange, {
     allowEmptySingleCell: false,
-    inferHeadersForExplicitMultiRow: true,
+    inferHeadersForExplicitMultiRow: false,
   });
 }
 

--- a/apps/spreadsheet/src/actions/handlers/__tests__/sort.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/sort.test.ts
@@ -206,7 +206,7 @@ describe('SORT_ASCENDING — current-region auto-expansion', () => {
     });
   });
 
-  test('explicit A2:A6 mixed data selection preserves a detected header row', async () => {
+  test('explicit A2:A6 mixed data selection is sorted as headerless', async () => {
     const setup = makeMockDeps({
       selectionRanges: [{ startRow: 1, startCol: 0, endRow: 5, endCol: 0 }],
       activeCell: { row: 1, col: 0 },
@@ -224,7 +224,7 @@ describe('SORT_ASCENDING — current-region auto-expansion', () => {
     expect(rangeArg).toEqual({ startRow: 1, startCol: 0, endRow: 5, endCol: 0 });
     expect(optionsArg).toEqual({
       columns: [{ column: 0, direction: 'asc' }],
-      hasHeaders: true,
+      hasHeaders: false,
     });
   });
 


### PR DESCRIPTION
## Summary
- Stop inferring headers for explicit multi-row mutating data command selections.
- Preserve header inference for expanded current regions and dialog targets.
- Update focused data-target and sort handler tests for explicit A2:A6 mixed-value quick sort.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `118`
- Scenario: `sort-numeric-vs-text`
- Worker verification: focused tests passed (`2` suites, `30` tests) and scenario passed `3/3`; sorted rows became `["1","3","10","Apple","Banana"]`.

## Notes
- The worker patch included unrelated selection-machine contamination; this PR intentionally kept only the data-target and sort-test files.