### PR TITLE
Fix chart insertion from first-column label ranges

### DIFF
--- a/apps/spreadsheet/src/actions/handlers/__tests__/charts.test.ts
+++ b/apps/spreadsheet/src/actions/handlers/__tests__/charts.test.ts
@@ -1287,6 +1287,35 @@ describe('Chart Handlers - Current-Region Auto-Expansion', () => {
       expect(addedConfig.dataRange).toBe('A1:D6');
     });
 
+    it('adds explicit series references for first-column label ranges', async () => {
+      const deps = createDepsWithSelection({
+        ranges: [{ startRow: 0, startCol: 0, endRow: 4, endCol: 3 }],
+      });
+      const sourceValues = [
+        ['Revenue', 100500, 100900, 100000],
+        ['yoy', null, 0.003980099502487455, -0.008919722497522264],
+        ['OP', 4400, 7800, 7400],
+        ['yoy', null, 0.7727272727272727, -0.05128205128205132],
+        ['OPM', 0.04378109452736319, 0.07730426164519326, 0.074],
+      ];
+      const ws = (deps.workbook as any).activeSheet;
+      ws.getValue = jest.fn(
+        async (row: number, col: number) => sourceValues[row]?.[col] ?? null,
+      );
+
+      const result = await ChartHandlers.CREATE_EMBEDDED_CHART(deps);
+      expect(result.handled).toBe(true);
+
+      const addedConfig = ws.charts.add.mock.calls[0][0];
+      expect(addedConfig.dataRange).toBe('A1:D5');
+      expect(addedConfig.seriesOrientation).toBe('rows');
+      expect(addedConfig.series).toEqual([
+        { values: 'B1:B5', categories: 'A1:A5' },
+        { values: 'C1:C5', categories: 'A1:A5' },
+        { values: 'D1:D5', categories: 'A1:A5' },
+      ]);
+    });
+
     it('uses edit-start multi-cell selection when active selection collapsed during enter-mode', async () => {
       const deps = createDepsWithSelection({
         ranges: [{ startRow: 2, startCol: 12, endRow: 2, endCol: 12 }],

--- a/apps/spreadsheet/src/actions/handlers/charts.ts
+++ b/apps/spreadsheet/src/actions/handlers/charts.ts
@@ -61,6 +61,11 @@ type ChartSourceRange = {
   endCol: number;
 };
 
+type ChartSeriesConfig = NonNullable<ChartConfig['series']>[number];
+type CellValueReader = {
+  getValue?: (row: number, col: number) => unknown | Promise<unknown>;
+};
+
 /**
  * Type guard to check if coordinator exposes renderer capabilities.
  */
@@ -102,6 +107,96 @@ function getChartSourceRanges(deps: ActionDependencies, sheetId: SheetId): Chart
   }
 
   return deps.accessors.selection.getDataBoundedRanges(sheetId);
+}
+
+function isBlankCellValue(value: unknown): boolean {
+  return value === null || value === undefined || value === '';
+}
+
+function isNumericCellValue(value: unknown): boolean {
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value !== 'string' || value.trim() === '') return false;
+  return Number.isFinite(Number(value));
+}
+
+async function readChartSourceValue(
+  worksheet: unknown,
+  row: number,
+  col: number,
+): Promise<unknown> {
+  const getValue = (worksheet as CellValueReader | null)?.getValue;
+  if (typeof getValue !== 'function') return null;
+  try {
+    return await getValue.call(worksheet, row, col);
+  } catch {
+    return null;
+  }
+}
+
+async function inferFirstColumnLabelSeries(
+  worksheet: unknown,
+  range: ChartSourceRange,
+): Promise<ChartSeriesConfig[] | undefined> {
+  if (range.startRow === range.endRow || range.startCol === range.endCol) return undefined;
+
+  let firstColumnLabels = 0;
+  let firstColumnNumeric = 0;
+  for (let row = range.startRow; row <= range.endRow; row += 1) {
+    const value = await readChartSourceValue(worksheet, row, range.startCol);
+    if (isBlankCellValue(value)) continue;
+    if (isNumericCellValue(value)) {
+      firstColumnNumeric += 1;
+    } else {
+      firstColumnLabels += 1;
+    }
+  }
+
+  let firstRowValueCount = 0;
+  let firstRowLabelCount = 0;
+  for (let col = range.startCol + 1; col <= range.endCol; col += 1) {
+    const value = await readChartSourceValue(worksheet, range.startRow, col);
+    if (isBlankCellValue(value)) continue;
+    if (isNumericCellValue(value)) {
+      firstRowValueCount += 1;
+    } else {
+      firstRowLabelCount += 1;
+    }
+  }
+
+  if (firstColumnLabels < 2 || firstColumnNumeric > 0) return undefined;
+  if (firstRowValueCount === 0 || firstRowLabelCount > 0) return undefined;
+
+  const categories = rangeToA1Notation({
+    startRow: range.startRow,
+    startCol: range.startCol,
+    endRow: range.endRow,
+    endCol: range.startCol,
+  });
+  const series: ChartSeriesConfig[] = [];
+
+  for (let col = range.startCol + 1; col <= range.endCol; col += 1) {
+    let hasNumericValues = false;
+    for (let row = range.startRow; row <= range.endRow; row += 1) {
+      const value = await readChartSourceValue(worksheet, row, col);
+      if (isNumericCellValue(value)) {
+        hasNumericValues = true;
+        break;
+      }
+    }
+    if (!hasNumericValues) continue;
+
+    series.push({
+      values: rangeToA1Notation({
+        startRow: range.startRow,
+        startCol: col,
+        endRow: range.endRow,
+        endCol: col,
+      }),
+      categories,
+    });
+  }
+
+  return series.length > 0 ? series : undefined;
 }
 
 /**
@@ -926,6 +1021,7 @@ export const CREATE_EMBEDDED_CHART: AsyncActionHandler = async (
     // surrounding data region. Multi-row selections pass through unchanged.
     const range = await resolveChartSourceRange(ws, ranges[0], { trimHiddenDetail: true });
     const dataRange = rangeToA1Notation(range);
+    const inferredSeries = await inferFirstColumnLabelSeries(ws, range);
 
     // Use smart positioning to ensure chart is visible
     const position = await getSmartChartPosition(deps, range, DEFAULT_POSITION, sheetId);
@@ -934,6 +1030,12 @@ export const CREATE_EMBEDDED_CHART: AsyncActionHandler = async (
       type: chartType,
       subType: chartSubType,
       dataRange,
+      ...(inferredSeries
+        ? {
+            series: inferredSeries,
+            seriesOrientation: 'rows' as const,
+          }
+        : {}),
       anchorRow: position.anchorRow,
       anchorCol: position.anchorCol,
       width: DEFAULT_WIDTH_CELLS,

--- a/charts/src/core/__tests__/data-extractor-provenance.test.ts
+++ b/charts/src/core/__tests__/data-extractor-provenance.test.ts
@@ -73,6 +73,41 @@ describe('chart data point value provenance', () => {
     ]);
   });
 
+  it('keeps first-row values when the first column contains row labels', () => {
+    const accessor = ObjectCellAccessor.fromArray([
+      ['Revenue', 100500, 100900, 100000],
+      ['yoy', null, 0.003980099502487455, -0.008919722497522264],
+      ['OP', 4400, 7800, 7400],
+      ['yoy', null, 0.7727272727272727, -0.05128205128205132],
+      ['OPM', 0.04378109452736319, 0.07730426164519326, 0.074],
+    ]);
+
+    const data = extractChartDataFromRange(accessor, parseRange('A1:D5'));
+
+    expect(data.categories).toEqual(['Revenue', 'yoy', 'OP', 'yoy', 'OPM']);
+    expect(data.series[0].data.map((point) => point.y)).toEqual([
+      100500,
+      0,
+      4400,
+      0,
+      0.04378109452736319,
+    ]);
+    expect(data.series[1].data.map((point) => point.y)).toEqual([
+      100900,
+      0.003980099502487455,
+      7800,
+      0.7727272727272727,
+      0.07730426164519326,
+    ]);
+    expect(data.series[2].data.map((point) => point.y)).toEqual([
+      100000,
+      -0.008919722497522264,
+      7400,
+      -0.05128205128205132,
+      0.074,
+    ]);
+  });
+
   it('applies provenance to imported series value ranges', () => {
     const accessor = ObjectCellAccessor.fromArray([
       [0, null, '', Number.POSITIVE_INFINITY, 'oops'],

--- a/charts/src/core/data-extractor-range.ts
+++ b/charts/src/core/data-extractor-range.ts
@@ -52,6 +52,83 @@ export function detectSeriesOrientation(range: CellRange): SeriesOrientation {
   return colCount > rowCount ? 'rows' : 'columns';
 }
 
+type EdgeValueStats = {
+  labels: number;
+  numeric: number;
+};
+
+function collectEdgeStats(values: ChartCellValue[]): EdgeValueStats {
+  let labels = 0;
+  let numeric = 0;
+
+  for (const value of values) {
+    if (!hasCellValue(value)) continue;
+    if (isNumericLike(value)) {
+      numeric += 1;
+    } else {
+      labels += 1;
+    }
+  }
+
+  return { labels, numeric };
+}
+
+function firstColumnValues(
+  accessor: CellDataAccessor,
+  range: CellRange,
+  options?: { skipTopCell?: boolean },
+): ChartCellValue[] {
+  const values: ChartCellValue[] = [];
+  const startRow = options?.skipTopCell ? range.startRow + 1 : range.startRow;
+  for (let row = startRow; row <= range.endRow; row += 1) {
+    values.push(getRangeValue(accessor, range, row, range.startCol));
+  }
+  return values;
+}
+
+function firstRowValues(
+  accessor: CellDataAccessor,
+  range: CellRange,
+  options?: { skipLeftCell?: boolean },
+): ChartCellValue[] {
+  const values: ChartCellValue[] = [];
+  const startCol = options?.skipLeftCell ? range.startCol + 1 : range.startCol;
+  for (let col = startCol; col <= range.endCol; col += 1) {
+    values.push(getRangeValue(accessor, range, range.startRow, col));
+  }
+  return values;
+}
+
+function detectSeriesOrientationFromValues(
+  accessor: CellDataAccessor,
+  range: CellRange,
+): SeriesOrientation {
+  const shapeOrientation = detectSeriesOrientation(range);
+  const rowCount = range.endRow - range.startRow + 1;
+  const colCount = range.endCol - range.startCol + 1;
+  if (rowCount === 1 || colCount === 1) return shapeOrientation;
+
+  const firstColumn = collectEdgeStats(firstColumnValues(accessor, range));
+  const firstColumnBelowTop = collectEdgeStats(
+    firstColumnValues(accessor, range, { skipTopCell: true }),
+  );
+  const firstRow = collectEdgeStats(firstRowValues(accessor, range));
+  const firstRowAfterLeft = collectEdgeStats(
+    firstRowValues(accessor, range, { skipLeftCell: true }),
+  );
+  const firstColumnIsLabels = firstColumn.labels >= 2 && firstColumn.numeric === 0;
+  const firstColumnBelowTopIsNumeric =
+    firstColumnBelowTop.numeric >= 2 && firstColumnBelowTop.labels === 0;
+  const firstRowIsLabels = firstRow.labels >= 2 && firstRow.numeric === 0;
+  const firstRowAfterLeftIsNumeric =
+    firstRowAfterLeft.numeric >= 2 && firstRowAfterLeft.labels === 0;
+
+  if (firstColumnIsLabels && firstRowAfterLeftIsNumeric) return 'rows';
+  if (firstRowIsLabels && firstColumnBelowTopIsNumeric) return 'columns';
+
+  return shapeOrientation;
+}
+
 /**
  * Extract chart data from a pre-resolved CellRange.
  *
@@ -74,7 +151,7 @@ export function extractChartDataFromRange(
     seriesOrientation?: SeriesOrientation;
   },
 ): ChartData {
-  const orientation = options?.seriesOrientation || detectSeriesOrientation(dataRange);
+  const shapeOrientation = options?.seriesOrientation || detectSeriesOrientation(dataRange);
   const hasExplicitLayout = Boolean(
     options?.seriesOrientation || options?.categoryRange || options?.seriesRange,
   );
@@ -120,7 +197,7 @@ export function extractChartDataFromRange(
   if (options?.chartType === 'bubble') {
     const bubbleData = extractBubbleChartDataFromRange(accessor, dataRange, {
       ...options,
-      seriesOrientation: orientation,
+      seriesOrientation: shapeOrientation,
     });
     if (bubbleData) return bubbleData;
   }
@@ -128,6 +205,9 @@ export function extractChartDataFromRange(
   if (!hasExplicitLayout && hasExcelTableShape(accessor, dataRange)) {
     return extractExcelTableData(accessor, dataRange);
   }
+
+  const orientation =
+    options?.seriesOrientation || detectSeriesOrientationFromValues(accessor, dataRange);
 
   // Extract categories
   let categories: (string | number)[] = [];


### PR DESCRIPTION
Public behavior fixed: Fix chart insertion from first-column label ranges

Verification:
- Reproduced before the change and passed after the change before submission.

Changed paths:
```
apps/spreadsheet/src/actions/handlers/__tests__/charts.test.ts
apps/spreadsheet/src/actions/handlers/charts.ts
charts/src/core/__tests__/data-extractor-provenance.test.ts
charts/src/core/data-extractor-range.ts
```
