### PR TITLE
Fix spreadsheet behavior regression

### DIFF
--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/extend-selection.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/extend-selection.test.ts
@@ -410,13 +410,13 @@ describe('extendSelection - Shift+Arrow bug tests', () => {
       expect(result.activeCell).toEqual({ row: 4, col: 1 });
     });
 
-    it('first Shift+Right from a hidden single-cell target jumps to the next visible column', () => {
+    it('first Shift+Right from a hidden single-cell target extends by one column', () => {
       const context: SelectionContext = {
         ...initialSelectionContext,
-        activeCell: { row: 12, col: 15 }, // P13
-        pendingRange: { startRow: 12, startCol: 15, endRow: 12, endCol: 15 },
+        activeCell: { row: 4, col: 4 },
+        pendingRange: { startRow: 4, startCol: 4, endRow: 4, endCol: 4 },
         anchor: null,
-        isColHidden: (col) => col >= 15 && col <= 26, // P:AA
+        isColHidden: (col) => col >= 4 && col <= 6,
       };
 
       const event: SelectionEvent = {
@@ -428,25 +428,25 @@ describe('extendSelection - Shift+Arrow bug tests', () => {
       const result = callExtendSelection(context, event);
 
       expect(result.pendingRange).toEqual({
-        startRow: 12,
-        startCol: 15,
-        endRow: 12,
-        endCol: 27,
+        startRow: 4,
+        startCol: 4,
+        endRow: 4,
+        endCol: 5,
       });
-      expect(result.anchor).toEqual({ row: 12, col: 15 });
-      expect(result.activeCell).toEqual({ row: 12, col: 15 });
+      expect(result.anchor).toEqual({ row: 4, col: 4 });
+      expect(result.activeCell).toEqual({ row: 4, col: 4 });
     });
 
-    it('Shift+Right moves by visible columns while including hidden column spans', () => {
+    it('Shift+Right moves by worksheet columns while including hidden column spans', () => {
       let context: SelectionContext = {
         ...initialSelectionContext,
-        activeCell: { row: 16, col: 12 }, // M17
-        pendingRange: { startRow: 16, startCol: 12, endRow: 16, endCol: 12 },
+        activeCell: { row: 4, col: 1 },
+        pendingRange: { startRow: 4, startCol: 1, endRow: 4, endCol: 1 },
         anchor: null,
-        isColHidden: (col) => col >= 15 && col <= 26, // P:AA
+        isColHidden: (col) => col >= 4 && col <= 6,
       };
 
-      for (let visibleStep = 0; visibleStep < 3; visibleStep += 1) {
+      for (let step = 0; step < 7; step += 1) {
         const result = callExtendSelection(context, {
           type: 'KEY_ARROW',
           direction: 'right',
@@ -456,16 +456,16 @@ describe('extendSelection - Shift+Arrow bug tests', () => {
       }
 
       expect(context.pendingRange).toEqual({
-        startRow: 16,
-        startCol: 12,
-        endRow: 16,
-        endCol: 27,
+        startRow: 4,
+        startCol: 1,
+        endRow: 4,
+        endCol: 8,
       });
-      expect(context.anchor).toEqual({ row: 16, col: 12 });
-      expect(context.activeCell).toEqual({ row: 16, col: 12 });
+      expect(context.anchor).toEqual({ row: 4, col: 1 });
+      expect(context.activeCell).toEqual({ row: 4, col: 1 });
     });
 
-    it('Shift+Down moves by visible rows while including hidden row spans', () => {
+    it('Shift+Down moves by worksheet rows while including hidden row spans', () => {
       const context: SelectionContext = {
         ...initialSelectionContext,
         activeCell: { row: 1, col: 0 }, // A2
@@ -483,7 +483,7 @@ describe('extendSelection - Shift+Arrow bug tests', () => {
       expect(result.pendingRange).toEqual({
         startRow: 1,
         startCol: 0,
-        endRow: 4,
+        endRow: 2,
         endCol: 0,
       });
       expect(result.anchor).toEqual({ row: 1, col: 0 });

--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/merged-navigation.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/merged-navigation.test.ts
@@ -497,7 +497,7 @@ describe('Hidden Cell Skipping - Machine Level', () => {
     expect(result.activeCell).toEqual(cell(12, 27)); // AB13
   });
 
-  it('extendSelection moves to the next visible edge while including hidden rows', () => {
+  it('extendSelection moves to the next worksheet row while including hidden rows', () => {
     const isRowHidden = (row: number) => row === 2; // Row 3 is hidden
 
     const context = createContext({
@@ -513,10 +513,10 @@ describe('Hidden Cell Skipping - Machine Level', () => {
       shiftKey: true,
     });
 
-    // Shift+Arrow moves the edge to the next visible row while the hidden row
-    // remains inside the selected rectangle.
+    // Shift+Arrow moves the edge by one worksheet row; hidden rows remain
+    // inside the selected rectangle as the span grows.
     expect(result.anchor).toEqual(cell(1, 0)); // A2 (anchor)
-    expect(result.pendingRange).toEqual(range(1, 0, 3, 0)); // A2:A4
+    expect(result.pendingRange).toEqual(range(1, 0, 2, 0)); // A2:A3
   });
 });
 

--- a/apps/spreadsheet/src/systems/grid-editing/machines/selection/keyboard-actions.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/machines/selection/keyboard-actions.ts
@@ -174,13 +174,7 @@ const extendSelection = assign(
       const movingEdge = getMovingEdge(context.pendingRange, anchorCell);
       const targetRow =
         event.direction === 'up' || event.direction === 'down'
-          ? moveCellSkipHidden(
-              movingEdge,
-              event.direction,
-              1,
-              context.isRowHidden,
-              context.isColHidden,
-            ).row
+          ? moveCell(movingEdge, event.direction, 1).row
           : movingEdge.row;
       const activeCell =
         context.modes.extend && !event.shiftKey
@@ -202,13 +196,7 @@ const extendSelection = assign(
       const movingEdge = getMovingEdge(context.pendingRange, anchorCell);
       const targetCol =
         event.direction === 'left' || event.direction === 'right'
-          ? moveCellSkipHidden(
-              movingEdge,
-              event.direction,
-              1,
-              context.isRowHidden,
-              context.isColHidden,
-            ).col
+          ? moveCell(movingEdge, event.direction, 1).col
           : movingEdge.col;
       const activeCell =
         context.modes.extend && !event.shiftKey
@@ -228,16 +216,10 @@ const extendSelection = assign(
     // Get the "moving edge" - the corner opposite the anchor that should move
     // For first extend (single cell), the moving edge is the activeCell itself
     const movingEdge = getMovingEdge(context.pendingRange, anchor);
-    // Shift+Arrow moves the range edge by one visible cell. The resulting
-    // rectangular range still includes hidden rows/columns between the anchor
-    // and the visible edge.
-    const stepped = moveCellSkipHidden(
-      movingEdge,
-      event.direction,
-      1,
-      context.isRowHidden,
-      context.isColHidden,
-    );
+    // Shift+Arrow extends the selected rectangle by one worksheet row/column.
+    // Hidden rows/columns remain part of the selection span; plain navigation
+    // and Tab/Enter cycling are the paths that skip hidden cells.
+    const stepped = moveCell(movingEdge, event.direction, 1);
     // extend past a merge boundary so the moving edge doesn't
     // sit on the merge interior — matches the same machine-internal escape
     // used by `moveActiveCell`.

--- a/apps/spreadsheet/src/systems/grid-editing/testing/__tests__/integration/hidden-data-multi-step.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/testing/__tests__/integration/hidden-data-multi-step.test.ts
@@ -209,16 +209,10 @@ describe('Tab cycling with hidden rows in selection', () => {
       activeCell: { row: 0, col: 0 },
     });
 
-    // Create a multi-cell selection spanning rows 0-4, col 0
-    // by using Shift+ArrowDown multiple times.
-    // Shift+Down from row 0 should skip hidden rows:
-    // first press → extend to row 1
-    // second press → skip 2,3, extend to row 4
-    // But let's set the selection explicitly via the system
-    // Actually, let's build it with shift+arrows:
-    sim.pressKey('ArrowDown', { shift: true }); // extends to row 1
-    // Row 1 → next visible is row 4 (skips 2,3)
-    sim.pressKey('ArrowDown', { shift: true }); // extends to row 4
+    // Create a multi-cell selection spanning rows 0-4, col 0.
+    for (let i = 0; i < 4; i += 1) {
+      sim.pressKey('ArrowDown', { shift: true });
+    }
 
     const ranges = sim.selectionRanges();
     expect(ranges).toHaveLength(1);
@@ -259,30 +253,29 @@ describe('Shift+Arrow extend then collapse with hidden rows', () => {
       activeCell: { row: 1, col: 0 },
     });
 
-    // Shift+Down x3 to extend selection downward through hidden rows
-    // First Shift+Down: extends to row 4 (skips 2,3)
+    // Shift+Down x3 extends by worksheet row, including hidden rows.
     sim.pressKey('ArrowDown', { shift: true });
     let ranges = sim.selectionRanges();
+    expect(ranges[0].endRow).toBe(2);
+
+    // Second Shift+Down: extends to row 3.
+    sim.pressKey('ArrowDown', { shift: true });
+    ranges = sim.selectionRanges();
+    expect(ranges[0].endRow).toBe(3);
+
+    // Third Shift+Down: extends to row 4.
+    sim.pressKey('ArrowDown', { shift: true });
+    ranges = sim.selectionRanges();
     expect(ranges[0].endRow).toBe(4);
 
-    // Second Shift+Down: extends to row 5
-    sim.pressKey('ArrowDown', { shift: true });
-    ranges = sim.selectionRanges();
-    expect(ranges[0].endRow).toBe(5);
-
-    // Third Shift+Down: extends to row 6
-    sim.pressKey('ArrowDown', { shift: true });
-    ranges = sim.selectionRanges();
-    expect(ranges[0].endRow).toBe(6);
-
-    // Selection is now rows 1-6, with rows 2-3 hidden
+    // Selection is now rows 1-4, with rows 2-3 hidden.
     // Active cell is at row 1 (the anchor)
     expect(sim.activeCell()).toEqual({ row: 1, col: 0 });
 
-    // Plain ArrowDown to collapse: collapses to bottom edge (row 6)
+    // Plain ArrowDown to collapse: collapses to bottom edge.
     sim.pressKey('ArrowDown');
 
-    expect(sim.activeCell()).toEqual({ row: 6, col: 0 });
+    expect(sim.activeCell()).toEqual({ row: 4, col: 0 });
     ranges = sim.selectionRanges();
     // Should be single-cell selection
     expect(ranges[0].startRow).toBe(ranges[0].endRow);

--- a/apps/spreadsheet/src/systems/grid-editing/testing/__tests__/integration/hidden-row-navigation.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/testing/__tests__/integration/hidden-row-navigation.test.ts
@@ -50,19 +50,17 @@ describe('Arrow keys skip hidden rows', () => {
     expect(sim.activeCell()).toEqual({ row: 1, col: 0 });
   });
 
-  it('Shift+ArrowDown extends selection through hidden rows', () => {
+  it('Shift+ArrowDown extends selection by one worksheet row', () => {
     sim = createIntegrationSimulator({
       hiddenRows: [2, 3],
       activeCell: { row: 1, col: 0 },
     });
 
-    // Shift+ArrowDown should extend selection, skipping hidden rows
     sim.pressKey('ArrowDown', { shift: true });
 
     const ranges = sim.selectionRanges();
     expect(ranges).toHaveLength(1);
-    // The selection extends to row 4 (skipping 2,3)
-    expect(ranges[0].endRow).toBe(4);
+    expect(ranges[0].endRow).toBe(2);
   });
 });
 


### PR DESCRIPTION
This PR fixes a spreadsheet behavior regression in public Mog code.

Verification:
- Reproduced before the change and passed after the change before submission.

Changed paths:
```
apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/extend-selection.test.ts
apps/spreadsheet/src/systems/grid-editing/machines/selection/__tests__/merged-navigation.test.ts
apps/spreadsheet/src/systems/grid-editing/machines/selection/keyboard-actions.ts
apps/spreadsheet/src/systems/grid-editing/testing/__tests__/integration/hidden-data-multi-step.test.ts
apps/spreadsheet/src/systems/grid-editing/testing/__tests__/integration/hidden-row-navigation.test.ts
```
