### PR TITLE
[fleet v0.9.3] Select merged-cell origin for direct single-cell selection

### DIFF
--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/selection-modes.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/selection-modes.test.ts
@@ -535,6 +535,23 @@ describe('selection-mode lifecycle', () => {
     actor.stop();
   });
 
+  it('14d. set_selection_single_cell_inside_merge_resolves_to_merge_anchor', () => {
+    const actor = startActorAt(0, 0);
+    pushMerge(actor, rng(6, 26, 6, 27)); // AA7:AB7
+
+    actor.send({
+      type: 'SET_SELECTION',
+      ranges: [rng(6, 27, 6, 27)],
+      activeCell: cell(6, 27),
+    });
+
+    const after = actor.getSnapshot().context;
+    expect(after.activeCell).toEqual(cell(6, 26));
+    expect(after.anchor).toEqual(cell(6, 26));
+    expect(after.pendingRange).toEqual(rng(6, 26, 6, 27));
+    actor.stop();
+  });
+
   it('15. additive_mode_arrow_into_merge_enters_origin', () => {
     // Additive on with one committed range. Arrow into merge → pending
     // collapses to the merge origin; committed untouched.

--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/system-actions.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/system-actions.ts
@@ -36,6 +36,40 @@ import type { SelectionContext, SelectionEvent, SelectionModes } from './types';
 // SYSTEM ACTIONS
 // =============================================================================
 
+function isSingleCellRange(range: CellRange): boolean {
+  return (
+    range.isFullColumn !== true &&
+    range.isFullRow !== true &&
+    range.startRow === range.endRow &&
+    range.startCol === range.endCol
+  );
+}
+
+function resolveSingleCellMergeSelection(
+  context: SelectionContext,
+  ranges: CellRange[],
+  activeCell: CellCoord,
+): { ranges: CellRange[]; activeCell: CellCoord } {
+  if (ranges.length !== 1) return { ranges, activeCell };
+
+  const target = ranges[0]!;
+  if (
+    !isSingleCellRange(target) ||
+    target.startRow !== activeCell.row ||
+    target.startCol !== activeCell.col
+  ) {
+    return { ranges, activeCell };
+  }
+
+  const merged = context.getMergedRegionAt?.(activeCell.row, activeCell.col) ?? null;
+  if (!merged) return { ranges, activeCell };
+
+  return {
+    ranges: [merged],
+    activeCell: { row: merged.startRow, col: merged.startCol },
+  };
+}
+
 /**
  * Direct set selection. Source-aware: only `event.source === 'user'`
  * preserves modes and `committedRanges`. All other sources
@@ -58,7 +92,9 @@ const setSelection = assign(
 
     const source = event.source ?? 'user';
     const isUser = source === 'user';
-    const ranges = event.ranges.length > 0 ? event.ranges : [singleCellRange(event.activeCell)];
+    let ranges = event.ranges.length > 0 ? event.ranges : [singleCellRange(event.activeCell)];
+    let activeCell = event.activeCell;
+    ({ ranges, activeCell } = resolveSingleCellMergeSelection(context, ranges, activeCell));
     const trailing = ranges[ranges.length - 1]!;
     const leading = ranges.slice(0, -1);
 
@@ -82,9 +118,9 @@ const setSelection = assign(
       committedRanges: nextCommitted,
       pendingRange: nextPending,
       modes: nextModes,
-      activeCell: event.activeCell,
+      activeCell,
       // Use provided anchor or fallback to activeCell for backwards compatibility
-      anchor: event.anchor !== undefined ? event.anchor : event.activeCell,
+      anchor: event.anchor !== undefined ? event.anchor : activeCell,
       // Support column/row selection restoration
       anchorCol: event.anchorCol ?? null,
       anchorRow: event.anchorRow ?? null,


### PR DESCRIPTION
## Summary
- Normalize direct single-cell `SET_SELECTION` through merged-region lookup.
- When the requested cell is inside a merge, select the full merged range and set active cell/anchor to the merge origin.
- Add focused selection-machine coverage.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `102`
- Scenario: `kewpie-format-presentation-merge-center-section-heading-hidden-outline-precondition-collapsed-fiscal-columns`
- Worker verification: focused selection-machine test passed (`28` tests), production bundle built, scenario passed `5/5` after the product fix and paired readback correction.

## Notes
- This is the product half of worker `102`; app-eval raw readback helper/spec changes belong in `mog-internal` as a separate PR.