### PR TITLE
Fix Filtering after Showing Outline Detail

### DIFF
--- a/apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts
+++ b/apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts
@@ -2,7 +2,11 @@ import { jest } from '@jest/globals';
 
 import type { Worksheet } from '@mog-sdk/contracts/api';
 import type { CellRange } from '@mog-sdk/contracts/core';
-import { resolveDataCommandTarget, resolveDataDialogTarget } from '../data-command-target';
+import {
+  resolveAutoFilterCommandTarget,
+  resolveDataCommandTarget,
+  resolveDataDialogTarget,
+} from '../data-command-target';
 
 function makeWorksheet(opts: {
   currentRegion?: CellRange;
@@ -99,6 +103,31 @@ describe('resolveDataCommandTarget', () => {
       }),
     ).resolves.toMatchObject({ range: expanded, wasExpanded: true });
     expect(ws.getCurrentRegion).toHaveBeenCalledWith(4, 2);
+  });
+
+  test('AutoFilter single-cell selection can lift a body-only region to a nearby header row', async () => {
+    const expanded = { startRow: 6, startCol: 15, endRow: 37, endCol: 42 };
+    const values: Record<string, unknown> = {};
+    for (let col = expanded.startCol; col <= expanded.endCol; col++) {
+      values[`2,${col}`] = '1Q';
+    }
+    values['6,27'] = 100536;
+
+    const ws = makeWorksheet({ currentRegion: expanded, values });
+
+    await expect(
+      resolveAutoFilterCommandTarget(ws as Worksheet, {
+        startRow: 12,
+        startCol: 27,
+        endRow: 12,
+        endCol: 27,
+      }),
+    ).resolves.toEqual({
+      range: { startRow: 2, startCol: 15, endRow: 37, endCol: 42 },
+      hasHeaders: true,
+      wasExpanded: true,
+    });
+    expect(ws.getCurrentRegion).toHaveBeenCalledWith(12, 27);
   });
 
   test('single-row selection expands through getCurrentRegion', async () => {

--- a/apps/spreadsheet/src/actions/data-command-target.ts
+++ b/apps/spreadsheet/src/actions/data-command-target.ts
@@ -13,6 +13,7 @@ interface ResolveDataTargetOptions {
 }
 
 const HEADER_BODY_SCAN_ROW_LIMIT = 100;
+const HEADER_ROW_SCAN_LIMIT = 25;
 
 export function normalizeCommandRange(range: CellRange): CellRange {
   return {
@@ -80,6 +81,62 @@ export async function resolveDataCommandTarget(
     allowEmptySingleCell: false,
     inferHeadersForExplicitMultiRow: false,
   });
+}
+
+export async function resolveAutoFilterCommandTarget(
+  ws: Worksheet,
+  userRange: CellRange,
+): Promise<DataCommandTarget | null> {
+  const target = await resolveDataTarget(ws, userRange, {
+    allowEmptySingleCell: false,
+    inferHeadersForExplicitMultiRow: false,
+  });
+  if (!target || target.hasHeaders || !target.wasExpanded) {
+    return target;
+  }
+
+  const liftedRange = await findNearbyHeaderRange(
+    ws,
+    target.range,
+    normalizeCommandRange(userRange),
+  );
+  if (!liftedRange) {
+    return target;
+  }
+
+  return {
+    range: liftedRange,
+    hasHeaders: true,
+    wasExpanded: target.wasExpanded,
+  };
+}
+
+async function findNearbyHeaderRange(
+  ws: Worksheet,
+  expandedRange: CellRange,
+  userRange: CellRange,
+): Promise<CellRange | null> {
+  if (expandedRange.startRow <= 0) return null;
+
+  const activeCol = userRange.startCol;
+  if (activeCol < expandedRange.startCol || activeCol > expandedRange.endCol) {
+    return null;
+  }
+
+  const minHeaderRow = Math.max(0, expandedRange.startRow - HEADER_ROW_SCAN_LIMIT);
+  for (let headerRow = expandedRange.startRow - 1; headerRow >= minHeaderRow; headerRow--) {
+    const candidate = {
+      startRow: headerRow,
+      startCol: expandedRange.startCol,
+      endRow: expandedRange.endRow,
+      endCol: expandedRange.endCol,
+    };
+    if (await rangeLooksLikeHeaderTable(ws, candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
 }
 
 async function resolveDataTarget(

--- a/apps/spreadsheet/src/actions/handlers/ui/view-handlers.ts
+++ b/apps/spreadsheet/src/actions/handlers/ui/view-handlers.ts
@@ -24,7 +24,7 @@ import type { CellRange, SheetId } from '@mog-sdk/contracts/core';
 // G5: Zoom utilities
 import { clampZoom, getZoomLevel, zoomIn, zoomOut } from '../../../infra/utils/zoom-utils';
 import { DEFAULT_ZOOM } from '@mog-sdk/contracts/rendering';
-import { resolveDataCommandTarget } from '../../data-command-target';
+import { resolveAutoFilterCommandTarget } from '../../data-command-target';
 import { getUIStore, handled, notHandled } from '../handler-utils';
 import { useExtensionStore } from '../../../infra/state/extension-store';
 
@@ -115,7 +115,7 @@ export const TOGGLE_AUTO_FILTER: AsyncActionHandler = async (deps): Promise<Acti
   }
 
   // No existing filter - resolve the Data-tab tabular command target and create.
-  const target = await resolveDataCommandTarget(ws, userRange);
+  const target = await resolveAutoFilterCommandTarget(ws, userRange);
 
   if (!target) {
     // No data region found (empty cell selected)


### PR DESCRIPTION
## Summary
Fix Filtering after Showing Outline Detail.

## Changed Files
- `apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts`
- `apps/spreadsheet/src/actions/data-command-target.ts`
- `apps/spreadsheet/src/actions/handlers/ui/view-handlers.ts`

## Verification
No source changes were made during this metadata cleanup pass. Existing PR checks and prior implementation verification still apply.
