### PR TITLE
Fix Freeze Panes Navigation

### DIFF
--- a/apps/spreadsheet/src/chrome/formula-bar/NameBoxDropdown.tsx
+++ b/apps/spreadsheet/src/chrome/formula-bar/NameBoxDropdown.tsx
@@ -437,7 +437,10 @@ export const NameBoxDropdown = memo(function NameBoxDropdown({
       ): void => {
         deps.commands.object.deselectAll();
         deps.commands.chart.deselectAll();
-        selectionCommands.setSelection([range], nextActiveCell);
+        selectionCommands.setSelection([range], nextActiveCell, {
+          row: range.startRow,
+          col: range.startCol,
+        });
       };
 
       if (trimmedAddress.includes(':')) {


### PR DESCRIPTION
## Summary
Fix Freeze Panes Navigation.

## Changed Files
- `apps/spreadsheet/src/chrome/formula-bar/NameBoxDropdown.tsx`

## Verification
No source changes were made during this metadata cleanup pass. Existing PR checks and prior implementation verification still apply.
