### PR TITLE
[fleet v0.9.3] Open Freeze Panes from collapsed View ribbon

### DIFF
--- a/apps/spreadsheet/src/chrome/toolbar/primitives/CollapsedGroupDropdown.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/CollapsedGroupDropdown.tsx
@@ -17,7 +17,7 @@
  */
 
 import type { ReactNode } from 'react';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { Popover, PopoverContent, PopoverTrigger, Tooltip } from '@mog/shell';
 import { useRibbonCollapseLevel } from '../collapse';
@@ -60,6 +60,10 @@ export interface CollapsedGroupDropdownProps {
   isLast?: boolean;
   /** Group content - rendered inside the dropdown panel */
   children: ReactNode;
+  /** Optional controlled open state for keytip-driven nested dropdowns. */
+  open?: boolean;
+  /** Called when the collapsed group dropdown should open or close. */
+  onOpenChange?: (open: boolean) => void;
 }
 
 // =============================================================================
@@ -83,8 +87,20 @@ export const CollapsedGroupDropdown = React.memo(function CollapsedGroupDropdown
   icon,
   isLast = false,
   children,
+  open,
+  onOpenChange,
 }: CollapsedGroupDropdownProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isOpen = open ?? uncontrolledOpen;
+  const setIsOpen = useCallback(
+    (nextOpen: boolean) => {
+      if (open === undefined) {
+        setUncontrolledOpen(nextOpen);
+      }
+      onOpenChange?.(nextOpen);
+    },
+    [onOpenChange, open],
+  );
   const { level } = useRibbonCollapseLevel();
   const isDense = level >= 3;
   const labelClassName = isDense

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarGroup.tsx
@@ -102,6 +102,10 @@ export interface ToolbarGroupProps {
    * If not provided, children are rendered inside the dropdown.
    */
   dropdownContent?: ReactNode;
+  /** Optional controlled open state for the collapsed group dropdown. */
+  dropdownOpen?: boolean;
+  /** Called when the collapsed group dropdown opens or closes. */
+  onDropdownOpenChange?: (open: boolean) => void;
   /** Optional typed ribbon visibility key. Defaults to a normalized label. */
   visibilityKey?: string;
 }
