### PR TITLE
Fix spreadsheet behavior regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "compute-core-pyo3"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bridge-pyo3",
  "bridge-types",

--- a/compute/core/src/storage/engine/services/cell_editing/identity.rs
+++ b/compute/core/src/storage/engine/services/cell_editing/identity.rs
@@ -1,4 +1,4 @@
-use cell_types::{CellId, SheetId};
+use cell_types::{CellId, SheetId, SheetPos};
 use yrs::{Array, Map, Origin, Out, Transact};
 
 use crate::mirror::CellMirror;
@@ -57,6 +57,16 @@ pub(in crate::storage::engine) fn find_cell_id_at_mirrored(
         return Some(cid);
     }
 
+    if let Some(cid) = mirror.resolve_cell_id(sheet_id, SheetPos::new(row, col))
+        && !cid.is_virtual()
+    {
+        stores
+            .grid_indexes
+            .get_mut(sheet_id)?
+            .register_cell(cid, row, col);
+        return Some(cid);
+    }
+
     // Check the mirror for Range coverage and pre-register if found.
     let grid = stores.grid_indexes.get_mut(sheet_id)?;
     crate::storage::cells::values::maybe_register_virtual_cell_id(mirror, sheet_id, grid, row, col);
@@ -78,10 +88,20 @@ pub(in crate::storage::engine) fn ensure_cell_id_mirrored(
         .get(sheet_id)
         .and_then(|grid| grid.cell_id_at(row, col));
 
+    if already_registered.is_none()
+        && let Some(cid) = mirror.resolve_cell_id(sheet_id, SheetPos::new(row, col))
+        && !cid.is_virtual()
+    {
+        stores
+            .grid_indexes
+            .get_mut(sheet_id)?
+            .register_cell(cid, row, col);
+    }
+
     // For Range-resident positions, pre-register the virtual CellId so
     // ensure_cell_id returns it instead of minting a fresh random one.
     let grid = stores.grid_indexes.get_mut(sheet_id)?;
-    if already_registered.is_none() {
+    if grid.cell_id_at(row, col).is_none() {
         cell_values::maybe_register_virtual_cell_id(mirror, sheet_id, grid, row, col);
     }
 

--- a/compute/core/tests/imported_api_eval_regressions.rs
+++ b/compute/core/tests/imported_api_eval_regressions.rs
@@ -2,7 +2,7 @@ use cell_types::{CellId, SheetId, SheetPos};
 use compute_core::bridge_types::CellInput;
 use compute_core::engine_types::fill::{BridgeAutoFillRequest, BridgeFillRangeSpec};
 use compute_core::storage::engine::YrsComputeEngine;
-use snapshot_types::{RecalcOptions, WorkbookSnapshot};
+use snapshot_types::{RecalcOptions, SheetSnapshot, WorkbookSnapshot};
 use value_types::{CellError, CellValue};
 use xlsx_parser::write::ZipWriter;
 
@@ -222,4 +222,123 @@ fn imported_data_table_recalc_mutation_preserves_cached_table_values() {
 
     assert_eq!(value_at(&engine, &sheet_id, 2, 3), CellValue::number(16.5));
     assert_eq!(value_at(&engine, &sheet_id, 3, 3), CellValue::number(18.5));
+}
+
+#[test]
+fn batch_position_writes_reuse_formula_reference_identities() {
+    let snapshot = WorkbookSnapshot {
+        sheets: vec![SheetSnapshot {
+            id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
+            name: "Dependencies".to_string(),
+            rows: 100,
+            cols: 26,
+            cells: vec![],
+            ranges: vec![],
+        }],
+        ..Default::default()
+    };
+    let (mut engine, _) = YrsComputeEngine::from_snapshot(snapshot).expect("bootstrap engine");
+    let sheet_id = first_sheet_id(&engine);
+
+    engine
+        .batch_set_cells_by_position(
+            vec![
+                (
+                    sheet_id,
+                    6,
+                    2,
+                    CellInput::Value {
+                        value: CellValue::number(599.9),
+                    },
+                ),
+                (
+                    sheet_id,
+                    20,
+                    2,
+                    CellInput::Parse {
+                        text: "=C7/C14".to_string(),
+                    },
+                ),
+                (
+                    sheet_id,
+                    34,
+                    3,
+                    CellInput::Parse {
+                        text: "=D14/C14-1".to_string(),
+                    },
+                ),
+            ],
+            true,
+        )
+        .expect("seed formulas before their referenced value cells exist");
+
+    engine
+        .batch_set_cells_by_position(
+            vec![
+                (
+                    sheet_id,
+                    13,
+                    2,
+                    CellInput::Value {
+                        value: CellValue::number(13.3),
+                    },
+                ),
+                (
+                    sheet_id,
+                    13,
+                    3,
+                    CellInput::Value {
+                        value: CellValue::number(14.3),
+                    },
+                ),
+            ],
+            true,
+        )
+        .expect("write referenced value cells by position");
+
+    assert_number_close(
+        value_at(&engine, &sheet_id, 20, 2),
+        599.9 / 13.3,
+        "C21",
+    );
+    assert_number_close(
+        value_at(&engine, &sheet_id, 34, 3),
+        14.3 / 13.3 - 1.0,
+        "D35",
+    );
+
+    engine
+        .batch_set_cells_by_position(
+            vec![(
+                sheet_id,
+                13,
+                2,
+                CellInput::Value {
+                    value: CellValue::number(14.3),
+                },
+            )],
+            true,
+        )
+        .expect("edit referenced value cell by position");
+
+    assert_number_close(
+        value_at(&engine, &sheet_id, 20, 2),
+        599.9 / 14.3,
+        "C21",
+    );
+    assert_number_close(value_at(&engine, &sheet_id, 34, 3), 0.0, "D35");
+}
+
+fn assert_number_close(actual: CellValue, expected: f64, label: &str) {
+    match actual {
+        CellValue::Number(n) => {
+            let delta = (n.get() - expected).abs();
+            assert!(
+                delta < 1e-9,
+                "{label} expected {expected}, got {} (delta {delta})",
+                n.get()
+            );
+        }
+        other => panic!("{label} expected number {expected}, got {other:?}"),
+    }
 }


### PR DESCRIPTION
This PR fixes a spreadsheet behavior regression in public Mog code.

Verification:
- Reproduced before the change and passed after the change before submission.

Changed paths:
```
Cargo.lock
compute/core/src/storage/engine/services/cell_editing/identity.rs
compute/core/tests/imported_api_eval_regressions.rs
```
