### PR TITLE
Fix Freeze Panes Navigation

### DIFF
--- a/apps/spreadsheet/src/chrome/toolbar/primitives/CollapsedGroupDropdown.test.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/CollapsedGroupDropdown.test.ts
@@ -17,4 +17,30 @@ describe('CollapsedGroupDropdown dense layout', () => {
     expect(source).toContain('text-ribbon-compact text-ss-text-secondary');
     expect(source).toContain('<span className={labelClassName}>{label}</span>');
   });
+
+  it('can be forced open by store-controlled child dropdown state', () => {
+    const source = readFileSync(
+      nodePath.resolve(APP_ROOT, 'src/chrome/toolbar/primitives/CollapsedGroupDropdown.tsx'),
+      'utf8',
+    );
+    const toolbarGroupSource = readFileSync(
+      nodePath.resolve(APP_ROOT, 'src/chrome/toolbar/primitives/ToolbarGroup.tsx'),
+      'utf8',
+    );
+    const viewRibbonSource = readFileSync(
+      nodePath.resolve(APP_ROOT, 'src/chrome/toolbar/tabs/ViewRibbon.tsx'),
+      'utf8',
+    );
+
+    expect(source).toContain('forceOpen?: boolean');
+    expect(source).toContain('const popoverOpen = isOpen || forceOpen');
+    expect(toolbarGroupSource).toContain('openWhenRibbonDropdowns?: readonly RibbonDropdownId[]');
+    expect(toolbarGroupSource).toContain('state.ribbonDropdowns[dropdownId] === true');
+    expect(viewRibbonSource).toContain("openWhenRibbonDropdowns={['view.freeze-panes']}");
+    expect(viewRibbonSource).toContain("const renderFreezeMenuInline = windowGroupRenderMode === 'dropdown'");
+    expect(viewRibbonSource).toContain('const freezePanesMenu = (');
+    expect(viewRibbonSource).toContain('firstItem?.focus()');
+    expect(viewRibbonSource).toContain('restoreGridFocusAfterMenuClose');
+    expect(viewRibbonSource).toContain('coordinatorInput?.focusGrid?.()');
+  });
 });

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/CollapsedGroupDropdown.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/CollapsedGroupDropdown.tsx
@@ -58,6 +58,8 @@ export interface CollapsedGroupDropdownProps {
   icon?: ReactNode;
   /** Whether this is the last group (no right separator) */
   isLast?: boolean;
+  /** Open the collapsed group while a child dropdown is open from keytip state. */
+  forceOpen?: boolean;
   /** Group content - rendered inside the dropdown panel */
   children: ReactNode;
 }
@@ -82,9 +84,11 @@ export const CollapsedGroupDropdown = React.memo(function CollapsedGroupDropdown
   label,
   icon,
   isLast = false,
+  forceOpen = false,
   children,
 }: CollapsedGroupDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const popoverOpen = isOpen || forceOpen;
   const { level } = useRibbonCollapseLevel();
   const isDense = level >= 3;
   const labelClassName = isDense