@@ -115,6 +119,8 @@ export const ToolbarGroup = React.memo(function ToolbarGroup({
   collapseConfig,
   dropdownIcon,
   dropdownContent,
+  dropdownOpen,
+  onDropdownOpenChange,
   visibilityKey,
 }: ToolbarGroupProps) {
   const groupVisibility = useRibbonGroupVisibility(label, visibilityKey);
@@ -138,7 +144,13 @@ export const ToolbarGroup = React.memo(function ToolbarGroup({
   if (renderMode === 'dropdown') {
     return (
       <RibbonVisibilityGroup group={groupVisibility.groupKey}>
-        <CollapsedGroupDropdown label={label} icon={dropdownIcon} isLast={isLast}>
+        <CollapsedGroupDropdown
+          label={label}
+          icon={dropdownIcon}
+          isLast={isLast}
+          open={dropdownOpen}
+          onOpenChange={onDropdownOpenChange}
+        >
           {dropdownContent ?? children}
         </CollapsedGroupDropdown>
       </RibbonVisibilityGroup>

--- a/apps/spreadsheet/src/chrome/toolbar/tabs/ViewRibbon.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/tabs/ViewRibbon.tsx
@@ -11,7 +11,7 @@
  * Ribbon Polish (V1, V2, V3, V4, V5)
  */
 
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { dispatch, useActiveSheetId, useUIStore } from '../../../internal-api';
 import type { SpreadsheetDisplayMode } from '../../../ui-store/slices/core/display-mode';
 
@@ -447,12 +447,26 @@ export function ViewRibbon({
   const isDropdownOpen = useUIStore((s) => s.ribbonDropdowns['view.freeze-panes'] ?? false);
   const openRibbonDropdown = useUIStore((s) => s.openRibbonDropdown);
   const closeRibbonDropdown = useUIStore((s) => s.closeRibbonDropdown);
+  const [isWindowGroupOpen, setIsWindowGroupOpen] = useState(false);
   const displayMode = useUIStore((s) => s.spreadsheetDisplayMode);
   const setDisplayMode = useUIStore((s) => s.setSpreadsheetDisplayMode);
   const setIsDropdownOpen = useCallback(
     (open: boolean) =>
       open ? openRibbonDropdown('view.freeze-panes') : closeRibbonDropdown('view.freeze-panes'),
     [openRibbonDropdown, closeRibbonDropdown],
+  );
+  const setWindowGroupOpen = useCallback(
+    (open: boolean) => {
+      if (open) {
+        setIsWindowGroupOpen(true);
+        return;
+      }
+      setIsWindowGroupOpen(open);
+      if (!isDropdownOpen) {
+        setIsDropdownOpen(false);
+      }
+    },
+    [isDropdownOpen, setIsDropdownOpen],
   );
   const isAppearanceOpen = useUIStore((s) => s.ribbonDropdowns['view.appearance-mode'] ?? false);
   const setAppearanceOpen = useCallback(
@@ -492,8 +506,71 @@ export function ViewRibbon({
     (action: () => void) => {
       action();
       setIsDropdownOpen(false);
+      setIsWindowGroupOpen(false);
+      window.requestAnimationFrame(() => deps.coordinator.input.focusGrid());
     },
-    [setIsDropdownOpen],
+    [deps.coordinator.input, setIsDropdownOpen],
+  );
+
+  useEffect(() => {
+    if (!isDropdownOpen) return;
+    const handle = window.setTimeout(() => {
+      const firstItem = document.querySelector<HTMLElement>(
+        '[data-testid="ribbon-dropdown-menu-freeze-panes"] [role="menuitem"]:not([aria-disabled="true"])',
+      );
+      firstItem?.focus({ preventScroll: true });
+    }, 0);
+    return () => window.clearTimeout(handle);
+  }, [isDropdownOpen]);
+
+  const freezePanesMenu = (
+    <div
+      data-testid="ribbon-dropdown-menu-freeze-panes"
+      className="bg-ss-surface rounded shadow-ss-md border border-ss-border min-w-[180px] py-1"
+      role="menu"
+      aria-label="Freeze Panes Options"
+    >
+      {/* Freeze Panes (at selection) */}
+      <RibbonDropdownItem
+        dataValue="freeze-panes"
+        icon={
+          isFrozen && frozenRows > 1 && frozenCols > 0 ? <CheckIcon /> : <span className="w-4" />
+        }
+        onClick={() => handleMenuItemClick(onFreezePanes!)}
+      >
+        Freeze Panes
+      </RibbonDropdownItem>
+
+      {/* Freeze Top Row */}
+      <RibbonDropdownItem
+        dataValue="freeze-top-row"
+        icon={frozenRows === 1 && frozenCols === 0 ? <CheckIcon /> : <span className="w-4" />}
+        onClick={() => handleMenuItemClick(onFreezeTopRow!)}
+      >
+        Freeze Top Row
+      </RibbonDropdownItem>
+
+      {/* Freeze First Column */}
+      <RibbonDropdownItem
+        dataValue="freeze-first-column"
+        icon={frozenRows === 0 && frozenCols === 1 ? <CheckIcon /> : <span className="w-4" />}
+        onClick={() => handleMenuItemClick(onFreezeFirstColumn!)}
+      >
+        Freeze First Column
+      </RibbonDropdownItem>
+
+      <RibbonDropdownDivider />
+
+      {/* Unfreeze Panes */}
+      <RibbonDropdownItem
+        dataValue="unfreeze"
+        icon={<span className="w-4" />}
+        onClick={() => handleMenuItemClick(onUnfreeze!)}
+        disabled={!isFrozen}
+      >
+        Unfreeze Panes
+      </RibbonDropdownItem>
+    </div>
   );
 
   // ===========================================================================
@@ -835,6 +912,9 @@ export function ViewRibbon({
         label="Window"
         collapseConfig={WINDOW_COLLAPSE_CONFIG}
         dropdownIcon={<FreezePanesIcon />}
+        dropdownOpen={isWindowGroupOpen || isDropdownOpen}
+        onDropdownOpenChange={setWindowGroupOpen}
+        dropdownContent={isDropdownOpen ? freezePanesMenu : undefined}
       >
         <div className="flex items-center gap-1">
           {/* New Window Button - Disabled stub */}
@@ -886,61 +966,7 @@ export function ViewRibbon({
               open={isDropdownOpen && isFreezeEnabled}
               onClose={() => setIsDropdownOpen(false)}
             >
-              <div
-                data-testid="ribbon-dropdown-menu-freeze-panes"
-                className="bg-ss-surface rounded shadow-ss-md border border-ss-border min-w-[180px] py-1"
-                role="menu"
-                aria-label="Freeze Panes Options"
-              >
-                {/* Freeze Panes (at selection) */}
-                <RibbonDropdownItem
-                  dataValue="freeze-panes"
-                  icon={
-                    isFrozen && frozenRows > 1 && frozenCols > 0 ? (
-                      <CheckIcon />
-                    ) : (
-                      <span className="w-4" />
-                    )
-                  }
-                  onClick={() => handleMenuItemClick(onFreezePanes!)}
-                >
-                  Freeze Panes
-                </RibbonDropdownItem>
-
-                {/* Freeze Top Row */}
-                <RibbonDropdownItem
-                  dataValue="freeze-top-row"
-                  icon={
-                    frozenRows === 1 && frozenCols === 0 ? <CheckIcon /> : <span className="w-4" />
-                  }
-                  onClick={() => handleMenuItemClick(onFreezeTopRow!)}
-                >
-                  Freeze Top Row
-                </RibbonDropdownItem>
-
-                {/* Freeze First Column */}
-                <RibbonDropdownItem
-                  dataValue="freeze-first-column"
-                  icon={
-                    frozenRows === 0 && frozenCols === 1 ? <CheckIcon /> : <span className="w-4" />
-                  }
-                  onClick={() => handleMenuItemClick(onFreezeFirstColumn!)}
-                >
-                  Freeze First Column
-                </RibbonDropdownItem>
-
-                <RibbonDropdownDivider />
-
-                {/* Unfreeze Panes */}
-                <RibbonDropdownItem
-                  dataValue="unfreeze"
-                  icon={<span className="w-4" />}
-                  onClick={() => handleMenuItemClick(onUnfreeze!)}
-                  disabled={!isFrozen}
-                >
-                  Unfreeze Panes
-                </RibbonDropdownItem>
-              </div>
+              {freezePanesMenu}
             </RibbonDropdownPanel>
           </div>
 


### PR DESCRIPTION
## Summary
- Adds controlled open state for collapsed toolbar groups.
- Mounts the Freeze Panes menu inside the collapsed Window group when the keytip opens `view.freeze-panes`.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `73`
- Scenario: `kewpie-navigation-view-freeze-at-section-keyboard-shortcuts-balance-sheet`
- Worker result: final scenario rerun passed `7/7`; focused collapsed dropdown coverage passed `1/1`.

Verification was performed by the fleet worker on the cloud; I did not rerun local verification.
