### PR TITLE
[fleet v0.9.3] Defer Insert Table dialog apply

### DIFF
--- a/apps/spreadsheet/src/dialogs/insert/InsertTableDialog.test.tsx
+++ b/apps/spreadsheet/src/dialogs/insert/InsertTableDialog.test.tsx
@@ -1,0 +1,195 @@
+import { jest } from '@jest/globals';
+
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const closeInsertTableDialog = jest.fn();
+const tablesAdd = jest.fn(async () => undefined);
+const undoGroup = jest.fn(async (fn: () => Promise<unknown>) => fn());
+const workbook = {
+  getSheetById: jest.fn(() => ({
+    tables: {
+      add: tablesAdd,
+    },
+  })),
+  undoGroup,
+};
+
+jest.unstable_mockModule('@mog/grid-renderer', () => ({
+  getTableStyleColors: () => ({
+    headerBackground: '#4472c4',
+    headerText: '#ffffff',
+    rowBackground1: '#ffffff',
+    rowBackground2: '#d9e2f3',
+    dataText: '#000000',
+  }),
+}));
+
+jest.unstable_mockModule('@mog/shell', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    'data-testid': testId,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    variant?: string;
+    'data-testid'?: string;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled} data-testid={testId}>
+      {children}
+    </button>
+  ),
+  Checkbox: ({
+    checked,
+    onChange,
+    label,
+    'data-testid': testId,
+  }: {
+    checked: boolean;
+    onChange: (checked: boolean) => void;
+    label: string;
+    'data-testid'?: string;
+  }) => (
+    <label>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.currentTarget.checked)}
+        data-testid={testId}
+      />
+      {label}
+    </label>
+  ),
+  DialogBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <footer>{children}</footer>,
+  DialogHeader: ({ children, onClose }: { children: React.ReactNode; onClose?: () => void }) => (
+    <header>
+      {children}
+      <button type="button" aria-label="Close" onClick={onClose}>
+        Close
+      </button>
+    </header>
+  ),
+  FormField: ({
+    children,
+    label,
+    htmlFor,
+  }: {
+    children: React.ReactNode;
+    label: string;
+    htmlFor?: string;
+    error?: string;
+  }) => (
+    <label htmlFor={htmlFor}>
+      {label}
+      {children}
+    </label>
+  ),
+  Label: ({ children }: { children: React.ReactNode; className?: string }) => <div>{children}</div>,
+}));
+
+jest.unstable_mockModule('../../internal-api', () => ({
+  CollapsibleRangeInput: ({
+    value,
+    onChange,
+    inputId,
+    label,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    inputId?: string;
+    label?: string;
+  }) => (
+    <input
+      id={inputId}
+      aria-label={label}
+      value={value}
+      onChange={(event) => onChange(event.currentTarget.value)}
+    />
+  ),
+  MinimizableDialog: ({
+    children,
+    open,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    onClose?: () => void;
+    dialogId?: string;
+    title?: string;
+    width?: string;
+    onEnterKeyDown?: () => void;
+  }) =>
+    open === false ? null : (
+      <div role="dialog" aria-modal="true">
+        {children}
+      </div>
+    ),
+  useActiveSheetId: () => 'sheet-1',
+  useUIStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      insertTableDialogOpen: true,
+      closeInsertTableDialog,
+      setTablePreviewRange: jest.fn(),
+      insertTableInitialRange: { startRow: 457, startCol: 0, endRow: 479, endCol: 10 },
+      insertTableInitialHasHeaders: false,
+      insertTableInitialStylePreset: 'medium2',
+    }),
+  useWorkbook: () => workbook,
+}));
+
+const { InsertTableDialog } = await import('./InsertTableDialog');
+
+describe('InsertTableDialog', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    closeInsertTableDialog.mockClear();
+    workbook.getSheetById.mockClear();
+    undoGroup.mockClear();
+    tablesAdd.mockClear();
+    delete (window as typeof window & { __MOG_PENDING_DIALOG_ACTION__?: Promise<void> })
+      .__MOG_PENDING_DIALOG_ACTION__;
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('closes before creating the table on a later macrotask', async () => {
+    render(<InsertTableDialog />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByLabelText(/Table range/i)).toHaveValue('A458:K480');
+
+    fireEvent.click(within(dialog).getByRole('button', { name: /^OK$/ }));
+
+    expect(closeInsertTableDialog).toHaveBeenCalledTimes(1);
+    expect(undoGroup).not.toHaveBeenCalled();
+    expect(tablesAdd).not.toHaveBeenCalled();
+    const pendingAction = (
+      window as typeof window & { __MOG_PENDING_DIALOG_ACTION__?: Promise<void> }
+    ).__MOG_PENDING_DIALOG_ACTION__;
+    expect(pendingAction).toBeInstanceOf(Promise);
+
+    jest.advanceTimersByTime(99);
+    expect(undoGroup).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    await pendingAction;
+
+    expect(workbook.getSheetById).toHaveBeenCalledWith('sheet-1');
+    expect(undoGroup).toHaveBeenCalledTimes(1);
+    expect(tablesAdd).toHaveBeenCalledWith('A458:K480', {
+      hasHeaders: false,
+      style: 'medium2',
+    });
+    expect(
+      (window as typeof window & { __MOG_PENDING_DIALOG_ACTION__?: Promise<void> })
+        .__MOG_PENDING_DIALOG_ACTION__,
+    ).toBeUndefined();
+  });
+});

