### PR TITLE
Apply Mixed Formatting Across Hidden Columns

### DIFF
--- a/apps/spreadsheet/src/actions/handlers/__tests__/borders-direct-mode.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/borders-direct-mode.test.ts
@@ -35,11 +35,17 @@ interface MockSetup {
   setLastUsedBorderFormatMock: jest.Mock;
 }
 
-function createMockDeps(opts: { ranges: CellRange[] }): MockSetup {
+function createMockDeps(opts: {
+  ranges: CellRange[];
+  hiddenCols?: number[];
+  bitmapHiddenCols?: number[];
+}): MockSetup {
   const activeSheetId = makeSheetId('sheet1');
 
   const setRangesMock = jest.fn().mockResolvedValue(undefined);
   const setLastUsedBorderFormatMock = jest.fn();
+  const hiddenCols = new Set(opts.hiddenCols ?? []);
+  const bitmapHiddenCols = new Set(opts.bitmapHiddenCols ?? opts.hiddenCols ?? []);
 
   // The outline branch clamps full-row/column selections to data bounds.
   // For unit testing we return the range unchanged so we can assert on
@@ -48,6 +54,12 @@ function createMockDeps(opts: { ranges: CellRange[] }): MockSetup {
 
   const mockWorksheet = {
     formats: { setRanges: setRangesMock },
+    layout: {
+      getHiddenRowsBitmap: jest.fn(async () => new Set<number>()),
+      getHiddenColumnsBitmap: jest.fn(async () => bitmapHiddenCols),
+      isRowHidden: jest.fn(async () => false),
+      isColumnHidden: jest.fn(async (col: number) => hiddenCols.has(col)),
+    },
     _internal: { clampRangeToDataBounds: clampMock },
   };
 
@@ -137,6 +149,31 @@ describe('APPLY_BORDERS — direct-mode preset routing', () => {
       const isFullRange = r.startRow === 0 && r.startCol === 0 && r.endRow === 2 && r.endCol === 2;
       expect(isFullRange && Object.keys(call.payload.borders ?? {}).length === 4).toBe(false);
     }
+  });
+
+  it("preset 'outline' treats hidden-column gaps as visible perimeter boundaries", async () => {
+    const range: CellRange = { startRow: 0, startCol: 0, endRow: 2, endCol: 4 };
+    const { deps, setRangesMock } = createMockDeps({
+      ranges: [range],
+      hiddenCols: [2, 3],
+      bitmapHiddenCols: [],
+    });
+
+    await APPLY_BORDERS(deps, { borders: outlineBorders, preset: 'outline' });
+
+    const calls = setRangesMock.mock.calls.map((c: unknown[]) => ({
+      ranges: c[0] as CellRange[],
+      payload: c[1] as { borders?: CellBorders },
+    }));
+
+    expect(calls).toContainEqual({
+      ranges: [{ startRow: 0, startCol: 1, endRow: 2, endCol: 1 }],
+      payload: { borders: { right: thinBlack } },
+    });
+    expect(calls).toContainEqual({
+      ranges: [{ startRow: 0, startCol: 4, endRow: 2, endCol: 4 }],
+      payload: { borders: { left: thinBlack } },
+    });
   });
 
   it('preset null (no preset) on a multi-cell range applies borders per-cell', async () => {

--- a/apps/spreadsheet/src/actions/handlers/__tests__/font-styles.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/font-styles.test.ts
@@ -3,21 +3,28 @@ import { jest } from '@jest/globals';
 import type { ActionDependencies } from '@mog-sdk/contracts/actions';
 import type { CellRange, SheetId } from '@mog-sdk/contracts/core';
 
-import { SET_FONT_SIZE, TOGGLE_WRAP_TEXT } from '../formatting/font-styles';
+import { SET_FONT_SIZE, TOGGLE_BOLD, TOGGLE_WRAP_TEXT } from '../formatting/font-styles';
 
 const activeSheetId = 'sheet1' as SheetId;
 
-function createMockDeps(ranges: CellRange[]) {
+function createMockDeps(
+  ranges: CellRange[],
+  opts: {
+    activeFormat?: Record<string, unknown>;
+    displayedFormats?: Array<Array<Record<string, unknown>>>;
+  } = {},
+) {
   const calls: string[] = [];
 
   const worksheet = {
     viewport: {
       getCellData: jest.fn(() => ({
         displayText: 'wrapped text',
-        format: { wrapText: false },
+        format: opts.activeFormat ?? { wrapText: false },
       })),
     },
     formats: {
+      getDisplayedRangeProperties: jest.fn(async () => opts.displayedFormats ?? [[{}]]),
       setRanges: jest.fn(async () => {
         calls.push('setRanges');
       }),
@@ -85,5 +92,19 @@ describe('font style formatting actions', () => {
     expect(worksheet.formats.setRanges).toHaveBeenCalledWith([range], { wrapText: true });
     expect(worksheet.layout.autoFitRows).toHaveBeenCalledWith([0]);
     expect(calls).toEqual(['undoGroup:start', 'setRanges', 'autoFitRows', 'undoGroup:end']);
+  });
+
+  it('turns bold on for a mixed selected range even when the active cell is already bold', async () => {
+    const range: CellRange = { startRow: 0, startCol: 0, endRow: 0, endCol: 1 };
+    const { deps, worksheet } = createMockDeps([range], {
+      activeFormat: { bold: true },
+      displayedFormats: [[{ bold: true }, { bold: false }]],
+    });
+
+    const result = await TOGGLE_BOLD(deps);
+
+    expect(result.handled).toBe(true);
+    expect(worksheet.formats.getDisplayedRangeProperties).toHaveBeenCalledWith(range);
+    expect(worksheet.formats.setRanges).toHaveBeenCalledWith([range], { bold: true });
   });
 });

--- a/apps/spreadsheet/src/actions/handlers/formatting/borders.ts
+++ b/apps/spreadsheet/src/actions/handlers/formatting/borders.ts
@@ -29,7 +29,7 @@
  */
 
 import type { AsyncActionHandler } from '@mog-sdk/contracts/actions';
-import type { BorderPresetMode, CellBorders } from '@mog-sdk/contracts/core';
+import type { BorderPresetMode, CellBorders, CellRange } from '@mog-sdk/contracts/core';
 
 import {
   callUIStoreAction,
@@ -45,6 +45,122 @@ const thinBorder = { style: 'thin' as const, color: '#000000' };
 const thickBorder = { style: 'thick' as const, color: '#000000' };
 const doubleBorder = { style: 'double' as const, color: '#000000' };
 const noBorders: CellBorders = {};
+const MAX_VISIBILITY_SCAN_INDEXES = 1000;
+
+type HiddenLayout = {
+  getHiddenRowsBitmap?: () => Promise<Set<number>>;
+  getHiddenColumnsBitmap?: () => Promise<Set<number>>;
+  isRowHidden?: (row: number) => Promise<boolean>;
+  isColumnHidden?: (col: number) => Promise<boolean>;
+};
+
+type WorksheetWithLayout = {
+  layout?: HiddenLayout;
+};
+
+function contiguousVisibleSpans(
+  start: number,
+  end: number,
+  hiddenIndexes: Set<number>,
+): Array<{ start: number; end: number }> {
+  const spans: Array<{ start: number; end: number }> = [];
+  let spanStart: number | null = null;
+
+  for (let index = start; index <= end; index++) {
+    if (hiddenIndexes.has(index)) {
+      if (spanStart != null) {
+        spans.push({ start: spanStart, end: index - 1 });
+        spanStart = null;
+      }
+      continue;
+    }
+
+    spanStart ??= index;
+  }
+
+  if (spanStart != null) {
+    spans.push({ start: spanStart, end });
+  }
+
+  return spans;
+}
+
+async function readHiddenBitmap(
+  layout: HiddenLayout | undefined,
+  method: 'getHiddenRowsBitmap' | 'getHiddenColumnsBitmap',
+): Promise<Set<number>> {
+  const read = layout?.[method];
+  return typeof read === 'function' ? read.call(layout) : new Set<number>();
+}
+
+async function readHiddenIndexesInRange(
+  layout: HiddenLayout | undefined,
+  bitmapMethod: 'getHiddenRowsBitmap' | 'getHiddenColumnsBitmap',
+  itemMethod: 'isRowHidden' | 'isColumnHidden',
+  start: number,
+  end: number,
+): Promise<Set<number>> {
+  const hidden = new Set(await readHiddenBitmap(layout, bitmapMethod));
+  const count = end - start + 1;
+  const readItem = layout?.[itemMethod];
+  if (typeof readItem !== 'function' || count <= 0 || count > MAX_VISIBILITY_SCAN_INDEXES) {
+    return hidden;
+  }
+
+  const visibility = await Promise.all(
+    Array.from({ length: count }, async (_, offset) => {
+      const index = start + offset;
+      return [index, await readItem.call(layout, index)] as const;
+    }),
+  );
+  for (const [index, isHidden] of visibility) {
+    if (isHidden) hidden.add(index);
+  }
+
+  return hidden;
+}
+
+async function splitRangeByVisibleDimensions(
+  worksheet: WorksheetWithLayout,
+  range: CellRange,
+): Promise<CellRange[]> {
+  const [hiddenRows, hiddenCols] = await Promise.all([
+    readHiddenIndexesInRange(
+      worksheet.layout,
+      'getHiddenRowsBitmap',
+      'isRowHidden',
+      range.startRow,
+      range.endRow,
+    ),
+    readHiddenIndexesInRange(
+      worksheet.layout,
+      'getHiddenColumnsBitmap',
+      'isColumnHidden',
+      range.startCol,
+      range.endCol,
+    ),
+  ]);
+  if (hiddenRows.size === 0 && hiddenCols.size === 0) {
+    return [range];
+  }
+
+  const rowSpans = contiguousVisibleSpans(range.startRow, range.endRow, hiddenRows);
+  const colSpans = contiguousVisibleSpans(range.startCol, range.endCol, hiddenCols);
+  const visibleRanges: CellRange[] = [];
+
+  for (const rowSpan of rowSpans) {
+    for (const colSpan of colSpans) {
+      visibleRanges.push({
+        startRow: rowSpan.start,
+        startCol: colSpan.start,
+        endRow: rowSpan.end,
+        endCol: colSpan.end,
+      });
+    }
+  }
+
+  return visibleRanges;
+}
 
 // =============================================================================
 // Border Handlers
@@ -71,24 +187,28 @@ export const APPLY_OUTLINE_BORDER: AsyncActionHandler = async (deps) => {
     for (const range of ranges) {
       // Performance: Clamp full row/column selections to data bounds
       const clampedRange = await ws._internal.clampRangeToDataBounds(range);
-      const { startRow, startCol, endRow, endCol } = clampedRange;
+      const outlineRanges = await splitRangeByVisibleDimensions(ws, clampedRange);
 
-      // Decompose outline into 4 edge ranges — 4 IPC calls instead of N*M
-      // Top edge: apply top border to first row
-      const topRange = { startRow, startCol, endRow: startRow, endCol };
-      await ws.formats.setRanges([topRange], { borders: { top: thinBorder } });
+      for (const outlineRange of outlineRanges) {
+        const { startRow, startCol, endRow, endCol } = outlineRange;
 
-      // Bottom edge: apply bottom border to last row
-      const bottomRange = { startRow: endRow, startCol, endRow, endCol };
-      await ws.formats.setRanges([bottomRange], { borders: { bottom: thinBorder } });
+        // Decompose outline into 4 edge ranges — 4 IPC calls instead of N*M
+        // Top edge: apply top border to first row
+        const topRange = { startRow, startCol, endRow: startRow, endCol };
+        await ws.formats.setRanges([topRange], { borders: { top: thinBorder } });
 
-      // Left edge: apply left border to first column
-      const leftRange = { startRow, startCol, endRow, endCol: startCol };
-      await ws.formats.setRanges([leftRange], { borders: { left: thinBorder } });
+        // Bottom edge: apply bottom border to last row
+        const bottomRange = { startRow: endRow, startCol, endRow, endCol };
+        await ws.formats.setRanges([bottomRange], { borders: { bottom: thinBorder } });
 
-      // Right edge: apply right border to last column
-      const rightRange = { startRow, startCol: endCol, endRow, endCol };
-      await ws.formats.setRanges([rightRange], { borders: { right: thinBorder } });
+        // Left edge: apply left border to first column
+        const leftRange = { startRow, startCol, endRow, endCol: startCol };
+        await ws.formats.setRanges([leftRange], { borders: { left: thinBorder } });
+
+        // Right edge: apply right border to last column
+        const rightRange = { startRow, startCol: endCol, endRow, endCol };
+        await ws.formats.setRanges([rightRange], { borders: { right: thinBorder } });
+      }
     }
   }
 
@@ -223,27 +343,35 @@ export const APPLY_BORDERS: AsyncActionHandler = async (
     for (const range of ranges) {
       // Performance: Clamp full row/column selections to data bounds
       const clampedRange = await ws._internal.clampRangeToDataBounds(range);
-      const { startRow, startCol, endRow, endCol } = clampedRange;
 
       if (borderPreset === 'outline') {
-        // Outline preset: 4 edge ranges instead of N*M per-cell writes
-        if (borderFormat.top) {
-          const topRange = { startRow, startCol, endRow: startRow, endCol };
-          await ws.formats.setRanges([topRange], { borders: { top: borderFormat.top } });
-        }
-        if (borderFormat.bottom) {
-          const bottomRange = { startRow: endRow, startCol, endRow, endCol };
-          await ws.formats.setRanges([bottomRange], { borders: { bottom: borderFormat.bottom } });
-        }
-        if (borderFormat.left) {
-          const leftRange = { startRow, startCol, endRow, endCol: startCol };
-          await ws.formats.setRanges([leftRange], { borders: { left: borderFormat.left } });
-        }
-        if (borderFormat.right) {
-          const rightRange = { startRow, startCol: endCol, endRow, endCol };
-          await ws.formats.setRanges([rightRange], { borders: { right: borderFormat.right } });
+        // Outline preset: 4 edge ranges per visible rectangle. Hidden rows/columns
+        // split the rectangle because users see each visible block as its own perimeter.
+        const outlineRanges = await splitRangeByVisibleDimensions(ws, clampedRange);
+        for (const outlineRange of outlineRanges) {
+          const { startRow, startCol, endRow, endCol } = outlineRange;
+
+          if (borderFormat.top) {
+            const topRange = { startRow, startCol, endRow: startRow, endCol };
+            await ws.formats.setRanges([topRange], { borders: { top: borderFormat.top } });
+          }
+          if (borderFormat.bottom) {
+            const bottomRange = { startRow: endRow, startCol, endRow, endCol };
+            await ws.formats.setRanges([bottomRange], {
+              borders: { bottom: borderFormat.bottom },
+            });
+          }
+          if (borderFormat.left) {
+            const leftRange = { startRow, startCol, endRow, endCol: startCol };
+            await ws.formats.setRanges([leftRange], { borders: { left: borderFormat.left } });
+          }
+          if (borderFormat.right) {
+            const rightRange = { startRow, startCol: endCol, endRow, endCol };
+            await ws.formats.setRanges([rightRange], { borders: { right: borderFormat.right } });
+          }
         }
       } else if (borderPreset === 'inside') {
+        const { startRow, startCol, endRow, endCol } = clampedRange;
         // Inside preset: internal horizontal + vertical dividers
         // Bottom border on all rows except the last (horizontal dividers)
         if (endRow > startRow && borderFormat.bottom) {

--- a/apps/spreadsheet/src/actions/handlers/formatting/font-styles.ts
+++ b/apps/spreadsheet/src/actions/handlers/formatting/font-styles.ts
@@ -36,6 +36,53 @@ import { autoFitRowsForBoundedRanges } from './row-autofit';
 const FONT_SIZES = [8, 9, 10, 11, 12, 14, 16, 18, 20, 22, 24, 26, 28, 36, 48, 72];
 const MAX_FONT_SIZE = 409;
 const MIN_FONT_SIZE = 1;
+const MAX_TOGGLE_FORMAT_SCAN_CELLS = 10000;
+
+function rangeCellCount(range: CellRange): number {
+  const rowCount = Math.abs(range.endRow - range.startRow) + 1;
+  const colCount = Math.abs(range.endCol - range.startCol) + 1;
+  return rowCount * colCount;
+}
+
+async function getBooleanToggleValue(
+  deps: ActionDependencies,
+  ranges: CellRange[],
+  property: 'bold' | 'italic' | 'strikethrough' | 'wrapText',
+  activeCellFormat: Record<string, unknown> | undefined,
+): Promise<{ currentValue: boolean; newValue: boolean }> {
+  const totalCells = ranges.reduce((sum, range) => sum + rangeCellCount(range), 0);
+  if (totalCells > 0 && totalCells <= MAX_TOGGLE_FORMAT_SCAN_CELLS) {
+    try {
+      const ws = deps.workbook.activeSheet;
+      let sawCell = false;
+      let allSelectedCellsEnabled = true;
+
+      for (const range of ranges) {
+        const formats = await ws.formats.getDisplayedRangeProperties(range);
+        for (const row of formats) {
+          for (const format of row) {
+            sawCell = true;
+            if ((format as Record<string, unknown> | undefined)?.[property] !== true) {
+              allSelectedCellsEnabled = false;
+            }
+          }
+        }
+      }
+
+      if (sawCell) {
+        return {
+          currentValue: allSelectedCellsEnabled,
+          newValue: !allSelectedCellsEnabled,
+        };
+      }
+    } catch {
+      // Fall back to the active cell for very old worksheet mocks or transient read failures.
+    }
+  }
+
+  const currentValue = (activeCellFormat?.[property] as boolean) ?? false;
+  return { currentValue, newValue: !currentValue };
+}
 
 // =============================================================================
 // Font Style Toggle Handlers
@@ -43,7 +90,8 @@ const MIN_FONT_SIZE = 1;
 
 /**
  * Toggle a boolean format property on selected cells.
- * Reads the active cell's current value, then applies the inverse to all selected cells.
+ * For bounded selections, turns the property on unless every selected cell already has it.
+ * Falls back to the active cell for very large ranges.
  *
  * Rich Text Editing Support
  * - Detects if in rich text editing mode with character selection
@@ -53,7 +101,7 @@ const MIN_FONT_SIZE = 1;
  *
  * Multi-Sheet Support
  * - Broadcasts to all selected sheets when multiple sheets are selected
- * - The toggle state is determined from the active cell on the active sheet
+ * - The toggle state is determined from the active sheet's selected range
  * - Same new value is applied to all selected sheets
  */
 async function toggleFormatProperty(
@@ -90,8 +138,7 @@ async function toggleFormatProperty(
   // refreshed after format mutations, so we use getCellData(row, col) instead.
   const activeCellData = ws.viewport.getCellData(activeCell.row, activeCell.col);
   const activeCellFormat = activeCellData?.format as Record<string, unknown> | undefined;
-  const currentValue = (activeCellFormat?.[property] as boolean) ?? false;
-  const newValue = !currentValue;
+  const { newValue } = await getBooleanToggleValue(deps, ranges, property, activeCellFormat);
 
   // Apply to all selected ranges on ALL selected sheets
   for (const sheetId of targetSheetIds) {


### PR DESCRIPTION
## Summary
Apply Mixed Formatting Across Hidden Columns.

## Changed Files
- `apps/spreadsheet/src/actions/handlers/__tests__/borders-direct-mode.test.ts`
- `apps/spreadsheet/src/actions/handlers/__tests__/font-styles.test.ts`
- `apps/spreadsheet/src/actions/handlers/formatting/borders.ts`
- `apps/spreadsheet/src/actions/handlers/formatting/font-styles.ts`

## Verification
- Rebased this replacement branch onto the sanitized public base.
- Ran diff validation and leak-token scans over the exposed PR patch.
