### PR TITLE
Fix formulas after deleting spreadsheet columns

### DIFF
--- a/compute/api/tests/delete_columns_ref_error.rs
+++ b/compute/api/tests/delete_columns_ref_error.rs
@@ -177,3 +177,64 @@ fn delete_column_shifts_surviving_ref() {
     // (deleting an unrelated middle column doesn't change a `=C1` result —
     // C1 just shifts). The point is the test passes either way without #REF!.
 }
+
+#[test]
+fn delete_column_retargets_shifted_formula_to_previous_column() {
+    let (wb, _) = Workbook::from_snapshot(blank_snapshot()).unwrap();
+    let sheet = wb.sheet_by_index(0).unwrap();
+
+    sheet.set_cell("K14", "100").unwrap();
+    sheet.set_cell("L14", "200").unwrap();
+    sheet.set_cell("M35", "0.25").unwrap();
+    sheet.set_cell("M14", "=L14*(1+M35)").unwrap();
+
+    let res = sheet.structure().delete_columns(11, 1).unwrap();
+
+    let l14 = res
+        .recalc
+        .changed_cells
+        .iter()
+        .find(|c| {
+            c.position
+                .as_ref()
+                .map_or(false, |p| p.row == 13 && p.col == 11)
+        })
+        .expect("L14 should be recalculated after deleting column L");
+
+    use value_types::{CellValue, FiniteF64};
+    assert_eq!(
+        l14.value,
+        CellValue::Number(FiniteF64::must(125.0)),
+        "shifted formula should recalculate from the previous surviving column"
+    );
+}
+
+#[test]
+fn delete_column_retargets_shifted_formula_to_empty_previous_column() {
+    let (wb, _) = Workbook::from_snapshot(blank_snapshot()).unwrap();
+    let sheet = wb.sheet_by_index(0).unwrap();
+
+    sheet.set_cell("L14", "200").unwrap();
+    sheet.set_cell("M35", "0.25").unwrap();
+    sheet.set_cell("M14", "=L14*(1+M35)").unwrap();
+
+    let res = sheet.structure().delete_columns(11, 1).unwrap();
+
+    let l14 = res
+        .recalc
+        .changed_cells
+        .iter()
+        .find(|c| {
+            c.position
+                .as_ref()
+                .map_or(false, |p| p.row == 13 && p.col == 11)
+        })
+        .expect("L14 should be recalculated after deleting column L");
+
+    use value_types::{CellValue, FiniteF64};
+    assert_eq!(
+        l14.value,
+        CellValue::Number(FiniteF64::must(0.0)),
+        "shifted formula should reference the empty previous surviving column"
+    );
+}

--- a/compute/api/tests/delete_columns_ref_error.rs
+++ b/compute/api/tests/delete_columns_ref_error.rs
@@ -210,6 +210,37 @@ fn delete_column_retargets_shifted_formula_to_previous_column() {
 }
 
 #[test]
+fn delete_column_retargets_shifted_absolute_formula_to_previous_column() {
+    let (wb, _) = Workbook::from_snapshot(blank_snapshot()).unwrap();
+    let sheet = wb.sheet_by_index(0).unwrap();
+
+    sheet.set_cell("K14", "100").unwrap();
+    sheet.set_cell("L14", "200").unwrap();
+    sheet.set_cell("M35", "0.25").unwrap();
+    sheet.set_cell("M14", "=$L14*(1+$M$35)").unwrap();
+
+    let res = sheet.structure().delete_columns(11, 1).unwrap();
+
+    let l14 = res
+        .recalc
+        .changed_cells
+        .iter()
+        .find(|c| {
+            c.position
+                .as_ref()
+                .map_or(false, |p| p.row == 13 && p.col == 11)
+        })
+        .expect("L14 should be recalculated after deleting column L");
+
+    use value_types::{CellValue, FiniteF64};
+    assert_eq!(
+        l14.value,
+        CellValue::Number(FiniteF64::must(125.0)),
+        "absolute shifted formula should recalculate from the previous surviving column"
+    );
+}
+
+#[test]
 fn delete_column_retargets_shifted_formula_to_empty_previous_column() {
     let (wb, _) = Workbook::from_snapshot(blank_snapshot()).unwrap();
     let sheet = wb.sheet_by_index(0).unwrap();
@@ -236,5 +267,97 @@ fn delete_column_retargets_shifted_formula_to_empty_previous_column() {
         l14.value,
         CellValue::Number(FiniteF64::must(0.0)),
         "shifted formula should reference the empty previous surviving column"
+    );
+}
+
+#[test]
+fn delete_row_retargets_shifted_formula_to_previous_row() {
+    let (wb, _) = Workbook::from_snapshot(blank_snapshot()).unwrap();
+    let sheet = wb.sheet_by_index(0).unwrap();
+
+    sheet.set_cell("A10", "100").unwrap();
+    sheet.set_cell("A11", "200").unwrap();
+    sheet.set_cell("B12", "0.25").unwrap();
+    sheet.set_cell("A12", "=A11*(1+B12)").unwrap();
+
+    let res = sheet.structure().delete_rows(10, 1).unwrap();
+
+    let a11 = res
+        .recalc
+        .changed_cells
+        .iter()
+        .find(|c| {
+            c.position
+                .as_ref()
+                .map_or(false, |p| p.row == 10 && p.col == 0)
+        })
+        .expect("A11 should be recalculated after deleting row 11");
+
+    use value_types::{CellValue, FiniteF64};
+    assert_eq!(
+        a11.value,
+        CellValue::Number(FiniteF64::must(125.0)),
+        "shifted formula should recalculate from the previous surviving row"
+    );
+}
+
+#[test]
+fn delete_row_retargets_shifted_absolute_formula_to_previous_row() {
+    let (wb, _) = Workbook::from_snapshot(blank_snapshot()).unwrap();
+    let sheet = wb.sheet_by_index(0).unwrap();
+
+    sheet.set_cell("A10", "100").unwrap();
+    sheet.set_cell("A11", "200").unwrap();
+    sheet.set_cell("B12", "0.25").unwrap();
+    sheet.set_cell("A12", "=$A$11*(1+$B$12)").unwrap();
+
+    let res = sheet.structure().delete_rows(10, 1).unwrap();
+
+    let a11 = res
+        .recalc
+        .changed_cells
+        .iter()
+        .find(|c| {
+            c.position
+                .as_ref()
+                .map_or(false, |p| p.row == 10 && p.col == 0)
+        })
+        .expect("A11 should be recalculated after deleting row 11");
+
+    use value_types::{CellValue, FiniteF64};
+    assert_eq!(
+        a11.value,
+        CellValue::Number(FiniteF64::must(125.0)),
+        "absolute shifted formula should recalculate from the previous surviving row"
+    );
+}
+
+#[test]
+fn delete_row_retargets_shifted_formula_to_empty_previous_row() {
+    let (wb, _) = Workbook::from_snapshot(blank_snapshot()).unwrap();
+    let sheet = wb.sheet_by_index(0).unwrap();
+
+    sheet.set_cell("A11", "200").unwrap();
+    sheet.set_cell("B12", "0.25").unwrap();
+    sheet.set_cell("A12", "=A11*(1+B12)").unwrap();
+
+    let res = sheet.structure().delete_rows(10, 1).unwrap();
+
+    let a11 = res
+        .recalc
+        .changed_cells
+        .iter()
+        .find(|c| {
+            c.position
+                .as_ref()
+                .map_or(false, |p| p.row == 10 && p.col == 0)
+        })
+        .expect("A11 should be recalculated after deleting row 11");
+
+    use value_types::{CellValue, FiniteF64};
+    assert_eq!(
+        a11.value,
+        CellValue::Number(FiniteF64::must(0.0)),
+        "shifted formula should reference the empty previous surviving row"
     );
 }

