### PR TITLE
[fleet v0.9.3] Normalize default chart source to visible block

### DIFF
--- a/apps/spreadsheet/src/actions/handlers/__tests__/charts.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/charts.test.ts
@@ -73,6 +73,10 @@ function createMockDeps(overrides?: Partial<ActionDependencies>): ActionDependen
       bringForward: jest.fn().mockResolvedValue(undefined),
       sendBackward: jest.fn().mockResolvedValue(undefined),
     },
+    layout: {
+      isRowHidden: jest.fn().mockResolvedValue(false),
+      isColumnHidden: jest.fn().mockResolvedValue(false),
+    },
     // Legacy flat aliases for backward-compatible test assertions
     getChart: jest.fn().mockResolvedValue(null),
     listCharts: jest.fn().mockResolvedValue([]),
@@ -1318,6 +1322,48 @@ describe('Chart Handlers - Current-Region Auto-Expansion', () => {
       expect(ws.getCurrentRegion).toHaveBeenCalled();
       const addedConfig = ws.charts.add.mock.calls[0][0];
       expect(addedConfig.dataRange).toBe('A1:D10');
+    });
+
+    it('uses the first contiguous visible nonblank block for one-row shortcut chart creation', async () => {
+      const deps = createDepsWithSelection({
+        ranges: [{ startRow: 20, startCol: 11, endRow: 20, endCol: 27 }],
+      });
+      const ws = (deps.workbook as any).activeSheet;
+      const values = new Map<string, unknown>([
+        ['20,12', 34500],
+        ['20,13', 45000],
+        ['20,15', 6026],
+        ['20,27', 6732],
+      ]);
+      ws.getValue = jest.fn(
+        async (row: number, col: number) => values.get(`${row},${col}`) ?? null,
+      );
+      ws.layout.isColumnHidden = jest.fn(
+        async (col: number) => col >= 15 && col <= 26,
+      );
+
+      const result = await ChartHandlers.CREATE_EMBEDDED_CHART(deps);
+
+      expect(result.handled).toBe(true);
+      expect(ws.layout.isColumnHidden).toHaveBeenCalledWith(15);
+      const addedConfig = ws.charts.add.mock.calls[0][0];
+      expect(addedConfig.dataRange).toBe('L21:N21');
+    });
+
+    it('preserves explicit typed chart ranges even when columns are hidden', async () => {
+      const deps = createDepsWithSelection({
+        ranges: [{ startRow: 20, startCol: 11, endRow: 20, endCol: 27 }],
+      });
+      const ws = (deps.workbook as any).activeSheet;
+      ws.layout.isColumnHidden = jest.fn(
+        async (col: number) => col >= 15 && col <= 26,
+      );
+
+      const result = await ChartHandlers.CREATE_EMBEDDED_CHART(deps, { type: 'column' });
+
+      expect(result.handled).toBe(true);
+      const addedConfig = ws.charts.add.mock.calls[0][0];
+      expect(addedConfig.dataRange).toBe('L21:AB21');
     });
   });
 

--- a/apps/spreadsheet/src/actions/handlers/charts.ts
+++ b/apps/spreadsheet/src/actions/handlers/charts.ts
@@ -61,6 +61,14 @@ type ChartSourceRange = {
   endCol: number;
 };
 
+type VisibilityAwareWorksheet = {
+  getValue?: (row: number, col: number) => Promise<unknown>;
+  layout?: {
+    isRowHidden?: (row: number) => Promise<boolean>;
+    isColumnHidden?: (col: number) => Promise<boolean>;
+  };
+};
+
 /**
  * Type guard to check if coordinator exposes renderer capabilities.
  */
@@ -102,6 +110,125 @@ function getChartSourceRanges(deps: ActionDependencies, sheetId: SheetId): Chart
   }
 
   return deps.accessors.selection.getDataBoundedRanges(sheetId);
