### PR TITLE
Fix spreadsheet behavior regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "compute-core-pyo3"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bridge-pyo3",
  "bridge-types",

--- a/compute/core/src/storage/cells/values.rs
+++ b/compute/core/src/storage/cells/values.rs
@@ -35,7 +35,7 @@ use yrs::{Any, Doc, Map, MapPrelim, MapRef, Origin, Out, Transact};
 use crate::mirror::{CellMirror, SheetMirror};
 use crate::scheduler::input::CellWrite;
 use crate::storage::engine::mutation::CellInput;
-use cell_types::{CellId, SheetId};
+use cell_types::{CellId, SheetId, SheetPos};
 use compute_document::cell_serde::{cell_value_to_any, yrs_any_to_cell_value};
 use compute_document::hex::id_to_hex;
 use compute_document::schema::{
@@ -509,6 +509,36 @@ pub(crate) fn maybe_register_virtual_cell_id(
     }
 }
 
+/// Reuse mirror-owned identities for positions whose CellId was allocated
+/// while parsing formulas against blank cells, then fall back to Range virtuals.
+pub(crate) fn maybe_register_mirrored_cell_id(
+    mirror: &CellMirror,
+    sheet_id: &SheetId,
+    grid_index: &mut crate::identity::GridIndex,
+    row: u32,
+    col: u32,
+) {
+    if grid_index.cell_id_at(row, col).is_some() {
+        return;
+    }
+    if let Some(cell_id) = mirror.resolve_cell_id(sheet_id, SheetPos::new(row, col)) {
+        grid_index.register_cell(cell_id, row, col);
+        return;
+    }
+    maybe_register_virtual_cell_id(mirror, sheet_id, grid_index, row, col);
+}
+
+fn should_register_mirrored_identity_for_write(input: &CellInput) -> bool {
+    match input {
+        CellInput::Clear => false,
+        CellInput::Value {
+            value: CellValue::Null,
+        } => false,
+        CellInput::Parse { text } if text.trim().is_empty() => false,
+        _ => true,
+    }
+}
+
 /// Resolve the effective format category for a single cell *before* the
 /// write transaction opens. Used by `set_cell_value` / `set_cell_values`
 /// so the read-side cascade (which opens its own `transact()`) never
