### PR TITLE
Fix spreadsheet behavior regression

### DIFF
--- a/compute/core/src/scheduler/dep_extract/refs.rs
+++ b/compute/core/src/scheduler/dep_extract/refs.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use crate::mirror::CellMirror;
 use crate::projection::ProjectionRegistry;
-use cell_types::SheetId;
+use cell_types::{SheetId, SheetPos};
 use formula_types::CellRef;
 
 pub(super) fn ref_in_sheet_ctx(cell_ref: &CellRef, sheet_ctx: SheetId) -> CellRef {
@@ -67,6 +67,13 @@ pub(super) fn push_cell_ref_dep_targets(
                 RangePos::new(*sheet, *row, *col, *row, *col),
                 RangeAccess::Aggregate,
             ));
+
+            if let Some(cell_id) = mirror.resolve_cell_id(sheet, SheetPos::new(*row, *col)) {
+                let is_self = current_cell.is_some_and(|c| cell_id == *c);
+                if !is_self {
+                    out.push(DepTarget::Cell(cell_id));
+                }
+            }
 
             // If registry is available, check if this position is inside a projection
             if let Some(reg) = registry

--- a/compute/core/src/scheduler/scheduler_tests/cell_edits.rs
+++ b/compute/core/src/scheduler/scheduler_tests/cell_edits.rs
@@ -251,3 +251,63 @@ fn test_set_cells_batch() {
         .collect();
     assert!(changed_ids.contains(&c1_id.to_uuid_string()));
 }
+
+#[test]
+fn formula_entered_before_precedents_recalculates_after_precedent_edit() {
+    let mut core = ComputeCore::new();
+    let mut mirror = CellMirror::new();
+    core.init_from_snapshot(&mut mirror, basic_snapshot())
+        .unwrap();
+
+    let sheet_id = sid(1);
+    let formula_id = cid(0x4000);
+
+    core.set_cell(&mut mirror, &sheet_id, formula_id, 31, 3, "=D11/C11-1")
+        .unwrap();
+
+    let c11_id = mirror
+        .resolve_cell_id(&sheet_id, SheetPos::new(10, 2))
+        .unwrap();
+    let d11_id = mirror
+        .resolve_cell_id(&sheet_id, SheetPos::new(10, 3))
+        .unwrap();
+
+    use crate::storage::engine::mutation::CellInput;
+    let edits = vec![
+        (
+            sheet_id,
+            c11_id,
+            10u32,
+            2u32,
+            CellInput::Parse {
+                text: "899.4".to_string(),
+            },
+        ),
+        (
+            sheet_id,
+            d11_id,
+            10,
+            3,
+            CellInput::Parse {
+                text: "773.8".to_string(),
+            },
+        ),
+    ];
+    core.set_cells(&mut mirror, &edits, false).unwrap();
+
+    core.set_cell(&mut mirror, &sheet_id, c11_id, 10, 2, "950.4")
+        .unwrap();
+
+    let formula_val = core.get_cell_value(&mirror, &formula_id).unwrap();
+    match formula_val {
+        CellValue::Number(n) => {
+            let expected = 773.8 / 950.4 - 1.0;
+            assert!(
+                (n.get() - expected).abs() < 1e-12,
+                "expected {expected}, got {}",
+                n.get()
+            );
+        }
+        other => panic!("expected recalculated number, got {other:?}"),
+    }
+}

