### PR TITLE
[fleet v0.9.3] Defer context-menu Insert Cut Cells

### DIFF
--- a/apps/spreadsheet/src/hooks/toolbar/use-context-menu-actions.ts
+++ b/apps/spreadsheet/src/hooks/toolbar/use-context-menu-actions.ts
@@ -35,6 +35,7 @@ import { useActionDependencies } from './use-action-dependencies';
 import { isPickerBackedValidation } from '../../systems/grid-editing/coordination/editor-validation-resolution';
 import { clipboardSelectors } from '../../selectors';
 import { useCoordinator } from '../shared/use-coordinator';
+import { trackPendingClipboardPaste } from '../../systems/grid-editing/coordination/pending-clipboard-paste';
 import type { ClipboardState } from '@mog-sdk/contracts/actors';
 import type { CellCoord } from '@mog-sdk/contracts/rendering';
 
@@ -83,6 +84,20 @@ function waitForClipboardPasteIdle(actor: ClipboardActorLike, signal?: AbortSign
     if (!isClipboardPastePending(actor.getSnapshot())) {
       finish();
     }
+  });
+}
+
+const CONTEXT_MENU_ACTION_DELAY_MS = 50;
+
+function runAfterInputClick<T>(callback: () => T | Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    setTimeout(() => {
+      try {
+        resolve(callback());
+      } catch (error) {
+        reject(error);
+      }
+    }, CONTEXT_MENU_ACTION_DELAY_MS);
   });
 }
 
@@ -542,11 +557,13 @@ export function useContextMenuActions(
   }, [actionDeps, closeContextMenu]);
 
   const insertCutCells = useCallback(() => {
-    selectResolvedContextCell();
     closeContextMenu();
-    setTimeout(() => {
-      dispatch('INSERT_CUT_CELLS_SHIFT_DOWN', actionDeps);
-    }, 0);
+    trackPendingClipboardPaste(
+      runAfterInputClick(() => {
+        selectResolvedContextCell();
+        return dispatch('INSERT_CUT_CELLS_SHIFT_DOWN', actionDeps);
+      }),
+    );
   }, [actionDeps, closeContextMenu, selectResolvedContextCell]);
 
   // ==========================================================================


### PR DESCRIPTION
## Summary
- Close the context menu immediately before running the expensive Insert Cut Cells structural operation.
- Register the deferred work with the existing clipboard-paste settle barrier so app-eval waits for the mutation before readback.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `114`
- Scenario: `kewpie-structural-edit-cut-insert-cut-cells-hidden-outline-precondition-collapsed-fiscal-columns`
- Worker verification: post-fix click returned in `53ms`, final cell state was correct, and scenario passed `3/3`.

## Notes
- Worker `114` captured unrelated Rust sort files that were already dirty; this PR intentionally keeps only `use-context-menu-actions.ts`.