### PR TITLE
Fix imported sheet activation during hydration

### DIFF
--- a/apps/spreadsheet/src/coordinator/__tests__/floating-object-sheet-population.test.ts
+++ b/apps/spreadsheet/src/coordinator/__tests__/floating-object-sheet-population.test.ts
@@ -51,6 +51,7 @@ function createHarness(options?: { activeSheetId?: string; durabilityPromise?: P
   };
   const resyncScene = jest.fn();
   const awaitImportDurability = jest.fn(() => options?.durabilityPromise ?? Promise.resolve());
+  const scheduleDeferredHydration = jest.fn(() => options?.durabilityPromise ?? Promise.resolve());
 
   const cleanup = setupFloatingObjectSheetPopulation({
     uiStore,
@@ -60,6 +61,7 @@ function createHarness(options?: { activeSheetId?: string; durabilityPromise?: P
     getActiveSheetId: () => activeSheetId,
     importDurability: {
       isImportDurabilityPending: !!options?.durabilityPromise,
+      scheduleDeferredHydration,
       awaitImportDurability,
     },
     isDisposed: () => false,
@@ -76,6 +78,7 @@ function createHarness(options?: { activeSheetId?: string; durabilityPromise?: P
       activeSheetId = sheetId;
     },
     awaitImportDurability,
+    scheduleDeferredHydration,
     floatingObjects,
     setObjectsForSheet,
     resyncScene,
@@ -85,14 +88,15 @@ function createHarness(options?: { activeSheetId?: string; durabilityPromise?: P
 }
 
 describe('setupFloatingObjectSheetPopulation', () => {
-  it('waits for import durability before populating and resyncing a switched sheet', async () => {
+  it('waits for scheduled import hydration before populating a switched sheet', async () => {
     const gate = deferred();
     const harness = createHarness({ activeSheetId: 'sheet-2', durabilityPromise: gate.promise });
 
     harness.listener({ activeSheetId: 'sheet-2' }, { activeSheetId: 'sheet-1' });
     await Promise.resolve();
 
-    expect(harness.awaitImportDurability).toHaveBeenCalledTimes(1);
+    expect(harness.scheduleDeferredHydration).toHaveBeenCalledTimes(1);
+    expect(harness.awaitImportDurability).not.toHaveBeenCalled();
     expect(harness.floatingObjects.getObjectsInSheet).not.toHaveBeenCalled();
     expect(harness.setObjectsForSheet).not.toHaveBeenCalled();
     expect(harness.resyncScene).not.toHaveBeenCalled();

--- a/apps/spreadsheet/src/coordinator/floating-object-sheet-population.ts
+++ b/apps/spreadsheet/src/coordinator/floating-object-sheet-population.ts
@@ -41,12 +41,14 @@ export function setupFloatingObjectSheetPopulation({
     if (isDisposed()) return;
     const generation = getGeneration();
 
-    if (importDurability) {
+    if (importDurability?.isImportDurabilityPending) {
+      const waitForBackgroundHydration = importDurability.scheduleDeferredHydration?.();
+      if (!waitForBackgroundHydration) return;
       try {
-        await importDurability.awaitImportDurability();
+        await waitForBackgroundHydration;
       } catch (err) {
         console.warn(
-          '[SheetCoordinator] Failed to wait for import durability before floating-object population:',
+          '[SheetCoordinator] Failed to wait for import hydration before floating-object population:',
           err,
         );
       }

--- a/apps/spreadsheet/src/hooks/structure/__tests__/use-sheet-tab-actions.test.tsx
+++ b/apps/spreadsheet/src/hooks/structure/__tests__/use-sheet-tab-actions.test.tsx
@@ -64,13 +64,9 @@ describe('useSheetTabActions', () => {
     workbookOnMock.mockReturnValue(jest.fn());
   });
 
-  it('waits for target sheet materialization before activating a pending imported sheet', async () => {
-    let resolveMaterialization!: () => void;
-    const materialization = new Promise<void>((resolve) => {
-      resolveMaterialization = resolve;
-    });
+  it('activates a pending imported sheet without waiting for materialization', () => {
     const awaitMaterialized = jest.fn<Promise<void>, [SheetId | 'allSheets'?]>(
-      () => materialization,
+      () => new Promise(() => {}),
     );
     importDurabilityMock = {
       isImportDurabilityPending: true,
@@ -84,24 +80,14 @@ describe('useSheetTabActions', () => {
       result.current.handleSelectSheet('sheet-2' as SheetId);
     });
 
-    expect(awaitMaterialized).toHaveBeenCalledWith('sheet-2');
-    expect(setActiveSheetMock).not.toHaveBeenCalled();
-
-    await act(async () => {
-      resolveMaterialization();
-      await materialization;
-    });
-
+    expect(awaitMaterialized).not.toHaveBeenCalled();
+    expect(importDurabilityMock.awaitImportDurability).not.toHaveBeenCalled();
     expect(setActiveSheetMock).toHaveBeenCalledWith('sheet-2');
   });
 
-  it('activates only the latest requested sheet after materialization resolves', async () => {
-    let resolveMaterialization!: () => void;
-    const materialization = new Promise<void>((resolve) => {
-      resolveMaterialization = resolve;
-    });
+  it('activates each requested sheet immediately while import durability is pending', () => {
     const awaitMaterialized = jest.fn<Promise<void>, [SheetId | 'allSheets'?]>(
-      () => materialization,
+      () => new Promise(() => {}),
     );
     importDurabilityMock = {
       isImportDurabilityPending: true,
@@ -116,14 +102,10 @@ describe('useSheetTabActions', () => {
       result.current.handleSelectSheet('sheet-3' as SheetId);
     });
 
-    await act(async () => {
-      resolveMaterialization();
-      await materialization;
-    });
-
-    expect(awaitMaterialized).toHaveBeenCalledWith('sheet-2');
-    expect(awaitMaterialized).toHaveBeenCalledWith('sheet-3');
-    expect(setActiveSheetMock).toHaveBeenCalledTimes(1);
+    expect(awaitMaterialized).not.toHaveBeenCalled();
+    expect(importDurabilityMock.awaitImportDurability).not.toHaveBeenCalled();
+    expect(setActiveSheetMock).toHaveBeenCalledTimes(2);
+    expect(setActiveSheetMock).toHaveBeenNthCalledWith(1, 'sheet-2');
     expect(setActiveSheetMock).toHaveBeenCalledWith('sheet-3');
   });
 });

--- a/apps/spreadsheet/src/hooks/structure/use-sheet-tab-actions.ts
+++ b/apps/spreadsheet/src/hooks/structure/use-sheet-tab-actions.ts
@@ -23,11 +23,11 @@
  * Worksheet API setTabColor (async)
  */
 
-import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useReducer } from 'react';
 
 import type { SheetId } from '@mog-sdk/contracts/core';
 
-import { useActiveSheetId, useDocumentContext, useUIStore, useWorkbook } from '../../infra/context';
+import { useActiveSheetId, useUIStore, useWorkbook } from '../../infra/context';
 
 // =============================================================================
 // Types
@@ -83,17 +83,9 @@ export function useSheetTabActions(
   options: UseSheetTabActionsOptions = {},
 ): UseSheetTabActionsReturn {
   const wb = useWorkbook();
-  const importDurability = useDocumentContext().importDurability;
   const storeActiveSheetId = useActiveSheetId();
   const setActiveSheet = useUIStore((s) => s.setActiveSheet);
   const openDeleteSheetConfirmDialog = useUIStore((s) => s.openDeleteSheetConfirmDialog);
-  const sheetActivationGenerationRef = useRef(0);
-
-  useEffect(() => {
-    return () => {
-      sheetActivationGenerationRef.current += 1;
-    };
-  }, []);
 
   // Allow override for testing or custom use cases
   const activeSheetId = options.sheetId ?? storeActiveSheetId;
@@ -182,33 +174,9 @@ export function useSheetTabActions(
    */
   const handleSelectSheet = useCallback(
     (sheetId: SheetId) => {
-      const generation = ++sheetActivationGenerationRef.current;
-
-      const activateIfLatest = () => {
-        if (sheetActivationGenerationRef.current === generation) {
-          setActiveSheet(sheetId);
-        }
-      };
-
-      if (!importDurability?.isImportDurabilityPending || sheetId === activeSheetId) {
-        activateIfLatest();
-        return;
-      }
-
-      void (async () => {
-        try {
-          if (importDurability.awaitMaterialized) {
-            await importDurability.awaitMaterialized(sheetId);
-          } else {
-            await importDurability.awaitImportDurability();
-          }
-        } catch (error) {
-          console.warn('[SheetTabs] Failed to materialize sheet before activation:', error);
-        }
-        activateIfLatest();
-      })();
+      setActiveSheet(sheetId);
     },
-    [activeSheetId, importDurability, setActiveSheet],
+    [setActiveSheet],
   );
 
   /**

--- a/kernel/src/bridges/compute/__tests__/mutation-admission.test.ts
+++ b/kernel/src/bridges/compute/__tests__/mutation-admission.test.ts
@@ -151,6 +151,48 @@ describe('Compute mutation admission', () => {
     expect(gate.bypassDepth).toBe(0);
   });
 
+  it('lets UI-state workbook settings patch without waiting for all sheets', async () => {
+    const materialized = deferred<void>();
+    const awaitMaterialized = jest.fn(() => materialized.promise);
+    const ctx = makeMockContext({ awaitMaterialized } as Partial<IKernelContext>);
+    const transport: BridgeTransport & { call: jest.Mock } = {
+      call: jest.fn(async () => [new Uint8Array(), mutationResult()]),
+    };
+    const bridge = createStartedBridge(ctx, transport);
+
+    await bridge.patchWorkbookSettings({ selectedSheetIds: ['sheet-a'] });
+
+    expect(awaitMaterialized).not.toHaveBeenCalled();
+    expect(transport.call).toHaveBeenCalledWith('compute_patch_workbook_settings', {
+      docId: 'test-doc',
+      patch: { selectedSheetIds: ['sheet-a'] },
+    });
+  });
+
+  it('keeps non-UI workbook settings behind the all-sheet materialization barrier', async () => {
+    const materialized = deferred<void>();
+    const awaitMaterialized = jest.fn(() => materialized.promise);
+    const ctx = makeMockContext({ awaitMaterialized } as Partial<IKernelContext>);
+    const transport: BridgeTransport & { call: jest.Mock } = {
+      call: jest.fn(async () => [new Uint8Array(), mutationResult()]),
+    };
+    const bridge = createStartedBridge(ctx, transport);
+
+    const promise = bridge.patchWorkbookSettings({ culture: 'de-DE' });
+    await Promise.resolve();
+
+    expect(awaitMaterialized).toHaveBeenCalledWith('allSheets');
+    expect(transport.call).not.toHaveBeenCalled();
+
+    materialized.resolve();
+    await promise;
+
+    expect(transport.call).toHaveBeenCalledWith('compute_patch_workbook_settings', {
+      docId: 'test-doc',
+      patch: { culture: 'de-DE' },
+    });
+  });
+
   it('does not begin compound removeSheet mutation before materialization', async () => {
     const materialized = deferred<void>();
     const awaitMaterialized = jest.fn(() => materialized.promise);

--- a/kernel/src/bridges/compute/compute-bridge.ts
+++ b/kernel/src/bridges/compute/compute-bridge.ts
@@ -486,6 +486,16 @@ function appendPropertyChanges(result: MutationResult, extra: MutationResult): M
   };
 }
 
+const UI_STATE_WORKBOOK_SETTINGS_KEYS = new Set<keyof RustWorkbookSettingsPatch>([
+  'customSettings',
+  'selectedSheetIds',
+]);
+
+function isUiStateWorkbookSettingsPatch(settings: RustWorkbookSettingsPatch): boolean {
+  const keys = Object.keys(settings) as Array<keyof RustWorkbookSettingsPatch>;
+  return keys.length > 0 && keys.every((key) => UI_STATE_WORKBOOK_SETTINGS_KEYS.has(key));
+}
+
 // =============================================================================
 // ComputeBridge Class — Thin Composition Root
 // =============================================================================
@@ -1696,6 +1706,14 @@ export class ComputeBridge extends GeneratedBridgeBase {
   /** Patch Rust-owned workbook settings through the generated Rust bridge. */
   async patchWorkbookSettings(settings: RustWorkbookSettingsPatch): Promise<MutationResult> {
     this.core.ensureInitialized();
+    if (isUiStateWorkbookSettingsPatch(settings)) {
+      return this.core.mutatePublicUiState('compute_patch_workbook_settings', () =>
+        this.core.transport.call<[Uint8Array, MutationResult]>('compute_patch_workbook_settings', {
+          docId: this.core.docId,
+          patch: settings,
+        }),
+      );
+    }
     return super.patchWorkbookSettings(settings);
   }
 

--- a/kernel/src/bridges/compute/compute-core.ts
+++ b/kernel/src/bridges/compute/compute-core.ts
@@ -1031,6 +1031,24 @@ export class ComputeCore {
   }
 
   /**
+   * Public UI-state mutation entrypoint.
+   *
+   * UI-only workbook settings are independent of deferred sheet data
+   * materialization, but still need the normal write-gate and mutation-result
+   * pipeline so mirrors, events, undo-state observers, and provider drains stay
+   * consistent.
+   */
+  async mutatePublicUiState(
+    operation: string,
+    call: () => Promise<MutationTuple>,
+    directEdits?: DirectEditPosition[],
+  ): Promise<MutationResult> {
+    this.ensureInitialized();
+    this._writeGate?.assertWritable(operation);
+    return this.mutate(call(), directEdits, operation);
+  }
+
+  /**
    * Public mutation entrypoint for backend calls whose raw return includes
    * caller-visible data next to the MutationResult.
    */

--- a/kernel/src/document/document-lifecycle-system.ts
+++ b/kernel/src/document/document-lifecycle-system.ts
@@ -1055,10 +1055,7 @@ export class DocumentLifecycleSystem {
     // durability/materialization barriers promote the scheduled run immediately,
     // so close/dispose never waits out the background grace period.
     this.importDurabilityPending = true;
-    const delayMs =
-      !options?.immediate && this.hostLifecycleInput !== undefined && this.environment === 'browser'
-        ? 60_000
-        : 0;
+    const delayMs = !options?.immediate && this.environment === 'browser' ? 60_000 : 0;
     const scheduled = new Promise<void>((resolve, reject) => {
       const start = () => {
         if (this.startDeferredHydrationNow !== start) return;


### PR DESCRIPTION
## Summary
- activate sheet tabs immediately while import hydration is pending instead of waiting for target-sheet materialization
- route UI-only workbook settings patches through the normal mutation pipeline without forcing all-sheet materialization
- use scheduled deferred hydration for floating-object population and keep browser background hydration deferred

## Verification
- pnpm --filter @mog/app-spreadsheet test -- floating-object-sheet-population.test.ts use-sheet-tab-actions.test.tsx
- pnpm --filter @mog-sdk/kernel test -- mutation-admission.test.ts
- pnpm --filter @mog-sdk/contracts build
- pnpm --filter @mog-sdk/kernel typecheck
- pnpm --filter @mog/icons build
- pnpm check:private-leaks
- git diff --check
- app-eval real-file-deloitte-lite-baseline against candidate Vite: 14/14 assertions passed

Known existing issue: pnpm --filter @mog/app-spreadsheet typecheck is currently blocked by unresolved shell imports for @mog/platform-memory and @mog/kernel-host-internal.