--- a/compute/core/src/scheduler/edit.rs
+++ b/compute/core/src/scheduler/edit.rs
@@ -595,6 +595,15 @@ impl ComputeCore {
         mirror: &mut CellMirror,
         change: Option<(&formula_types::StructureChange, SheetId)>,
     ) -> Result<RecalcResult, ComputeError> {
+        self.structure_change_with_formula_refresh(mirror, change, &[])
+    }
+
+    pub fn structure_change_with_formula_refresh(
+        &mut self,
+        mirror: &mut CellMirror,
+        change: Option<(&formula_types::StructureChange, SheetId)>,
+        refresh_formula_cells: &[CellId],
+    ) -> Result<RecalcResult, ComputeError> {
         // NOTE: mirror.apply_structure_change() is NOT called here — the caller
         // (StructuralOps) already updated the mirror before delegating to ComputeCore.
         // Calling it again would double-shift cell positions.
@@ -631,6 +640,11 @@ impl ComputeCore {
         //    pointed at deleted cells render as `#REF!` (their backing
         //    CellId / RowId / ColId is unregistered after the structural op).
         self.regenerate_formula_strings_and_cell_formula_text(mirror);
+
+        // 3.5. Reparse formulas whose identity refs were retargeted before
+        //      the delete so evaluation uses the same references that
+        //      structural display text now exposes.
+        self.refresh_ast_cache_from_formula_text(mirror, refresh_formula_cells);
 
         // 4. Rebuild dep graph edges.
         //    Inserting/deleting between range corners changes the range
@@ -669,6 +683,59 @@ impl ComputeCore {
                     is_dynamic_array,
                 },
             );
+        }
+    }
+
+    /// Reparse formula text for selected live cell formulas after structural
+    /// display text has been regenerated.
+    fn refresh_ast_cache_from_formula_text(&mut self, mirror: &CellMirror, cell_ids: &[CellId]) {
+        use crate::eval::GLOBAL_REGISTRY;
+
+        let mut refreshed = Vec::new();
+
+        for cell_id in cell_ids {
+            let Some(sheet_id) = mirror.sheet_for_cell(cell_id) else {
+                continue;
+            };
+            if mirror.get_formula(cell_id).is_none() {
+                continue;
+            }
+
+            let Some(formula_text) = self
+                .cell_formula_text
+                .get(cell_id)
+                .or_else(|| self.formula_strings.get(cell_id))
+                .cloned()
+            else {
+                continue;
+            };
+
+            let resolver = CoreResolver {
+                mirror,
+                current_sheet: sheet_id,
+            };
+            match parse_formula(&formula_text, Some(&resolver)) {
+                Ok(spanned) => {
+                    let ast = spanned.into_inner();
+                    let is_dynamic_array =
+                        Self::ast_contains_array_function(&ast, &GLOBAL_REGISTRY);
+                    refreshed.push((
+                        *cell_id,
+                        AstEntry {
+                            ast,
+                            is_dynamic_array,
+                        },
+                    ));
+                }
+                Err(_) => {
+                    self.ast_cache.remove(cell_id);
+                    self.cell_range_keys.remove(cell_id);
+                }
+            }
+        }
+
+        for (cell_id, entry) in refreshed {
+            self.ast_cache.insert(cell_id, entry);
         }
     }
 

--- a/compute/core/src/storage/engine/services/structural/pre_delete_reanchor.rs
+++ b/compute/core/src/storage/engine/services/structural/pre_delete_reanchor.rs
@@ -86,7 +86,10 @@ pub(super) fn pre_delete_re_anchor_range_refs(
             sheet_mirror
                 .cells_iter()
                 .filter_map(|(cell_id, entry)| {
-                    entry.formula.as_ref().map(|formula| (*cell_id, formula.clone()))
+                    entry
+                        .formula
+                        .as_ref()
+                        .map(|formula| (*cell_id, formula.clone()))
                 })
                 .collect::<Vec<_>>()
         })

--- a/compute/core/src/storage/engine/services/structural/pre_delete_reanchor.rs
+++ b/compute/core/src/storage/engine/services/structural/pre_delete_reanchor.rs
@@ -1,4 +1,4 @@
-use cell_types::{CellId, SheetId, SheetPos};
+use cell_types::{CellId, IdAllocator, SheetId, SheetPos};
 
 use crate::mirror::CellMirror;
 
