### PR TITLE
[fleet v0.9.3] Route keyboard sort through active AutoFilter

### DIFF
--- a/apps/spreadsheet/src/actions/handlers/__tests__/sort.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/sort.test.ts
@@ -23,6 +23,7 @@ interface MockSetup {
   sortRange: jest.Mock;
   getCurrentRegion: jest.Mock;
   getMergedRegions: jest.Mock;
+  listSummaries: jest.Mock;
   openSortDialog: jest.Mock;
 }
 
@@ -37,6 +38,14 @@ function makeMockDeps(opts: {
   currentRegion?: CellRange;
   mergedRegions?: CellRange[];
   cellValues?: Record<string, unknown>;
+  filterSummaries?: Array<{
+    id: string;
+    filterKind: 'autoFilter' | 'tableFilter' | 'advancedFilter';
+    range: CellRange;
+    tableId?: string;
+    activeColumnCount: number;
+    hasActiveCriteria: boolean;
+  }>;
   activeFormat?: { backgroundColor?: string; fontColor?: string };
 }): MockSetup {
   const activeCell = opts.activeCell ?? { row: 0, col: 0 };
@@ -56,11 +65,15 @@ function makeMockDeps(opts: {
   const getCell = jest.fn((row: number, col: number) =>
     Promise.resolve({ value: opts.cellValues?.[`${row},${col}`] ?? null }),
   );
+  const listSummaries = jest.fn().mockResolvedValue((opts.filterSummaries ?? []) as never);
 
   const ws = {
     getCell,
     getCurrentRegion,
     sortRange,
+    filters: {
+      listSummaries,
+    },
     formats: {
       get: jest.fn().mockResolvedValue((opts.activeFormat ?? {}) as never),
     },
@@ -91,7 +104,7 @@ function makeMockDeps(opts: {
     getActiveSheetId: () => 'sheet1' as any,
   } as unknown as ActionDependencies;
 
-  return { deps, sortRange, getCurrentRegion, getMergedRegions, openSortDialog };
+  return { deps, sortRange, getCurrentRegion, getMergedRegions, listSummaries, openSortDialog };
 }
 
 describe('SORT_ASCENDING — current-region auto-expansion', () => {
@@ -133,6 +146,36 @@ describe('SORT_ASCENDING — current-region auto-expansion', () => {
     expect(optionsArg).toEqual({
       columns: [{ column: 2, direction: 'asc' }],
       hasHeaders: false,
+    });
+  });
+
+  test('single cell inside an AutoFilter sorts the filter range over visible rows', async () => {
+    const setup = makeMockDeps({
+      selectionRanges: [{ startRow: 12, startCol: 27, endRow: 12, endCol: 27 }],
+      activeCell: { row: 12, col: 27 },
+      currentRegion: { startRow: 6, startCol: 15, endRow: 37, endCol: 42 },
+      filterSummaries: [
+        {
+          id: 'filter-1',
+          filterKind: 'autoFilter',
+          range: { startRow: 2, startCol: 11, endRow: 20, endCol: 27 },
+          activeColumnCount: 1,
+          hasActiveCriteria: true,
+        },
+      ],
+    });
+
+    await SORT_ASCENDING(setup.deps);
+
+    expect(setup.listSummaries).toHaveBeenCalledWith({ scope: 'available' });
+    expect(setup.getCurrentRegion).not.toHaveBeenCalled();
+    expect(setup.sortRange).toHaveBeenCalledTimes(1);
+    const [rangeArg, optionsArg] = setup.sortRange.mock.calls[0] as [unknown, unknown];
+    expect(rangeArg).toEqual({ startRow: 2, startCol: 11, endRow: 20, endCol: 27 });
+    expect(optionsArg).toEqual({
+      columns: [{ column: 16, direction: 'asc' }],
+      hasHeaders: true,
+      visibleRowsOnly: true,
     });
   });
 

--- a/apps/spreadsheet/src/actions/handlers/editor.ts
+++ b/apps/spreadsheet/src/actions/handlers/editor.ts
@@ -30,7 +30,7 @@ import type { CellRange, SheetId } from '@mog-sdk/contracts/core';
 import { MAX_COLS, MAX_ROWS } from '@mog-sdk/contracts/core';
 import type { Direction } from '@mog-sdk/contracts/machines';
 import type { CellCoord } from '@mog-sdk/contracts/rendering';
-import type { Worksheet, WorksheetWithInternals } from '@mog-sdk/contracts/api';
+import type { FilterSummaryInfo, Worksheet, WorksheetWithInternals } from '@mog-sdk/contracts/api';
 // Fill operations - use executeFillViaWorksheet for proper formula adjustment
 import type { FillDirection } from '../../domain/fill/types';
 import { executeFillViaWorksheet } from './fill/types';
@@ -46,7 +46,12 @@ import {
 
 import { letterToCol, parseA1Range as parseA1RangeNotation } from '@mog/spreadsheet-utils/a1';
 
-import { getRelativeCommandColumn, resolveDataCommandTarget } from '../data-command-target';
+import {
+  getRelativeCommandColumn,
+  normalizeCommandRange,
+  resolveDataCommandTarget,
+  type DataCommandTarget,
+} from '../data-command-target';
 import { guardBridgeMutation } from './bridge-error-guard';
 import { beginEditSessionFromAction } from './edit-entry';
 import { requestFormulaBarRefresh } from '../../infra/events/formula-bar-refresh';
@@ -99,6 +104,60 @@ function getSelectionContext(deps: ActionDependencies): {
   return {
     activeCell: deps.accessors.selection.getActiveCell(),
     ranges: deps.accessors.selection.getRanges(),
+  };
+}
+
+type SortCommandTarget = DataCommandTarget & {
+  readonly visibleRowsOnly?: boolean;
+};
+
+function isSingleCellRange(range: CellRange): boolean {
+  return range.startRow === range.endRow && range.startCol === range.endCol;
+}
+
+function rangeContainsCell(range: CellRange, cell: CellCoord): boolean {
+  return (
+    cell.row >= range.startRow &&
+    cell.row <= range.endRow &&
+    cell.col >= range.startCol &&
+    cell.col <= range.endCol
+  );
+}
+
+function rangeArea(range: CellRange): number {
+  return (range.endRow - range.startRow + 1) * (range.endCol - range.startCol + 1);
+}
+
+async function resolveAutoFilterSortTarget(
+  ws: Worksheet,
+  activeCell: CellCoord,
+  userRange: CellRange,
+): Promise<SortCommandTarget | null> {
+  if (!isSingleCellRange(userRange)) return null;
+
+  let filters: FilterSummaryInfo[];
+  try {
+    filters = await ws.filters.listSummaries({ scope: 'available' });
+  } catch {
+    return null;
+  }
+
+  const matchingFilter = filters
+    .filter(
+      (filter) =>
+        filter.filterKind === 'autoFilter' &&
+        !filter.tableId &&
+        rangeContainsCell(filter.range, activeCell),
+    )
+    .sort((left, right) => rangeArea(left.range) - rangeArea(right.range))[0];
+
+  if (!matchingFilter) return null;
+
+  return {
+    range: normalizeCommandRange(matchingFilter.range),
+    hasHeaders: true,
+    wasExpanded: false,
+    visibleRowsOnly: true,
   };
 }
 
@@ -679,7 +738,9 @@ async function sortInDirection(
 
   let sorted = false;
   for (const range of ranges) {
-    const target = await resolveDataCommandTarget(ws, range);
+    const autoFilterTarget = await resolveAutoFilterSortTarget(ws, activeCell, range);
+    const resolvedTarget = autoFilterTarget ?? (await resolveDataCommandTarget(ws, range));
+    const target: SortCommandTarget | null = resolvedTarget ? { ...resolvedTarget } : null;
     if (!target) continue;
 
     // E4: Excel refuses to sort ranges containing merged cells.
@@ -704,6 +765,7 @@ async function sortInDirection(
     await ws.sortRange(target.range, {
       columns: [{ column: getRelativeCommandColumn(activeCell, target.range), direction }],
       hasHeaders: target.hasHeaders,
+      visibleRowsOnly: target.visibleRowsOnly,
     });
     sorted = true;
   }


### PR DESCRIPTION
## Summary
- Resolves single-cell keyboard sort commands inside AutoFilter ranges to the filter range instead of the broad current region.
- Marks the sort as `visibleRowsOnly` for the worksheet API call.

## Fleet evidence
- Fleet debugger run: `f1781141191822`
- Worker: `108`
- Scenario: keyboard sort inside AutoFilter
- Worker result: final scenario rerun passed `8/8`; focused sort handler coverage passed `18/18` in the worker.

This PR intentionally includes only the app keyboard-sort files from worker 108; the duplicated kernel visible-row forwarding is already in #62.
Verification was performed by the fleet worker on the cloud; I did not rerun local verification.
