### PR TITLE
Infer Sparse Title Rows for Table Targets

### DIFF
--- a/apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts
+++ b/apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts
@@ -86,6 +86,65 @@ describe('resolveDataCommandTarget', () => {
     expect(ws.getCurrentRegion).not.toHaveBeenCalled();
   });
 
+  test('explicit multi-row dialog target infers sparse text title row as headers', async () => {
+    const ws = makeWorksheet({
+      values: {
+        '457,0': 'Consolidated Report',
+        '458,0': 'Current items',
+        '458,1': 156332,
+        '467,0': 'Total items',
+        '467,9': 486344,
+      },
+    });
+    const range = { startRow: 457, startCol: 0, endRow: 479, endCol: 10 };
+
+    await expect(resolveDataDialogTarget(ws as Worksheet, range)).resolves.toEqual({
+      range,
+      hasHeaders: true,
+      wasExpanded: false,
+    });
+    expect(ws.getCurrentRegion).not.toHaveBeenCalled();
+  });
+
+  test('explicit multi-row dialog target can opt out of sparse text title row headers', async () => {
+    const ws = makeWorksheet({
+      values: {
+        '457,0': 'Consolidated Report',
+        '458,0': 'Current items',
+        '458,1': 156332,
+      },
+    });
+    const range = { startRow: 457, startCol: 0, endRow: 479, endCol: 10 };
+
+    await expect(
+      resolveDataDialogTarget(ws as Worksheet, range, { allowSparseHeaderRows: false }),
+    ).resolves.toEqual({
+      range,
+      hasHeaders: false,
+      wasExpanded: false,
+    });
+    expect(ws.getCurrentRegion).not.toHaveBeenCalled();
+  });
+
+  test('explicit multi-row dialog target does not infer headers from numeric first row', async () => {
+    const ws = makeWorksheet({
+      values: {
+        '0,0': 'Current items',
+        '0,1': 156332,
+        '1,0': 'Cash',
+        '1,1': 100,
+      },
+    });
+    const range = { startRow: 0, startCol: 0, endRow: 3, endCol: 1 };
+
+    await expect(resolveDataDialogTarget(ws as Worksheet, range)).resolves.toEqual({
+      range,
+      hasHeaders: false,
+      wasExpanded: false,
+    });
+    expect(ws.getCurrentRegion).not.toHaveBeenCalled();
+  });
+
   test('single-cell selection expands through getCurrentRegion', async () => {
     const expanded = { startRow: 0, startCol: 0, endRow: 9, endCol: 3 };
     const ws = makeWorksheet({ currentRegion: expanded });

--- a/apps/spreadsheet/src/actions/data-command-target.ts
+++ b/apps/spreadsheet/src/actions/data-command-target.ts
@@ -10,9 +10,14 @@ export interface DataCommandTarget {
 interface ResolveDataTargetOptions {
   readonly allowEmptySingleCell: boolean;
   readonly inferHeadersForExplicitMultiRow: boolean;
+  readonly allowSparseHeaderRows: boolean;
 }
 
 const HEADER_BODY_SCAN_ROW_LIMIT = 100;
+
+interface HeaderInferenceOptions {
+  readonly allowSparseHeaderRows: boolean;
+}
 
 export function normalizeCommandRange(range: CellRange): CellRange {
   return {
@@ -39,7 +44,11 @@ export function getRelativeCommandColumn(
   return activeCell.col - range.startCol;
 }
 
-async function rangeLooksLikeHeaderTable(ws: Worksheet, range: CellRange): Promise<boolean> {
+async function rangeLooksLikeHeaderTable(
+  ws: Worksheet,
+  range: CellRange,
+  options: HeaderInferenceOptions,
+): Promise<boolean> {
   if (range.startRow >= range.endRow) return false;
 
   const width = range.endCol - range.startCol + 1;
@@ -47,11 +56,29 @@ async function rangeLooksLikeHeaderTable(ws: Worksheet, range: CellRange): Promi
     Array.from({ length: width }, (_, i) => ws.getCell(range.startRow, range.startCol + i)),
   );
 
-  const firstRowAllText = firstRow.every((cell) => {
+  let firstRowHasText = false;
+  let firstRowAllPopulatedText = true;
+  const firstRowHasOnlyTextOrBlanks = firstRow.every((cell) => {
     const value = cell?.value;
-    return typeof value === 'string' && value.trim().length > 0;
+    if (value == null || value === '') {
+      firstRowAllPopulatedText = false;
+      return true;
+    }
+    if (typeof value !== 'string') {
+      firstRowAllPopulatedText = false;
+      return false;
+    }
+    if (value.trim().length === 0) {
+      firstRowAllPopulatedText = false;
+      return true;
+    }
+    firstRowHasText = true;
+    return true;
   });
-  if (!firstRowAllText) return false;
+  const firstRowLooksLikeHeaders = options.allowSparseHeaderRows
+    ? firstRowHasOnlyTextOrBlanks
+    : firstRowAllPopulatedText;
+  if (!firstRowHasText || !firstRowLooksLikeHeaders) return false;
 
   const rowHasDataSignal = (row: Array<{ value?: unknown } | null | undefined>): boolean =>
     row.some((cell) => {
@@ -79,6 +106,7 @@ export async function resolveDataCommandTarget(
   return resolveDataTarget(ws, userRange, {
     allowEmptySingleCell: false,
     inferHeadersForExplicitMultiRow: false,
+    allowSparseHeaderRows: false,
   });
 }
 
@@ -94,7 +122,7 @@ async function resolveDataTarget(
     return {
       range,
       hasHeaders: options.inferHeadersForExplicitMultiRow
-        ? await rangeLooksLikeHeaderTable(ws, range)
+        ? await rangeLooksLikeHeaderTable(ws, range, options)
         : false,
       wasExpanded: false,
     };
@@ -118,7 +146,7 @@ async function resolveDataTarget(
 
   return {
     range: expanded,
-    hasHeaders: await rangeLooksLikeHeaderTable(ws, expanded),
+    hasHeaders: await rangeLooksLikeHeaderTable(ws, expanded, options),
     wasExpanded: true,
   };
 }
@@ -135,10 +163,12 @@ async function resolveDataTarget(
 export async function resolveDataDialogTarget(
   ws: Worksheet,
   userRange: CellRange,
+  options: { allowSparseHeaderRows?: boolean } = {},
 ): Promise<DataCommandTarget> {
   const target = await resolveDataTarget(ws, userRange, {
     allowEmptySingleCell: true,
     inferHeadersForExplicitMultiRow: true,
+    allowSparseHeaderRows: options.allowSparseHeaderRows ?? true,
   });
   return (
     target ?? {

--- a/apps/spreadsheet/src/actions/handlers/__tests__/insert-table.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/insert-table.test.ts
@@ -168,6 +168,27 @@ describe('INSERT_TABLE — current-region auto-expansion', () => {
     });
   });
 
+  test('multi-cell selection can opt out of sparse title-row header inference', async () => {
+    const multiRange: CellRange = { startRow: 457, startCol: 0, endRow: 479, endCol: 10 };
+    const setup = makeMockDeps({
+      selectionRanges: [multiRange],
+      cellValues: {
+        '457,0': 'Consolidated Report',
+        '458,0': 'Current items',
+        '458,1': 156332,
+      },
+    });
+
+    const result = await INSERT_TABLE(setup.deps, { allowSparseHeaderRows: false });
+
+    expect(result.handled).toBe(true);
+    expect(setup.getCurrentRegion).not.toHaveBeenCalled();
+    expect(setup.openInsertTableDialog).toHaveBeenCalledWith({
+      range: multiRange,
+      hasHeaders: false,
+    });
+  });
+
   test('empty selection returns disabled', async () => {
     const setup = makeMockDeps({
       selectionRanges: [],

--- a/apps/spreadsheet/src/actions/handlers/formatting/cell-format-dialogs.ts
+++ b/apps/spreadsheet/src/actions/handlers/formatting/cell-format-dialogs.ts
@@ -210,7 +210,10 @@ export const APPLY_PROTECTION_FORMAT: AsyncActionHandler = async (deps) => {
  */
 export const INSERT_TABLE: AsyncActionHandler = async (
   deps,
-  payload?: { stylePreset?: import('@mog-sdk/contracts/tables').TableStylePreset },
+  payload?: {
+    stylePreset?: import('@mog-sdk/contracts/tables').TableStylePreset;
+    allowSparseHeaderRows?: boolean;
+  },
 ) => {
   const sheetId = deps.getActiveSheetId();
   const { ranges } = getSelectionContext(deps);
@@ -219,7 +222,9 @@ export const INSERT_TABLE: AsyncActionHandler = async (
   }
 
   const ws = deps.workbook.getSheetById(sheetId);
-  const target = await resolveDataDialogTarget(ws, ranges[0]);
+  const target = await resolveDataDialogTarget(ws, ranges[0], {
+    allowSparseHeaderRows: payload?.allowSparseHeaderRows,
+  });
 
   const uiState = getUIStore(deps).getState();
   if (uiState?.openInsertTableDialog) {

--- a/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.tsx
@@ -31,7 +31,7 @@
  *
  */
 
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { useFeatureGate, useUIStore } from '../../../internal-api';
 
 import { Tooltip } from '@mog/shell';
@@ -160,6 +160,7 @@ function StylePreviewChip({
  */
 export const StylesGroup = React.memo(function StylesGroup() {
   const isEnabled = useFeatureGate('groups', 'styles');
+  const tableStyleGalleryOpenSource = useRef<'button' | 'external'>('external');
 
   // ===========================================================================
   // Dispatch (unified action system - hook form per ArrangeGroup convention)
@@ -175,8 +176,8 @@ export const StylesGroup = React.memo(function StylesGroup() {
   const { handleApplyStyle } = useToolbarActions();
 
   const formatAsTable = useCallback(
-    (styleId: TableStylePreset) => {
-      void dispatch('INSERT_TABLE', { stylePreset: styleId });
+    (styleId: TableStylePreset, allowSparseHeaderRows?: boolean) => {
+      void dispatch('INSERT_TABLE', { stylePreset: styleId, allowSparseHeaderRows });
     },
     [dispatch],
   );
@@ -220,6 +221,12 @@ export const StylesGroup = React.memo(function StylesGroup() {
       open ? openRibbonDropdown('home.cell-styles') : closeRibbonDropdown('home.cell-styles'),
     [openRibbonDropdown, closeRibbonDropdown],
   );
+
+  useEffect(() => {
+    if (!tableStyleGalleryOpen) {
+      tableStyleGalleryOpenSource.current = 'external';
+    }
+  }, [tableStyleGalleryOpen]);
 
   // ===========================================================================
   // KeyTip Registration (display-only)
@@ -281,7 +288,10 @@ export const StylesGroup = React.memo(function StylesGroup() {
               hasDropdown
               dropdownPosition="inline"
               isOpen={tableStyleGalleryOpen}
-              onClick={() => setTableStyleGalleryOpen(!tableStyleGalleryOpen)}
+              onClick={() => {
+                tableStyleGalleryOpenSource.current = 'button';
+                setTableStyleGalleryOpen(!tableStyleGalleryOpen);
+              }}
               aria-label="Format as Table"
             />
           </Tooltip>
@@ -293,7 +303,7 @@ export const StylesGroup = React.memo(function StylesGroup() {
             <div data-testid="ribbon-dropdown-menu-format-as-table">
               <TableStyleGallery
                 onSelectStyle={(styleId) => {
-                  formatAsTable(styleId);
+                  formatAsTable(styleId, tableStyleGalleryOpenSource.current === 'button');
                   setTableStyleGalleryOpen(false);
                 }}
                 onClose={() => setTableStyleGalleryOpen(false)}


### PR DESCRIPTION
## Summary
Infer Sparse Title Rows for Table Targets.

## Changed Files
- `apps/spreadsheet/src/actions/__tests__/data-command-target.test.ts`
- `apps/spreadsheet/src/actions/data-command-target.ts`
- `apps/spreadsheet/src/actions/handlers/__tests__/insert-table.test.ts`
- `apps/spreadsheet/src/actions/handlers/formatting/cell-format-dialogs.ts`
- `apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.tsx`

## Verification
- Sanitized PR metadata, branch name, commit metadata, and source wording/fixtures for public repository hygiene.
- Ran diff validation for the source redaction patch.
