### PR TITLE
[fleet v0.9.3] Preserve internal HTML paste classification

### DIFF
--- a/apps/spreadsheet/src/actions/handlers/clipboard.ts
+++ b/apps/spreadsheet/src/actions/handlers/clipboard.ts
@@ -200,20 +200,28 @@ async function createCopyCutDeps(deps: ActionDependencies, sheetId: SheetId, ran
     for (let c = 0; c < rangeData2D[r].length; c++) {
       const cell = rangeData2D[r][c];
       const key = `${minRow + r},${minCol + c}`;
+      const legacyCell = cell as
+        | (typeof cell & {
+            raw?: unknown;
+            computed?: unknown;
+          })
+        | undefined;
       if (cell) {
-        const legacyCell = cell as typeof cell & {
-          raw?: unknown;
-          computed?: unknown;
-        };
         // Map ws.getRange() shape → StoreCellData-compatible shape
         cellDataLookup.set(key, {
-          raw: cell.value ?? legacyCell.raw,
-          computed: cell.formatted ?? legacyCell.computed ?? cell.value,
+          raw: cell.value ?? legacyCell?.raw,
+          computed: cell.formatted ?? legacyCell?.computed ?? cell.value,
           formula: cell.formula,
           hyperlink: cell.hyperlink,
         });
       }
-      displayLookup.set(key, cell?.value != null ? String(cell.value) : '');
+      displayLookup.set(
+        key,
+        cell?.formatted ??
+          (legacyCell?.computed != null ? String(legacyCell.computed) : undefined) ??
+          (legacyCell?.raw != null ? String(legacyCell.raw) : undefined) ??
+          (cell?.value != null ? String(cell.value) : ''),
+      );
     }
   }
 

--- a/apps/spreadsheet/src/domain/clipboard/__tests__/unified-paste-image.test.ts
+++ b/apps/spreadsheet/src/domain/clipboard/__tests__/unified-paste-image.test.ts
@@ -332,6 +332,39 @@ describe('unifiedPaste — image routing', () => {
     });
   });
 
+  it('keeps fresh internal clipboard when exported HTML has no cells', async () => {
+    installClipboard([
+      makeClipItem({
+        'text/html': blobLike('<table><tbody><tr></tr></tbody></table>', 'text/html'),
+      }),
+    ]);
+    const commands = makeCommands();
+
+    await unifiedPaste(ACTIVE_CELL, {
+      getClipboardSnapshot: () =>
+        ({
+          context: {
+            isCut: false,
+            isStale: false,
+            data: {
+              textSignature: '',
+              sourceRanges: [{ startRow: 6, startCol: 27, endRow: 6, endCol: 27 }],
+              sourceSheetId: 'sheet-1',
+              cells: {
+                '0,0': { raw: '103,188 ', formula: '=407039-AA7-Z7-Y7' },
+              },
+            },
+          },
+          matches: () => true,
+        }) as any,
+      commands,
+      readPasteDefaultsPreference: () => null,
+    });
+
+    expect((commands as any).paste).toHaveBeenCalledWith(ACTIVE_CELL);
+    expect((commands as any).externalPaste).not.toHaveBeenCalled();
+  });
+
   it('no-ops external plain text when the saved default is formats only', async () => {
     installClipboard([makeClipItem({ 'text/plain': blobLike('A', 'text/plain') })]);
     const commands = makeCommands();

--- a/apps/spreadsheet/src/domain/clipboard/unified-paste.ts
+++ b/apps/spreadsheet/src/domain/clipboard/unified-paste.ts
@@ -98,6 +98,13 @@ function normalizeClipboardSignature(text: string): string {
   return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/\n$/, '');
 }
 
+function htmlHasClipboardPayload(html: string | undefined): boolean {
+  if (!html?.trim()) return false;
+  if (/<(?:td|th)\b/i.test(html)) return true;
+  const text = html.replace(/<[^>]*>/g, '').replace(/&nbsp;/gi, ' ');
+  return normalizeClipboardSignature(text).trim() !== '';
+}
+
 function resolveNormalPasteOptions(
   deps: UnifiedPasteDeps,
   context: PasteDefaultContext,
@@ -282,11 +289,11 @@ export async function unifiedPaste(
     : '';
   const systemSignature = normalizeClipboardSignature(systemText);
   const hasFreshInternalClipboard =
-    Boolean(clipboardData?.textSignature) &&
+    Boolean(clipboardData) &&
     clipboardData?.sourceSheetId !== EXTERNAL_SOURCE_SHEET_ID &&
     clipboardState.context.isStale !== true;
   const hasExternalSystemPayload =
-    systemSignature !== '' || Boolean(systemHTML) || Boolean(imageBlob);
+    systemSignature !== '' || htmlHasClipboardPayload(systemHTML) || Boolean(imageBlob);
   const isOurClipboard =
     (internalSignature === systemSignature && systemSignature !== '') ||
     (!hasExternalSystemPayload && hasFreshInternalClipboard);

--- a/apps/spreadsheet/src/hooks/editing/use-clipboard.ts
+++ b/apps/spreadsheet/src/hooks/editing/use-clipboard.ts
@@ -94,6 +94,13 @@ function normalizeClipboardSignature(text: string): string {
   return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/\n$/, '');
 }
 
+function htmlHasClipboardPayload(html: string | undefined): boolean {
+  if (!html?.trim()) return false;
+  if (/<(?:td|th)\b/i.test(html)) return true;
+  const text = html.replace(/<[^>]*>/g, '').replace(/&nbsp;/gi, ' ');
+  return normalizeClipboardSignature(text).trim() !== '';
+}
+
 function isOurClipboardData(
   clipboardState: ClipboardState,
   clipboardData: ClipboardData | null,
@@ -105,7 +112,7 @@ function isOurClipboardData(
     : '';
   const systemSignature = normalizeClipboardSignature(systemText);
   const hasFreshInternalClipboard =
-    Boolean(clipboardData?.textSignature) &&
+    Boolean(clipboardData) &&
     clipboardData?.sourceSheetId !== EXTERNAL_SOURCE_SHEET_ID &&
     clipboardState.context.isStale !== true;
 
@@ -1205,7 +1212,7 @@ export function useClipboardEvents(options: UseClipboardEventsOptions): UseClipb
         const files = event.clipboardData?.files;
         const hasExternalSystemPayload =
           normalizeClipboardSignature(systemText) !== '' ||
-          html !== '' ||
+          htmlHasClipboardPayload(html) ||
           Boolean(files && Array.from(files).some((file) => file.type.startsWith('image/')));
 
         // Actor Access Layer: Point-in-time read (similar to action handler pattern)


### PR DESCRIPTION
## Summary
- Prevents empty exported HTML from reclassifying an internal clipboard copy as an external paste.
- Keeps the rich internal clipboard payload available when the system clipboard contains only an empty table shell.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `36`
- Scenario: far-right period formula copy/paste
- Worker result: final scenario rerun passed `11/11`; clipboard unit coverage passed `11/11`.

Verification was performed by the fleet worker on the cloud; I did not rerun local verification.
