### PR TITLE
Fix inserted spreadsheet rows preserving formulas

### DIFF
--- a/apps/spreadsheet/src/actions/handlers/__tests__/structure-autofit.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/structure-autofit.test.ts
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 
 import type { ActionDependencies } from '@mog-sdk/contracts/actions';
 import type { ClipboardData } from '@mog-sdk/contracts/actors';
+import type { CellData } from '@mog-sdk/contracts/api';
 import {
   MAX_COLS,
   MAX_ROWS,
@@ -45,6 +46,7 @@ function createDeps(
     hiddenCols?: number[];
     cutSourceRanges?: CellRange[] | null;
     clipboardData?: ClipboardData | null;
+    cellData?: Record<number, Record<number, CellData>>;
   } = {},
 ): ActionDependencies {
   const activeSheetId = makeSheetId('sheet1');
@@ -58,6 +60,23 @@ function createDeps(
   const worksheet = {
     formatValues: jest.fn(async () => []),
     getUsedRange: jest.fn(async () => options.usedRange ?? null),
+    getRange: jest.fn(async (range: CellRange) => {
+      const rows: CellData[][] = [];
+      for (let row = range.startRow; row <= range.endRow; row++) {
+        const rowCells: CellData[] = [];
+        for (let col = range.startCol; col <= range.endCol; col++) {
+          rowCells.push(options.cellData?.[row]?.[col] ?? { value: null });
+        }
+        rows.push(rowCells);
+      }
+      return rows;
+    }),
+    autoFill: jest.fn(async () => ({
+      patternType: 'copy',
+      filledCellCount: 1,
+      warnings: [],
+      changes: [],
+    })),
     layout: {
       setRowVisible: jest.fn(async () => undefined),
       setColumnVisible: jest.fn(async () => undefined),
@@ -186,6 +205,57 @@ describe('Structure autofit handlers', () => {
       [{ startRow: 4, startCol: 3, endRow: 4, endCol: 3 }],
       { row: 4, col: 3 },
     );
+  });
+
+  it('fills formula spans from the shifted row when inserting a row above', async () => {
+    const deps = createDeps({
+      activeCell: { row: 4, col: 1 },
+      ranges: [],
+      usedRange: { startRow: 0, startCol: 0, endRow: 8, endCol: 4 },
+      cellData: {
+        4: {
+          0: { value: null },
+          1: { value: null },
+          2: { value: null },
+          3: { value: null },
+          4: { value: null },
+        },
+        5: {
+          0: { value: 'Label' },
+          1: { value: 10, formula: '=B3' },
+          2: { value: 11, formula: '=C3' },
+          3: { value: 'note' },
+          4: { value: 12, formula: '=E3' },
+        },
+      },
+    });
+
+    await StructureHandlers.INSERT_ROW_ABOVE(deps);
+
+    const worksheet = getMockWorksheet(deps);
+    expect(worksheet.autoFill).toHaveBeenCalledTimes(2);
+    expect(worksheet.autoFill).toHaveBeenNthCalledWith(1, 'B6:C6', 'B5:C5', 'withoutFormats');
+    expect(worksheet.autoFill).toHaveBeenNthCalledWith(2, 'E6', 'E5', 'withoutFormats');
+  });
+
+  it('does not fill inserted rows from value-only neighbors', async () => {
+    const deps = createDeps({
+      activeCell: { row: 4, col: 1 },
+      ranges: [],
+      usedRange: { startRow: 0, startCol: 0, endRow: 8, endCol: 2 },
+      cellData: {
+        5: {
+          0: { value: 'Label' },
+          1: { value: 10 },
+          2: { value: 11 },
+        },
+      },
+    });
+
+    await StructureHandlers.INSERT_ROW_ABOVE(deps);
+
+    const worksheet = getMockWorksheet(deps);
+    expect(worksheet.autoFill).not.toHaveBeenCalled();
   });
 
   it('command-initiated row and column deletes keep the active cell at the vacated index', async () => {

--- a/apps/spreadsheet/src/actions/handlers/structure-row-column.ts
+++ b/apps/spreadsheet/src/actions/handlers/structure-row-column.ts
@@ -7,6 +7,8 @@
 
 import type { ActionDependencies, ActionResult } from '@mog-sdk/contracts/actions';
 import type { CellRange, SheetId } from '@mog-sdk/contracts/core';
+import type { CellData, Worksheet } from '@mog-sdk/contracts/api';
+import { toA1 } from '@mog/spreadsheet-utils/a1';
 
 import {
   handled,
@@ -74,6 +76,88 @@ function singleCellRange(cell: { row: number; col: number }): CellRange {
   };
 }
 
+type FormulaSpan = {
+  startCol: number;
+  endCol: number;
+};
+
+function cellHasFormula(cell: CellData | undefined): boolean {
+  return typeof cell?.formula === 'string' && cell.formula.length > 0;
+}
+
+function cellIsEmpty(cell: CellData | undefined): boolean {
+  return cell?.value == null && !cellHasFormula(cell);
+}
+
+function formulaSpansForRow(cells: CellData[], firstCol: number): FormulaSpan[] {
+  const spans: FormulaSpan[] = [];
+  let startCol: number | null = null;
+
+  cells.forEach((cell, offset) => {
+    const col = firstCol + offset;
+    if (cellHasFormula(cell)) {
+      if (startCol == null) startCol = col;
+      return;
+    }
+
+    if (startCol != null) {
+      spans.push({ startCol, endCol: col - 1 });
+      startCol = null;
+    }
+  });
+
+  if (startCol != null) {
+    spans.push({ startCol, endCol: firstCol + cells.length - 1 });
+  }
+
+  return spans;
+}
+
+function rangeA1(row: number, startCol: number, endCol: number): string {
+  const start = toA1(row, startCol);
+  const end = toA1(row, endCol);
+  return start === end ? start : `${start}:${end}`;
+}
+
+async function fillInsertedRowFormulaSpans(
+  ws: Worksheet,
+  insertAt: number,
+  sourceDirection: 'above' | 'below',
+): Promise<void> {
+  const usedRange = await ws.getUsedRange().catch(() => null);
+  if (!usedRange) return;
+
+  const startCol = usedRange.startCol;
+  const endCol = usedRange.endCol;
+  if (startCol > endCol) return;
+
+  const sourceRow = sourceDirection === 'below' ? insertAt + 1 : insertAt - 1;
+  if (sourceRow < usedRange.startRow || sourceRow > usedRange.endRow) return;
+
+  const [sourceCells] = await ws
+    .getRange({ startRow: sourceRow, startCol, endRow: sourceRow, endCol })
+    .catch(() => [[] as CellData[]]);
+  const spans = formulaSpansForRow(sourceCells ?? [], startCol);
+  if (spans.length === 0) return;
+
+  const [targetCells] = await ws
+    .getRange({ startRow: insertAt, startCol, endRow: insertAt, endCol })
+    .catch(() => [[] as CellData[]]);
+
+  for (const span of spans) {
+    const targetStartOffset = span.startCol - startCol;
+    const targetEndOffset = span.endCol - startCol;
+    const targetSpanCells = (targetCells ?? []).slice(targetStartOffset, targetEndOffset + 1);
+    if (!targetSpanCells.every(cellIsEmpty)) continue;
+
+    await ws.autoFill(
+      rangeA1(sourceRow, span.startCol, span.endCol),
+      rangeA1(insertAt, span.startCol, span.endCol),
+      'withoutFormats',
+    );
+  }
+}
+
 export async function insertRowAboveSelection(deps: ActionDependencies): Promise<ActionResult> {
   const targetSheetIds = getTargetSheetIds(deps);
   const { activeCell, ranges } = getSelectionContext(deps);
@@ -84,6 +168,7 @@ export async function insertRowAboveSelection(deps: ActionDependencies): Promise
     for (const sheetId of targetSheetIds) {
       const ws = deps.workbook.getSheetById(sheetId);
       await ws.structure.insertRows(insertAt, 1);
+      await fillInsertedRowFormulaSpans(ws, insertAt, 'below');
     }
   } catch (err) {
     if (isProtectionRejection(err)) {


### PR DESCRIPTION
Public behavior fixed: Fix inserted spreadsheet rows preserving formulas

Verification:
- Reproduced before the change and passed after the change before submission.

Changed paths:
```
apps/spreadsheet/src/actions/handlers/__tests__/structure-autofit.test.ts
apps/spreadsheet/src/actions/handlers/structure-row-column.ts
```