--- a/compute/core/src/storage/engine/services/mutation_handlers/cell_mutations/raw_edits.rs
+++ b/compute/core/src/storage/engine/services/mutation_handlers/cell_mutations/raw_edits.rs
@@ -105,6 +105,20 @@ pub(in crate::storage::engine) fn mutation_set_cells_raw_with_trust(
             .compute
             .set_cells_raw_with_trust(mirror, &edits, skip_cycle_check, trust)?;
 
+    let formula_identities: Vec<_> = edits
+        .iter()
+        .filter_map(|(_, cell_id, _, _, _, formula)| {
+            formula
+                .as_ref()
+                .and_then(|_| mirror.get_formula(cell_id).cloned())
+        })
+        .collect();
+    for identity in formula_identities {
+        super::super::super::cell_editing::persist_identity_formula_cell_identities(
+            stores, mirror, &identity,
+        );
+    }
+
     // Patch old_value onto seed changes (direct edits) that don't already have one.
     for change in &mut result.changed_cells {
         if change.old_value.is_none()

--- a/compute/core/src/storage/engine/services/mutation_handlers/cell_mutations/set_cells.rs
+++ b/compute/core/src/storage/engine/services/mutation_handlers/cell_mutations/set_cells.rs
@@ -204,6 +204,21 @@ pub(in crate::storage::engine) fn mutation_set_cells(
         skip_cycle_check,
     )?;
 
+    let formula_identities: Vec<_> = edits
+        .iter()
+        .zip(prepared_values.iter())
+        .filter_map(|((_, cell_id, _, _, _), (_, formula))| {
+            formula
+                .as_ref()
+                .and_then(|_| mirror.get_formula(cell_id).cloned())
+        })
+        .collect();
+    for identity in formula_identities {
+        super::super::super::cell_editing::persist_identity_formula_cell_identities(
+            stores, mirror, &identity,
+        );
+    }
+
     // Patch old_value onto seed changes (direct edits) that don't already have one.
     // Cascade changes already have old_value set by level_eval.rs.
     for change in &mut result.changed_cells {

--- a/compute/core/src/storage/engine/tests/test_undo_redo_bulk_position.rs
+++ b/compute/core/src/storage/engine/tests/test_undo_redo_bulk_position.rs
@@ -71,6 +71,90 @@ fn duplicate_set_cells_by_position_uses_last_write_and_one_identity() {
 }
 
 #[test]
+fn formula_precedent_identities_are_reused_by_later_position_edits() {
+    let (mut engine, _) = YrsComputeEngine::from_snapshot(empty_bulk_snapshot()).unwrap();
+    let sid = sheet_id();
+
+    engine
+        .batch_set_cells_by_position(
+            vec![(
+                sid,
+                31,
+                3,
+                crate::storage::engine::mutation::CellInput::Parse {
+                    text: "=D11/C11-1".into(),
+                },
+            )],
+            false,
+        )
+        .unwrap();
+
+    let c11_id = engine
+        .grid_index(&sid)
+        .expect("grid index")
+        .cell_id_at(10, 2)
+        .expect("formula precedent identity");
+
+    engine
+        .batch_set_cells_by_position(
+            vec![
+                (
+                    sid,
+                    10,
+                    2,
+                    crate::storage::engine::mutation::CellInput::Parse {
+                        text: "899.4".into(),
+                    },
+                ),
+                (
+                    sid,
+                    10,
+                    3,
+                    crate::storage::engine::mutation::CellInput::Parse {
+                        text: "773.8".into(),
+                    },
+                ),
+            ],
+            false,
+        )
+        .unwrap();
+
+    assert_eq!(
+        engine
+            .grid_index(&sid)
+            .expect("grid index")
+            .cell_id_at(10, 2),
+        Some(c11_id)
+    );
+
+    engine
+        .batch_set_cells_by_position(
+            vec![(
+                sid,
+                10,
+                2,
+                crate::storage::engine::mutation::CellInput::Parse {
+                    text: "950.4".into(),
+                },
+            )],
+            false,
+        )
+        .unwrap();
+
+    match cell_value_at(&engine, &sid, 31, 3) {
+        CellValue::Number(actual) => {
+            let expected = 773.8 / 950.4 - 1.0;
+            assert!(
+                (actual.get() - expected).abs() < 1e-12,
+                "expected {expected}, got {}",
+                actual.get()
+            );
+        }
+        other => panic!("expected recalculated number, got {other:?}"),
+    }
+}
+
+#[test]
 fn undo_redo_restores_bulk_dimension_growth() {
     let (mut engine, _) = YrsComputeEngine::from_snapshot(empty_bulk_snapshot()).unwrap();
     let sid = sheet_id();


### PR DESCRIPTION
This PR fixes a spreadsheet behavior regression in public Mog code.

Verification:
- Reproduced before the change and passed after the change before submission.

Changed paths:
```
compute/core/src/scheduler/dep_extract/refs.rs
compute/core/src/scheduler/scheduler_tests/cell_edits.rs
compute/core/src/storage/engine/services/mutation_handlers/cell_mutations/raw_edits.rs
compute/core/src/storage/engine/services/mutation_handlers/cell_mutations/set_cells.rs
compute/core/src/storage/engine/tests/test_undo_redo_bulk_position.rs
```
