### PR TITLE
[fleet v0.9.3] Make Shift-click active cell the clicked edge

### DIFF
--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/selection-modes.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/selection-modes.test.ts
@@ -243,14 +243,14 @@ describe('selection-mode lifecycle', () => {
     }
   });
 
-  it('8. mouse_shift_click_keeps_active_cell_at_anchor', () => {
+  it('8. mouse_shift_click_moves_active_cell_to_clicked_edge', () => {
     const actor = startActorAt(0, 0);
 
     actor.send({ type: 'MOUSE_DOWN', cell: cell(2, 2), shiftKey: true, ctrlKey: false });
 
     let after = actor.getSnapshot().context;
     expect(after.anchor).toEqual(cell(0, 0));
-    expect(after.activeCell).toEqual(cell(0, 0));
+    expect(after.activeCell).toEqual(cell(2, 2));
     expect(after.pendingRange).toEqual(rng(0, 0, 2, 2));
 
     actor.send({ type: 'MOUSE_UP' });
@@ -258,7 +258,7 @@ describe('selection-mode lifecycle', () => {
 
     after = actor.getSnapshot().context;
     expect(after.anchor).toEqual(cell(0, 0));
-    expect(after.activeCell).toEqual(cell(0, 0));
+    expect(after.activeCell).toEqual(cell(0, 1));
     expect(after.pendingRange).toEqual(rng(0, 0, 0, 1));
     actor.stop();
   });

--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/helpers.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/helpers.ts
@@ -130,9 +130,9 @@ export function computeDirection(anchor: CellCoord, active: CellCoord): Selectio
 }
 
 /**
- * Single source of truth for shift-extend on the pending range. activeCell is
- * always the anchor (Excel parity); the moving edge lives in the range
- * geometry. Returns the partial-context update for the assign() function.
+ * Single source of truth for shift-extend on the pending range. Callers choose
+ * the active cell; keyboard-style extension uses the anchor default, while
+ * mouse shift-click passes the clicked edge.
  *
  * `committedRanges` is intentionally not touched here — non-additive flows
  * keep it empty by invariant; additive flows leave it intact while the

--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/mouse-actions.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/mouse-actions.ts
@@ -53,14 +53,14 @@ const setAnchorAndSelect = assign(
 
 /**
  * Extend selection to clicked cell (shift+click).
- * Mouse Shift+click keeps the original anchor active, matching keyboard
- * extend and drag selection behavior. The moving edge lives in range geometry.
+ * Mouse Shift+click keeps the original anchor but moves the active cell to
+ * the clicked edge so follow-up edits and readbacks target the visible edge.
  */
 const extendToCell = assign(
   ({ context, event }: { context: SelectionContext; event: SelectionEvent }) => {
     if (event.type !== 'MOUSE_DOWN') return {};
     const anchor = context.anchor ?? context.activeCell;
-    return buildExtendUpdate(anchor, event.cell);
+    return buildExtendUpdate(anchor, event.cell, event.cell);
   },
 );
 


### PR DESCRIPTION
## Summary
- Make mouse Shift-click preserve the original anchor while moving the active cell to the clicked edge.
- Update helper docs and focused selection-machine expectations.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `64`
- Scenario: `shift-click-select`
- Worker verification: focused selection-machine test passed (`27` tests), and the scenario passed `9/9`, including active-edge checks for C3, B1, D3, and reverse A1.

## Notes
- The extracted patch was malformed at the end, so this branch reconstructs the exact small diff described in worker `64` from the report.