### PR TITLE
Fix Shift+Arrow Selection

### DIFF
--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/extend-selection.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/extend-selection.test.ts
@@ -490,6 +490,34 @@ describe('extendSelection - Shift+Arrow bug tests', () => {
       expect(result.activeCell).toEqual({ row: 1, col: 0 });
     });
 
+    it('Shift+Down from a hidden column advances activeCell to the vertical moving edge', () => {
+      let context: SelectionContext = {
+        ...initialSelectionContext,
+        activeCell: { row: 20, col: 26 }, // AA21
+        pendingRange: { startRow: 20, startCol: 26, endRow: 20, endCol: 26 },
+        anchor: null,
+        isColHidden: (col) => col === 26,
+      };
+
+      for (let visibleStep = 0; visibleStep < 2; visibleStep += 1) {
+        const result = callExtendSelection(context, {
+          type: 'KEY_ARROW',
+          direction: 'down',
+          shiftKey: true,
+        });
+        context = { ...context, ...result };
+      }
+
+      expect(context.pendingRange).toEqual({
+        startRow: 20,
+        startCol: 26,
+        endRow: 22,
+        endCol: 26,
+      });
+      expect(context.anchor).toEqual({ row: 20, col: 26 });
+      expect(context.activeCell).toEqual({ row: 22, col: 26 });
+    });
+
     it('preserves a full-column selection when extending right from Ctrl+Space', () => {
       const context: SelectionContext = {
         ...initialSelectionContext,

--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/keyboard-actions.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/keyboard-actions.ts
@@ -147,8 +147,11 @@ const moveActiveCell = assign(
 
 /**
  * Extend selection in direction (shift+arrow).
- * activeCell stays at the anchor (Excel parity); the range geometry tracks
- * the moving edge via getMovingEdge(range, anchor).
+ * activeCell normally stays at the anchor; the range geometry tracks the
+ * moving edge via getMovingEdge(range, anchor). When extending vertically from
+ * a hidden column, keep activeCell on the vertical moving edge so active-cell
+ * row state advances with the keyboard gesture even though the column remains
+ * hidden.
  *
  * writes only to `pendingRange`. `committedRanges` is untouched
  * (empty in non-additive flows by invariant; preserved verbatim in additive).
@@ -242,7 +245,15 @@ const extendSelection = assign(
     // sit on the merge interior — matches the same machine-internal escape
     // used by `moveActiveCell`.
     const newEnd = escapeMergeOnMove(stepped, event.direction, context.getMergedRegionAt);
-    const activeCell = context.modes.extend && !event.shiftKey ? newEnd : anchor;
+    const verticalHiddenColumnExtend =
+      (event.direction === 'up' || event.direction === 'down') &&
+      context.isColHidden?.(anchor.col) === true;
+    const activeCell =
+      context.modes.extend && !event.shiftKey
+        ? newEnd
+        : verticalHiddenColumnExtend
+          ? newEnd
+          : anchor;
     return buildExtendUpdate(anchor, newEnd, activeCell);
   },
 );


### PR DESCRIPTION
## Summary
Fix Shift+Arrow Selection.

## Changed Files
- `apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/extend-selection.test.ts`
- `apps/spreadsheet/src/systems/grid-editing/machines/selection/keyboard-actions.ts`

## Verification
No source changes were made during this metadata cleanup pass. Existing PR checks and prior implementation verification still apply.
