### PR TITLE
Fix spreadsheet behavior regression

### DIFF
--- a/apps/spreadsheet/src/app/CoordinatorProvider.tsx
+++ b/apps/spreadsheet/src/app/CoordinatorProvider.tsx
@@ -100,6 +100,11 @@ function isDialogKeyboardTarget(target: HTMLElement | null): boolean {
   return Boolean(target.closest('[role="dialog"]'));
 }
 
+function isNameBoxKeyboardTarget(target: HTMLElement | null): boolean {
+  if (!target) return false;
+  return Boolean(target.closest('[data-testid="name-box"]'));
+}
+
 function isNativeEditableShortcut(e: KeyboardEvent, target: HTMLElement | null): boolean {
   if (!isEditableKeyboardTarget(target)) return false;
   if (!(e.ctrlKey || e.metaKey) || e.altKey) return false;
@@ -338,6 +343,7 @@ function KeyboardCaptureSetup({
         editorSnapshot.matches('richTextEditing') ||
         editorSnapshot.matches('imeComposing');
       const target = keyboardEventTargetElement(e);
+      const isNameBoxTarget = isNameBoxKeyboardTarget(target);
 
       if (
         isGlobalShortcut(e) &&
@@ -389,6 +395,10 @@ function KeyboardCaptureSetup({
             e.stopPropagation();
           }
         }
+        return;
+      }
+
+      if (isNameBoxTarget) {
         return;
       }
 

--- a/apps/spreadsheet/src/chrome/formula-bar/NameBoxDropdown.tsx
+++ b/apps/spreadsheet/src/chrome/formula-bar/NameBoxDropdown.tsx
@@ -435,6 +435,14 @@ export const NameBoxDropdown = memo(function NameBoxDropdown({
         range: CellRange,
         nextActiveCell: { row: number; col: number },
       ): void => {
+        const editorSnapshot = coordinator.grid.access.actors.editor.getSnapshot();
+        if (
+          editorSnapshot.matches('editing') ||
+          editorSnapshot.matches('formulaEditing') ||
+          editorSnapshot.matches('richTextEditing')
+        ) {
+          deps.commands.editor.commit('none');
+        }
         deps.commands.object.deselectAll();
         deps.commands.chart.deselectAll();
         selectionCommands.setSelection([range], nextActiveCell, nextActiveCell);
@@ -606,6 +614,8 @@ export const NameBoxDropdown = memo(function NameBoxDropdown({
       openDefineNameDialog,
       wb,
       refreshNamedRanges,
+      coordinator,
+      deps.commands.editor,
       deps.commands.object,
       deps.commands.chart,
     ],
@@ -647,6 +657,7 @@ export const NameBoxDropdown = memo(function NameBoxDropdown({
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter') {
         e.preventDefault();
+        e.stopPropagation();
         // Read straight from the DOM so test harnesses (Playwright `fill`)
         // and rapid user input both commit the actual typed value, even if
         // the `inputValue` state hasn't flushed yet.
@@ -668,6 +679,7 @@ export const NameBoxDropdown = memo(function NameBoxDropdown({
         coordinator.input.focusGrid();
       } else if (e.key === 'Escape') {
         e.preventDefault();
+        e.stopPropagation();
         setValidationError(null);
         setIsEditing(false);
         setIsOpen(false);

--- a/compute/core/src/storage/engine/cell_bridge.rs
+++ b/compute/core/src/storage/engine/cell_bridge.rs
@@ -1,6 +1,10 @@
 use bridge_core as bridge;
 
-use super::{YrsComputeEngine, format_inference::is_formula_parse_input, mutation, services};
+use super::{
+    YrsComputeEngine,
+    format_inference::{is_formula_parse_input, is_plain_zero_parse_input},
+    mutation, services,
+};
 use crate::snapshot::MutationResult;
 use cell_types::{CellId, SheetId};
 use value_types::{CellValue, ComputeError};
@@ -28,6 +32,12 @@ impl YrsComputeEngine {
         col: u32,
         input: mutation::CellInput,
     ) -> Result<(Vec<u8>, MutationResult), ComputeError> {
+        let zero_replacement_format_candidates =
+            if is_plain_zero_parse_input(&input) && self.cell_has_formula_at(sheet_id, row, col) {
+                vec![(*sheet_id, row, col)]
+            } else {
+                Vec::new()
+            };
         let mut recalc = services::cell_editing::set_cell(
             &mut self.stores,
             &mut self.mirror,
@@ -38,6 +48,8 @@ impl YrsComputeEngine {
             col,
             &input,
         )?;
+        let zero_replacement_format_result = self
+            .apply_formula_replacement_zero_number_formats(&zero_replacement_format_candidates)?;
         let format_result = if is_formula_parse_input(&input) {
             self.apply_formula_inherited_number_formats(&[(*sheet_id, row, col)])?
         } else {
@@ -46,6 +58,9 @@ impl YrsComputeEngine {
         self.prepare_recalc_for_flush(&mut recalc);
         let patches = self.flush_viewport_patches();
         let mut result = MutationResult::from_recalc(recalc);
+        result
+            .property_changes
+            .extend(zero_replacement_format_result.property_changes);
         result
             .property_changes
             .extend(format_result.property_changes);
@@ -121,6 +136,15 @@ impl YrsComputeEngine {
         col: u32,
         raw_input: &str,
     ) -> Result<(Vec<u8>, MutationResult), ComputeError> {
+        let input = mutation::CellInput::Parse {
+            text: raw_input.to_string(),
+        };
+        let zero_replacement_format_candidates =
+            if is_plain_zero_parse_input(&input) && self.cell_has_formula_at(sheet_id, row, col) {
+                vec![(*sheet_id, row, col)]
+            } else {
+                Vec::new()
+            };
         let mut recalc = services::cell_editing::set_cell_value_parsed(
             &mut self.stores,
             &mut self.mirror,
@@ -130,6 +154,8 @@ impl YrsComputeEngine {
             col,
             raw_input,
         )?;
+        let zero_replacement_format_result = self
+            .apply_formula_replacement_zero_number_formats(&zero_replacement_format_candidates)?;
         let format_result = if raw_input.trim().starts_with('=') {
             self.apply_formula_inherited_number_formats(&[(*sheet_id, row, col)])?
         } else {
@@ -138,6 +164,9 @@ impl YrsComputeEngine {
         self.prepare_recalc_for_flush(&mut recalc);
         let patches = self.flush_viewport_patches();
         let mut result = MutationResult::from_recalc(recalc);
+        result
+            .property_changes
+            .extend(zero_replacement_format_result.property_changes);
         result
             .property_changes
             .extend(format_result.property_changes);
@@ -174,6 +203,14 @@ impl YrsComputeEngine {
         sheet_id: &SheetId,
         updates: Vec<(u32, u32, String)>,
     ) -> Result<(Vec<u8>, MutationResult), ComputeError> {
+        let zero_replacement_format_candidates: Vec<(SheetId, u32, u32)> = updates
+            .iter()
+            .filter_map(|(row, col, text)| {
+                let input = mutation::CellInput::Parse { text: text.clone() };
+                (is_plain_zero_parse_input(&input) && self.cell_has_formula_at(sheet_id, *row, *col))
+                    .then_some((*sheet_id, *row, *col))
+            })
+            .collect();
         let group_undo = !updates.is_empty();
         let mut recalc = self.with_undo_group_if(group_undo, |engine| {
             services::cell_editing::set_cell_values_parsed(
@@ -184,9 +221,15 @@ impl YrsComputeEngine {
                 &updates,
             )
         })?;
+        let zero_replacement_format_result = self
+            .apply_formula_replacement_zero_number_formats(&zero_replacement_format_candidates)?;
         self.prepare_recalc_for_flush(&mut recalc);
         let patches = self.flush_viewport_patches();
-        Ok((patches, MutationResult::from_recalc(recalc)))
+        let mut result = MutationResult::from_recalc(recalc);
+        result
+            .property_changes
+            .extend(zero_replacement_format_result.property_changes);
+        Ok((patches, result))
     }
 
     /// Import pre-parsed cell values in bulk.

--- a/compute/core/src/storage/engine/format_inference.rs
+++ b/compute/core/src/storage/engine/format_inference.rs
@@ -10,6 +10,74 @@ use value_types::{CellValue, ComputeError};
 use super::{YrsComputeEngine, mutation, services};
 
 impl YrsComputeEngine {
+    pub(in crate::storage::engine) fn cell_has_formula_at(
+        &self,
+        sheet_id: &SheetId,
+        row: u32,
+        col: u32,
+    ) -> bool {
+        let Some(cell_id) = self
+            .mirror
+            .resolve_cell_id(sheet_id, SheetPos::new(row, col))
+        else {
+            return false;
+        };
+
+        self.mirror.get_formula(&cell_id).is_some()
+            || self.stores.compute.get_formula(&cell_id).is_some()
+    }
+
+    pub(in crate::storage::engine) fn apply_formula_replacement_zero_number_formats(
+        &mut self,
+        candidates: &[(SheetId, u32, u32)],
+    ) -> Result<MutationResult, ComputeError> {
+        if candidates.is_empty() {
+            return Ok(MutationResult::empty());
+        }
+
+        let mut to_apply = Vec::new();
+        for (sheet_id, row, col) in candidates {
+            let Some(CellValue::Number(value)) = self
+                .mirror
+                .get_cell_value_at(sheet_id, SheetPos::new(*row, *col))
+            else {
+                continue;
+            };
+            if value.get() != 0.0 {
+                continue;
+            }
+            if self.cell_has_formula_at(sheet_id, *row, *col) {
+                continue;
+            }
+            to_apply.push((*sheet_id, *row, *col));
+        }
+
+        if to_apply.is_empty() {
+            return Ok(MutationResult::empty());
+        }
+
+        let _guard = self.mutation.suppress_guard();
+        let mut result = MutationResult::empty();
+        for (sheet_id, row, col) in to_apply {
+            let format = CellFormat {
+                number_format: Some("General".to_string()),
+                ..Default::default()
+            };
+            let (_affected, format_result) = services::formatting::set_format_for_ranges(
+                &mut self.stores,
+                &self.mirror,
+                &sheet_id,
+                &[(row, col, row, col)],
+                &format,
+            )?;
+            result
+                .property_changes
+                .extend(format_result.property_changes);
+        }
+
+        Ok(result)
+    }
+
     /// cell does not already have a date format applied, write the
     /// suggested format code (e.g. `"M/d/yyyy"`, `"yyyy-mm-dd"`) into the
     /// per-cell number_format. This is the Rust-side replacement for the
@@ -714,4 +782,29 @@ fn is_simple_identity_ref(value: &str) -> bool {
 
 pub(in crate::storage::engine) fn is_formula_parse_input(input: &mutation::CellInput) -> bool {
     matches!(input, mutation::CellInput::Parse { text } if text.trim().starts_with('='))
+}
+
+pub(in crate::storage::engine) fn is_plain_zero_parse_input(
+    input: &mutation::CellInput,
+) -> bool {
+    let mutation::CellInput::Parse { text } = input else {
+        return false;
+    };
+    is_plain_zero_text(text)
+}
+
+fn is_plain_zero_text(text: &str) -> bool {
+    let trimmed = text.trim();
+    if trimmed.is_empty() || trimmed.starts_with('=') || trimmed.starts_with('\'') {
+        return false;
+    }
+    if !trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_digit() || matches!(ch, '+' | '-' | '.'))
+    {
+        return false;
+    }
+    trimmed
+        .parse::<f64>()
+        .is_ok_and(|value| value.is_finite() && value == 0.0)
 }

--- a/compute/core/src/storage/engine/mutation_dispatch.rs
+++ b/compute/core/src/storage/engine/mutation_dispatch.rs
@@ -7,7 +7,7 @@ use crate::snapshot::{
     ChangeKind, MutationResult, RecalcResult, SheetLifecycleRuntimeHint, SortingChange,
 };
 
-use super::format_inference::is_formula_parse_input;
+use super::format_inference::{is_formula_parse_input, is_plain_zero_parse_input};
 use super::mutation::{self, EngineMutation, MutationOutput};
 use super::mutation_coordinator::SheetLifecycleHistoryHint;
 use super::stores::EngineStores;
@@ -106,6 +106,14 @@ impl YrsComputeEngine {
                 edits,
                 skip_cycle_check,
             } => {
+                let zero_replacement_format_candidates: Vec<(SheetId, u32, u32)> = edits
+                    .iter()
+                    .filter_map(|(sid, _cid, row, col, input)| {
+                        (is_plain_zero_parse_input(input)
+                            && self.cell_has_formula_at(sid, *row, *col))
+                        .then_some((*sid, *row, *col))
+                    })
+                    .collect();
                 let formula_format_candidates: Vec<(SheetId, u32, u32)> = edits
                     .iter()
                     .filter_map(|(sid, _cid, row, col, input)| {
@@ -119,10 +127,17 @@ impl YrsComputeEngine {
                     edits,
                     skip_cycle_check,
                 )?;
+                let zero_replacement_format_result = self
+                    .apply_formula_replacement_zero_number_formats(
+                        &zero_replacement_format_candidates,
+                    )?;
                 let format_result =
                     self.apply_formula_inherited_number_formats(&formula_format_candidates)?;
                 self.prepare_recalc_for_flush(&mut recalc);
                 let mut result = MutationResult::from_recalc(recalc);
+                result
+                    .property_changes
+                    .extend(zero_replacement_format_result.property_changes);
                 result
                     .property_changes
                     .extend(format_result.property_changes);
@@ -157,6 +172,14 @@ impl YrsComputeEngine {
                         _ => None,
                     })
                     .collect();
+                let zero_replacement_format_candidates: Vec<(SheetId, u32, u32)> = edits
+                    .iter()
+                    .filter_map(|(sid, row, col, input)| {
+                        (is_plain_zero_parse_input(input)
+                            && self.cell_has_formula_at(sid, *row, *col))
+                        .then_some((*sid, *row, *col))
+                    })
+                    .collect();
                 let formula_format_candidates: Vec<(SheetId, u32, u32)> = edits
                     .iter()
                     .filter_map(|(sid, row, col, input)| {
@@ -171,6 +194,10 @@ impl YrsComputeEngine {
                     edits,
                     skip_cycle_check,
                 )?;
+                let zero_replacement_format_result = self
+                    .apply_formula_replacement_zero_number_formats(
+                        &zero_replacement_format_candidates,
+                    )?;
                 let format_result =
                     self.apply_formula_inherited_number_formats(&formula_format_candidates)?;
                 self.prepare_recalc_for_flush(&mut recalc);
@@ -183,6 +210,9 @@ impl YrsComputeEngine {
                 }
 
                 let mut result = MutationResult::from_recalc(recalc);
+                result
+                    .property_changes
+                    .extend(zero_replacement_format_result.property_changes);
                 result
                     .property_changes
                     .extend(format_result.property_changes);

--- a/compute/core/src/storage/engine/tests/test_formatting.rs
+++ b/compute/core/src/storage/engine/tests/test_formatting.rs
@@ -715,6 +715,42 @@ fn formula_display_respects_cells_own_explicit_format() {
 }
 
 #[test]
+fn plain_zero_replacing_formula_displays_as_zero_and_recalculates_dependents() {
+    use domain_types::CellFormat;
+
+    let snap = simple_snapshot();
+    let (mut engine, _) = YrsComputeEngine::from_snapshot(snap).unwrap();
+    let sid = sheet_id();
+
+    engine
+        .set_format_for_ranges(
+            &sid,
+            &[(1, 0, 1, 0)],
+            &CellFormat {
+                number_format: Some(r#"_(* #,##0.0_);_(* \(#,##0.0\);_(* "-"??_);_(@_)"#.into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    engine.set_cell_value_parsed(&sid, 1, 0, "=A1-B1").unwrap();
+    engine.set_cell_value_parsed(&sid, 0, 2, "=A1/A2").unwrap();
+
+    engine.set_cell_value_parsed(&sid, 1, 0, "0").unwrap();
+
+    let value = engine
+        .mirror()
+        .get_cell_value_at(&sid, cell_types::SheetPos::new(1, 0));
+    match value {
+        Some(CellValue::Number(n)) => assert_eq!(n.get(), 0.0),
+        other => panic!("expected numeric zero, got {:?}", other),
+    }
+    assert_eq!(engine.get_raw_value(&sid, 0, 2), "=A1/A2");
+    assert_eq!(engine.get_resolved_format(&sid, 1, 0).number_format.as_deref(), Some("General"));
+    assert_eq!(engine.format_cell_display(&sid, 1, 0), "0");
+    assert_eq!(engine.format_cell_display(&sid, 0, 2), "#DIV/0!");
+}
+
+#[test]
 fn test_format_value_at_cell_directly() {
     let snap = simple_snapshot();
     let (engine, _) = YrsComputeEngine::from_snapshot(snap).unwrap();


### PR DESCRIPTION
This PR fixes a spreadsheet behavior regression in public Mog code.

Verification:
- Reproduced before the change and passed after the change before submission.

Changed paths:
```
apps/spreadsheet/src/app/CoordinatorProvider.tsx
apps/spreadsheet/src/chrome/formula-bar/NameBoxDropdown.tsx
compute/core/src/storage/engine/cell_bridge.rs
compute/core/src/storage/engine/format_inference.rs
compute/core/src/storage/engine/mutation_dispatch.rs
compute/core/src/storage/engine/tests/test_formatting.rs
```
