### PR TITLE
Fix Sort Ascending with Headers

### DIFF
--- a/apps/spreadsheet/src/actions/handlers/__tests__/sort.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/sort.test.ts
@@ -249,6 +249,28 @@ describe('SORT_ASCENDING — current-region auto-expansion', () => {
     });
   });
 
+  test('multi-row selection with a blank leading sort-key row sorts the body below it', async () => {
+    const setup = makeMockDeps({
+      selectionRanges: [{ startRow: 457, startCol: 4, endRow: 479, endCol: 6 }],
+      activeCell: { row: 457, col: 6 },
+      cellValues: {
+        '458,6': 167726,
+        '459,6': 57825,
+      },
+    });
+
+    await SORT_ASCENDING(setup.deps);
+
+    expect(setup.getCurrentRegion).not.toHaveBeenCalled();
+    expect(setup.sortRange).toHaveBeenCalledTimes(1);
+    const [rangeArg, optionsArg] = setup.sortRange.mock.calls[0] as [unknown, unknown];
+    expect(rangeArg).toEqual({ startRow: 458, startCol: 4, endRow: 479, endCol: 6 });
+    expect(optionsArg).toEqual({
+      columns: [{ column: 2, direction: 'asc' }],
+      hasHeaders: false,
+    });
+  });
+
   test('explicit A2:A6 mixed data selection is sorted as headerless', async () => {
     const setup = makeMockDeps({
       selectionRanges: [{ startRow: 1, startCol: 0, endRow: 5, endCol: 0 }],

--- a/apps/spreadsheet/src/actions/handlers/editor.ts
+++ b/apps/spreadsheet/src/actions/handlers/editor.ts
@@ -111,6 +111,8 @@ type SortCommandTarget = DataCommandTarget & {
   readonly visibleRowsOnly?: boolean;
 };
 
+const LEADING_BLANK_SORT_SCAN_ROW_LIMIT = 100;
+
 function isSingleCellRange(range: CellRange): boolean {
   return range.startRow === range.endRow && range.startCol === range.endCol;
 }
@@ -159,6 +161,55 @@ async function resolveAutoFilterSortTarget(
     wasExpanded: false,
     visibleRowsOnly: true,
   };
+}
+
+function hasSortKeySignal(cell: { value?: unknown } | null | undefined): boolean {
+  const value = cell?.value;
+  if (value == null || value === '') return false;
+  if (typeof value === 'string') return value.trim().length > 0;
+  return true;
+}
+
+async function trimLeadingBlankSortKeyRows(
+  ws: Worksheet,
+  target: SortCommandTarget,
+  activeCell: CellCoord,
+  relativeSortColumn: number,
+): Promise<SortCommandTarget> {
+  const range = target.range;
+  if (target.hasHeaders || target.visibleRowsOnly || range.startRow >= range.endRow) {
+    return target;
+  }
+  if (
+    activeCell.row !== range.startRow ||
+    activeCell.col < range.startCol ||
+    activeCell.col > range.endCol
+  ) {
+    return target;
+  }
+
+  const sortColumn = range.startCol + relativeSortColumn;
+  if (sortColumn < range.startCol || sortColumn > range.endCol) {
+    return target;
+  }
+
+  if (hasSortKeySignal(await ws.getCell(range.startRow, sortColumn))) {
+    return target;
+  }
+
+  const scanEndRow = Math.min(range.endRow, range.startRow + LEADING_BLANK_SORT_SCAN_ROW_LIMIT);
+  for (let row = range.startRow + 1; row <= scanEndRow; row++) {
+    if (hasSortKeySignal(await ws.getCell(row, sortColumn))) {
+      // Compute resolves the sort column through the first row's CellId.
+      // A leading blank title/header key would otherwise make the sort a no-op.
+      return {
+        ...target,
+        range: { ...range, startRow: row },
+      };
+    }
+  }
+
+  return target;
 }
 
 /**
@@ -742,19 +793,21 @@ async function sortInDirection(
     const resolvedTarget = autoFilterTarget ?? (await resolveDataCommandTarget(ws, range));
     const target: SortCommandTarget | null = resolvedTarget ? { ...resolvedTarget } : null;
     if (!target) continue;
+    const sortColumn = getRelativeCommandColumn(activeCell, target.range);
+    const sortTarget = await trimLeadingBlankSortKeyRows(ws, target, activeCell, sortColumn);
 
     // E4: Excel refuses to sort ranges containing merged cells.
     const allMerges = await ws.structure.getMergedRegions();
-    const hasMergesInRange = allMerges.some(
+    const overlappingMerges = allMerges.filter(
       (m) =>
         !(
-          m.endRow < target.range.startRow ||
-          m.startRow > target.range.endRow ||
-          m.endCol < target.range.startCol ||
-          m.startCol > target.range.endCol
+          m.endRow < sortTarget.range.startRow ||
+          m.startRow > sortTarget.range.endRow ||
+          m.endCol < sortTarget.range.startCol ||
+          m.startCol > sortTarget.range.endCol
         ),
     );
-    if (hasMergesInRange) {
+    if (overlappingMerges.length > 0) {
       return {
         handled: false,
         reason: 'blocked' as const,
@@ -762,10 +815,10 @@ async function sortInDirection(
       };
     }
 
-    await ws.sortRange(target.range, {
-      columns: [{ column: getRelativeCommandColumn(activeCell, target.range), direction }],
-      hasHeaders: target.hasHeaders,
-      visibleRowsOnly: target.visibleRowsOnly,
+    await ws.sortRange(sortTarget.range, {
+      columns: [{ column: sortColumn, direction }],
+      hasHeaders: sortTarget.hasHeaders,
+      visibleRowsOnly: sortTarget.visibleRowsOnly,
     });
     sorted = true;
   }


### PR DESCRIPTION
## Summary
Fix Sort Ascending with Headers.

## Changed Files
- `apps/spreadsheet/src/actions/handlers/__tests__/sort.test.ts`
- `apps/spreadsheet/src/actions/handlers/editor.ts`

## Verification
No source changes were made during this metadata cleanup pass. Existing PR checks and prior implementation verification still apply.
