### PR TITLE
Fix formula bar keyboard target routing

### DIFF
--- a/apps/spreadsheet/src/systems/input/keyboard/keyboard-coordinator.ts
+++ b/apps/spreadsheet/src/systems/input/keyboard/keyboard-coordinator.ts
@@ -41,7 +41,11 @@ import {
 } from '@mog-sdk/kernel/keyboard';
 import { sheetId as toSheetId } from '@mog-sdk/contracts/core';
 import { KEYBOARD_SHORTCUTS, type KeyboardShortcut, type ShortcutContext } from '../../../keyboard';
-import { shouldDeferNavigationKeyToEditableTarget } from '../../shared/utils/focus-utils';
+import {
+  isEditableChromeKeyboardTarget,
+  keyboardEventTargetElement,
+  shouldDeferNavigationKeyToEditableTarget,
+} from '../../shared/utils/focus-utils';
 
 import type { ActionDependencies, ActionType } from '@mog-sdk/contracts/actions';
 import type { ActorAccessors, ActorCommands } from '@mog-sdk/contracts/actors';
@@ -164,34 +168,6 @@ export interface KeyboardHandleResult {
   action?: string;
   /** Reason for not handling, if applicable */
   reason?: 'not_found' | 'not_implemented' | 'wrong_context' | 'browser_defer' | 'ime_composing';
-}
-
-// =============================================================================
-// DOM target helpers
-// =============================================================================
-
-function asElement(target: EventTarget | null): Element | null {
-  if (typeof Element === 'undefined') return null;
-  return target instanceof Element ? target : null;
-}
-
-function isInlineCellEditorTarget(element: Element): boolean {
-  return element.closest('[data-testid="inline-cell-editor"]') !== null;
-}
-
-function isEditableChromeTarget(target: EventTarget | null): boolean {
-  const element = asElement(target);
-  if (!element || isInlineCellEditorTarget(element)) return false;
-
-  if (
-    (typeof HTMLInputElement !== 'undefined' && element instanceof HTMLInputElement) ||
-    (typeof HTMLTextAreaElement !== 'undefined' && element instanceof HTMLTextAreaElement)
-  ) {
-    return true;
-  }
-
-  const htmlElement = element as HTMLElement;
-  return htmlElement.isContentEditable || element.closest('[contenteditable="true"]') !== null;
 }
 
 // =============================================================================
@@ -1063,7 +1039,7 @@ export class KeyboardCoordinator {
       return { handled: false, reason: 'ime_composing' };
     }
 
-    if (isEditableChromeTarget(e.target)) {
+    if (isEditableChromeKeyboardTarget(keyboardEventTargetElement(e))) {
       return { handled: false, reason: 'not_found' };
     }
 

--- a/apps/spreadsheet/src/systems/shared/utils/focus-utils.ts
+++ b/apps/spreadsheet/src/systems/shared/utils/focus-utils.ts
@@ -110,12 +110,16 @@ export function isSpreadsheetEditorKeyboardTarget(target: HTMLElement | null): b
   );
 }
 
+export function isEditableChromeKeyboardTarget(target: HTMLElement | null): boolean {
+  return isEditableKeyboardTarget(target) && !isSpreadsheetEditorKeyboardTarget(target);
+}
+
 export function shouldDeferNavigationKeyToEditableTarget(
   e: KeyboardEvent,
   target = keyboardEventTargetElement(e),
 ): boolean {
   if (!EDITABLE_NAVIGATION_KEYS.has(e.key)) return false;
-  return isEditableKeyboardTarget(target) && !isSpreadsheetEditorKeyboardTarget(target);
+  return isEditableChromeKeyboardTarget(target);
 }
 
 /**


### PR DESCRIPTION
## Summary
- centralize editable chrome target detection in focus utils
- allow spreadsheet-owned formula bar and inline editors to keep handling navigation keys
- remove the duplicated DOM target helper from the keyboard coordinator

## Verification
- pnpm --filter @mog/app-spreadsheet test -- src/systems/input/keyboard/__tests__/keyboard-coordinator.test.ts src/systems/shared/utils/__tests__/focus-utils.test.ts --runInBand
- pnpm --filter @mog/app-spreadsheet test -- src/actions/handlers/__tests__/borders-direct-mode.test.ts src/app/__tests__/coordinator-formula-bar-enter.test.ts src/app/__tests__/interactive-format-normalization.test.ts src/chrome/toolbar/tabs/__tests__/ViewRibbon-collapse.test.ts src/components/comments/CommentPopover.test.tsx src/components/grid/layout/__tests__/viewport-size.test.ts src/coordinator/__tests__/input-coordinator.test.ts src/dialogs/insert/InsertCellsDialog.test.tsx src/dialogs/insert/InsertTableDialog.test.tsx src/hooks/grid-mouse/__tests__/use-cell-interaction.test.ts src/hooks/shared/__tests__/use-grid-mouse-fill-handle.test.ts src/systems/grid-editing/coordination/__tests__/paste-integration.test.ts src/systems/grid-editing/machines/selection/__tests__/page-navigation-emits.test.ts src/systems/grid-editing/testing/__tests__/integration/commit-pipeline.test.ts src/systems/input/keyboard/__tests__/keyboard-coordinator.test.ts src/systems/input/testing/__tests__/keyboard-dispatch.test.ts src/systems/input/testing/__tests__/scroll-architecture-redesign.test.ts src/systems/renderer/coordination/__tests__/viewport-follow-coordination.test.ts src/systems/shared/utils/__tests__/focus-utils.test.ts --runInBand
- pnpm --filter @mog/app-spreadsheet typecheck
- pnpm --filter @mog-sdk/kernel test -- services/undo/__tests__/undo-service.test.ts --runInBand
- pnpm --filter @mog-sdk/sheet-view typecheck
- pnpm --filter @mog-sdk/sheet-view test --runInBand