### PR TITLE
[fleet v0.9.3] Prioritize exact whole-cell Find matches

### DIFF
--- a/apps/spreadsheet/src/systems/grid-editing/features/find-replace/find-replace-coordination.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/features/find-replace/find-replace-coordination.ts
@@ -28,7 +28,11 @@ import { toCellId, type CellId } from '@mog-sdk/contracts/cell-identity';
 import type { CellValue, SheetId } from '@mog-sdk/contracts/core';
 import type { SearchOptions, SearchResult } from '@mog-sdk/contracts/search';
 import { guardBridgeMutation } from '../../../../actions/handlers/bridge-error-guard';
-import { searchInScope, type SearchDataProvider } from '../../../../domain/search';
+import {
+  formatDisplayValue,
+  searchInScope,
+  type SearchDataProvider,
+} from '../../../../domain/search';
 import type {
   FindReplaceActor,
   FindReplaceState,
@@ -382,7 +386,8 @@ export class FindReplaceCoordinator {
       const activeSheetId = this.deps.getActiveSheetId();
 
       // Execute search (sync -- backed by cached data)
-      const results = searchInScope(provider, query, options, activeSheetId);
+      const rawResults = searchInScope(provider, query, options, activeSheetId);
+      const results = this.prioritizeWholeCellValueMatches(rawResults, query, options);
 
       const isReplacementQuery =
         this.lastExecutedQuery.trim() !== '' && this.lastExecutedQuery !== query;
@@ -654,6 +659,57 @@ export class FindReplaceCoordinator {
   ): { row: number; col: number; sheet: SheetId } | null {
     const cached = this.searchCache?.sheets.get(result.sheetId)?.cellIndex.get(result.cellId);
     return cached ? { row: cached.row, col: cached.col, sheet: result.sheetId } : null;
+  }
+
+  private prioritizeWholeCellValueMatches(
+    results: SearchResult[],
+    query: string,
+    options: SearchOptions,
+  ): SearchResult[] {
+    if (results.length <= 1 || options.matchEntireCell || options.useRegex) {
+      return results;
+    }
+
+    const exact: SearchResult[] = [];
+    const partial: SearchResult[] = [];
+
+    for (const result of results) {
+      if (this.isWholeCellValueMatch(result, query, options)) {
+        exact.push(result);
+      } else {
+        partial.push(result);
+      }
+    }
+
+    return exact.length > 0 ? [...exact, ...partial] : results;
+  }
+
+  private isWholeCellValueMatch(
+    result: SearchResult,
+    query: string,
+    options: SearchOptions,
+  ): boolean {
+    if (result.isInFormula) {
+      return this.textEqualsQuery(
+        this.searchCache?.sheets.get(result.sheetId)?.cellIndex.get(result.cellId)?.formulaText ??
+          '',
+        query,
+        options.caseSensitive,
+      );
+    }
+
+    const cached = this.searchCache?.sheets.get(result.sheetId)?.cellIndex.get(result.cellId);
+    if (!cached) return false;
+
+    return this.textEqualsQuery(
+      formatDisplayValue(cached.displayValue),
+      query,
+      options.caseSensitive,
+    );
+  }
+
+  private textEqualsQuery(text: string, query: string, caseSensitive: boolean): boolean {
+    return caseSensitive ? text === query : text.toLocaleLowerCase() === query.toLocaleLowerCase();
   }
 
   private getActiveCell(): { row: number; col: number } | null {

--- a/apps/spreadsheet/src/systems/grid-editing/testing/__tests__/find-replace-wiring.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/testing/__tests__/find-replace-wiring.test.ts
@@ -418,6 +418,60 @@ describe('Find-Replace Wiring (Bug #28)', () => {
     );
   });
 
+  it('prefers exact whole-cell matches over substring header matches on a fresh find', async () => {
+    const mockWorkbook = createMockWorkbook(sheetId('sheet-1'), [
+      { row: 2, col: 9, value: 'FY11/25E', cellId: 'partial-j3' },
+      { row: 2, col: 11, value: 'FY11/25', cellId: 'exact-l3' },
+      { row: 2, col: 12, value: 'FY11/25', cellId: 'exact-m3' },
+    ]);
+
+    system = new GridEditingSystem({
+      initialSheetId: 'sheet-1',
+      workbook: mockWorkbook,
+    });
+    system.start();
+
+    cleanupFindReplace = wireFindReplace(system, mockWorkbook, 'sheet-1');
+
+    system.access.actors.selection.send({
+      type: 'SET_SELECTION',
+      ranges: [{ startRow: 6, startCol: 12, endRow: 6, endCol: 12 }],
+      activeCell: { row: 6, col: 12 },
+    });
+
+    const actor = system.access.actors.findReplace;
+
+    actor.send({ type: 'OPEN' });
+    actor.send({ type: 'SET_QUERY', query: 'FY11/25' });
+    actor.send({ type: 'SEARCH' });
+
+    await waitForFindReplace(
+      system,
+      (snap) =>
+        snap.matches('hasResults' as any) &&
+        snap.context.results.length === 3 &&
+        getActiveCell(system).row === 2 &&
+        getActiveCell(system).col === 11,
+    );
+
+    expect(actor.getSnapshot().context.results.map((result) => result.cellId)).toEqual([
+      'exact-l3',
+      'exact-m3',
+      'partial-j3',
+    ]);
+    expect(actor.getSnapshot().context.currentIndex).toBe(-1);
+
+    actor.send({ type: 'FIND_NEXT' });
+
+    await waitForFindReplace(
+      system,
+      (snap) =>
+        snap.context.currentIndex === 0 &&
+        getActiveCell(system).row === 2 &&
+        getActiveCell(system).col === 11,
+    );
+  });
+
   // ---------------------------------------------------------------------------
   // Test 6: Without coordination wired, search hangs (documents the dep)
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reorders fresh Find results so exact whole-cell value matches are preferred ahead of partial matches.
- Keeps existing wrap-around and match-entire-cell behavior intact.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `58`
- Scenario: Find Enter navigation in Kewpie workbook
- Worker result: final scenario rerun passed `4/4`; focused find wiring suite passed `7/7`; regression scenarios `find-wrap-around` and `find-match-entire-cell` also passed in the worker.

Verification was performed by the fleet worker on the cloud; I did not rerun local verification.