--- a/apps/spreadsheet/src/dialogs/insert/InsertTableDialog.tsx
+++ b/apps/spreadsheet/src/dialogs/insert/InsertTableDialog.tsx
@@ -48,6 +48,37 @@ interface InsertTableDialogProps {
   }) => void;
 }
 
+const APPLY_AFTER_CLOSE_DELAY_MS = 100;
+
+type DialogActionWindow = typeof window & {
+  __MOG_PENDING_DIALOG_ACTION__?: Promise<void>;
+};
+
+function scheduleDialogAction(action: () => unknown): void {
+  const global = window as DialogActionWindow;
+  const pending = new Promise<void>((resolve, reject) => {
+    window.setTimeout(() => {
+      Promise.resolve()
+        .then(action)
+        .then(
+          () => {
+            if (global.__MOG_PENDING_DIALOG_ACTION__ === pending) {
+              delete global.__MOG_PENDING_DIALOG_ACTION__;
+            }
+            resolve();
+          },
+          (error) => {
+            if (global.__MOG_PENDING_DIALOG_ACTION__ === pending) {
+              delete global.__MOG_PENDING_DIALOG_ACTION__;
+            }
+            reject(error);
+          },
+        );
+    }, APPLY_AFTER_CLOSE_DELAY_MS);
+  });
+  global.__MOG_PENDING_DIALOG_ACTION__ = pending;
+}
+
 // =============================================================================
 // Style Presets for Preview
 // =============================================================================
@@ -281,28 +312,29 @@ export function InsertTableDialog({ onInsertTable }: InsertTableDialogProps) {
       return;
     }
 
-    // Create the table
-    if (onInsertTable) {
-      onInsertTable({
-        range: parsedRange,
-        hasHeaders,
-        stylePreset: selectedStyle,
-      });
-    } else {
+    closeDialog();
+    scheduleDialogAction(() => {
+      // Create the table
+      if (onInsertTable) {
+        return onInsertTable({
+          range: parsedRange,
+          hasHeaders,
+          stylePreset: selectedStyle,
+        });
+      }
+
       // Wrap table creation in an undo group so Cmd+Z reverts the entire
       // operation (table creation + style) in a single step.
       const ws = wb.getSheetById(activeSheetId);
       const rangeA1 = formatA1Range(parsedRange);
-      void wb
+      return wb
         .undoGroup(async () => {
           await ws.tables.add(rangeA1, { hasHeaders, style: selectedStyle });
         })
         .catch((err: unknown) => {
           console.error('Failed to create table:', err);
         });
-    }
-
-    closeDialog();
+    });
   }, [
     rangeInput,
     parsedRange,


### PR DESCRIPTION
## Summary
- Close the Insert Table dialog before running heavy table creation.
- Track the delayed operation via `window.__MOG_PENDING_DIALOG_ACTION__` so app-eval settling waits for completion.
- Add a focused dialog test proving close happens before workbook/table mutation starts.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `17`
- Scenario: `kewpie-format-presentation-format-as-table-keyboard-shortcuts-balance-sheet`
- Worker verification: InsertTableDialog test passed, production bundle built, scenario passed `5/5` after the product fix and paired scenario oracle correction.

## Notes
- This is the product half of worker `17`; the app-eval scenario correction belongs in `mog-internal` as a separate PR.