@@ -7,9 +7,15 @@ use crate::mirror::CellMirror;
 // -------------------------------------------------------------------
 
 /// Before a `DeleteRows` / `DeleteCols` op tears down the affected CellIds,
-/// shrink any `IdentityRangeRef` whose endpoint sits inside the doomed band
-/// to the nearest surviving cell so e.g. `SUM(A1:A5)` with row 0 deleted
-/// becomes `SUM(A1:A4)` instead of `SUM(#REF!)`.
+/// re-anchor formula refs that should keep pointing at the surviving adjacent
+/// model cell:
+///
+/// - Shrink any `IdentityRangeRef` whose endpoint sits inside the doomed band
+///   to the nearest surviving cell so e.g. `SUM(A1:A5)` with row 0 deleted
+///   becomes `SUM(A1:A4)` instead of `SUM(#REF!)`.
+/// - For formulas that are themselves shifted by the delete, move same-axis
+///   direct cell refs from the doomed band to the nearest surviving cell before
+///   the band.
 ///
 /// Semantics ("shrink to surviving sub-region"):
 /// - If the Range's START is doomed and the END survives, clamp START to
@@ -21,21 +27,22 @@ use crate::mirror::CellMirror;
 ///
 /// Only mutates `CellEntry.formula` in the mirror. Downstream
 /// (`structure_change()` → `regenerate_formula_strings` →
