### PR TITLE
Fix CSE array formula-bar readback

### DIFF
--- a/compute/core/src/storage/engine/cell_semantics.rs
+++ b/compute/core/src/storage/engine/cell_semantics.rs
@@ -108,26 +108,20 @@ impl YrsComputeEngine {
     pub fn get_cell_info(&self, sheet_id: &SheetId, row: u32, col: u32) -> Option<CellInfo> {
         let value = self.get_cell_value(sheet_id, row, col);
 
-        // Get formula: prefer ComputeCore's formula_strings (authoritative after
-        // structural changes), falling back to Yrs KEY_FORMULA for cold reads.
+        // Get formula: prefer ComputeCore's formula strings, then identity
+        // formulas, then formula-owning region anchors such as CSE arrays.
         let formula = {
-            let from_compute = self
+            let cell_id = self
                 .mirror
-                .resolve_cell_id(sheet_id, SheetPos::new(row, col))
-                .and_then(|cid| self.stores.compute.get_formula(&cid))
-                .map(|f| {
-                    if f.starts_with('=') {
-                        f.to_string()
-                    } else {
-                        format!("={}", f)
-                    }
-                });
-
-            if from_compute.is_some() {
-                from_compute
-            } else if let Some(formula) =
-                super::data_table_formula::formula_at(&self.mirror, sheet_id, row, col)
-            {
+                .resolve_cell_id(sheet_id, SheetPos::new(row, col));
+            if let Some(formula) = super::formula_read::formula_text_at(
+                &self.stores,
+                &self.mirror,
+                sheet_id,
+                row,
+                col,
+                cell_id.as_ref(),
+            ) {
                 Some(formula)
             } else if let Some(grid_index) = self.stores.grid_indexes.get(sheet_id) {
                 let raw = cell_values::get_raw_value(
@@ -204,19 +198,14 @@ impl YrsComputeEngine {
         let cell_id = self.mirror.resolve_cell_id(sheet_id, pos);
 
         let formula = if include_formula {
-            cell_id
-                .and_then(|cid| {
-                    self.stores
-                        .compute
-                        .get_formula(&cid)
-                        .map(|s| s.to_string())
-                        .or_else(|| {
-                            self.mirror.get_formula(&cid).map(|f| {
-                                self.stores.compute.to_a1_display(&self.mirror, sheet_id, f)
-                            })
-                        })
-                })
-                .or_else(|| super::data_table_formula::formula_at(&self.mirror, sheet_id, row, col))
+            super::formula_read::formula_text_at(
+                &self.stores,
+                &self.mirror,
+                sheet_id,
+                row,
+                col,
+                cell_id.as_ref(),
+            )
         } else {
             None
         };

--- a/compute/core/src/storage/engine/formula_read.rs
+++ b/compute/core/src/storage/engine/formula_read.rs
@@ -1,0 +1,42 @@
+use cell_types::{CellId, SheetId};
+
+use crate::mirror::CellMirror;
+
+use super::stores::EngineStores;
+
+pub(crate) fn formula_text_for_cell_id(
+    stores: &EngineStores,
+    mirror: &CellMirror,
+    sheet_id: &SheetId,
+    cell_id: &CellId,
+) -> Option<String> {
+    stores
+        .compute
+        .get_formula(cell_id)
+        .map(str::to_owned)
+        .or_else(|| {
+            mirror
+                .get_formula(cell_id)
+                .map(|formula| stores.compute.to_a1_display(mirror, sheet_id, formula))
+        })
+}
+
+pub(crate) fn formula_text_at(
+    stores: &EngineStores,
+    mirror: &CellMirror,
+    sheet_id: &SheetId,
+    row: u32,
+    col: u32,
+    cell_id: Option<&CellId>,
+) -> Option<String> {
+    cell_id
+        .and_then(|id| formula_text_for_cell_id(stores, mirror, sheet_id, id))
+        .or_else(|| {
+            mirror
+                .cse_anchor_covering(sheet_id, row, col)
+                .and_then(|(anchor_id, _)| {
+                    formula_text_for_cell_id(stores, mirror, sheet_id, &anchor_id)
+                })
+        })
+        .or_else(|| super::data_table_formula::formula_at(mirror, sheet_id, row, col))
+}

--- a/compute/core/src/storage/engine/mod.rs
+++ b/compute/core/src/storage/engine/mod.rs
@@ -42,6 +42,7 @@ mod features;
 mod filter_import_diagnostics;
 mod format_inference;
 mod formatting;
+mod formula_read;
 mod grid_indexing;
 mod layout;
 mod merge_index;

--- a/compute/core/src/storage/engine/queries/cell_regions.rs
+++ b/compute/core/src/storage/engine/queries/cell_regions.rs
@@ -20,6 +20,7 @@ use crate::snapshot::{
 };
 use crate::storage::cells::values as cell_values;
 use crate::storage::engine::YrsComputeEngine;
+use crate::storage::engine::formula_read;
 use crate::storage::engine::query_serialization::{cell_value_to_json, region_json};
 use crate::storage::engine::{data_table_formula, services};
 use crate::storage::sheet::{hyperlinks, merges, properties as sheets};
@@ -136,19 +137,21 @@ pub(in crate::storage::engine) fn get_cell_data(
     col: u32,
 ) -> Option<serde_json::Value> {
     if let Some(mut data) = services::queries::get_cell_data(&engine.stores, sheet_id, row, col) {
-        if let Some(cell_id_hex) = data.get("cell_id").and_then(|v| v.as_str())
+        let cell_id = if let Some(cell_id_hex) = data.get("cell_id").and_then(|v| v.as_str())
             && let Some(id_u128) = compute_document::hex::hex_to_id(cell_id_hex)
         {
-            let cell_id = cell_types::CellId::from_raw(id_u128);
-            if let Some(formula) = engine.stores.compute.get_formula(&cell_id) {
-                let body = formula.strip_prefix('=').unwrap_or(formula);
-                data["formula"] = serde_json::Value::String(body.to_string());
-            }
-        }
-        if data.get("formula").and_then(|v| v.as_str()).is_none()
-            && let Some(formula) =
-                data_table_formula::formula_at(&engine.mirror, sheet_id, row, col)
-        {
+            Some(cell_types::CellId::from_raw(id_u128))
+        } else {
+            None
+        };
+        if let Some(formula) = formula_read::formula_text_at(
+            &engine.stores,
+            &engine.mirror,
+            sheet_id,
+            row,
+            col,
+            cell_id.as_ref(),
+        ) {
             data["formula"] = serde_json::Value::String(
                 formula.strip_prefix('=').unwrap_or(&formula).to_string(),
             );
@@ -157,8 +160,9 @@ pub(in crate::storage::engine) fn get_cell_data(
         return Some(data);
     }
     let region = region_json(&engine.mirror, sheet_id, row, col);
-    let data_table_formula = data_table_formula::formula_at(&engine.mirror, sheet_id, row, col)
-        .map(|f| f.strip_prefix('=').unwrap_or(&f).to_string());
+    let formula =
+        formula_read::formula_text_at(&engine.stores, &engine.mirror, sheet_id, row, col, None)
+            .map(|f| f.strip_prefix('=').unwrap_or(&f).to_string());
     let value = cell_values::get_effective_value(&engine.mirror, sheet_id, row, col);
     match (value, &region) {
         (Some(v), _) if !v.is_null() => Some(serde_json::json!({
@@ -166,14 +170,14 @@ pub(in crate::storage::engine) fn get_cell_data(
             "row": row,
             "col": col,
             "value": cell_value_to_json(&v),
-            "formula": data_table_formula,
+            "formula": formula,
             "region": region,
         })),
         (_, serde_json::Value::Object(_)) => Some(serde_json::json!({
             "cell_id": serde_json::Value::Null,
             "row": row,
             "col": col,
-            "formula": data_table_formula,
+            "formula": formula,
             "region": region,
         })),
         _ => None,

--- a/compute/core/src/storage/engine/viewport/functions/active_cell.rs
+++ b/compute/core/src/storage/engine/viewport/functions/active_cell.rs
@@ -55,26 +55,24 @@ pub(in crate::storage::engine::viewport) fn get_active_cell(
                 .unwrap_or(CellValue::Null)
         });
 
-    // Get formula text from ComputeCore (A1-notation string), falling back to
-    // the mirror's identity formula template.
-    let formula = stores
-        .compute
-        .get_formula(&effective_cell_id)
-        .map(|s| s.to_string())
-        .or_else(|| {
-            mirror
-                .get_formula(&effective_cell_id)
-                .map(|f| format!("={}", f.template))
+    let formula = effective_pos
+        .and_then(|p| {
+            crate::storage::engine::formula_read::formula_text_at(
+                stores,
+                mirror,
+                sheet_id,
+                p.row(),
+                p.col(),
+                Some(&effective_cell_id),
+            )
         })
         .or_else(|| {
-            effective_pos.and_then(|p| {
-                crate::storage::engine::data_table_formula::formula_at(
-                    mirror,
-                    sheet_id,
-                    p.row(),
-                    p.col(),
-                )
-            })
+            crate::storage::engine::formula_read::formula_text_for_cell_id(
+                stores,
+                mirror,
+                sheet_id,
+                &effective_cell_id,
+            )
         });
 
     // Resolve format and metadata from properties.

--- a/compute/core/tests/cse_viewport_has_formula_flag.rs
+++ b/compute/core/tests/cse_viewport_has_formula_flag.rs
@@ -447,6 +447,26 @@ fn interactive_cse_source_workbook() -> WorkbookSnapshot {
         number_cell(23, 0, 1, 1.0),
         number_cell(24, 1, 1, 2.0),
         number_cell(25, 2, 1, 3.0),
+        // Blank cells in the target CSE range, matching UI-created grids
+        // where covered cells can already have identities before CSE entry.
+        CellData {
+            cell_id: cell_uuid(26),
+            row: 1,
+            col: 3,
+            value: CellValue::Null,
+            formula: None,
+            identity_formula: None,
+            array_ref: None,
+        },
+        CellData {
+            cell_id: cell_uuid(27),
+            row: 2,
+            col: 3,
+            value: CellValue::Null,
+            formula: None,
+            identity_formula: None,
+            array_ref: None,
+        },
     ];
 
     let sheet = SheetSnapshot {
@@ -541,6 +561,59 @@ fn cse_set_array_formula_preserves_array_value_and_projection() {
         0,
         "D3 (CSE projection member) missing HAS_FORMULA: flags=0x{:04x}",
         d3.flags,
+    );
+
+    // Read APIs should expose the formula-owning anchor's formula for covered
+    // CSE members. The formula remains stored on the anchor, but formula-bar
+    // consumers must see the same authored formula at every cell in the CSE
+    // rectangle.
+    let d2_id = cell_types::CellId::from_uuid_str(
+        &engine
+            .get_cell_id_at(&sheet_id, 1, 3)
+            .expect("D2 CSE member should have a cell id"),
+    )
+    .expect("D2 cell id should parse");
+    let d2_active = engine.get_active_cell(&sheet_id, &d2_id);
+    assert_eq!(
+        d2_active.formula.as_deref(),
+        Some("=A1:A3*B1:B3"),
+        "D2 active-cell read should expose the CSE anchor formula"
+    );
+
+    let metadata: snapshot_types::properties::CellMetadata = serde_json::from_value(
+        d2_active
+            .metadata
+            .clone()
+            .expect("D2 active cell should expose CSE metadata"),
+    )
+    .expect("D2 metadata should deserialize");
+    assert!(metadata.is_array_formula);
+    assert!(metadata.is_array_member);
+    assert!(matches!(
+        metadata.region.as_ref().map(|region| region.kind),
+        Some(snapshot_types::properties::RegionKind::CseArray)
+    ));
+
+    let d2_raw = engine
+        .get_raw_cell_data(&sheet_id, 1, 3, true)
+        .expect("D2 raw cell data should exist");
+    assert_eq!(
+        d2_raw.formula.as_deref(),
+        Some("=A1:A3*B1:B3"),
+        "D2 raw-cell-data read should expose the CSE anchor formula"
+    );
+    assert!(matches!(
+        d2_raw.computed,
+        Some(value_types::CellValue::Number(n)) if (n.get() - 40.0).abs() < 1e-9
+    ));
+
+    let d2_cell_data = engine
+        .get_cell_data(&sheet_id, 1, 3)
+        .expect("D2 cell data should exist");
+    assert_eq!(
+        d2_cell_data.get("formula").and_then(|value| value.as_str()),
+        Some("A1:A3*B1:B3"),
+        "D2 cell-data read should expose the CSE anchor formula body"
     );
 
     // 5. Assert partial write to D2 returns PartialArrayWrite error.


### PR DESCRIPTION
Public behavior fixed: Fix CSE array formula-bar readback

Verification:
- Reproduced before the change and passed after the change before submission.

Changed paths:
```
compute/core/src/storage/engine/cell_semantics.rs
compute/core/src/storage/engine/formula_read.rs
compute/core/src/storage/engine/mod.rs
compute/core/src/storage/engine/queries/cell_regions.rs
compute/core/src/storage/engine/viewport/functions/active_cell.rs
compute/core/tests/cse_viewport_has_formula_flag.rs
```
