### PR TITLE
Fix Filter Control Insertion from Ribbon

### DIFF
--- a/apps/spreadsheet/src/chrome/toolbar/tabs/InsertRibbon.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/tabs/InsertRibbon.tsx
@@ -23,8 +23,8 @@
  *
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useActiveSheetId, useUIStore, useWorkbook } from '../../../internal-api';
+import React, { useCallback, useEffect, useMemo } from 'react';
+import { useActiveSheetId, useUIStore } from '../../../internal-api';
 
 import type { ChartType } from '@mog/charts';
 import {
@@ -40,7 +40,6 @@ import {
 import { ChartsGroup } from '../../../components/charts/ChartsGroup';
 import { useDispatch } from '../../../hooks/toolbar/use-action-dependencies';
 import { useSheetProtectionPermissions } from '../../../hooks/structure/use-sheet-protection';
-import { useActiveCell } from '../../../hooks/selection/use-active-cell';
 import { useSelectionRanges } from '../../../hooks/selection/use-granular-selection';
 import { PRODUCT_VOCABULARY } from '../../../ux/product-vocabulary';
 import { keyTipRegistry } from '../keytips';
@@ -89,10 +88,9 @@ export function InsertRibbon() {
 
   const dispatchAction = useDispatch();
   const activeSheetId = useActiveSheetId();
-  const wb = useWorkbook();
-  const { row: activeRow, col: activeCol } = useActiveCell();
   const ranges = useSelectionRanges();
   const sheetPermissions = useSheetProtectionPermissions(activeSheetId);
+  const selectedTableId = useUIStore((s) => s.tableDesign.selectedTableId);
 
   // UIStore action for the inline shapes menu (anchored popover, not a
   // dialog). The visible ribbon click records an anchor; keytips open the
@@ -101,30 +99,10 @@ export function InsertRibbon() {
   const openRibbonDropdown = useUIStore((s) => s.openRibbonDropdown);
   const closeRibbonDropdown = useUIStore((s) => s.closeRibbonDropdown);
 
-  // Slicer is enabled only when the active cell is inside a table. This
-  // mirrors the prior `useInsertActions` derivation; it stays here as a
-  // granular state read at the call site.
-  const [selectionIsInTable, setSelectionIsInTable] = useState(false);
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const ws = wb.getSheetById(activeSheetId);
-        const table = await ws.tables.getAtCell(activeRow, activeCol);
-        if (!cancelled) setSelectionIsInTable(table != null);
-      } catch {
-        if (!cancelled) setSelectionIsInTable(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [wb, activeSheetId, activeRow, activeCol]);
-
   // Chart is disabled if there's no selection range
   const chartDisabled = useMemo(() => ranges.length === 0, [ranges]);
   // Slicer is disabled if not in a table
-  const slicerDisabled = !selectionIsInTable;
+  const slicerDisabled = selectedTableId === null;
 
   // Bound action callbacks
   const insertTable = useCallback(() => dispatchAction('INSERT_TABLE'), [dispatchAction]);

--- a/kernel/src/api/worksheet/operations/__tests__/table-operations.test.ts
+++ b/kernel/src/api/worksheet/operations/__tests__/table-operations.test.ts
@@ -46,4 +46,11 @@ describe('bridgeTableToTableInfo', () => {
   it('normalizes built-in table style casing and zero padding', () => {
     expect(bridgeTableToTableInfo(makeTable('tablestylemedium04')).style).toBe('TableStyleMedium4');
   });
+
+  it('falls back to the table name when the bridge table omits id', () => {
+    const table = makeTable('TableStyleMedium4') as Table & { id?: string };
+    delete table.id;
+
+    expect(bridgeTableToTableInfo(table as Table).id).toBe('Table1');
+  });
 });

--- a/kernel/src/api/worksheet/operations/table-operations.ts
+++ b/kernel/src/api/worksheet/operations/table-operations.ts
@@ -58,6 +58,7 @@ export function bridgeTableToTableInfo(table: Table): TableInfo {
 
   return {
     ...table,
+    id: table.id ?? table.name,
     displayName: table.displayName || table.name,
     columns: table.columns.map((col) => ({ ...col })),
     range,

--- a/kernel/src/api/worksheet/tables.ts
+++ b/kernel/src/api/worksheet/tables.ts
@@ -70,30 +70,45 @@ import {
   tableStyleIdForCompute,
 } from '../../domain/tables/style-normalization';
 
-type PendingClipboardPasteGlobal = typeof globalThis & {
+type PendingTableReadBarrierGlobal = typeof globalThis & {
   __MOG_PENDING_CLIPBOARD_PASTE__?: Promise<unknown>;
   __MOG_ACTIVE_CLIPBOARD_PASTE__?: Promise<unknown>;
+  __MOG_PENDING_DIALOG_ACTION__?: Promise<unknown>;
 };
 
-async function waitForPendingClipboardPaste(): Promise<void> {
+async function waitForPendingTableReadBarriers(): Promise<void> {
   const deadline = Date.now() + 2000;
 
   while (Date.now() < deadline) {
-    const global = globalThis as PendingClipboardPasteGlobal;
-    const pending = global.__MOG_PENDING_CLIPBOARD_PASTE__;
-    const active = global.__MOG_ACTIVE_CLIPBOARD_PASTE__;
-    if (
-      (!pending || typeof pending.then !== 'function') &&
-      (!active || typeof active.then !== 'function')
-    ) {
+    const global = globalThis as PendingTableReadBarrierGlobal;
+    const pendingActions = [
+      global.__MOG_PENDING_CLIPBOARD_PASTE__,
+      global.__MOG_ACTIVE_CLIPBOARD_PASTE__,
+      global.__MOG_PENDING_DIALOG_ACTION__,
+    ].filter((promise): promise is Promise<unknown> => typeof promise?.then === 'function');
+
+    if (pendingActions.length === 0) {
       return;
     }
 
     await Promise.race([
-      Promise.all([pending?.catch(() => undefined), active?.catch(() => undefined)]),
+      Promise.all(pendingActions.map((promise) => promise.catch(() => undefined))),
       new Promise<void>((resolve) => setTimeout(resolve, 16)),
     ]);
   }
+}
+
+function tableContainsCell(
+  table: { range: { startRow: number; startCol: number; endRow: number; endCol: number } },
+  row: number,
+  col: number,
+): boolean {
+  return (
+    row >= table.range.startRow &&
+    row <= table.range.endRow &&
+    col >= table.range.startCol &&
+    col <= table.range.endCol
+  );
 }
 
 // FIX-001-tables-hotcheck-v1
@@ -373,7 +388,7 @@ export class WorksheetTablesImpl implements WorksheetTables {
   }
 
   async list(): Promise<TableInfo[]> {
-    await waitForPendingClipboardPaste();
+    await waitForPendingTableReadBarriers();
     const tables = await this.ctx.computeBridge.getAllTablesInSheet(this.sheetId);
     return tables.map((t) => bridgeTableToTableInfo(t));
   }
@@ -547,8 +562,13 @@ export class WorksheetTablesImpl implements WorksheetTables {
   }
 
   async getAtCell(a: string | number, b?: number): Promise<TableInfo | null> {
+    await waitForPendingTableReadBarriers();
     const { row, col } = resolveCell(a, b);
-    const table = await this.ctx.computeBridge.getTableAtCell(this.sheetId, row, col);
+    const table =
+      (await this.ctx.computeBridge.getTableAtCell(this.sheetId, row, col)) ??
+      (await this.ctx.computeBridge.getAllTablesInSheet(this.sheetId)).find((candidate) =>
+        tableContainsCell(candidate, row, col),
+      );
     if (!table) return null;
     return bridgeTableToTableInfo(table);
   }


### PR DESCRIPTION
## Summary
Fix Filter Control Insertion from Ribbon.

## Changed Files
- `apps/spreadsheet/src/chrome/toolbar/tabs/InsertRibbon.tsx`
- `kernel/src/api/worksheet/operations/__tests__/table-operations.test.ts`
- `kernel/src/api/worksheet/operations/table-operations.ts`
- `kernel/src/api/worksheet/tables.ts`

## Verification
No source changes were made during this metadata cleanup pass. Existing PR checks and prior implementation verification still apply.
