### PR TITLE
[fleet v0.9.3] Route Insert Cut Cells through dialog action

### DIFF
--- a/apps/spreadsheet/src/actions/dispatcher.ts
+++ b/apps/spreadsheet/src/actions/dispatcher.ts
@@ -486,6 +486,7 @@ export const HANDLER_MAP: Record<ActionType, AnyActionHandler> = {
   // Insert/Delete cells with shift
   INSERT_CELLS: StructureHandlers.INSERT_CELLS,
   INSERT_CELLS_SHIFT_DOWN: StructureHandlers.INSERT_CELLS_SHIFT_DOWN,
+  INSERT_CUT_CELLS: StructureHandlers.INSERT_CUT_CELLS,
   INSERT_CUT_CELLS_SHIFT_DOWN: StructureHandlers.INSERT_CUT_CELLS_SHIFT_DOWN,
   DELETE_CELLS: StructureHandlers.DELETE_CELLS,
   HIDE_ROW: StructureHandlers.HIDE_ROW,

--- a/apps/spreadsheet/src/actions/handlers/__tests__/structure-autofit.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/structure-autofit.test.ts
@@ -212,6 +212,22 @@ describe('Structure autofit handlers', () => {
     expect(pasteHandler).toHaveBeenCalledWith(deps);
   });
 
+  it('INSERT_CUT_CELLS uses the dialog range and selected shift direction', async () => {
+    const deps = createDeps({ activeCell: { row: 4, col: 3 }, ranges: [] });
+    const range = { startRow: 6, startCol: 11, endRow: 6, endCol: 12 };
+
+    const result = await StructureHandlers.INSERT_CUT_CELLS(deps, {
+      range,
+      direction: 'right',
+    });
+
+    const worksheet = deps.workbook.activeSheet as any;
+    expect(result.handled).toBe(true);
+    expect(deps.workbook.batch).toHaveBeenCalledWith('Insert Cut Cells', expect.any(Function));
+    expect(worksheet.structure.insertCellsWithShift).toHaveBeenCalledWith(6, 11, 6, 12, 'right');
+    expect(pasteHandler).toHaveBeenCalledWith(deps);
+  });
+
   it('INSERT_CUT_CELLS_SHIFT_DOWN is disabled without an active cut clipboard', async () => {
     const deps = createDeps({ activeCell: { row: 4, col: 3 }, ranges: [] });
     (deps.accessors.clipboard.hasCut as jest.Mock).mockReturnValue(false);

--- a/apps/spreadsheet/src/actions/handlers/structure.ts
+++ b/apps/spreadsheet/src/actions/handlers/structure.ts
@@ -665,14 +665,19 @@ export const INSERT_CELLS_SHIFT_DOWN: AsyncActionHandler = async (deps) => {
  * Insert cells for an active cut range, then paste the cut data into the
  * inserted destination. Mirrors Excel's Home > Insert > Insert Cut Cells route.
  */
-export const INSERT_CUT_CELLS_SHIFT_DOWN: AsyncActionHandler = async (deps) => {
+export const INSERT_CUT_CELLS: AsyncActionHandler = async (deps, payload) => {
   const clipboard = deps.accessors.clipboard;
   if (!clipboard.hasCut() || !clipboard.getIsCut() || clipboard.isExternalClipboard()) {
     return notHandled('disabled');
   }
 
   const { activeCell, ranges } = getSelectionContext(deps);
-  const range = getRangesOrActiveCell(ranges, activeCell)[0];
+  const { range: payloadRange, direction: payloadDirection } = (payload ?? {}) as {
+    range?: CellRange;
+    direction?: 'right' | 'down';
+  };
+  const range = payloadRange ?? getRangesOrActiveCell(ranges, activeCell)[0];
+  const direction = payloadDirection === 'right' ? 'right' : 'down';
 
   return withProtectionFeedback(deps, () =>
     deps.workbook.batch('Insert Cut Cells', async () => {
@@ -688,7 +693,7 @@ export const INSERT_CUT_CELLS_SHIFT_DOWN: AsyncActionHandler = async (deps) => {
           range.startCol,
           range.endRow,
           range.endCol,
-          'down',
+          direction,
         );
       }
 
@@ -699,6 +704,9 @@ export const INSERT_CUT_CELLS_SHIFT_DOWN: AsyncActionHandler = async (deps) => {
     }),
   );
 };
+
+export const INSERT_CUT_CELLS_SHIFT_DOWN: AsyncActionHandler = async (deps) =>
+  INSERT_CUT_CELLS(deps, { direction: 'down' });
 
 /**
  * Insert cells by shifting existing cells in a specified direction.

--- a/apps/spreadsheet/src/actions/type-guards.ts
+++ b/apps/spreadsheet/src/actions/type-guards.ts
@@ -296,6 +296,7 @@ export function isStructureAction(action: string): action is StructureActionType
     'DELETE_COLUMNS',
     'INSERT_CELLS',
     'INSERT_CELLS_SHIFT_DOWN',
+    'INSERT_CUT_CELLS',
     'INSERT_CUT_CELLS_SHIFT_DOWN',
     'DELETE_CELLS',
     'HIDE_ROW',

--- a/apps/spreadsheet/src/chrome/toolbar/groups/CellsGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/CellsGroup.tsx
@@ -221,7 +221,7 @@ export const CellsGroup = React.memo(function CellsGroup() {
               onClick={() => {
                 if (hasCutCells) {
                   setInsertDropdownOpen(false);
-                  setTimeout(() => dispatchAction('INSERT_CUT_CELLS_SHIFT_DOWN'), 0);
+                  queueMicrotask(() => dispatchAction('OPEN_INSERT_CELLS_DIALOG'));
                 } else {
                   dispatchAction('OPEN_INSERT_CELLS_DIALOG');
                 }

--- a/apps/spreadsheet/src/dialogs/insert/InsertCellsDialog.tsx
+++ b/apps/spreadsheet/src/dialogs/insert/InsertCellsDialog.tsx
@@ -127,7 +127,8 @@ export function InsertCellsDialog() {
         // Shift cells in specified direction
         if (mode === 'insert') {
           if (deps.accessors.clipboard.hasCut()) {
-            return deps.commands.clipboard.paste({ row: range.startRow, col: range.startCol });
+            const direction = selectedOption === 'right' ? 'right' : 'down';
+            return dispatch('INSERT_CUT_CELLS', deps, { range, direction });
           }
 
           // Insert cells - shift existing cells right or down

--- a/types/editor/src/actions/action-types.ts
+++ b/types/editor/src/actions/action-types.ts
@@ -510,6 +510,7 @@ export type StructureActionType =
   // Insert/delete cells with shift (not entire rows/columns)
   | 'INSERT_CELLS'
   | 'INSERT_CELLS_SHIFT_DOWN'
+  | 'INSERT_CUT_CELLS'
   | 'INSERT_CUT_CELLS_SHIFT_DOWN'
   | 'DELETE_CELLS'
   | 'HIDE_ROW'


### PR DESCRIPTION
## Summary
- Add a generic `INSERT_CUT_CELLS` action that accepts range and shift direction.
- Make the Home > Insert dropdown open the Insert Cells dialog for active cut selections.
- Make Insert Cells OK dispatch the cut-aware insert action instead of plain paste.
- Keep `INSERT_CUT_CELLS_SHIFT_DOWN` as the quick-insert delegate.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `120`
- Scenario: `kewpie-structural-edit-cut-insert-cut-cells-dialog-apply-ok-collapsed-fiscal-columns`
- Worker verification: assigned scenario passed `5/5`; focused structure and InsertCellsDialog tests passed; `@mog/types-editor` typecheck passed in the worker.

## Notes
- Worker `120` captured unrelated find-replace files; this PR intentionally keeps only action/dialog/type paths for this root cause.