### PR TITLE
Infer Headers for Explicit Table Selections

### DIFF
--- a/apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts
+++ b/apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts
@@ -86,6 +86,59 @@ describe('resolveDataCommandTarget', () => {
     expect(ws.getCurrentRegion).not.toHaveBeenCalled();
   });
 
+  test('explicit multi-row dialog target tolerates dense text headers with blank separators', async () => {
+    const range = { startRow: 2, startCol: 11, endRow: 20, endCol: 27 };
+    const ws = makeWorksheet({
+      values: {
+        '2,11': 'FY11/25',
+        '2,12': 'FY11/25',
+        '2,13': 'FY11/28',
+        '2,14': null,
+        '2,15': '1Q',
+        '2,16': '2Q',
+        '2,17': '3Q',
+        '2,18': '4Q',
+        '2,19': '1Q',
+        '2,20': '2Q',
+        '2,21': '3Q',
+        '2,22': '4Q',
+        '2,23': '1Q',
+        '2,24': '2Q',
+        '2,25': '3Q',
+        '2,26': '4Q',
+        '2,27': '1Q',
+        '6,12': 505000,
+        '6,13': 600000,
+        '6,15': 128319,
+      },
+    });
+
+    await expect(resolveDataDialogTarget(ws as Worksheet, range)).resolves.toEqual({
+      range,
+      hasHeaders: true,
+      wasExpanded: false,
+    });
+    expect(ws.getCurrentRegion).not.toHaveBeenCalled();
+  });
+
+  test('explicit multi-row dialog target keeps sparse title blocks headerless', async () => {
+    const range = { startRow: 457, startCol: 0, endRow: 479, endCol: 10 };
+    const ws = makeWorksheet({
+      values: {
+        '457,0': 'Consolidated Report',
+        '463,6': 235658,
+        '467,9': 486344,
+      },
+    });
+
+    await expect(resolveDataDialogTarget(ws as Worksheet, range)).resolves.toEqual({
+      range,
+      hasHeaders: false,
+      wasExpanded: false,
+    });
+    expect(ws.getCurrentRegion).not.toHaveBeenCalled();
+  });
+
   test('single-cell selection expands through getCurrentRegion', async () => {
     const expanded = { startRow: 0, startCol: 0, endRow: 9, endCol: 3 };
     const ws = makeWorksheet({ currentRegion: expanded });

--- a/apps/spreadsheet/src/actions/data-command-target.ts
+++ b/apps/spreadsheet/src/actions/data-command-target.ts
@@ -13,6 +13,7 @@ interface ResolveDataTargetOptions {
 }
 
 const HEADER_BODY_SCAN_ROW_LIMIT = 100;
+const MIN_HEADER_TEXT_DENSITY = 0.6;
 
 export function normalizeCommandRange(range: CellRange): CellRange {
   return {
@@ -47,11 +48,16 @@ async function rangeLooksLikeHeaderTable(ws: Worksheet, range: CellRange): Promi
     Array.from({ length: width }, (_, i) => ws.getCell(range.startRow, range.startCol + i)),
   );
 
-  const firstRowAllText = firstRow.every((cell) => {
+  let firstRowTextCount = 0;
+  for (const cell of firstRow) {
     const value = cell?.value;
-    return typeof value === 'string' && value.trim().length > 0;
-  });
-  if (!firstRowAllText) return false;
+    if (value == null) continue;
+    if (typeof value !== 'string') return false;
+    if (value.trim().length === 0) continue;
+    firstRowTextCount += 1;
+  }
+  const minTextHeaders = Math.max(1, Math.ceil(width * MIN_HEADER_TEXT_DENSITY));
+  if (firstRowTextCount < minTextHeaders) return false;
 
   const rowHasDataSignal = (row: Array<{ value?: unknown } | null | undefined>): boolean =>
     row.some((cell) => {


### PR DESCRIPTION
## Summary
Infer Headers for Explicit Table Selections.

## Changed Files
- `apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts`
- `apps/spreadsheet/src/actions/data-command-target.ts`

## Verification
- Rebased this replacement branch onto the sanitized public base.
- Ran diff validation and leak-token scans over the exposed PR patch.