-/// `invalidate_stale_yrs_formulas`) does the rest.
+/// targeted formula-cache refresh) does the rest.
 ///
 /// Must run BEFORE the structural op removes the doomed cells' identities,
 /// so their pre-delete positions can still be resolved via the mirror.
 pub(super) fn pre_delete_re_anchor_range_refs(
     mirror: &mut CellMirror,
     sheet_id: &SheetId,
+    id_alloc: &IdAllocator,
     at: u32,
     count: u32,
     is_row: bool,
-) {
+) -> Vec<CellId> {
     use formula_types::{IdentityFormulaRef, IdentityRangeRef};
 
     if count == 0 || mirror.get_sheet(sheet_id).is_none() {
-        return;
+        return Vec::new();
     }
 
     let doomed_end = at.saturating_add(count); // exclusive: [at, doomed_end)
@@ -60,8 +67,8 @@ pub(super) fn pre_delete_re_anchor_range_refs(
         Some((sid, p.row(), p.col()))
     };
 
-    // Pass 1 — read: collect (owning_cell_id, new_refs) updates. We can't
-    // mutate the mirror while iterating its sheets.
+    // Pass 1 — collect formula entries before applying any identity-only
+    // allocations for replacement references.
     struct Update {
         owning_cell: CellId,
         new_refs: Vec<IdentityFormulaRef>,
@@ -72,159 +79,212 @@ pub(super) fn pre_delete_re_anchor_range_refs(
     // `sheet_id` get re-anchored too.
     let all_sheet_ids: Vec<SheetId> = mirror.sheet_ids().copied().collect();
 
-    for owning_sheet in &all_sheet_ids {
-        let Some(sheet_mirror) = mirror.get_sheet(owning_sheet) else {
-            continue;
-        };
+    let formula_cells: Vec<(CellId, Box<formula_types::IdentityFormula>)> = all_sheet_ids
+        .iter()
+        .filter_map(|owning_sheet| mirror.get_sheet(owning_sheet))
+        .flat_map(|sheet_mirror| {
+            sheet_mirror
+                .cells_iter()
+                .filter_map(|(cell_id, entry)| {
+                    entry.formula.as_ref().map(|formula| (*cell_id, formula.clone()))
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
 
-        for (cell_id, entry) in sheet_mirror.cells_iter() {
-            let Some(formula) = &entry.formula else {
-                continue;
-            };
+    for (cell_id, formula) in &formula_cells {
+        let mut new_refs: Vec<IdentityFormulaRef> = Vec::with_capacity(formula.refs.len());
+        let mut any_change = false;
 
-            let mut new_refs: Vec<IdentityFormulaRef> = Vec::with_capacity(formula.refs.len());
-            let mut any_change = false;
+        let owning_pos = resolve_pos(mirror, cell_id);
+        let owner_shifts_with_delete = matches!(
+            owning_pos,
+            Some((sid, row, col)) if sid == *sheet_id
+                && if is_row { row >= doomed_end } else { col >= doomed_end }
+        );
 
-            for r in &formula.refs {
-                match r {
-                    IdentityFormulaRef::Range(rng) => {
-                        let start_pos = resolve_pos(mirror, &rng.start_id);
-                        let end_pos = resolve_pos(mirror, &rng.end_id);
+        for r in &formula.refs {
+            match r {
+                IdentityFormulaRef::Cell(cell) => {
+                    if !owner_shifts_with_delete {
+                        new_refs.push(r.clone());
+                        continue;
+                    }
 
-                        let start_doomed = in_doomed_band(start_pos);
-                        let end_doomed = in_doomed_band(end_pos);
+                    let Some((ref_sheet, row, col)) = resolve_pos(mirror, &cell.id) else {
+                        new_refs.push(r.clone());
+                        continue;
+                    };
 
-                        if !start_doomed && !end_doomed {
-                            new_refs.push(r.clone());
-                            continue;
-                        }
+                    if !in_doomed_band(Some((ref_sheet, row, col))) || at == 0 {
+                        new_refs.push(r.clone());
+                        continue;
+                    }
 
-                        let mut new_rng: IdentityRangeRef = *rng;
-                        let mut changed = false;
+                    let Some((_, owner_row, owner_col)) = owning_pos else {
+                        new_refs.push(r.clone());
+                        continue;
+                    };
+                    if (is_row && col != owner_col) || (!is_row && row != owner_row) {
+                        new_refs.push(r.clone());
+                        continue;
+                    }
 
-                        // Clamp START if doomed and END survives, so the new
-                        // START sits just past the doomed band.
-                        if start_doomed {
-                            let end_survives = !end_doomed && end_pos.is_some();
-                            let start_other_axis = match start_pos {
-                                Some((_, row, col)) => {
-                                    if is_row {
-                                        col
-                                    } else {
-                                        row
-                                    }
-                                }
-                                None => {
-                                    new_refs.push(r.clone());
-                                    continue;
-                                }
-                            };
-                            if is_row {
-                                let new_row = doomed_end;
-                                let end_row = end_pos.map(|(_, r, _)| r);
-                                if end_survives
-                                    && end_row.is_some_and(|er| new_row <= er)
-                                    && let Some(new_id) = mirror.resolve_cell_id(
-                                        sheet_id,
-                                        SheetPos::new(new_row, start_other_axis),
-                                    )
-                                {
-                                    new_rng.start_id = new_id;
-                                    changed = true;
-                                }
-                            } else {
-                                let new_col = doomed_end;
-                                let end_col = end_pos.map(|(_, _, c)| c);
-                                if end_survives
-                                    && end_col.is_some_and(|ec| new_col <= ec)
-                                    && let Some(new_id) = mirror.resolve_cell_id(
-                                        sheet_id,
-                                        SheetPos::new(start_other_axis, new_col),
-                                    )
-                                {
-                                    new_rng.start_id = new_id;
-                                    changed = true;
+                    let replacement_pos = if is_row {
+                        SheetPos::new(at - 1, col)
+                    } else {
+                        SheetPos::new(row, at - 1)
+                    };
+                    if let Some(new_id) =
+                        mirror.ensure_cell_id_identity_only(sheet_id, replacement_pos, id_alloc)
+                    {
+                        let mut new_cell = *cell;
+                        new_cell.id = new_id;
+                        new_refs.push(IdentityFormulaRef::Cell(new_cell));
+                        any_change = true;
+                    } else {
+                        new_refs.push(r.clone());
+                    }
+                }
+                IdentityFormulaRef::Range(rng) => {
+                    let start_pos = resolve_pos(mirror, &rng.start_id);
+                    let end_pos = resolve_pos(mirror, &rng.end_id);
+
+                    let start_doomed = in_doomed_band(start_pos);
+                    let end_doomed = in_doomed_band(end_pos);
+
+                    if !start_doomed && !end_doomed {
+                        new_refs.push(r.clone());
+                        continue;
+                    }
+
+                    let mut new_rng: IdentityRangeRef = *rng;
+                    let mut changed = false;
+
+                    // Clamp START if doomed and END survives, so the new
+                    // START sits just past the doomed band.
+                    if start_doomed {
+                        let end_survives = !end_doomed && end_pos.is_some();
+                        let start_other_axis = match start_pos {
+                            Some((_, row, col)) => {
+                                if is_row {
+                                    col
+                                } else {
+                                    row
                                 }
                             }
+                            None => {
+                                new_refs.push(r.clone());
+                                continue;
+                            }
+                        };
+                        if is_row {
+                            let new_row = doomed_end;
+                            let end_row = end_pos.map(|(_, r, _)| r);
+                            if end_survives
+                                && end_row.is_some_and(|er| new_row <= er)
+                                && let Some(new_id) = mirror.resolve_cell_id(
+                                    sheet_id,
+                                    SheetPos::new(new_row, start_other_axis),
+                                )
+                            {
+                                new_rng.start_id = new_id;
+                                changed = true;
+                            }
+                        } else {
+                            let new_col = doomed_end;
+                            let end_col = end_pos.map(|(_, _, c)| c);
+                            if end_survives
+                                && end_col.is_some_and(|ec| new_col <= ec)
+                                && let Some(new_id) = mirror.resolve_cell_id(
+                                    sheet_id,
+                                    SheetPos::new(start_other_axis, new_col),
+                                )
+                            {
+                                new_rng.start_id = new_id;
+                                changed = true;
+                            }
                         }
+                    }
 
-                        // Clamp END if doomed and START survives, so the new
-                        // END sits just before the doomed band (`at - 1`).
-                        if end_doomed {
-                            let start_survives = !start_doomed && start_pos.is_some();
-                            let end_other_axis = match end_pos {
-                                Some((_, row, col)) => {
-                                    if is_row {
-                                        col
-                                    } else {
-                                        row
-                                    }
+                    // Clamp END if doomed and START survives, so the new
+                    // END sits just before the doomed band (`at - 1`).
+                    if end_doomed {
+                        let start_survives = !start_doomed && start_pos.is_some();
+                        let end_other_axis = match end_pos {
+                            Some((_, row, col)) => {
+                                if is_row {
+                                    col
+                                } else {
+                                    row
                                 }
-                                None => {
-                                    if changed {
-                                        new_refs.push(IdentityFormulaRef::Range(new_rng));
-                                        any_change = true;
-                                    } else {
-                                        new_refs.push(r.clone());
-                                    }
-                                    continue;
+                            }
+                            None => {
+                                if changed {
+                                    new_refs.push(IdentityFormulaRef::Range(new_rng));
+                                    any_change = true;
+                                } else {
+                                    new_refs.push(r.clone());
                                 }
-                            };
-                            if is_row {
-                                if at > 0 {
-                                    let new_row = at - 1;
-                                    let start_row = start_pos.map(|(_, r, _)| r);
-                                    if start_survives
-                                        && start_row.is_some_and(|sr| sr <= new_row)
-                                        && let Some(new_id) = mirror.resolve_cell_id(
-                                            sheet_id,
-                                            SheetPos::new(new_row, end_other_axis),
-                                        )
-                                    {
-                                        new_rng.end_id = new_id;
-                                        changed = true;
-                                    }
-                                }
-                                // at == 0 → nothing survives above the deleted band.
-                            } else if at > 0 {
-                                let new_col = at - 1;
-                                let start_col = start_pos.map(|(_, _, c)| c);
+                                continue;
+                            }
+                        };
+                        if is_row {
+                            if at > 0 {
+                                let new_row = at - 1;
+                                let start_row = start_pos.map(|(_, r, _)| r);
                                 if start_survives
-                                    && start_col.is_some_and(|sc| sc <= new_col)
+                                    && start_row.is_some_and(|sr| sr <= new_row)
                                     && let Some(new_id) = mirror.resolve_cell_id(
                                         sheet_id,
-                                        SheetPos::new(end_other_axis, new_col),
+                                        SheetPos::new(new_row, end_other_axis),
                                     )
                                 {
                                     new_rng.end_id = new_id;
                                     changed = true;
                                 }
                             }
-                            // at == 0 → nothing survives to the left of the deleted band.
+                            // at == 0 → nothing survives above the deleted band.
+                        } else if at > 0 {
+                            let new_col = at - 1;
+                            let start_col = start_pos.map(|(_, _, c)| c);
+                            if start_survives
+                                && start_col.is_some_and(|sc| sc <= new_col)
+                                && let Some(new_id) = mirror.resolve_cell_id(
+                                    sheet_id,
+                                    SheetPos::new(end_other_axis, new_col),
+                                )
+                            {
+                                new_rng.end_id = new_id;
+                                changed = true;
+                            }
                         }
-
-                        if changed {
-                            new_refs.push(IdentityFormulaRef::Range(new_rng));
-                            any_change = true;
-                        } else {
-                            new_refs.push(r.clone());
-                        }
+                        // at == 0 → nothing survives to the left of the deleted band.
                     }
-                    other => new_refs.push(other.clone()),
-                }
-            }
 
-            if any_change {
-                updates.push(Update {
-                    owning_cell: *cell_id,
-                    new_refs,
-                });
+                    if changed {
+                        new_refs.push(IdentityFormulaRef::Range(new_rng));
+                        any_change = true;
+                    } else {
+                        new_refs.push(r.clone());
+                    }
+                }
+                other => new_refs.push(other.clone()),
             }
+        }
+
+        if any_change {
+            updates.push(Update {
+                owning_cell: *cell_id,
+                new_refs,
+            });
         }
     }
 
     // Pass 2 — write: install the re-anchored IdentityFormulas. Only the
     // refs vector changes; template and flags are preserved.
+    let updated_cells: Vec<CellId> = updates.iter().map(|update| update.owning_cell).collect();
+
     for Update {
         owning_cell,
         new_refs,
@@ -242,4 +302,6 @@ pub(super) fn pre_delete_re_anchor_range_refs(
             mirror.set_formula(&owning_cell, Some(new_formula));
         }
     }
+
+    updated_cells
 }

--- a/compute/core/src/storage/engine/services/structural/structure_change.rs
+++ b/compute/core/src/storage/engine/services/structural/structure_change.rs
@@ -65,26 +65,22 @@ pub(in crate::storage::engine) fn apply_structure_change(
     // `SUM(#REF!)`. Must run BEFORE the structural op tears down the affected
     // CellIds so their pre-delete positions can still be resolved.
     let reanchored_formula_cells = match change {
-        StructureChange::DeleteRows { at, count, .. } => {
-            pre_delete_re_anchor_range_refs(
-                mirror,
-                sheet_id,
-                &stores.grid_id_alloc,
-                *at,
-                *count,
-                true,
-            )
-        }
-        StructureChange::DeleteCols { at, count, .. } => {
-            pre_delete_re_anchor_range_refs(
-                mirror,
-                sheet_id,
-                &stores.grid_id_alloc,
-                *at,
-                *count,
-                false,
-            )
-        }
+        StructureChange::DeleteRows { at, count, .. } => pre_delete_re_anchor_range_refs(
+            mirror,
+            sheet_id,
+            &stores.grid_id_alloc,
+            *at,
+            *count,
+            true,
+        ),
+        StructureChange::DeleteCols { at, count, .. } => pre_delete_re_anchor_range_refs(
+            mirror,
+            sheet_id,
+            &stores.grid_id_alloc,
+            *at,
+            *count,
+            false,
+        ),
         _ => Vec::new(),
     };
 
@@ -187,13 +183,11 @@ pub(in crate::storage::engine) fn apply_structure_change(
     // persist them to Yrs KEY_FORMULA. The get_cell_data() read path overlays
     // the authoritative formula_strings on top of Yrs data, so callers always
     // see the updated formulas without needing to write back to Yrs.
-    let result = stores
-        .compute
-        .structure_change_with_formula_refresh(
-            mirror,
-            Some((change, *sheet_id)),
-            &reanchored_formula_cells,
-        )?;
+    let result = stores.compute.structure_change_with_formula_refresh(
+        mirror,
+        Some((change, *sheet_id)),
+        &reanchored_formula_cells,
+    )?;
 
     // Refresh stale KEY_FORMULA entries in Yrs for every formula cell whose
     // A1 text changed. Cross-sheet formulas can shift when a different sheet's

--- a/compute/core/src/storage/engine/services/structural/structure_change.rs
+++ b/compute/core/src/storage/engine/services/structural/structure_change.rs
@@ -64,15 +64,29 @@ pub(in crate::storage::engine) fn apply_structure_change(
     // `SUM(A1:A5)` with row 0 deleted becomes `SUM(A1:A4)` instead of
     // `SUM(#REF!)`. Must run BEFORE the structural op tears down the affected
     // CellIds so their pre-delete positions can still be resolved.
-    match change {
+    let reanchored_formula_cells = match change {
         StructureChange::DeleteRows { at, count, .. } => {
-            pre_delete_re_anchor_range_refs(mirror, sheet_id, *at, *count, true);
+            pre_delete_re_anchor_range_refs(
+                mirror,
+                sheet_id,
+                &stores.grid_id_alloc,
+                *at,
+                *count,
+                true,
+            )
         }
         StructureChange::DeleteCols { at, count, .. } => {
-            pre_delete_re_anchor_range_refs(mirror, sheet_id, *at, *count, false);
+            pre_delete_re_anchor_range_refs(
+                mirror,
+                sheet_id,
+                &stores.grid_id_alloc,
+                *at,
+                *count,
+                false,
+            )
         }
-        _ => {}
-    }
+        _ => Vec::new(),
+    };
 
     // Collect virtual CellIds from Range views in the doomed band BEFORE
     // StructuralOps runs. StructuralOps::delete_rows/cols only removes
@@ -175,7 +189,11 @@ pub(in crate::storage::engine) fn apply_structure_change(
     // see the updated formulas without needing to write back to Yrs.
     let result = stores
         .compute
-        .structure_change(mirror, Some((change, *sheet_id)))?;
+        .structure_change_with_formula_refresh(
+            mirror,
+            Some((change, *sheet_id)),
+            &reanchored_formula_cells,
+        )?;
 
     // Refresh stale KEY_FORMULA entries in Yrs for every formula cell whose
     // A1 text changed. Cross-sheet formulas can shift when a different sheet's
@@ -228,10 +246,65 @@ fn preflight_structure_change(
     // deleted, otherwise references into the deleted band are reparsed against
     // the post-delete sheet and can silently bind to the shifted survivor.
     stores.compute.ensure_graph_built(mirror)?;
+    hydrate_stored_formula_identities_for_structure_change(stores, mirror);
 
     Ok(StructureChangePreflight {
         inherited_insert_row_height,
     })
+}
+
+fn hydrate_stored_formula_identities_for_structure_change(
+    stores: &mut EngineStores,
+    mirror: &mut CellMirror,
+) {
+    enum FormulaSeed {
+        Identity(formula_types::IdentityFormula),
+        A1(String),
+    }
+
+    let sheet_ids: Vec<SheetId> = mirror.sheet_ids().copied().collect();
+    let mut formulas_to_seed: Vec<(SheetId, CellId, FormulaSeed)> = Vec::new();
+
+    for sheet_id in &sheet_ids {
+        let Some(sheet_snap) =
+            construction::build_sheet_snapshot_from_yrs(&stores.storage, sheet_id)
+        else {
+            continue;
+        };
+
+        for cell_data in sheet_snap.cells {
+            let Ok(cell_id) = CellId::from_uuid_str(&cell_data.cell_id) else {
+                continue;
+            };
+            if mirror.get_formula(&cell_id).is_some() {
+                continue;
+            }
+
+            if let Some(identity_formula) = cell_data.identity_formula {
+                formulas_to_seed.push((
+                    *sheet_id,
+                    cell_id,
+                    FormulaSeed::Identity(identity_formula),
+                ));
+            } else if let Some(formula_a1) = cell_data.formula {
+                formulas_to_seed.push((*sheet_id, cell_id, FormulaSeed::A1(formula_a1)));
+            }
+        }
+    }
+
+    for (sheet_id, cell_id, seed) in formulas_to_seed {
+        let identity_formula = match seed {
+            FormulaSeed::Identity(identity_formula) => Some(identity_formula),
+            FormulaSeed::A1(formula_a1) => stores
+                .compute
+                .to_identity_formula(mirror, &sheet_id, &formula_a1)
+                .ok(),
+        };
+
+        if let Some(identity_formula) = identity_formula {
+            mirror.set_formula(&cell_id, Some(identity_formula));
+        }
+    }
 }
 
 fn grid_index<'a>(

--- a/compute/core/src/storage/engine/tests/test_deferred_xlsx_import/structural_shared_formulas.rs
+++ b/compute/core/src/storage/engine/tests/test_deferred_xlsx_import/structural_shared_formulas.rs
@@ -163,6 +163,158 @@ fn shared_formula_delete_fixture_xlsx() -> Vec<u8> {
         .expect("shared formula structural fixture should be writable")
 }
 
+fn same_row_shared_formula_delete_fixture_xlsx() -> Vec<u8> {
+    let mut formula_cells = String::new();
+    formula_cells.push_str(&value_cell(13, 10, 100.0));
+    formula_cells.push_str(&shared_master(
+        13,
+        11,
+        19,
+        1,
+        "K14*(1+L35)".to_string(),
+        110.0,
+    ));
+    for col in 12..=19 {
+        formula_cells.push_str(&shared_follower(13, col, 1, 100.0 + (col - 10) as f64 * 10.0));
+    }
+
+    let mut driver_cells = String::new();
+    for col in 11..=19 {
+        driver_cells.push_str(&value_cell(34, col, (col - 10) as f64 / 10.0));
+    }
+
+    let sheet_data = format!(
+        r#"<sheetData>
+  <row r="14">
+    {formula_cells}
+  </row>
+  <row r="35">
+    {driver_cells}
+  </row>
+</sheetData>"#,
+    );
+
+    let sheet = format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <dimension ref="A1:T35"/>
+  {sheet_data}
+</worksheet>"#
+    );
+
+    let mut zip = ZipWriter::new();
+    zip.add_file(
+        "[Content_Types].xml",
+        br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"#
+            .to_vec(),
+    )
+    .add_file(
+        "_rels/.rels",
+        br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"#
+            .to_vec(),
+    )
+    .add_file(
+        "xl/workbook.xml",
+        br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"#
+            .to_vec(),
+    )
+    .add_file(
+        "xl/_rels/workbook.xml.rels",
+        br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"#
+            .to_vec(),
+    )
+    .add_file("xl/worksheets/sheet1.xml", sheet.into_bytes());
+
+    zip.finish()
+        .expect("same-row shared formula fixture should be writable")
+}
+
+fn same_row_formula_delete_fixture_xlsx() -> Vec<u8> {
+    let mut formula_cells = String::new();
+    formula_cells.push_str(&value_cell(13, 10, 100.0));
+    formula_cells.push_str(&formula_cell(13, 11, "K14*(1+L35)", 110.0));
+    formula_cells.push_str(&formula_cell(13, 12, "L14*(1+M35)", 120.0));
+
+    let mut driver_cells = String::new();
+    driver_cells.push_str(&value_cell(34, 11, 0.10));
+    driver_cells.push_str(&value_cell(34, 12, 0.20));
+
+    let sheet_data = format!(
+        r#"<sheetData>
+  <row r="14">
+    {formula_cells}
+  </row>
+  <row r="35">
+    {driver_cells}
+  </row>
+</sheetData>"#,
+    );
+
+    let sheet = format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <dimension ref="A1:M35"/>
+  {sheet_data}
+</worksheet>"#
+    );
+
+    let mut zip = ZipWriter::new();
+    zip.add_file(
+        "[Content_Types].xml",
+        br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"#
+            .to_vec(),
+    )
+    .add_file(
+        "_rels/.rels",
+        br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"#
+            .to_vec(),
+    )
+    .add_file(
+        "xl/workbook.xml",
+        br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"#
+            .to_vec(),
+    )
+    .add_file(
+        "xl/_rels/workbook.xml.rels",
+        br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"#
+            .to_vec(),
+    )
+    .add_file("xl/worksheets/sheet1.xml", sheet.into_bytes());
+
+    zip.finish()
+        .expect("same-row formula fixture should be writable")
+}
+
 fn import_deferred() -> (YrsComputeEngine, SheetId) {
     let bytes = shared_formula_delete_fixture_xlsx();
     let (mut engine, _) = YrsComputeEngine::from_snapshot(simple_snapshot()).unwrap();
@@ -184,6 +336,46 @@ fn import_deferred_then_complete() -> (YrsComputeEngine, SheetId) {
     engine
         .complete_deferred_hydration()
         .expect("full deferred hydration should succeed");
+    (engine, sheet_id)
+}
+
+fn import_same_row_shared_deferred() -> (YrsComputeEngine, SheetId) {
+    let bytes = same_row_shared_formula_delete_fixture_xlsx();
+    let (mut engine, _) = YrsComputeEngine::from_snapshot(simple_snapshot()).unwrap();
+    engine
+        .import_from_xlsx_bytes_deferred(&bytes)
+        .expect("deferred XLSX import should succeed");
+    let sheet_id = SheetId::from_uuid_str(
+        engine
+            .get_all_sheet_ids()
+            .first()
+            .expect("imported workbook should have a sheet"),
+    )
+    .expect("sheet id should parse");
+    (engine, sheet_id)
+}
+
+fn import_same_row_shared_deferred_then_complete() -> (YrsComputeEngine, SheetId) {
+    let (mut engine, sheet_id) = import_same_row_shared_deferred();
+    engine
+        .complete_deferred_hydration()
+        .expect("full deferred hydration should succeed");
+    (engine, sheet_id)
+}
+
+fn import_same_row_formula_deferred() -> (YrsComputeEngine, SheetId) {
+    let bytes = same_row_formula_delete_fixture_xlsx();
+    let (mut engine, _) = YrsComputeEngine::from_snapshot(simple_snapshot()).unwrap();
+    engine
+        .import_from_xlsx_bytes_deferred(&bytes)
+        .expect("deferred XLSX import should succeed");
+    let sheet_id = SheetId::from_uuid_str(
+        engine
+            .get_all_sheet_ids()
+            .first()
+            .expect("imported workbook should have a sheet"),
+    )
+    .expect("sheet id should parse");
     (engine, sheet_id)
 }
 
@@ -269,6 +461,130 @@ fn delete_column_completes_deferred_hydration_before_invalidating_shared_formula
     for row in [9, 19, 99, 195] {
         assert_direct_ref_error(&engine, &sheet_id, row, 4);
     }
+}
+
+#[test]
+fn delete_column_retargets_shifted_imported_same_row_shared_formula() {
+    let (mut engine, sheet_id) = import_same_row_shared_deferred_then_complete();
+
+    engine
+        .structure_change(
+            &sheet_id,
+            &StructureChange::DeleteCols {
+                at: 11,
+                count: 1,
+                deleted_cell_ids: vec![],
+            },
+        )
+        .expect("delete column should succeed");
+
+    let cell_id = CellId::from_uuid_str(
+        &engine
+            .get_cell_id_at(&sheet_id, 13, 11)
+            .expect("shifted formula cell should stay materialized"),
+    )
+    .expect("cell id should parse");
+    assert_eq!(
+        engine.get_formula(&cell_id).as_deref(),
+        Some("=K14*(1+L35)")
+    );
+    assert_eq!(
+        engine.get_cell_value(&sheet_id, 13, 11),
+        CellValue::Number(value_types::FiniteF64::must(120.0))
+    );
+}
+
+#[test]
+fn delete_columns_retarget_shifted_imported_same_row_shared_formula() {
+    let (mut engine, sheet_id) = import_same_row_shared_deferred_then_complete();
+
+    engine
+        .structure_change(
+            &sheet_id,
+            &StructureChange::DeleteCols {
+                at: 11,
+                count: 8,
+                deleted_cell_ids: vec![],
+            },
+        )
+        .expect("delete columns should succeed");
+
+    let cell_id = CellId::from_uuid_str(
+        &engine
+            .get_cell_id_at(&sheet_id, 13, 11)
+            .expect("shifted formula cell should stay materialized"),
+    )
+    .expect("cell id should parse");
+    assert_eq!(
+        engine.get_formula(&cell_id).as_deref(),
+        Some("=K14*(1+L35)")
+    );
+    assert_eq!(
+        engine.get_cell_value(&sheet_id, 13, 11),
+        CellValue::Number(value_types::FiniteF64::must(190.0))
+    );
+}
+
+#[test]
+fn delete_columns_retarget_shifted_deferred_same_row_shared_formula() {
+    let (mut engine, sheet_id) = import_same_row_shared_deferred();
+
+    engine
+        .structure_change(
+            &sheet_id,
+            &StructureChange::DeleteCols {
+                at: 11,
+                count: 8,
+                deleted_cell_ids: vec![],
+            },
+        )
+        .expect("delete columns should complete hydration and succeed");
+
+    let cell_id = CellId::from_uuid_str(
+        &engine
+            .get_cell_id_at(&sheet_id, 13, 11)
+            .expect("shifted formula cell should stay materialized"),
+    )
+    .expect("cell id should parse");
+    assert_eq!(
+        engine.get_formula(&cell_id).as_deref(),
+        Some("=K14*(1+L35)")
+    );
+    assert_eq!(
+        engine.get_cell_value(&sheet_id, 13, 11),
+        CellValue::Number(value_types::FiniteF64::must(190.0))
+    );
+}
+
+#[test]
+fn delete_column_retargets_shifted_imported_same_row_formula() {
+    let (mut engine, sheet_id) = import_same_row_formula_deferred();
+
+    engine
+        .structure_change(
+            &sheet_id,
+            &StructureChange::DeleteCols {
+                at: 11,
+                count: 1,
+                deleted_cell_ids: vec![],
+            },
+        )
+        .expect("delete column should complete hydration and succeed");
+
+    let cell_id = CellId::from_uuid_str(
+        &engine
+            .get_cell_id_at(&sheet_id, 13, 11)
+            .expect("shifted formula cell should stay materialized"),
+    )
+    .expect("cell id should parse");
+    assert_eq!(
+        engine.get_formula(&cell_id).as_deref(),
+        Some("=K14*(1+L35)")
+    );
+    assert_eq!(
+        engine.get_cell_value(&sheet_id, 13, 11),
+        CellValue::Number(value_types::FiniteF64::must(120.0))
+    );
 }
 
 #[test]

--- a/compute/core/src/storage/engine/tests/test_deferred_xlsx_import/structural_shared_formulas.rs
+++ b/compute/core/src/storage/engine/tests/test_deferred_xlsx_import/structural_shared_formulas.rs
@@ -175,7 +175,12 @@ fn same_row_shared_formula_delete_fixture_xlsx() -> Vec<u8> {
         110.0,
     ));
     for col in 12..=19 {
-        formula_cells.push_str(&shared_follower(13, col, 1, 100.0 + (col - 10) as f64 * 10.0));
+        formula_cells.push_str(&shared_follower(
+            13,
+            col,
+            1,
+            100.0 + (col - 10) as f64 * 10.0,
+        ));
     }
 
     let mut driver_cells = String::new();

--- a/compute/core/src/storage/engine/tests/test_structural_viewport.rs
+++ b/compute/core/src/storage/engine/tests/test_structural_viewport.rs
@@ -2,6 +2,7 @@
 
 use super::super::*;
 use super::helpers::*;
+use cell_types::CellId;
 use formula_types::StructureChange;
 use value_types::{CellValue, FiniteF64};
 
@@ -236,6 +237,100 @@ fn structural_formula_text_preserves_explicit_same_sheet_qualifier() {
     assert_eq!(
         cell_value_at(&engine, &sid, 1, 1),
         CellValue::Number(FiniteF64::must(10.0))
+    );
+}
+
+#[test]
+fn delete_column_retargets_shifted_absolute_formula_text() {
+    let snap = simple_snapshot();
+    let (mut engine, _) = YrsComputeEngine::from_snapshot(snap).unwrap();
+    let sid = sheet_id();
+
+    engine
+        .set_cell_value_parsed(&sid, 13, 10, "100")
+        .expect("seed K14");
+    engine
+        .set_cell_value_parsed(&sid, 13, 11, "200")
+        .expect("seed L14");
+    engine
+        .set_cell_value_parsed(&sid, 34, 12, "0.25")
+        .expect("seed M35");
+    engine
+        .set_cell_value_parsed(&sid, 13, 12, "=$L14*(1+$M$35)")
+        .expect("seed M14 formula");
+
+    engine
+        .structure_change(
+            &sid,
+            &StructureChange::DeleteCols {
+                at: 11,
+                count: 1,
+                deleted_cell_ids: vec![],
+            },
+        )
+        .expect("delete column L");
+
+    let l14 = CellId::from_uuid_str(
+        &engine
+            .get_cell_id_at(&sid, 13, 11)
+            .expect("shifted formula should stay materialized"),
+    )
+    .expect("cell id should parse");
+    assert_eq!(
+        engine.get_formula(&l14).as_deref(),
+        Some("=$K14*(1+$L$35)"),
+        "absolute markers should be preserved when the formula is retargeted"
+    );
+    assert_eq!(
+        cell_value_at(&engine, &sid, 13, 11),
+        CellValue::Number(FiniteF64::must(125.0))
+    );
+}
+
+#[test]
+fn delete_row_retargets_shifted_absolute_formula_text() {
+    let snap = simple_snapshot();
+    let (mut engine, _) = YrsComputeEngine::from_snapshot(snap).unwrap();
+    let sid = sheet_id();
+
+    engine
+        .set_cell_value_parsed(&sid, 9, 0, "100")
+        .expect("seed A10");
+    engine
+        .set_cell_value_parsed(&sid, 10, 0, "200")
+        .expect("seed A11");
+    engine
+        .set_cell_value_parsed(&sid, 11, 1, "0.25")
+        .expect("seed B12");
+    engine
+        .set_cell_value_parsed(&sid, 11, 0, "=$A$11*(1+$B$12)")
+        .expect("seed A12 formula");
+
+    engine
+        .structure_change(
+            &sid,
+            &StructureChange::DeleteRows {
+                at: 10,
+                count: 1,
+                deleted_cell_ids: vec![],
+            },
+        )
+        .expect("delete row 11");
+
+    let a11 = CellId::from_uuid_str(
+        &engine
+            .get_cell_id_at(&sid, 10, 0)
+            .expect("shifted formula should stay materialized"),
+    )
+    .expect("cell id should parse");
+    assert_eq!(
+        engine.get_formula(&a11).as_deref(),
+        Some("=$A$10*(1+$B$11)"),
+        "absolute markers should be preserved when the formula is retargeted"
+    );
+    assert_eq!(
+        cell_value_at(&engine, &sid, 10, 0),
+        CellValue::Number(FiniteF64::must(125.0))
     );
 }
 


### PR DESCRIPTION
Public behavior fixed: Fix formulas after deleting spreadsheet columns

Verification:
- Reproduced before the change and passed after the change before submission.

Changed paths:
```
compute/api/tests/delete_columns_ref_error.rs
compute/core/src/scheduler/edit.rs
compute/core/src/storage/engine/services/structural/pre_delete_reanchor.rs
compute/core/src/storage/engine/services/structural/structure_change.rs
compute/core/src/storage/engine/tests/test_deferred_xlsx_import/structural_shared_formulas.rs
```
