### PR TITLE
Infer Table Headers from Sparse Title Rows

### DIFF
--- a/apps/spreadsheet/src/actions/data-command-target.ts
+++ b/apps/spreadsheet/src/actions/data-command-target.ts
@@ -47,11 +47,18 @@ async function rangeLooksLikeHeaderTable(ws: Worksheet, range: CellRange): Promi
     Array.from({ length: width }, (_, i) => ws.getCell(range.startRow, range.startCol + i)),
   );
 
-  const firstRowAllText = firstRow.every((cell) => {
+  let firstRowTextCells = 0;
+  const firstRowLooksLikeHeaders = firstRow.every((cell) => {
     const value = cell?.value;
-    return typeof value === 'string' && value.trim().length > 0;
+    if (value == null) return true;
+    if (typeof value !== 'string') return false;
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return true;
+    if (Number.isFinite(Number(trimmed))) return false;
+    firstRowTextCells += 1;
+    return true;
   });
-  if (!firstRowAllText) return false;
+  if (!firstRowLooksLikeHeaders || firstRowTextCells === 0) return false;
 
   const rowHasDataSignal = (row: Array<{ value?: unknown } | null | undefined>): boolean =>
     row.some((cell) => {

--- a/apps/spreadsheet/src/actions/handlers/__tests__/insert-table.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/insert-table.test.ts
@@ -168,6 +168,27 @@ describe('INSERT_TABLE — current-region auto-expansion', () => {
     });
   });
 
+  test('multi-cell selection with sparse text title row seeds dialog with hasHeaders=true', async () => {
+    const multiRange: CellRange = { startRow: 457, startCol: 0, endRow: 479, endCol: 10 };
+    const setup = makeMockDeps({
+      selectionRanges: [multiRange],
+      cellValues: {
+        '457,0': 'Consolidated Report',
+        '458,0': 'Current items',
+        '463,6': 235658,
+      },
+    });
+
+    const result = await INSERT_TABLE(setup.deps);
+
+    expect(result.handled).toBe(true);
+    expect(setup.getCurrentRegion).not.toHaveBeenCalled();
+    expect(setup.openInsertTableDialog).toHaveBeenCalledWith({
+      range: multiRange,
+      hasHeaders: true,
+    });
+  });
+
   test('empty selection returns disabled', async () => {
     const setup = makeMockDeps({
       selectionRanges: [],


### PR DESCRIPTION
## Summary
Infer Table Headers from Sparse Title Rows.

## Changed Files
- `apps/spreadsheet/src/actions/data-command-target.ts`
- `apps/spreadsheet/src/actions/handlers/__tests__/insert-table.test.ts`

## Verification
- Rebased this replacement branch onto the sanitized public base.
- Ran diff validation and leak-token scans over the exposed PR patch.
