### PR TITLE
[fleet v0.9.3] Open header context menus from resize handles

### DIFF
--- a/apps/spreadsheet/src/hooks/grid-mouse/__tests__/use-context-menu-handler.test.ts
+++ b/apps/spreadsheet/src/hooks/grid-mouse/__tests__/use-context-menu-handler.test.ts
@@ -112,7 +112,14 @@ function createMockHitTest(hitResult: ReturnType<typeof createHitResult>) {
  * Create hit test results for different scenarios.
  */
 function createHitResult(
-  type: 'cell' | 'column-header' | 'row-header' | 'empty' | 'floating-object',
+  type:
+    | 'cell'
+    | 'column-header'
+    | 'column-resize-handle'
+    | 'row-header'
+    | 'row-resize-handle'
+    | 'empty'
+    | 'floating-object',
   options?: { row?: number; col?: number; objectId?: string; region?: string },
 ) {
   switch (type) {
@@ -120,8 +127,12 @@ function createHitResult(
       return { type: 'cell' as const, row: options?.row ?? 5, col: options?.col ?? 3 };
     case 'column-header':
       return { type: 'column-header' as const, col: options?.col ?? 3 };
+    case 'column-resize-handle':
+      return { type: 'column-resize-handle' as const, col: options?.col ?? 3 };
     case 'row-header':
       return { type: 'row-header' as const, row: options?.row ?? 5 };
+    case 'row-resize-handle':
+      return { type: 'row-resize-handle' as const, row: options?.row ?? 5 };
     case 'floating-object':
       return {
         type: 'floating-object' as const,
@@ -571,6 +582,35 @@ describe('useContextMenuHandler', () => {
 
       expect(selection.selectColumn).not.toHaveBeenCalled();
     });
+
+    it('treats column resize-handle right-clicks as column-header context menus', () => {
+      const hitResult = createHitResult('column-resize-handle', { col: 5 });
+      const hitTest = createMockHitTest(hitResult);
+      const selection = createMockSelectionApi();
+      const onContextMenu = jest.fn();
+
+      const deps = createTestDeps({
+        getHitTest: () => hitTest,
+        selection,
+        onContextMenu,
+      });
+
+      const { result } = renderHook(() => useContextMenuHandler(deps));
+      const event = createContextMenuEvent({ clientX: 200, clientY: 15 });
+
+      act(() => {
+        result.current.handleContextMenu(event);
+      });
+
+      expect(selection.selectColumn).toHaveBeenCalledWith(5, false, false);
+      expect(onContextMenu).toHaveBeenCalledWith({
+        x: 200,
+        y: 15,
+        target: 'column-header',
+        targetRow: undefined,
+        targetCol: 5,
+      });
+    });
   });
 
   describe('row header context menu', () => {
@@ -642,6 +682,35 @@ describe('useContextMenuHandler', () => {
       });
 
       expect(selection.selectRow).not.toHaveBeenCalled();
+    });
+
+    it('treats row resize-handle right-clicks as row-header context menus', () => {
+      const hitResult = createHitResult('row-resize-handle', { row: 7 });
+      const hitTest = createMockHitTest(hitResult);
+      const selection = createMockSelectionApi();
+      const onContextMenu = jest.fn();
+
+      const deps = createTestDeps({
+        getHitTest: () => hitTest,
+        selection,
+        onContextMenu,
+      });
+
+      const { result } = renderHook(() => useContextMenuHandler(deps));
+      const event = createContextMenuEvent({ clientX: 25, clientY: 200 });
+
+      act(() => {
+        result.current.handleContextMenu(event);
+      });
+
+      expect(selection.selectRow).toHaveBeenCalledWith(7, false, false);
+      expect(onContextMenu).toHaveBeenCalledWith({
+        x: 25,
+        y: 200,
+        target: 'row-header',
+        targetRow: 7,
+        targetCol: undefined,
+      });
     });
   });
 

--- a/apps/spreadsheet/src/hooks/grid-mouse/use-context-menu-handler.ts
+++ b/apps/spreadsheet/src/hooks/grid-mouse/use-context-menu-handler.ts
@@ -230,6 +230,17 @@ export function useContextMenuHandler(
           break;
         }
 
+        case 'column-resize-handle': {
+          targetCol = hit.col;
+          target = 'column-header';
+
+          const hasFullColumnSelection = selection.ranges.some((r) => r.isFullColumn);
+          if (!hasFullColumnSelection || !isColumnInSelection(hit.col, selection.ranges)) {
+            selection.selectColumn(hit.col, false, false);
+          }
+          break;
+        }
+
         case 'row-header': {
           targetRow = hit.row;
           target = 'row-header';
@@ -239,6 +250,17 @@ export function useContextMenuHandler(
           // (e.g. A1:B5 left by a chart insert) must be replaced with just the
           // right-clicked row so that INSERT_ROW_ABOVE inserts at the correct row
           // rather than at rows[0] of the partial selection.
+          const hasFullRowSelection = selection.ranges.some((r) => r.isFullRow);
+          if (!hasFullRowSelection || !isRowInSelection(hit.row, selection.ranges)) {
+            selection.selectRow(hit.row, false, false);
+          }
+          break;
+        }
+
+        case 'row-resize-handle': {
+          targetRow = hit.row;
+          target = 'row-header';
+
           const hasFullRowSelection = selection.ranges.some((r) => r.isFullRow);
           if (!hasFullRowSelection || !isRowInSelection(hit.row, selection.ranges)) {
             selection.selectRow(hit.row, false, false);


### PR DESCRIPTION
## Summary
- Normalize right-clicks on row/column resize-handle hit targets to their owning row/column header for context-menu routing.
- Preserve left-click/drag resize behavior.
- Add row and column resize-handle context-menu regression tests.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `99`
- Scenario: `kewpie-structural-edit-hide-row-then-delete-neighbor-far-right-latest-quarter-view-collapsed-fiscal-columns`
- Worker verification: focused context-menu handler tests passed (`42` tests), production bundle built, scenario passed `4/4`.

## Notes
- Worker `99` captured unrelated Rust sort files that were dirty before its investigation; this PR intentionally keeps only the context-menu handler and test paths.