+}
+
+async function isChartSourceRowHidden(
+  ws: VisibilityAwareWorksheet,
+  row: number,
+): Promise<boolean> {
+  try {
+    return (await ws.layout?.isRowHidden?.(row)) === true;
+  } catch {
+    return false;
+  }
+}
+
+async function isChartSourceColumnHidden(
+  ws: VisibilityAwareWorksheet,
+  col: number,
+): Promise<boolean> {
+  try {
+    return (await ws.layout?.isColumnHidden?.(col)) === true;
+  } catch {
+    return false;
+  }
+}
+
+function isBlankChartSourceValue(value: unknown): boolean {
+  return value == null || (typeof value === 'string' && value.trim() === '');
+}
+
+async function isChartSourceColumnBlank(
+  ws: VisibilityAwareWorksheet,
+  range: ChartSourceRange,
+  col: number,
+): Promise<boolean> {
+  if (typeof ws.getValue !== 'function') return false;
+  for (let row = range.startRow; row <= range.endRow; row++) {
+    if (await isChartSourceRowHidden(ws, row)) continue;
+    try {
+      if (!isBlankChartSourceValue(await ws.getValue(row, col))) return false;
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function isChartSourceRowBlank(
+  ws: VisibilityAwareWorksheet,
+  range: ChartSourceRange,
+  row: number,
+): Promise<boolean> {
+  if (typeof ws.getValue !== 'function') return false;
+  for (let col = range.startCol; col <= range.endCol; col++) {
+    if (await isChartSourceColumnHidden(ws, col)) continue;
+    try {
+      if (!isBlankChartSourceValue(await ws.getValue(row, col))) return false;
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function normalizeShortcutChartSourceRange(
+  ws: VisibilityAwareWorksheet,
+  range: ChartSourceRange,
+): Promise<ChartSourceRange> {
+  let startRow = range.startRow;
+  while (
+    startRow <= range.endRow &&
+    (await isChartSourceRowHidden(ws, startRow))
+  ) {
+    startRow++;
+  }
+
+  let startCol = range.startCol;
+  while (
+    startCol <= range.endCol &&
+    (await isChartSourceColumnHidden(ws, startCol))
+  ) {
+    startCol++;
+  }
+
+  if (startRow > range.endRow || startCol > range.endCol) {
+    return range;
+  }
+
+  let endRow = startRow;
+  while (
+    endRow + 1 <= range.endRow &&
+    !(await isChartSourceRowHidden(ws, endRow + 1))
+  ) {
+    endRow++;
+  }
+
+  let endCol = startCol;
+  while (
+    endCol + 1 <= range.endCol &&
+    !(await isChartSourceColumnHidden(ws, endCol + 1))
+  ) {
+    endCol++;
+  }
+
+  let normalized = { startRow, startCol, endRow, endCol };
+
+  while (
+    normalized.endCol > normalized.startCol &&
+    (await isChartSourceColumnBlank(ws, normalized, normalized.endCol))
+  ) {
+    normalized = { ...normalized, endCol: normalized.endCol - 1 };
+  }
+
+  while (
+    normalized.endRow > normalized.startRow &&
+    (await isChartSourceRowBlank(ws, normalized, normalized.endRow))
+  ) {
+    normalized = { ...normalized, endRow: normalized.endRow - 1 };
+  }
+
+  return normalized;
 }
 
 /**
@@ -925,8 +1052,13 @@ export const CREATE_EMBEDDED_CHART: AsyncActionHandler = async (
 
     // Excel parity: expand single-cell / single-row selections to the
     // surrounding data region. Multi-row selections pass through unchanged.
-    const expanded = await expandToDataRegion(ws, ranges[0]);
-    const range = expanded ?? ranges[0];
+    const sourceRange = ranges[0];
+    const expanded = await expandToDataRegion(ws, sourceRange);
+    const expandedRange = expanded ?? sourceRange;
+    const range =
+      !payload?.type && sourceRange.startRow === sourceRange.endRow
+        ? await normalizeShortcutChartSourceRange(ws, expandedRange)
+        : expandedRange;
     const dataRange = rangeToA1Notation(range);
 
     // Use smart positioning to ensure chart is visible


### PR DESCRIPTION
## Summary
- For default Alt+F1 chart creation on one-row selections, normalize the source to the first contiguous visible nonblank block.
- Use effective row/column hidden predicates and trim trailing blank visible cells.
- Preserve explicit typed/ribbon chart creation ranges.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `59`
- Scenario: `kewpie-outline-hidden-detail-hide-detail-then-chart-keyboard-shortcuts-collapsed-fiscal-columns`
- Worker verification: assigned scenario passed `6/6` after fix with chart source `L21:N21`; regression check for column-chart keyboard shortcut passed `4/4`; focused chart tests passed (`82` tests); production bundle built.

## Notes
- No WASM changes were involved.