@@ -96,7 +100,7 @@ export const CollapsedGroupDropdown = React.memo(function CollapsedGroupDropdown
       className={`relative flex flex-col ${isDense ? 'px-1' : 'px-[var(--ribbon-group-padding-x)]'}`}
     >
       {/* Collapsed button with Radix Popover */}
-      <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <Popover open={popoverOpen} onOpenChange={setIsOpen}>
         <div className="flex items-center justify-center h-[var(--ribbon-content-height)]">
           <Tooltip title={label}>
             <PopoverTrigger asChild>
@@ -105,7 +109,7 @@ export const CollapsedGroupDropdown = React.memo(function CollapsedGroupDropdown
                 className={`flex flex-col items-center justify-center rounded hover:bg-ss-surface-hover transition-colors duration-ss-fast ${
                   isDense ? 'gap-0.5 px-1 py-1 min-w-[42px]' : 'gap-1 px-2 py-1'
                 }`}
-                aria-expanded={isOpen}
+                aria-expanded={popoverOpen}
                 aria-haspopup="true"
                 aria-label={`${label} group`}
               >

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarGroup.tsx
@@ -20,7 +20,9 @@ import type { ReactNode } from 'react';
 import React from 'react';
 
 import { Tooltip } from '@mog/shell';
+import type { RibbonDropdownId } from '@mog-sdk/contracts/actions';
 import type { GroupCollapseConfig, GroupRenderMode } from '@mog-sdk/contracts/ribbon';
+import { useUIStore } from '../../../internal-api';
 import { GroupRenderModeProvider, useRibbonCollapseLevel } from '../collapse';
 import {
   RibbonVisibilityGroup,
@@ -102,6 +104,12 @@ export interface ToolbarGroupProps {
    * If not provided, children are rendered inside the dropdown.
    */
   dropdownContent?: ReactNode;
+  /**
+   * Store-controlled child dropdown ids that should open this collapsed group
+   * before the child can mount. This preserves keytip-opened dropdowns when
+   * responsive ribbon collapse has moved the trigger into a group menu.
+   */
+  openWhenRibbonDropdowns?: readonly RibbonDropdownId[];
   /** Optional typed ribbon visibility key. Defaults to a normalized label. */
   visibilityKey?: string;
 }
@@ -115,9 +123,16 @@ export const ToolbarGroup = React.memo(function ToolbarGroup({
   collapseConfig,
   dropdownIcon,
   dropdownContent,
+  openWhenRibbonDropdowns,
   visibilityKey,
 }: ToolbarGroupProps) {
   const groupVisibility = useRibbonGroupVisibility(label, visibilityKey);
+  const forceDropdownOpen = useUIStore((state) => {
+    if (!openWhenRibbonDropdowns || openWhenRibbonDropdowns.length === 0) {
+      return false;
+    }
+    return openWhenRibbonDropdowns.some((dropdownId) => state.ribbonDropdowns[dropdownId] === true);
+  });
   // Get current collapse level from context (provided by TabbedToolbar)
   const { level } = useRibbonCollapseLevel();
 
@@ -138,7 +153,12 @@ export const ToolbarGroup = React.memo(function ToolbarGroup({
   if (renderMode === 'dropdown') {
     return (
       <RibbonVisibilityGroup group={groupVisibility.groupKey}>
-        <CollapsedGroupDropdown label={label} icon={dropdownIcon} isLast={isLast}>
+        <CollapsedGroupDropdown
+          label={label}
+          icon={dropdownIcon}
+          isLast={isLast}
+          forceOpen={forceDropdownOpen}
+        >
           {dropdownContent ?? children}
         </CollapsedGroupDropdown>
       </RibbonVisibilityGroup>

--- a/apps/spreadsheet/src/chrome/toolbar/tabs/ViewRibbon.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/tabs/ViewRibbon.tsx
@@ -27,6 +27,7 @@ import {
 import { useActionDependencies } from '../../../hooks/toolbar/use-action-dependencies';
 import { useSplitConfig } from '../../../hooks/view/use-split-config';
 import { formatZoomPercent } from '../../../infra/utils';
+import { useRibbonCollapseLevel } from '../collapse';
 import { keyTipRegistry } from '../keytips';
 import { RibbonButton } from '../primitives/RibbonButton';
 import {
@@ -399,6 +400,12 @@ function twoLineViewRibbonLabel(label: string): string {
   return breakAt === -1 ? label : `${label.slice(0, breakAt)}\n${label.slice(breakAt + 1)}`;
 }
 
+type GridFocusCoordinator = {
+  input?: {
+    focusGrid?: () => void;
+  };
+};
+
 export function ViewRibbon({
   showGridlines = true,
   onToggleGridlines,
@@ -441,6 +448,9 @@ export function ViewRibbon({
   const isZoomEnabled = !!(onZoomIn && onZoomOut && onZoomChange);
   const isFreezeEnabled = !!(onFreezePanes && onFreezeTopRow && onFreezeFirstColumn && onUnfreeze);
   const isFrozen = frozenRows > 0 || frozenCols > 0;
+  const { level: ribbonCollapseLevel } = useRibbonCollapseLevel();
+  const windowGroupRenderMode = WINDOW_COLLAPSE_CONFIG.levels[ribbonCollapseLevel] ?? 'full';
+  const renderFreezeMenuInline = windowGroupRenderMode === 'dropdown';
 
   // freeze-panes dropdown lifted into the ribbonDropdowns slice so the
   // keytip chord (Alt+W,F) can open it via OPEN_RIBBON_DROPDOWN.
@@ -488,12 +498,79 @@ export function ViewRibbon({
     }
   }, [isFreezeEnabled, isDropdownOpen, setIsDropdownOpen]);
 
+  const restoreGridFocusAfterMenuClose = useCallback(() => {
+    window.setTimeout(() => {
+      const coordinatorInput = (deps.coordinator as GridFocusCoordinator | undefined)?.input;
+      coordinatorInput?.focusGrid?.();
+    }, 0);
+  }, [deps.coordinator]);
+
   const handleMenuItemClick = useCallback(
     (action: () => void) => {
       action();
       setIsDropdownOpen(false);
+      restoreGridFocusAfterMenuClose();
     },
-    [setIsDropdownOpen],
+    [setIsDropdownOpen, restoreGridFocusAfterMenuClose],
+  );
+
+  useEffect(() => {
+    if (!isDropdownOpen || !isFreezeEnabled) return;
+    const focusTimer = window.setTimeout(() => {
+      const firstItem = document.querySelector<HTMLElement>(
+        '[data-testid="ribbon-dropdown-menu-freeze-panes"] [role="menuitem"]:not([aria-disabled="true"])',
+      );
+      firstItem?.focus();
+    }, 0);
+    return () => window.clearTimeout(focusTimer);
+  }, [isDropdownOpen, isFreezeEnabled]);
+
+  const freezePanesMenu = (
+    <div
+      data-testid="ribbon-dropdown-menu-freeze-panes"
+      className="bg-ss-surface rounded shadow-ss-md border border-ss-border min-w-[180px] py-1"
+      role="menu"
+      aria-label="Freeze Panes Options"
+    >
+      {/* Freeze Panes (at selection) */}
+      <RibbonDropdownItem
+        dataValue="freeze-panes"
+        icon={isFrozen && frozenRows > 1 && frozenCols > 0 ? <CheckIcon /> : <span className="w-4" />}
+        onClick={() => handleMenuItemClick(onFreezePanes!)}
+      >
+        Freeze Panes
+      </RibbonDropdownItem>
+
+      {/* Freeze Top Row */}
+      <RibbonDropdownItem
+        dataValue="freeze-top-row"
+        icon={frozenRows === 1 && frozenCols === 0 ? <CheckIcon /> : <span className="w-4" />}
+        onClick={() => handleMenuItemClick(onFreezeTopRow!)}
+      >
+        Freeze Top Row
+      </RibbonDropdownItem>
+
+      {/* Freeze First Column */}
+      <RibbonDropdownItem
+        dataValue="freeze-first-column"
+        icon={frozenRows === 0 && frozenCols === 1 ? <CheckIcon /> : <span className="w-4" />}
+        onClick={() => handleMenuItemClick(onFreezeFirstColumn!)}
+      >
+        Freeze First Column
+      </RibbonDropdownItem>
+
+      <RibbonDropdownDivider />
+
+      {/* Unfreeze Panes */}
+      <RibbonDropdownItem
+        dataValue="unfreeze"
+        icon={<span className="w-4" />}
+        onClick={() => handleMenuItemClick(onUnfreeze!)}
+        disabled={!isFrozen}
+      >
+        Unfreeze Panes
+      </RibbonDropdownItem>
+    </div>
   );
 
   // ===========================================================================
@@ -835,6 +912,7 @@ export function ViewRibbon({
         label="Window"
         collapseConfig={WINDOW_COLLAPSE_CONFIG}
         dropdownIcon={<FreezePanesIcon />}
+        openWhenRibbonDropdowns={['view.freeze-panes']}
       >
         <div className="flex items-center gap-1">
           {/* New Window Button - Disabled stub */}
@@ -882,66 +960,18 @@ export function ViewRibbon({
             />
 
             {/* Portal-based dropdown - escapes stacking context issues */}
-            <RibbonDropdownPanel
-              open={isDropdownOpen && isFreezeEnabled}
-              onClose={() => setIsDropdownOpen(false)}
-            >
-              <div
-                data-testid="ribbon-dropdown-menu-freeze-panes"
-                className="bg-ss-surface rounded shadow-ss-md border border-ss-border min-w-[180px] py-1"
-                role="menu"
-                aria-label="Freeze Panes Options"
+            {renderFreezeMenuInline ? (
+              isDropdownOpen && isFreezeEnabled ? (
+                freezePanesMenu
+              ) : null
+            ) : (
+              <RibbonDropdownPanel
+                open={isDropdownOpen && isFreezeEnabled}
+                onClose={() => setIsDropdownOpen(false)}
               >
-                {/* Freeze Panes (at selection) */}
-                <RibbonDropdownItem
-                  dataValue="freeze-panes"
-                  icon={
-                    isFrozen && frozenRows > 1 && frozenCols > 0 ? (
-                      <CheckIcon />
-                    ) : (
-                      <span className="w-4" />
-                    )
-                  }
-                  onClick={() => handleMenuItemClick(onFreezePanes!)}
-                >
-                  Freeze Panes
-                </RibbonDropdownItem>
-
-                {/* Freeze Top Row */}
-                <RibbonDropdownItem
-                  dataValue="freeze-top-row"
-                  icon={
-                    frozenRows === 1 && frozenCols === 0 ? <CheckIcon /> : <span className="w-4" />
-                  }
-                  onClick={() => handleMenuItemClick(onFreezeTopRow!)}
-                >
-                  Freeze Top Row
-                </RibbonDropdownItem>
-
-                {/* Freeze First Column */}
-                <RibbonDropdownItem
-                  dataValue="freeze-first-column"
-                  icon={
-                    frozenRows === 0 && frozenCols === 1 ? <CheckIcon /> : <span className="w-4" />
-                  }
-                  onClick={() => handleMenuItemClick(onFreezeFirstColumn!)}
-                >
-                  Freeze First Column
-                </RibbonDropdownItem>
-
-                <RibbonDropdownDivider />
-
-                {/* Unfreeze Panes */}
-                <RibbonDropdownItem
-                  dataValue="unfreeze"
-                  icon={<span className="w-4" />}
-                  onClick={() => handleMenuItemClick(onUnfreeze!)}
-                  disabled={!isFrozen}
-                >
-                  Unfreeze Panes
-                </RibbonDropdownItem>
-              </div>
-            </RibbonDropdownPanel>
+                {freezePanesMenu}
+              </RibbonDropdownPanel>
+            )}
           </div>
 
           {/* V3: Split Button - Uses dispatch('TOGGLE_SPLIT') directly */}


### PR DESCRIPTION
## Summary
Fix Freeze Panes Navigation.

## Changed Files
- `apps/spreadsheet/src/chrome/toolbar/primitives/CollapsedGroupDropdown.test.ts`
- `apps/spreadsheet/src/chrome/toolbar/primitives/CollapsedGroupDropdown.tsx`
- `apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarGroup.tsx`
- `apps/spreadsheet/src/chrome/toolbar/tabs/ViewRibbon.tsx`

## Verification
No source changes were made during this metadata cleanup pass. Existing PR checks and prior implementation verification still apply.
