### PR TITLE
Fix formula Enter commit navigation

### DIFF
--- a/apps/spreadsheet/src/systems/grid-editing/coordination/cross-coordination.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/coordination/cross-coordination.ts
@@ -49,10 +49,6 @@ export type EditorState = SnapshotFrom<typeof editorMachine>;
 export type ClipboardState = SnapshotFrom<typeof clipboardMachine>;
 export type RendererState = SnapshotFrom<typeof rendererMachine>;
 
-function isFormulaSourceCommit(state: EditorState): boolean {
-  return !state.context.formulaInputIsLiteral && state.context.value.trimStart().startsWith('=');
-}
-
 /**
  * Callback to notify renderer of layer invalidation.
  */
@@ -190,10 +186,6 @@ export function setupEditorToSelectionCoordination(
     if (wasCommitting && isInactive && previousState?.context.commitDirection) {
       const direction = previousState.context.commitDirection;
       const commitKey = previousState.context.commitKey;
-      const isEnterKeyCommit = commitKey === 'enter' || commitKey === 'shift-enter';
-      const suppressEnterNavigation =
-        isEnterKeyCommit &&
-        (previousState.context.entryMode === 'doubleClick' || isFormulaSourceCommit(previousState));
       const editingSheetId = previousState.context.sheetId;
       const currentSheetId = getCurrentSheetId?.();
       const committedFromDifferentSheet =
@@ -209,7 +201,7 @@ export function setupEditorToSelectionCoordination(
         return;
       }
 
-      if (direction !== 'none' && !suppressEnterNavigation) {
+      if (direction !== 'none') {
         if (commitKey === 'tab' || commitKey === 'shift-tab') {
           // Route through KEY_TAB so selection machine tracks tabOriginCol
           selectionActor.send({ type: 'KEY_TAB', shiftKey: commitKey === 'shift-tab' });

--- a/apps/spreadsheet/src/systems/grid-editing/testing/__tests__/integration/commit-pipeline.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/testing/__tests__/integration/commit-pipeline.test.ts
@@ -16,10 +16,35 @@ import { createIntegrationSimulator, type IntegrationSimulator } from '../../int
 // =============================================================================
 
 let sim: IntegrationSimulator;
+const TEST_SHEET_ID = 'sheet-1';
 
 afterEach(() => {
   sim?.destroy();
 });
+
+async function startFormulaEditingWithEntryMode(
+  entryMode: 'F2' | 'doubleClick',
+  formula = '=A1+B1',
+): Promise<void> {
+  const cell = sim.activeCell();
+  const preEditSelectionRanges = sim.selectionRanges().map((range) => ({ ...range }));
+  const rawSystem = sim.system as any;
+
+  rawSystem.selectionActor.send({
+    type: 'BEGIN_CELL_EDIT',
+    cell,
+  });
+  rawSystem.editorActor.send({
+    type: 'START_EDITING',
+    cell,
+    sheetId: TEST_SHEET_ID,
+    initialValue: formula,
+    entryMode,
+    preEditSelectionRanges,
+  });
+
+  await sim.flush();
+}
 
 // =============================================================================
 // Auto-Commit Lifecycle
@@ -272,16 +297,52 @@ describe('Formula editing mode', () => {
     expect(sim.activeCell()).toEqual({ row: 1, col: 0 });
   });
 
-  it('formula edit committed with Enter advances from the edited cell', async () => {
+  it('formula edit committed through the production Enter action advances from the edited cell', async () => {
     sim = createIntegrationSimulator({
       activeCell: { row: 4, col: 2 },
     });
 
     sim.startEditing('=A1+B1');
-    await sim.system.commitWithKey('enter');
+    await sim.dispatch('COMMIT_ENTER');
     await sim.flush();
 
     expect(sim.isEditing()).toBe(false);
     expect(sim.activeCell()).toEqual({ row: 5, col: 2 });
   });
+
+  it('formula edit committed through the production Shift+Enter action moves upward', async () => {
+    sim = createIntegrationSimulator({
+      activeCell: { row: 4, col: 2 },
+    });
+
+    sim.startEditing('=A1+B1');
+    await sim.dispatch('COMMIT_SHIFT_ENTER');
+    await sim.flush();
+
+    expect(sim.isEditing()).toBe(false);
+    expect(sim.activeCell()).toEqual({ row: 3, col: 2 });
+  });
+
+  it.each([
+    ['F2', 'COMMIT_ENTER', { row: 5, col: 2 }],
+    ['doubleClick', 'COMMIT_ENTER', { row: 5, col: 2 }],
+    ['F2', 'COMMIT_SHIFT_ENTER', { row: 3, col: 2 }],
+    ['doubleClick', 'COMMIT_SHIFT_ENTER', { row: 3, col: 2 }],
+  ] as const)(
+    'formula edit started from %s follows production %s navigation',
+    async (entryMode, commitAction, expectedActiveCell) => {
+      sim = createIntegrationSimulator({
+        activeCell: { row: 4, col: 2 },
+      });
+
+      await startFormulaEditingWithEntryMode(entryMode);
+      expect(sim.isEditing()).toBe(true);
+
+      await sim.dispatch(commitAction);
+      await sim.flush();
+
+      expect(sim.isEditing()).toBe(false);
+      expect(sim.activeCell()).toEqual(expectedActiveCell);
+    },
+  );
 });

--- a/apps/spreadsheet/src/systems/grid-editing/testing/__tests__/integration/commit-pipeline.test.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/testing/__tests__/integration/commit-pipeline.test.ts
@@ -272,7 +272,7 @@ describe('Formula editing mode', () => {
     expect(sim.activeCell()).toEqual({ row: 1, col: 0 });
   });
 
-  it('formula edit committed with Enter keeps the edited cell selected', async () => {
+  it('formula edit committed with Enter advances from the edited cell', async () => {
     sim = createIntegrationSimulator({
       activeCell: { row: 4, col: 2 },
     });
@@ -282,6 +282,6 @@ describe('Formula editing mode', () => {
     await sim.flush();
 
     expect(sim.isEditing()).toBe(false);
-    expect(sim.activeCell()).toEqual({ row: 4, col: 2 });
+    expect(sim.activeCell()).toEqual({ row: 5, col: 2 });
   });
 });

--- a/apps/spreadsheet/src/systems/grid-editing/testing/integration-simulator.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/testing/integration-simulator.ts
@@ -64,6 +64,7 @@ import {
   PAGE_DOWN,
   PAGE_UP,
 } from '../../../actions/handlers/selection/page-navigation';
+import { COMMIT_ENTER, COMMIT_SHIFT_ENTER } from '../../../actions/handlers/editor';
 import {
   ENTER_NAVIGATE,
   SHIFT_ENTER_NAVIGATE,
@@ -156,6 +157,8 @@ const HANDLER_MAP: Record<SelectionActionType, AnyActionHandler> = {
   TAB_BACKWARD,
   ENTER_NAVIGATE,
   SHIFT_ENTER_NAVIGATE,
+  COMMIT_ENTER,
+  COMMIT_SHIFT_ENTER,
 
   // Page navigation
   PAGE_UP,

--- a/apps/spreadsheet/src/systems/grid-editing/testing/key-action-map.ts
+++ b/apps/spreadsheet/src/systems/grid-editing/testing/key-action-map.ts
@@ -55,6 +55,8 @@ export type SelectionActionType =
   | 'TAB_BACKWARD'
   | 'ENTER_NAVIGATE'
   | 'SHIFT_ENTER_NAVIGATE'
+  | 'COMMIT_ENTER'
+  | 'COMMIT_SHIFT_ENTER'
   // Page navigation
   | 'PAGE_UP'
   | 'PAGE_DOWN'


### PR DESCRIPTION
Public behavior fixed: Fix formula Enter commit navigation

Verification:
- Reproduced before the change and passed after the change before submission.

Changed paths:
```
apps/spreadsheet/src/systems/grid-editing/coordination/cross-coordination.ts
apps/spreadsheet/src/systems/grid-editing/testing/__tests__/integration/commit-pipeline.test.ts
```
