### PR TITLE
[fleet v0.9.3] Route Ctrl+G globally

### DIFF
--- a/apps/spreadsheet/src/systems/shared/utils/__tests__/focus-utils.test.ts
+++ b/apps/spreadsheet/src/systems/shared/utils/__tests__/focus-utils.test.ts
@@ -10,6 +10,8 @@ describe('focus utils global shortcuts', () => {
     ['Ctrl+Shift+F1', { key: 'F1', ctrlKey: true, shiftKey: true }],
     ['Meta+F1', { key: 'F1', metaKey: true }],
     ['Meta+Shift+F1', { key: 'F1', metaKey: true, shiftKey: true }],
+    ['Ctrl+G', { key: 'g', ctrlKey: true }],
+    ['Meta+G', { key: 'g', metaKey: true }],
   ] satisfies Array<[string, KeyboardEventInit]>)('routes %s globally', (_name, init) => {
     expect(isGlobalShortcut(keyboardEvent(init))).toBe(true);
   });

--- a/apps/spreadsheet/src/systems/shared/utils/focus-utils.ts
+++ b/apps/spreadsheet/src/systems/shared/utils/focus-utils.ts
@@ -48,6 +48,9 @@ export const GLOBAL_SHORTCUTS: readonly KeyboardShortcut[] = [
   // Find and replace
   { ctrl: true, key: 'h' },
   { meta: true, key: 'h' },
+  // Go To
+  { ctrl: true, key: 'g' },
+  { meta: true, key: 'g' },
   // Formula view
   { ctrl: true, key: '`' },
   { meta: true, key: '`' },


### PR DESCRIPTION
## Summary
- Add Ctrl/Cmd+G to spreadsheet-global shortcut routing.
- Allows Go To to open when focus is on chrome controls, including the View ribbon Formula Bar checkbox after hiding the formula bar.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `61`
- Scenario: `kewpie-navigation-view-hide-formula-bar-then-edit-hidden-outline-precondition-collapsed-fiscal-columns`
- Worker verification: focused focus-utils test passed (`7` tests), production bundle built, scenario passed `5/5`.

## Notes
- This is a narrow shortcut-routing fix; it does not change Go To dialog logic.