### PR TITLE
[fleet v0.9.3] Skip full viewport refresh for recalc-only undo

### DIFF
--- a/kernel/src/bridges/compute/__tests__/viewport-sheet-switch.test.ts
+++ b/kernel/src/bridges/compute/__tests__/viewport-sheet-switch.test.ts
@@ -525,7 +525,34 @@ describe('refreshViewportForRegion — sheet-scoped viewport IDs', () => {
     expect(refreshOrder).toBeLessThan(emitOrder);
   });
 
-  it('undo refreshes registered viewports after history replay', async () => {
+  it('undo skips full viewport refresh for cell-only history replay', async () => {
+    const transport = {
+      call: jest.fn(async (command: string): Promise<any> => {
+        if (command === 'compute_undo') {
+          return [
+            new Uint8Array(),
+            {
+              recalc: makeRecalcResult({
+                changedCells: [{ sheetId: 'sheet-1', row: 0, col: 0 }],
+              }),
+            },
+          ];
+        }
+        return undefined;
+      }) as any,
+    } as BridgeTransport & { call: jest.Mock };
+    const core = createStartedCore(transport);
+
+    await core.undo();
+
+    expect(transport.call).toHaveBeenCalledWith('compute_undo', { docId: 'test-doc' });
+    expect(transport.call).not.toHaveBeenCalledWith(
+      'compute_get_viewport_binary',
+      expect.anything(),
+    );
+  });
+
+  it('undo refreshes registered viewports for table history replay', async () => {
     const initialBuffer = buildTestViewportBuffer({
       rows: 100,
       cols: 40,
@@ -548,7 +575,13 @@ describe('refreshViewportForRegion — sheet-scoped viewport IDs', () => {
           return viewportFetchCount === 1 ? initialBuffer : undoBuffer;
         }
         if (command === 'compute_undo') {
-          return [new Uint8Array(), {}];
+          return [
+            new Uint8Array(),
+            {
+              recalc: makeRecalcResult(),
+              tableChanges: [{ name: 'Table1', sheetId: 'sheet-1', kind: 'Removed' }],
+            },
+          ];
         }
         return undefined;
       }) as any,

--- a/kernel/src/bridges/compute/compute-core.ts
+++ b/kernel/src/bridges/compute/compute-core.ts
@@ -89,6 +89,39 @@ function isShowFormulasChange(change: SheetSettingsChange): boolean {
   return change.changedKey === 'showFormulas';
 }
 
+function historyReplayNeedsFullViewportRefresh(result: MutationResult): boolean {
+  return Boolean(
+    result.propertyChanges?.length ||
+      result.dimensionChanges?.length ||
+      result.mergeChanges?.length ||
+      result.visibilityChanges?.length ||
+      result.commentChanges?.length ||
+      result.filterChanges?.length ||
+      result.tableChanges?.length ||
+      result.slicerChanges?.length ||
+      result.sheetChanges?.length ||
+      result.settingsChanges?.length ||
+      result.pageBreakChanges?.length ||
+      result.printAreaChanges?.length ||
+      result.printTitlesChanges?.length ||
+      result.printSettingsChanges?.length ||
+      result.splitConfigChanges?.length ||
+      result.scrollPositionChanges?.length ||
+      result.viewSelectionChanges?.length ||
+      result.workbookSettingsChanges?.length ||
+      result.cfChanges?.length ||
+      result.namedRangeChanges?.length ||
+      result.groupingChanges?.length ||
+      result.sparklineChanges?.length ||
+      result.sortingChanges?.length ||
+      result.structureChanges?.length ||
+      result.floatingObjectChanges?.length ||
+      result.floatingObjectGroupChanges?.length ||
+      result.pivotChanges?.length ||
+      result.rangeChanges?.length,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Active instance registry — prevents stale compute_destroy from killing
 // a newer instance that was initialized with the same docId.
@@ -1627,11 +1660,9 @@ export class ComputeCore {
       undefined,
       'compute_undo',
     );
-    // History replay can change derived/effective viewport state without
-    // Rust emitting the same fine-grained viewport patches as the original
-    // forward mutation. Re-read visible buffers so undo never paints stale
-    // effective formatting, table styles, or related derived state.
-    await this.forceRefreshAllViewports();
+    if (historyReplayNeedsFullViewportRefresh(result)) {
+      await this.forceRefreshAllViewports();
+    }
     return result;
   }
 
@@ -1642,7 +1673,9 @@ export class ComputeCore {
       undefined,
       'compute_redo',
     );
-    await this.forceRefreshAllViewports();
+    if (historyReplayNeedsFullViewportRefresh(result)) {
+      await this.forceRefreshAllViewports();
+    }
     return result;
   }
 


### PR DESCRIPTION
## Summary
- Adds a history replay classifier for undo/redo mutation results.
- Keeps full viewport refreshes for structural/formatting/table changes, but skips them for recalc-only undo/redo.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `20`
- Scenario: `stress-undo-deep`
- Worker result: final scenario rerun passed `5/5`; focused compute viewport tests passed `13/13`.

Verification was performed by the fleet worker on the cloud; I did not rerun local verification.
