### PR TITLE
[fleet v0.9.3] Follow active cell on direct range selection

### DIFF
--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/page-navigation-emits.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/page-navigation-emits.test.ts
@@ -51,6 +51,55 @@ describe('page navigation emits', () => {
     actor.stop();
   });
 
+  it('direct range selection follows the active cell rather than the opposite corner', () => {
+    const actor = createActor(selectionMachine);
+    const emitted: SelectionEmitted[] = [];
+    const subscription = actor.on('userSelectionChanged', (event) => emitted.push(event));
+
+    actor.start();
+    actor.send({
+      type: 'SET_SELECTION',
+      ranges: [{ startRow: 6, startCol: 13, endRow: 6, endCol: 27 }],
+      activeCell: { row: 6, col: 13 },
+      source: 'user',
+    });
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      activeCell: { row: 6, col: 13 },
+      followCell: { row: 6, col: 13 },
+    });
+    expect(emitted[0].scrollIntent).toBeUndefined();
+
+    subscription.unsubscribe();
+    actor.stop();
+  });
+
+  it('explicit-anchor range selection still follows the moving edge', () => {
+    const actor = createActor(selectionMachine);
+    const emitted: SelectionEmitted[] = [];
+    const subscription = actor.on('userSelectionChanged', (event) => emitted.push(event));
+
+    actor.start();
+    actor.send({
+      type: 'SET_SELECTION',
+      ranges: [{ startRow: 6, startCol: 13, endRow: 6, endCol: 27 }],
+      activeCell: { row: 6, col: 13 },
+      anchor: { row: 6, col: 13 },
+      source: 'user',
+    });
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      activeCell: { row: 6, col: 13 },
+      followCell: { row: 6, col: 27 },
+    });
+    expect(emitted[0].scrollIntent).toBeUndefined();
+
+    subscription.unsubscribe();
+    actor.stop();
+  });
+
   it('annotates Ctrl+Home with a top-left origin scroll intent', () => {
     const actor = createActor(selectionMachine);
     const emitted: SelectionEmitted[] = [];

--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/emits.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/emits.ts
@@ -56,11 +56,14 @@ function getSelectionScrollIntent(event: SelectionEvent): SelectionScrollIntent 
  */
 export const emitUserSelectionChanged = emit(
   ({ context, event }: { context: SelectionContext; event: SelectionEvent }) => {
-    const followCell = getSelectionViewportFollowCell(
-      context.pendingRange,
-      context.activeCell,
-      context.anchor,
-    );
+    const followCell =
+      event.type === 'SET_SELECTION' && event.anchor === undefined
+        ? context.activeCell
+        : getSelectionViewportFollowCell(
+            context.pendingRange,
+            context.activeCell,
+            context.anchor,
+          );
     const scrollIntent = getSelectionScrollIntent(event);
 
     return {


### PR DESCRIPTION
## Summary
- Fixes direct `SET_SELECTION` range navigation so viewport-follow tracks the active cell when no explicit anchor is provided.
- Preserves moving-edge follow behavior for explicit-anchor extension flows.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `19`
- Scenario: direct Name Box range navigation / copy viewport follow
- Worker result: scenario rerun passed `3/3`; focused selection emits suite passed `5/5`.

Verification was performed by the fleet worker on the cloud; I did not rerun local verification.
