### PR TITLE
Fix formula bar after referenced sheet removal

### DIFF
--- a/apps/spreadsheet/src/chrome/formula-bar/FormulaBarContainer.tsx
+++ b/apps/spreadsheet/src/chrome/formula-bar/FormulaBarContainer.tsx
@@ -51,6 +51,7 @@ import {
 } from '../../infra/events/formula-bar-refresh';
 import { FormulaBar } from './FormulaBar';
 import { FormulaBarContextMenu } from './FormulaBarContextMenu';
+import { subscribeToFormulaBarWorkbookRefreshes } from './formula-bar-refresh-subscriptions';
 // =============================================================================
 // Component
 // =============================================================================
@@ -150,14 +151,10 @@ function FormulaBarContainerImpl() {
     return unsub;
   }, [wb]);
 
-  // When a sheet is renamed, cross-sheet formula references on the active sheet
-  // are rewritten (e.g. =Sheet2!A1 → =Revenue!A1). The formula bar must re-fetch
-  // the active cell's formula text so it reflects the new sheet prefix, even when
-  // the active cell position hasn't changed (clicking the same cell again doesn't
-  // re-trigger the activeCellRow/activeCellCol useEffect).
+  // When sheet references are rewritten, the formula bar must re-fetch the active
+  // cell's formula text even if the active cell position hasn't changed.
   useEffect(() => {
-    const unsub = wb.on('sheet:renamed', () => setStructureVersion((v) => v + 1));
-    return unsub;
+    return subscribeToFormulaBarWorkbookRefreshes(wb, () => setStructureVersion((v) => v + 1));
   }, [wb]);
 
   useEffect(() => {

--- a/apps/spreadsheet/src/chrome/formula-bar/__tests__/formula-bar-refresh-subscriptions.test.ts
+++ b/apps/spreadsheet/src/chrome/formula-bar/__tests__/formula-bar-refresh-subscriptions.test.ts
@@ -1,0 +1,39 @@
+import { jest } from '@jest/globals';
+
+import {
+  FORMULA_BAR_WORKBOOK_REFRESH_EVENTS,
+  subscribeToFormulaBarWorkbookRefreshes,
+} from '../formula-bar-refresh-subscriptions';
+
+describe('subscribeToFormulaBarWorkbookRefreshes', () => {
+  it('subscribes to workbook events that can rewrite formula text', () => {
+    const unsubscribes = [jest.fn(), jest.fn()];
+    let nextUnsubscribe = 0;
+    const on = jest.fn(
+      (_event: string, _handler: () => void) => unsubscribes[nextUnsubscribe++] ?? jest.fn(),
+    );
+
+    const unsubscribe = subscribeToFormulaBarWorkbookRefreshes({ on }, jest.fn());
+
+    expect(on.mock.calls.map(([event]) => event)).toEqual(FORMULA_BAR_WORKBOOK_REFRESH_EVENTS);
+
+    unsubscribe();
+    expect(unsubscribes[0]).toHaveBeenCalledTimes(1);
+    expect(unsubscribes[1]).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs the refresh callback when a subscribed workbook event fires', () => {
+    const handlers = new Map<string, () => void>();
+    const on = jest.fn((event: string, handler: () => void) => {
+      handlers.set(event, handler);
+      return jest.fn();
+    });
+    const refresh = jest.fn();
+
+    subscribeToFormulaBarWorkbookRefreshes({ on }, refresh);
+    handlers.get('sheet:deleted')?.();
+    handlers.get('sheet:renamed')?.();
+
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/spreadsheet/src/chrome/formula-bar/formula-bar-refresh-subscriptions.ts
+++ b/apps/spreadsheet/src/chrome/formula-bar/formula-bar-refresh-subscriptions.ts
@@ -1,0 +1,22 @@
+type WorkbookRefreshEvent = 'sheet:renamed' | 'sheet:deleted';
+
+type WorkbookRefreshSource = {
+  on(event: WorkbookRefreshEvent, handler: () => void): () => void;
+};
+
+export const FORMULA_BAR_WORKBOOK_REFRESH_EVENTS: readonly WorkbookRefreshEvent[] = [
+  'sheet:renamed',
+  'sheet:deleted',
+];
+
+export function subscribeToFormulaBarWorkbookRefreshes(
+  wb: WorkbookRefreshSource,
+  refresh: () => void,
+): () => void {
+  const unsubscribes = FORMULA_BAR_WORKBOOK_REFRESH_EVENTS.map((event) => wb.on(event, refresh));
+  return () => {
+    for (const unsubscribe of unsubscribes) {
+      unsubscribe();
+    }
+  };
+}


### PR DESCRIPTION
Public behavior fixed: Fix formula bar after referenced sheet removal

Verification:
- Reproduced before the change and passed after the change before submission.

Changed paths:
```
apps/spreadsheet/src/chrome/formula-bar/FormulaBarContainer.tsx
apps/spreadsheet/src/chrome/formula-bar/__tests__/formula-bar-refresh-subscriptions.test.ts
apps/spreadsheet/src/chrome/formula-bar/formula-bar-refresh-subscriptions.ts
```