@@ -607,9 +637,9 @@ pub(crate) fn set_cell_value(
     _id_alloc: &cell_types::IdAllocator,
     grid_index: &mut crate::identity::GridIndex,
 ) {
-    // For Range-resident positions, pre-register the virtual CellId so
-    // ensure_cell_id returns it instead of minting a new one.
-    maybe_register_virtual_cell_id(mirror, sheet_id, grid_index, row, col);
+    if should_register_mirrored_identity_for_write(&input) {
+        maybe_register_mirrored_cell_id(mirror, sheet_id, grid_index, row, col);
+    }
 
     // Resolve the format hint BEFORE opening the write txn so the read-side
     // cascade in `properties::get_effective_format` doesn't try to open a
@@ -666,8 +696,10 @@ pub(crate) fn set_cell_values(
     _id_alloc: &cell_types::IdAllocator,
     grid_index: &mut crate::identity::GridIndex,
 ) {
-    for &(r, c, _) in &updates {
-        maybe_register_virtual_cell_id(mirror, sheet_id, grid_index, r, c);
+    for (r, c, input) in &updates {
+        if should_register_mirrored_identity_for_write(input) {
+            maybe_register_mirrored_cell_id(mirror, sheet_id, grid_index, *r, *c);
+        }
     }
 
     let sheet_hex = id_to_hex(sheet_id.as_u128());
@@ -779,9 +811,7 @@ pub fn import_values(
         };
 
         for (row, col, value, formula) in updates {
-            // For Range-resident positions, pre-register the virtual CellId so
-            // ensure_cell_id returns it instead of minting a new one.
-            maybe_register_virtual_cell_id(mirror, sheet_id, grid_index, *row, *col);
+            maybe_register_mirrored_cell_id(mirror, sheet_id, grid_index, *row, *col);
 
             let cell_id = grid_index.ensure_cell_id(*row, *col);
             let cell_hex = id_to_hex(cell_id.as_u128());

--- a/compute/core/src/storage/engine/services/cell_editing/identity.rs
+++ b/compute/core/src/storage/engine/services/cell_editing/identity.rs
@@ -40,11 +40,8 @@ pub(in crate::storage::engine) fn cell_id_for_region_guard(
 
 /// Mirror-aware variant of [`find_cell_id_at`].
 ///
-/// When the GridIndex has no CellId at `(row, col)`, checks the mirror's
-/// Range spatial index. If the position falls inside a Range, derives and
-/// pre-registers the virtual CellId so that the caller (and any subsequent
-/// `ensure_cell_id`) returns the deterministic virtual ID instead of
-/// minting a fresh random one.
+/// When the GridIndex has no CellId at `(row, col)`, checks identities that
+/// the mirror already owns before falling back to Range virtual identities.
 pub(in crate::storage::engine) fn find_cell_id_at_mirrored(
     stores: &mut EngineStores,
     mirror: &crate::mirror::CellMirror,
@@ -57,9 +54,10 @@ pub(in crate::storage::engine) fn find_cell_id_at_mirrored(
         return Some(cid);
     }
 
-    // Check the mirror for Range coverage and pre-register if found.
     let grid = stores.grid_indexes.get_mut(sheet_id)?;
-    crate::storage::cells::values::maybe_register_virtual_cell_id(mirror, sheet_id, grid, row, col);
+    crate::storage::cells::values::maybe_register_mirrored_cell_id(
+        mirror, sheet_id, grid, row, col,
+    );
 
     // Re-check — will succeed if a virtual CellId was just registered.
     stores.grid_indexes.get(sheet_id)?.cell_id_at(row, col)
@@ -78,11 +76,9 @@ pub(in crate::storage::engine) fn ensure_cell_id_mirrored(
         .get(sheet_id)
         .and_then(|grid| grid.cell_id_at(row, col));
 
-    // For Range-resident positions, pre-register the virtual CellId so
-    // ensure_cell_id returns it instead of minting a fresh random one.
     let grid = stores.grid_indexes.get_mut(sheet_id)?;
     if already_registered.is_none() {
-        cell_values::maybe_register_virtual_cell_id(mirror, sheet_id, grid, row, col);
+        cell_values::maybe_register_mirrored_cell_id(mirror, sheet_id, grid, row, col);
     }
 
     let cell_id = mirror_cell_position_to_yrs(

--- a/compute/core/src/storage/engine/tests/test_cell_input_value.rs
+++ b/compute/core/src/storage/engine/tests/test_cell_input_value.rs
@@ -1,7 +1,7 @@
 use super::helpers::*;
 use crate::bridge_types::CellInput;
 use domain_types::CellFormat;
-use value_types::CellValue;
+use value_types::{CellError, CellValue};
 
 #[test]
 fn typed_number_in_percent_cell_is_not_reparsed_as_user_text() {
@@ -62,4 +62,92 @@ fn typed_number_in_percent_cell_is_not_reparsed_as_user_text() {
         other => panic!("expected Number(0.00185), got {:?}", other),
     }
     assert_eq!(engine.format_cell_display(&sid, 0, 10), "0.2%");
+}
+
+#[test]
+fn formulas_recalculate_after_writing_previously_blank_direct_reference() {
+    let snap = empty_bulk_snapshot();
+    let (mut engine, _) = crate::storage::engine::YrsComputeEngine::from_snapshot(snap).unwrap();
+    let sid = sheet_id();
+
+    engine
+        .batch_set_cells_by_position(
+            vec![(
+                sid,
+                0,
+                1,
+                CellInput::Parse {
+                    text: "10".to_string(),
+                },
+            )],
+            true,
+        )
+        .unwrap();
+
+    engine
+        .batch_set_cells_by_position(
+            vec![
+                (
+                    sid,
+                    0,
+                    2,
+                    CellInput::Parse {
+                        text: "=A1/B1".to_string(),
+                    },
+                ),
+                (
+                    sid,
+                    0,
+                    3,
+                    CellInput::Parse {
+                        text: "=B1/A1-1".to_string(),
+                    },
+                ),
+            ],
+            true,
+        )
+        .unwrap();
+
+    assert_eq!(cell_value_at(&engine, &sid, 0, 2), num(0.0));
+    assert!(matches!(
+        cell_value_at(&engine, &sid, 0, 3),
+        CellValue::Error(CellError::Div0, _)
+    ));
+
+    engine
+        .batch_set_cells_by_position(vec![(sid, 0, 0, CellInput::Clear)], true)
+        .unwrap();
+
+    assert_eq!(cell_value_at(&engine, &sid, 0, 2), num(0.0));
+    assert!(matches!(
+        cell_value_at(&engine, &sid, 0, 3),
+        CellValue::Error(CellError::Div0, _)
+    ));
+
+    engine
+        .batch_set_cells_by_position(
+            vec![(
+                sid,
+                0,
+                0,
+                CellInput::Parse {
+                    text: "50".to_string(),
+                },
+            )],
+            true,
+        )
+        .unwrap();
+
+    assert_eq!(cell_value_at(&engine, &sid, 0, 2), num(5.0));
+    assert_eq!(cell_value_at(&engine, &sid, 0, 3), num(-0.8));
+
+    engine
+        .batch_set_cells_by_position(vec![(sid, 0, 0, CellInput::Clear)], true)
+        .unwrap();
+
+    assert_eq!(cell_value_at(&engine, &sid, 0, 2), num(0.0));
+    assert!(matches!(
+        cell_value_at(&engine, &sid, 0, 3),
+        CellValue::Error(CellError::Div0, _)
+    ));
 }


### PR DESCRIPTION
This PR fixes a spreadsheet behavior regression in public Mog code.

Verification:
- Reproduced before the change and passed after the change before submission.

Changed paths:
```
Cargo.lock
compute/core/src/storage/cells/values.rs
compute/core/src/storage/engine/services/cell_editing/identity.rs
compute/core/src/storage/engine/tests/test_cell_input_value.rs
```
