### PR TITLE
Fix imported row height resize round trips

### DIFF
--- a/apps/spreadsheet/src/hooks/shared/__tests__/use-grid-mouse-scrollbar.test.ts
+++ b/apps/spreadsheet/src/hooks/shared/__tests__/use-grid-mouse-scrollbar.test.ts
@@ -96,7 +96,7 @@ function isInGridArea(clientX: number, clientY: number): boolean {
  * Returns { container, handler } where handler is a jest.fn() that's called
  * only when the pointer event passes the scrollbar guard (i.e., is in the grid area).
  */
-function createGuardedContainer() {
+function createGuardedContainer(options: { isHeaderResizeActive?: () => boolean } = {}) {
   const container = document.createElement('div');
   document.body.appendChild(container);
 
@@ -129,7 +129,13 @@ function createGuardedContainer() {
     const rect = container.getBoundingClientRect();
     const relX = e.clientX - rect.left;
     const relY = e.clientY - rect.top;
-    if (relX >= rect.width - SCROLL_BAR_WIDTH || relY >= rect.height - SCROLL_BAR_WIDTH) return;
+    const isHeaderResizeActive = options.isHeaderResizeActive?.() ?? false;
+    if (
+      !isHeaderResizeActive &&
+      (relX >= rect.width - SCROLL_BAR_WIDTH || relY >= rect.height - SCROLL_BAR_WIDTH)
+    ) {
+      return;
+    }
     handleMouseMove(e);
   });
 
@@ -344,6 +350,19 @@ describe('Scrollbar region guard (handlePointerMove)', () => {
     // Move back into grid area — should be accepted again
     firePointerMove(container, CONTAINER_LEFT + 300, CONTAINER_TOP + 300);
     expect(handleMouseMove).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps header resize active when pointer moves into scrollbar region', () => {
+    document.body.removeChild(container);
+    ({ container, handleMouseDown, handleMouseMove } = createGuardedContainer({
+      isHeaderResizeActive: () => true,
+    }));
+
+    firePointerMove(container, CONTAINER_LEFT + 250, CONTAINER_TOP + CONTAINER_HEIGHT - 3);
+    firePointerMove(container, CONTAINER_LEFT + CONTAINER_WIDTH - 3, CONTAINER_TOP + 250);
+
+    expect(handleMouseMove).toHaveBeenCalledTimes(2);
+    expect(handleMouseDown).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/spreadsheet/src/hooks/shared/use-grid-mouse.ts
+++ b/apps/spreadsheet/src/hooks/shared/use-grid-mouse.ts
@@ -2035,7 +2035,12 @@ export function useGridMouse(options: UseGridMouseOptions): UseGridMouseReturn {
       const rect = container.getBoundingClientRect();
       const relX = e.clientX - rect.left;
       const relY = e.clientY - rect.top;
-      if (relX >= rect.width - SCROLL_BAR_WIDTH || relY >= rect.height - SCROLL_BAR_WIDTH) return;
+      if (
+        !selection.isResizingHeader &&
+        (relX >= rect.width - SCROLL_BAR_WIDTH || relY >= rect.height - SCROLL_BAR_WIDTH)
+      ) {
+        return;
+      }
 
       handleMouseMove(e);
     };

--- a/compute/core/src/storage/engine/construction/indexes.rs
+++ b/compute/core/src/storage/engine/construction/indexes.rs
@@ -243,10 +243,12 @@ pub(in crate::storage::engine) fn build_layout_indexes_from_parse_output_range(
             .map(|c| c.col as usize)
             .collect();
 
-        let _gi = grid_indexes.get(&sheet_id);
+        let gi = grid_indexes.get(&sheet_id);
+        let row_count = layout_row_count_from_parse_output(sheet_snap.rows, dims, gi);
+        let col_count = layout_col_count_from_parse_output(sheet_snap.cols, dims, gi);
         let li = LayoutIndex::from_sparse(
-            sheet_snap.rows as usize,
-            sheet_snap.cols as usize,
+            row_count,
+            col_count,
             default_row_height_px,
             default_col_width_px,
             custom_row_heights,
@@ -257,6 +259,36 @@ pub(in crate::storage::engine) fn build_layout_indexes_from_parse_output_range(
         indexes.insert(sheet_id, li);
     }
     Ok(indexes)
+}
+
+fn layout_row_count_from_parse_output(
+    snapshot_rows: u32,
+    dims: &domain_types::SheetDimensions,
+    grid_index: Option<&GridIndex>,
+) -> usize {
+    let mut count = snapshot_rows as usize;
+    if let Some(grid) = grid_index {
+        count = count.max(grid.row_count() as usize);
+    }
+    for row in &dims.row_heights {
+        count = count.max(row.row.saturating_add(1) as usize);
+    }
+    count
+}
+
+fn layout_col_count_from_parse_output(
+    snapshot_cols: u32,
+    dims: &domain_types::SheetDimensions,
+    grid_index: Option<&GridIndex>,
+) -> usize {
+    let mut count = snapshot_cols as usize;
+    if let Some(grid) = grid_index {
+        count = count.max(grid.col_count() as usize);
+    }
+    for col in &dims.col_widths {
+        count = count.max(col.col.saturating_add(1) as usize);
+    }
+    count
 }
 
 /// Build merge spatial indexes for every sheet.
@@ -375,9 +407,12 @@ pub(in crate::storage::engine) fn build_layout_index_for_sheet(
     ));
     hidden_cols.sort_unstable();
     hidden_cols.dedup();
+    let row_count = layout_row_count_from_yrs(rows, grid_index, &custom_row_heights, &hidden_rows);
+    let col_count = layout_col_count_from_yrs(cols, grid_index, &custom_col_widths, &hidden_cols);
+
     LayoutIndex::from_sparse(
-        rows as usize,
-        cols as usize,
+        row_count,
+        col_count,
         default_row_height_px,
         default_col_width_px,
         custom_row_heights,
@@ -385,4 +420,42 @@ pub(in crate::storage::engine) fn build_layout_index_for_sheet(
         hidden_rows.into_iter().map(|r| r as usize),
         hidden_cols.into_iter().map(|c| c as usize),
     )
+}
+
+fn layout_row_count_from_yrs(
+    snapshot_rows: u32,
+    grid_index: Option<&GridIndex>,
+    custom_row_heights: &[(usize, domain_types::units::Pixels)],
+    hidden_rows: &[u32],
+) -> usize {
+    let mut count = snapshot_rows as usize;
+    if let Some(grid) = grid_index {
+        count = count.max(grid.row_count() as usize);
+    }
+    for (row, _) in custom_row_heights {
+        count = count.max(row.saturating_add(1));
+    }
+    for row in hidden_rows {
+        count = count.max(row.saturating_add(1) as usize);
+    }
+    count
+}
+
+fn layout_col_count_from_yrs(
+    snapshot_cols: u32,
+    grid_index: Option<&GridIndex>,
+    custom_col_widths: &[(usize, domain_types::units::Pixels)],
+    hidden_cols: &[u32],
+) -> usize {
+    let mut count = snapshot_cols as usize;
+    if let Some(grid) = grid_index {
+        count = count.max(grid.col_count() as usize);
+    }
+    for (col, _) in custom_col_widths {
+        count = count.max(col.saturating_add(1));
+    }
+    for col in hidden_cols {
+        count = count.max(col.saturating_add(1) as usize);
+    }
+    count
 }

--- a/compute/core/src/storage/engine/services/queries/dimensions.rs
+++ b/compute/core/src/storage/engine/services/queries/dimensions.rs
@@ -153,12 +153,17 @@ pub(in crate::storage::engine) fn get_data_bounds(
 // -------------------------------------------------------------------
 
 /// Returns row height in **pixels** (for TypeScript bridge).
-/// Reads canonical (points) from Yrs and converts.
+/// Prefer LayoutIndex so readback matches the renderer, including imported
+/// sheet-level defaults.
 pub(in crate::storage::engine) fn get_row_height_query(
     stores: &EngineStores,
     sheet_id: &SheetId,
     row: u32,
 ) -> Pixels {
+    if let Some(layout) = stores.layout_indexes.get(sheet_id) {
+        return layout.get_row_height(row as usize);
+    }
+
     let height_pt = sheet_dimensions::get_row_height(
         stores.storage.doc(),
         stores.storage.sheets(),
@@ -174,12 +179,17 @@ pub(in crate::storage::engine) fn get_row_height_query(
 }
 
 /// Returns column width in **pixels** (for TypeScript bridge).
-/// Reads canonical (char-width) from Yrs and converts.
+/// Prefer LayoutIndex so readback matches the renderer, including imported
+/// sheet-level defaults.
 pub(in crate::storage::engine) fn get_col_width_query(
     stores: &EngineStores,
     sheet_id: &SheetId,
     col: u32,
 ) -> Pixels {
+    if let Some(layout) = stores.layout_indexes.get(sheet_id) {
+        return layout.get_col_width(col as usize);
+    }
+
     let width_cw = sheet_dimensions::get_col_width(
         stores.storage.doc(),
         stores.storage.sheets(),
@@ -222,23 +232,7 @@ pub(in crate::storage::engine) fn get_row_heights_batch(
     end_row: u32,
 ) -> Vec<(u32, Pixels)> {
     (start_row..=end_row)
-        .map(|row| {
-            let pt = sheet_dimensions::get_row_height(
-                stores.storage.doc(),
-                stores.storage.sheets(),
-                sheet_id,
-                row,
-                stores.grid_indexes.get(sheet_id),
-            );
-            (
-                row,
-                if pt.0 == 0.0 {
-                    Pixels(0.0)
-                } else {
-                    domain_types::units::points_to_pixels(pt)
-                },
-            )
-        })
+        .map(|row| (row, get_row_height_query(stores, sheet_id, row)))
         .collect()
 }
 
@@ -286,25 +280,8 @@ pub(in crate::storage::engine) fn get_col_widths_batch(
     start_col: u32,
     end_col: u32,
 ) -> Vec<(u32, Pixels)> {
-    let mdw = domain_types::units::platform_mdw();
     (start_col..=end_col)
-        .map(|col| {
-            let cw = sheet_dimensions::get_col_width(
-                stores.storage.doc(),
-                stores.storage.sheets(),
-                sheet_id,
-                col,
-                stores.grid_indexes.get(sheet_id),
-            );
-            (
-                col,
-                if cw.0 == 0.0 {
-                    Pixels(0.0)
-                } else {
-                    domain_types::units::char_width_to_pixels(cw, mdw)
-                },
-            )
-        })
+        .map(|col| (col, get_col_width_query(stores, sheet_id, col)))
         .collect()
 }
 

--- a/compute/core/src/storage/engine/tests/test_queries.rs
+++ b/compute/core/src/storage/engine/tests/test_queries.rs
@@ -3,6 +3,7 @@
 use super::super::*;
 use super::helpers::*;
 use crate::snapshot::{SheetSnapshot, WorkbookSnapshot};
+use domain_types::{ParseOutput, RowDimension, SheetData, SheetDimensions};
 use value_types::{CellValue, FiniteF64};
 
 // -------------------------------------------------------------------
@@ -284,5 +285,121 @@ fn batch_column_width_setters_update_queries_and_dimension_changes() {
     assert_eq!(
         engine.get_col_widths_batch_chars(&sid, 6, 7),
         vec![(6, 10.0), (7, 11.0)]
+    );
+}
+
+#[test]
+fn imported_custom_row_height_is_available_to_layout_queries() {
+    let row = 38;
+    let height_pt = 12.75;
+    let input = ParseOutput {
+        sheets: vec![SheetData {
+            name: "Dimensions".to_string(),
+            rows: 1,
+            cols: 1,
+            dimensions: SheetDimensions {
+                default_row_height: Some(15.0),
+                row_heights: vec![RowDimension {
+                    row,
+                    height: height_pt,
+                    custom_height: true,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let engine = engine_from_parse_output_normal(&input);
+    let sid = *engine.mirror().sheet_ids().next().expect("sheet present");
+    let expected_px =
+        domain_types::units::points_to_pixels(domain_types::units::Points(height_pt)).0;
+
+    let queried = engine.get_row_height_query(&sid, row);
+    assert!(
+        (queried - expected_px).abs() < 0.01,
+        "expected imported row height {expected_px}px from query, got {queried}px"
+    );
+
+    let indexed = engine.get_row_height_from_index(&sid, row);
+    assert!(
+        (indexed - expected_px).abs() < 0.01,
+        "expected imported row height {expected_px}px from layout index, got {indexed}px"
+    );
+}
+
+#[test]
+fn imported_sheet_default_dimensions_are_available_to_layout_queries() {
+    let row = 38;
+    let col = 11;
+    let default_row_height_pt = 12.75;
+    let default_col_width_cw = 12.0;
+    let input = ParseOutput {
+        sheets: vec![SheetData {
+            name: "Defaults".to_string(),
+            rows: 1,
+            cols: 1,
+            dimensions: SheetDimensions {
+                default_row_height: Some(default_row_height_pt),
+                default_col_width: Some(default_col_width_cw),
+                ..Default::default()
+            },
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let engine = engine_from_parse_output_normal(&input);
+    let sid = *engine.mirror().sheet_ids().next().expect("sheet present");
+    let expected_row_px = domain_types::units::points_to_pixels(domain_types::units::Points(
+        default_row_height_pt,
+    ))
+    .0;
+    let expected_col_px = domain_types::units::char_width_to_pixels(
+        domain_types::units::CharWidth(default_col_width_cw),
+        domain_types::units::platform_mdw(),
+    )
+    .0;
+
+    let default_row = engine.get_default_row_height(&sid);
+    assert!(
+        (default_row - expected_row_px).abs() < 0.01,
+        "expected imported default row height {expected_row_px}px, got {default_row}px"
+    );
+    let queried_row = engine.get_row_height_query(&sid, row);
+    assert!(
+        (queried_row - expected_row_px).abs() < 0.01,
+        "expected row height query to use imported default {expected_row_px}px, got {queried_row}px"
+    );
+    assert_eq!(
+        engine.get_row_heights_batch(&sid, row, row),
+        vec![(row, queried_row)]
+    );
+    let indexed_row = engine.get_row_height_from_index(&sid, row);
+    assert!(
+        (indexed_row - expected_row_px).abs() < 0.01,
+        "expected layout index to use imported default row height {expected_row_px}px, got {indexed_row}px"
+    );
+
+    let default_col = engine.get_default_col_width(&sid);
+    assert!(
+        (default_col - expected_col_px).abs() < 0.01,
+        "expected imported default column width {expected_col_px}px, got {default_col}px"
+    );
+    let queried_col = engine.get_col_width_query(&sid, col);
+    assert!(
+        (queried_col - expected_col_px).abs() < 0.01,
+        "expected column width query to use imported default {expected_col_px}px, got {queried_col}px"
+    );
+    assert_eq!(
+        engine.get_col_widths_batch(&sid, col, col),
+        vec![(col, queried_col)]
+    );
+    let indexed_col = engine.get_col_width_from_index(&sid, col);
+    assert!(
+        (indexed_col - expected_col_px).abs() < 0.01,
+        "expected layout index to use imported default column width {expected_col_px}px, got {indexed_col}px"
     );
 }

--- a/compute/core/src/storage/infra/hydration/sheet/identity.rs
+++ b/compute/core/src/storage/infra/hydration/sheet/identity.rs
@@ -29,6 +29,19 @@ pub(crate) fn sheet_identity_extent(sheet: &SheetData) -> (u32, u32) {
         cols = cols.max(cell.col.saturating_add(1));
     }
 
+    for row_dimension in &sheet.dimensions.row_heights {
+        rows = rows.max(row_dimension.row.saturating_add(1));
+    }
+    for col_dimension in &sheet.dimensions.col_widths {
+        cols = cols.max(col_dimension.col.saturating_add(1));
+    }
+    for row_style in &sheet.row_styles {
+        rows = rows.max(row_style.row.saturating_add(1));
+    }
+    for col_style in &sheet.col_styles {
+        cols = cols.max(col_style.col.saturating_add(1));
+    }
+
     for &(row, col) in collect_identity_required_anchors(sheet).keys() {
         rows = rows.max(row.saturating_add(1));
         cols = cols.max(col.saturating_add(1));


### PR DESCRIPTION
Public behavior fixed: Fix imported row height resize round trips

Verification:
- Reproduced before the change and passed after the change before submission.

Changed paths:
```
apps/spreadsheet/src/hooks/shared/__tests__/use-grid-mouse-scrollbar.test.ts
apps/spreadsheet/src/hooks/shared/use-grid-mouse.ts
compute/core/src/storage/engine/construction/indexes.rs
compute/core/src/storage/engine/services/queries/dimensions.rs
compute/core/src/storage/engine/tests/test_queries.rs
compute/core/src/storage/infra/hydration/sheet/identity.rs
```
