### PR TITLE
Fix spreadsheet behavior regression

### DIFF
--- a/kernel/src/services/undo/__tests__/undo-service.test.ts
+++ b/kernel/src/services/undo/__tests__/undo-service.test.ts
@@ -40,7 +40,7 @@ describe('UndoService pivot history replay metadata', () => {
       { reason: 'historyReplay', refreshPolicy: 'refreshAndMaterialize' },
       expect.any(Function),
     );
-    expect(bridge.forceRefreshAllViewports).toHaveBeenCalledTimes(1);
+    expect(bridge.forceRefreshAllViewports).not.toHaveBeenCalled();
   });
 
   it('wraps redo in historyReplay pivot update options', async () => {
@@ -56,10 +56,10 @@ describe('UndoService pivot history replay metadata', () => {
       { reason: 'historyReplay', refreshPolicy: 'refreshAndMaterialize' },
       expect.any(Function),
     );
-    expect(bridge.forceRefreshAllViewports).toHaveBeenCalledTimes(1);
+    expect(bridge.forceRefreshAllViewports).not.toHaveBeenCalled();
   });
 
-  it('does not fail undo when viewport refresh after replay fails', async () => {
+  it('does not issue a service-level viewport refresh after replay', async () => {
     const { bridge } = createComputeBridgeMock();
     bridge.forceRefreshAllViewports.mockRejectedValueOnce(new Error('refresh failed'));
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -70,11 +70,8 @@ describe('UndoService pivot history replay metadata', () => {
 
     expect(result.ok).toBe(true);
     expect(bridge.undo).toHaveBeenCalledTimes(1);
-    expect(bridge.forceRefreshAllViewports).toHaveBeenCalledTimes(1);
-    expect(errorSpy).toHaveBeenCalledWith(
-      '[UndoService] viewport refresh after history replay failed:',
-      expect.any(Error),
-    );
+    expect(bridge.forceRefreshAllViewports).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
 
     errorSpy.mockRestore();
   });

--- a/kernel/src/services/undo/undo-service.ts
+++ b/kernel/src/services/undo/undo-service.ts
@@ -204,17 +204,9 @@ class UndoService extends Subscribable<UndoStateChangeEvent> implements IUndoSer
 
   private async runHistoryReplayMutation<T>(fn: () => Promise<T>): Promise<T> {
     const mutationHandler = this.computeBridge.getMutationHandler();
-    const result = mutationHandler
+    return mutationHandler
       ? await mutationHandler.withPivotUpdateOptions(UndoService.HISTORY_REPLAY_PIVOT_UPDATE, fn)
       : await fn();
-
-    try {
-      await this.computeBridge.forceRefreshAllViewports();
-    } catch (error) {
-      console.error('[UndoService] viewport refresh after history replay failed:', error);
-    }
-
-    return result;
   }
 
   setNextDescription(description: string): void {


### PR DESCRIPTION
This PR fixes a spreadsheet behavior regression in public Mog code.

Verification:
- Reproduced before the change and passed after the change before submission.

Changed paths:
```
kernel/src/services/undo/__tests__/undo-service.test.ts
kernel/src/services/undo/undo-service.ts
```
