### PR TITLE
Polish spreadsheet ribbon chrome

### DIFF
--- a/apps/spreadsheet/src/chrome/formula-bar/FormulaBar.tsx
+++ b/apps/spreadsheet/src/chrome/formula-bar/FormulaBar.tsx
@@ -272,7 +272,7 @@ export function FormulaBar({
     <div
       data-formula-bar
       data-testid="formula-bar"
-      className={`relative flex px-2 bg-ss-surface text-ss-text gap-2 ${
+      className={`relative flex px-2 bg-ss-surface-secondary text-ss-text gap-2 ${
         usesTallLayout ? 'items-start py-1' : 'items-center'
       }`}
       style={{ height: formulaBarHeightPx }}
@@ -395,9 +395,7 @@ export function FormulaBar({
             onCompositionEnd={(e) => onCompositionEnd?.(e.data)}
             resize="none"
             rows={usesTallLayout ? 3 : 1}
-            className={`h-full min-h-0 ${
-              isEditing ? 'border-ss-primary ring-2 ring-ss-primary/20' : ''
-            }`}
+            className="h-full min-h-0 focus:!border-ss-border focus:!ring-0 focus-visible:!ring-0 focus-visible:!ring-offset-0"
             style={{
               // D.2: Enable word wrapping for long formulas
               wordWrap: 'break-word',
@@ -432,9 +430,7 @@ export function FormulaBar({
             onCompositionStart={() => onCompositionStart?.()}
             onCompositionUpdate={(e) => onCompositionUpdate?.(e.data)}
             onCompositionEnd={(e) => onCompositionEnd?.(e.data)}
-            className={`h-full ${
-              isEditing ? 'border-ss-primary ring-2 ring-ss-primary/20' : ''
-            } ${isFormula ? 'text-transparent' : ''}`}
+            className={`h-full focus:!border-ss-border focus:!ring-0 focus-visible:!ring-0 focus-visible:!ring-offset-0 ${isFormula ? 'text-transparent' : ''}`}
             // Keep caret visible when text is transparent for syntax highlighting overlay
             style={isFormula ? { caretColor: 'var(--color-ss-text)' } : undefined}
             spellCheck={false}

--- a/apps/spreadsheet/src/chrome/sheet-tabs/Tab.tsx
+++ b/apps/spreadsheet/src/chrome/sheet-tabs/Tab.tsx
@@ -399,7 +399,7 @@ export function Tab({
           <span>{name}</span>
           {/* Active underline is separate from the persisted tab color marker. */}
           <div
-            className="absolute bottom-0 left-0 right-0 rounded-b-sm"
+            className="absolute bottom-0 left-0 right-0"
             data-testid="active-tab-indicator"
             style={{
               backgroundColor: activeIndicatorColor,
@@ -408,7 +408,7 @@ export function Tab({
           />
           {/* `tab-color-indicator` reflects only the sheet tabColor. */}
           <div
-            className="absolute bottom-0 left-0 right-0 rounded-b-sm"
+            className="absolute bottom-0 left-0 right-0"
             data-testid="tab-color-indicator"
             style={{
               backgroundColor: tabColorIndicatorColor,

--- a/apps/spreadsheet/src/chrome/status-bar/ZoomSlider.tsx
+++ b/apps/spreadsheet/src/chrome/status-bar/ZoomSlider.tsx
@@ -175,7 +175,7 @@ export function ZoomSlider({ className = '' }: ZoomSliderProps) {
         max={MAX_ZOOM * 100}
         value={currentZoom * 100}
         onChange={handleSliderChange}
-        className="w-20 h-1 bg-ss-surface-hover rounded-ss-lg appearance-none cursor-pointer accent-ss-primary"
+        className="mog-zoom-slider w-20 h-1 bg-ss-surface-hover rounded-ss-lg appearance-none cursor-pointer"
         title={`Zoom: ${formatZoomPercent(currentZoom)}`}
         aria-label="Zoom level"
       />

--- a/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.test.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.test.ts
@@ -12,4 +12,27 @@ describe('ribbon collapse breakpoints', () => {
     expect(__testing__.computeCollapseLevel(900)).toBe(3);
     expect(__testing__.computeCollapseLevel(640)).toBe(4);
   });
+
+  it('re-expands after a width-only collapse when no overflow escalation is pending', () => {
+    expect(
+      __testing__.resolveWidthCollapseLevel(
+        1800,
+        __testing__.computeCollapseLevel(1800),
+        3,
+        Number.POSITIVE_INFINITY,
+      ).level,
+    ).toBe(0);
+  });
+
+  it('keeps overflow escalation until the release width is crossed', () => {
+    expect(
+      __testing__.resolveWidthCollapseLevel(1400, __testing__.computeCollapseLevel(1400), 2, 1500)
+        .level,
+    ).toBe(2);
+
+    expect(
+      __testing__.resolveWidthCollapseLevel(1608, __testing__.computeCollapseLevel(1608), 2, 1500)
+        .level,
+    ).toBe(0);
+  });
 });

--- a/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.ts
@@ -83,6 +83,22 @@ function computeCollapseLevel(width: number): CollapseLevel {
   return 4;
 }
 
+function resolveWidthCollapseLevel(
+  width: number,
+  widthLevel: CollapseLevel,
+  previousLevel: CollapseLevel,
+  releaseWidth: number,
+): { level: CollapseLevel; releaseWidth: number } {
+  if (releaseWidth === Number.POSITIVE_INFINITY || width > releaseWidth) {
+    return { level: widthLevel, releaseWidth: Number.POSITIVE_INFINITY };
+  }
+
+  return {
+    level: Math.max(widthLevel, previousLevel) as CollapseLevel,
+    releaseWidth,
+  };
+}
+
 // =============================================================================
 // Hook
 // =============================================================================
@@ -154,17 +170,14 @@ export function useRibbonCollapse(
     const applyWidth = (width: number) => {
       const widthLevel = computeCollapseLevel(width);
       setState((prev) => {
-        let level: CollapseLevel;
-        if (width > releaseWidthRef.current) {
-          // Container is now comfortably wider than the level that overflowed —
-          // release the escalation and fall back to the width-based level.
-          releaseWidthRef.current = Number.POSITIVE_INFINITY;
-          level = widthLevel;
-        } else {
-          // Still within the escalated regime. Never render *fuller* than the
-          // width breakpoints allow, but keep any escalation already applied.
-          level = Math.max(widthLevel, prev.level) as CollapseLevel;
-        }
+        const resolved = resolveWidthCollapseLevel(
+          width,
+          widthLevel,
+          prev.level,
+          releaseWidthRef.current,
+        );
+        releaseWidthRef.current = resolved.releaseWidth;
+        const level = resolved.level;
         if (prev.level === level && prev.containerWidth === width) return prev;
         return { level, containerWidth: width };
       });
@@ -249,5 +262,6 @@ export function useRibbonCollapse(
  */
 export const __testing__ = {
   computeCollapseLevel,
+  resolveWidthCollapseLevel,
   COLLAPSE_BREAKPOINTS,
 };

--- a/apps/spreadsheet/src/chrome/toolbar/galleries/ConditionalFormattingMenu.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/galleries/ConditionalFormattingMenu.tsx
@@ -42,7 +42,8 @@ import {
   RibbonDropdownItem,
   RibbonDropdownSubmenu,
 } from '../primitives/RibbonDropdown';
-import { ConditionalFormatIcon, DropdownArrowIcon } from '../primitives/ToolbarIcons';
+import { StackedRibbonMenuButton } from '../primitives/StackedRibbonMenuButton';
+import { ConditionalFormatIcon } from '../primitives/ToolbarIcons';
 
 // =============================================================================
 // Types
@@ -105,11 +106,7 @@ function ConditionalFormattingStackIcon() {
   return (
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
       <rect x="1.5" y="2" width="13" height="12" rx="1" fill="#ffffff" stroke="#6b7280" />
-      <path
-        d="M5.8 2v12M10.2 2v12M1.5 6.1h13M1.5 10.4h13"
-        stroke="#9ca3af"
-        strokeWidth="0.7"
-      />
+      <path d="M5.8 2v12M10.2 2v12M1.5 6.1h13M1.5 10.4h13" stroke="#9ca3af" strokeWidth="0.7" />
       <rect x="2.4" y="2.9" width="2.6" height="2.4" fill="#f7c7c7" />
       <rect x="6.7" y="2.9" width="2.6" height="2.4" fill="#b7d7f0" />
       <rect x="11" y="6.9" width="2.6" height="2.7" fill="#f7c7c7" />
@@ -226,26 +223,17 @@ export const ConditionalFormattingMenu = React.memo(function ConditionalFormatti
   // Get table at selection for conditional rendering
   const tableAtSelection = cf.getTableAtSelection();
 
-  // Trigger button - uses RibbonButton with vertical layout and full height
+  // Trigger button: vertical RibbonButton by default, compact stack row in Styles.
   const trigger =
     variant === 'stacked' ? (
-      <Tooltip title="Conditional Formatting" description="Highlight cells based on rules">
-        <button
-          type="button"
-          data-testid="ribbon-dropdown-conditional-formatting"
-          onClick={() => setIsOpen(!isOpen)}
-          className="flex h-5 min-w-[132px] items-center gap-1.5 rounded px-1.5 text-ribbon-compact leading-none text-ss-text-secondary transition-colors duration-ss-fast hover:bg-ss-surface-hover focus:outline-none focus-visible:ring-1 focus-visible:ring-ss-primary"
-          aria-label="Conditional Formatting"
-          aria-expanded={isOpen}
-          aria-haspopup="menu"
-        >
-          <span className="flex h-4 w-4 shrink-0 items-center justify-center">
-            <ConditionalFormattingStackIcon />
-          </span>
-          <span className="flex-1 whitespace-nowrap text-left">Conditional Formatting</span>
-          <DropdownArrowIcon className={isOpen ? 'rotate-180' : ''} />
-        </button>
-      </Tooltip>
+      <StackedRibbonMenuButton
+        id="conditional-formatting"
+        testId="ribbon-dropdown-conditional-formatting"
+        icon={<ConditionalFormattingStackIcon />}
+        label="Conditional Formatting"
+        isOpen={isOpen}
+        onClick={() => setIsOpen(!isOpen)}
+      />
     ) : (
       <Tooltip title="Conditional Formatting" description="Highlight cells based on rules">
         <RibbonButton

--- a/apps/spreadsheet/src/chrome/toolbar/galleries/ConditionalFormattingMenu.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/galleries/ConditionalFormattingMenu.tsx
@@ -42,7 +42,7 @@ import {
   RibbonDropdownItem,
   RibbonDropdownSubmenu,
 } from '../primitives/RibbonDropdown';
-import { ConditionalFormatIcon } from '../primitives/ToolbarIcons';
+import { ConditionalFormatIcon, DropdownArrowIcon } from '../primitives/ToolbarIcons';
 
 // =============================================================================
 // Types
@@ -51,6 +51,8 @@ import { ConditionalFormatIcon } from '../primitives/ToolbarIcons';
 interface ConditionalFormattingMenuProps {
   /** Callback when CF dialog should open (existing flow) */
   onOpenCFDialog?: () => void;
+  /** Compact three-row style used inside the Home ribbon Styles group. */
+  variant?: 'button' | 'stacked';
 }
 
 // =============================================================================
@@ -107,6 +109,7 @@ const TOP_BOTTOM_RULES: Array<{ label: string; type: QuickRuleDialogType; descri
  */
 export const ConditionalFormattingMenu = React.memo(function ConditionalFormattingMenu({
   onOpenCFDialog,
+  variant = 'button',
 }: ConditionalFormattingMenuProps) {
   // lifted into the ribbonDropdowns slice so the keytip chord
   // (Alt+H,J) can open the menu via OPEN_RIBBON_DROPDOWN.
@@ -203,21 +206,40 @@ export const ConditionalFormattingMenu = React.memo(function ConditionalFormatti
   const tableAtSelection = cf.getTableAtSelection();
 
   // Trigger button - uses RibbonButton with vertical layout and full height
-  const trigger = (
-    <Tooltip title="Conditional Formatting" description="Highlight cells based on rules">
-      <RibbonButton
-        layout="vertical"
-        height="full"
-        data-testid="ribbon-dropdown-conditional-formatting"
-        icon={<ConditionalFormatIcon />}
-        label={'Conditional\nFormatting'}
-        hasDropdown
-        dropdownPosition="inline"
-        isOpen={isOpen}
-        aria-label="Conditional Formatting"
-      />
-    </Tooltip>
-  );
+  const trigger =
+    variant === 'stacked' ? (
+      <Tooltip title="Conditional Formatting" description="Highlight cells based on rules">
+        <button
+          type="button"
+          data-testid="ribbon-dropdown-conditional-formatting"
+          onClick={() => setIsOpen(!isOpen)}
+          className="flex h-5 min-w-[134px] items-center gap-1.5 rounded px-1.5 text-ribbon leading-none text-ss-text-secondary transition-colors duration-ss-fast hover:bg-ss-surface-hover focus:outline-none focus-visible:ring-1 focus-visible:ring-ss-primary"
+          aria-label="Conditional Formatting"
+          aria-expanded={isOpen}
+          aria-haspopup="menu"
+        >
+          <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+            <ConditionalFormatIcon />
+          </span>
+          <span className="flex-1 whitespace-nowrap text-left">Conditional Formatting</span>
+          <DropdownArrowIcon className={isOpen ? 'rotate-180' : ''} />
+        </button>
+      </Tooltip>
+    ) : (
+      <Tooltip title="Conditional Formatting" description="Highlight cells based on rules">
+        <RibbonButton
+          layout="vertical"
+          height="full"
+          data-testid="ribbon-dropdown-conditional-formatting"
+          icon={<ConditionalFormatIcon />}
+          label={'Conditional\nFormatting'}
+          hasDropdown
+          dropdownPosition="inline"
+          isOpen={isOpen}
+          aria-label="Conditional Formatting"
+        />
+      </Tooltip>
+    );
 
   return (
     <div className="relative inline-flex">

--- a/apps/spreadsheet/src/chrome/toolbar/galleries/ConditionalFormattingMenu.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/galleries/ConditionalFormattingMenu.tsx
@@ -103,9 +103,15 @@ const TOP_BOTTOM_RULES: Array<{ label: string; type: QuickRuleDialogType; descri
 // Trigger Icon
 // =============================================================================
 
-function ConditionalFormattingStackIcon() {
+export function ConditionalFormattingStackIcon() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <svg
+      width="var(--ribbon-icon-size)"
+      height="var(--ribbon-icon-size)"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+    >
       <rect x="1.5" y="2" width="13" height="12" rx="1" fill="#ffffff" stroke="#6b7280" />
       <path d="M5.8 2v12M10.2 2v12M1.5 6.1h13M1.5 10.4h13" stroke="#9ca3af" strokeWidth="0.7" />
       <rect x="2.4" y="2.9" width="2.6" height="2.4" fill="#f7c7c7" />

--- a/apps/spreadsheet/src/chrome/toolbar/galleries/ConditionalFormattingMenu.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/galleries/ConditionalFormattingMenu.tsx
@@ -98,6 +98,27 @@ const TOP_BOTTOM_RULES: Array<{ label: string; type: QuickRuleDialogType; descri
 ];
 
 // =============================================================================
+// Trigger Icon
+// =============================================================================
+
+function ConditionalFormattingStackIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <rect x="1.5" y="2" width="13" height="12" rx="1" fill="#ffffff" stroke="#6b7280" />
+      <path
+        d="M5.8 2v12M10.2 2v12M1.5 6.1h13M1.5 10.4h13"
+        stroke="#9ca3af"
+        strokeWidth="0.7"
+      />
+      <rect x="2.4" y="2.9" width="2.6" height="2.4" fill="#f7c7c7" />
+      <rect x="6.7" y="2.9" width="2.6" height="2.4" fill="#b7d7f0" />
+      <rect x="11" y="6.9" width="2.6" height="2.7" fill="#f7c7c7" />
+      <rect x="6.7" y="11.2" width="2.6" height="1.9" fill="#f7c7c7" />
+    </svg>
+  );
+}
+
+// =============================================================================
 // Component
 // =============================================================================
 
@@ -213,13 +234,13 @@ export const ConditionalFormattingMenu = React.memo(function ConditionalFormatti
           type="button"
           data-testid="ribbon-dropdown-conditional-formatting"
           onClick={() => setIsOpen(!isOpen)}
-          className="flex h-5 min-w-[134px] items-center gap-1.5 rounded px-1.5 text-ribbon leading-none text-ss-text-secondary transition-colors duration-ss-fast hover:bg-ss-surface-hover focus:outline-none focus-visible:ring-1 focus-visible:ring-ss-primary"
+          className="flex h-5 min-w-[132px] items-center gap-1.5 rounded px-1.5 text-ribbon-compact leading-none text-ss-text-secondary transition-colors duration-ss-fast hover:bg-ss-surface-hover focus:outline-none focus-visible:ring-1 focus-visible:ring-ss-primary"
           aria-label="Conditional Formatting"
           aria-expanded={isOpen}
           aria-haspopup="menu"
         >
           <span className="flex h-4 w-4 shrink-0 items-center justify-center">
-            <ConditionalFormatIcon />
+            <ConditionalFormattingStackIcon />
           </span>
           <span className="flex-1 whitespace-nowrap text-left">Conditional Formatting</span>
           <DropdownArrowIcon className={isOpen ? 'rotate-180' : ''} />

--- a/apps/spreadsheet/src/chrome/toolbar/galleries/ConditionalFormattingMenu.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/galleries/ConditionalFormattingMenu.tsx
@@ -44,6 +44,7 @@ import {
 } from '../primitives/RibbonDropdown';
 import { StackedRibbonMenuButton } from '../primitives/StackedRibbonMenuButton';
 import { ConditionalFormatIcon } from '../primitives/ToolbarIcons';
+import { RibbonVisibilityItem } from '../visibility/RibbonVisibilityContext';
 
 // =============================================================================
 // Types
@@ -231,6 +232,7 @@ export const ConditionalFormattingMenu = React.memo(function ConditionalFormatti
         testId="ribbon-dropdown-conditional-formatting"
         icon={<ConditionalFormattingStackIcon />}
         label="Conditional Formatting"
+        visibilityKey="conditionalFormatting"
         isOpen={isOpen}
         onClick={() => setIsOpen(!isOpen)}
       />
@@ -250,7 +252,7 @@ export const ConditionalFormattingMenu = React.memo(function ConditionalFormatti
       </Tooltip>
     );
 
-  return (
+  const menu = (
     <div className="relative inline-flex">
       <RibbonDropdown open={isOpen} onOpenChange={setIsOpen} trigger={trigger} width={220}>
         {/* Wrapper carries the chrome-symmetry menu testid; the popover
@@ -438,6 +440,12 @@ export const ConditionalFormattingMenu = React.memo(function ConditionalFormatti
         </div>
       </RibbonDropdown>
     </div>
+  );
+
+  return variant === 'stacked' ? (
+    <RibbonVisibilityItem item="conditionalFormatting">{menu}</RibbonVisibilityItem>
+  ) : (
+    menu
   );
 });
 

--- a/apps/spreadsheet/src/chrome/toolbar/galleries/PasteDropdown.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/galleries/PasteDropdown.tsx
@@ -216,6 +216,7 @@ export const PasteDropdown = React.memo(function PasteDropdown({
       icon={<PasteIcon />}
       label="Paste"
       variant="large"
+      width="narrow"
       isOpen={isOpen}
       title="Paste (Ctrl+V)"
       aria-label="Paste"

--- a/apps/spreadsheet/src/chrome/toolbar/groups/AlignmentGroup.test.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/AlignmentGroup.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+
+const APP_ROOT = process.cwd().endsWith(`${nodePath.sep}apps${nodePath.sep}spreadsheet`)
+  ? process.cwd()
+  : nodePath.resolve(process.cwd(), 'apps/spreadsheet');
+
+describe('AlignmentGroup merge control', () => {
+  test('keeps Merge & Center as a direct-action split button', () => {
+    const source = readFileSync(
+      nodePath.resolve(APP_ROOT, 'src/chrome/toolbar/groups/AlignmentGroup.tsx'),
+      'utf8',
+    );
+
+    expect(source).toContain('<SplitButton');
+    expect(source).toContain('id="merge-center"');
+    expect(source).toContain('setMergeDropdownOpen(false)');
+    expect(source).toContain("dispatch('MERGE_AND_CENTER')");
+    expect(source).toContain('onDropdownClick={() => setMergeDropdownOpen(!mergeDropdownOpen)}');
+  });
+});

--- a/apps/spreadsheet/src/chrome/toolbar/groups/AlignmentGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/AlignmentGroup.tsx
@@ -6,8 +6,7 @@
  * text orientation, and indent controls.
  *
  * Text formatting dispatch: every onClick routes through `useDispatch`
- * — the same hook form ArrangeGroup uses. The horizontal-alignment
- * three-button cluster is now a single `<SegmentedControl>` instance.
+ * — the same hook form ArrangeGroup uses.
  *
  * COLLAPSE SUPPORT (
  * - Passes ALIGNMENT_COLLAPSE_CONFIG to ToolbarGroup
@@ -51,6 +50,7 @@ import {
 } from '../primitives/HomeAlignmentIcons';
 import { RibbonButton } from '../primitives/RibbonButton';
 import { RibbonDropdownPanel } from '../primitives/RibbonDropdown';
+import { SplitButton } from '../primitives/SplitButton';
 import { ToolbarGroup } from '../primitives/ToolbarGroup';
 import { useRibbonVisibilityPathVisible } from '../visibility/RibbonVisibilityContext';
 import {
@@ -60,7 +60,6 @@ import {
   AlignMiddleIcon,
   AlignRightIcon,
   AlignTopIcon,
-  DropdownArrowIcon,
   MergeAcrossIcon,
   MergeAndCenterIcon,
   MergeCellsIcon,
@@ -98,12 +97,9 @@ export const AlignmentGroup = React.memo(function AlignmentGroup() {
   const dispatch = useDispatch();
 
   // ===========================================================================
-  // Derived alignment state — granular Zustand selectors. Horizontal alignment
-  // binds the SegmentedControl to the *raw* engine value: when raw is
-  // 'general'/'fill'/'centerContinuous'/'justify'/'distributed' (none of which
-  // map to a Row-1 segment), no segment is highlighted — matching Excel's
-  // unset-state visual. Vertical alignment still uses the mapped form because
-  // its three icon-only buttons are not yet a SegmentedControl.
+  // Derived alignment state. Horizontal alignment binds to the raw engine
+  // value so non-rendered values such as general/fill/centerContinuous leave
+  // the three icon buttons unhighlighted, matching Excel's unset state.
   // ===========================================================================
 
   const rawHAlign = useUIStore((s) => s.activeCellFormat?.horizontalAlign ?? 'general');
@@ -272,8 +268,6 @@ export const AlignmentGroup = React.memo(function AlignmentGroup() {
       label="Alignment"
       collapseConfig={ALIGNMENT_COLLAPSE_CONFIG}
       dropdownIcon={<AlignCenterIcon />}
-      onDialogLaunch={() => dispatch('OPEN_FORMAT_CELLS_DIALOG', { initialTab: 'alignment' })}
-      dialogLaunchTitle="Alignment Settings"
     >
       <div className="flex items-center gap-2">
         <div className="grid grid-cols-3 gap-[var(--ribbon-button-inline-gap)]">
@@ -319,42 +313,42 @@ export const AlignmentGroup = React.memo(function AlignmentGroup() {
               />
             </Tooltip>
           )}
-            <Tooltip title="Align Top">
-              <RibbonButton
-                id="align-top"
-                layout="icon-only"
-                icon={<AlignTopIcon />}
-                onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'top' })}
-                isOpen={verticalAlign === 'top'}
-                disabled={!canFormatCells}
-                aria-label="Align top"
-                aria-pressed={verticalAlign === 'top'}
-              />
-            </Tooltip>
-            <Tooltip title="Align Middle">
-              <RibbonButton
-                id="align-middle"
-                layout="icon-only"
-                icon={<AlignMiddleIcon />}
-                onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'middle' })}
-                isOpen={verticalAlign === 'middle'}
-                disabled={!canFormatCells}
-                aria-label="Align middle"
-                aria-pressed={verticalAlign === 'middle'}
-              />
-            </Tooltip>
-            <Tooltip title="Align Bottom">
-              <RibbonButton
-                id="align-bottom"
-                layout="icon-only"
-                icon={<AlignBottomIcon />}
-                onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'bottom' })}
-                isOpen={verticalAlign === 'bottom'}
-                disabled={!canFormatCells}
-                aria-label="Align bottom"
-                aria-pressed={verticalAlign === 'bottom'}
-              />
-            </Tooltip>
+          <Tooltip title="Align Top">
+            <RibbonButton
+              id="align-top"
+              layout="icon-only"
+              icon={<AlignTopIcon />}
+              onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'top' })}
+              isOpen={verticalAlign === 'top'}
+              disabled={!canFormatCells}
+              aria-label="Align top"
+              aria-pressed={verticalAlign === 'top'}
+            />
+          </Tooltip>
+          <Tooltip title="Align Middle">
+            <RibbonButton
+              id="align-middle"
+              layout="icon-only"
+              icon={<AlignMiddleIcon />}
+              onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'middle' })}
+              isOpen={verticalAlign === 'middle'}
+              disabled={!canFormatCells}
+              aria-label="Align middle"
+              aria-pressed={verticalAlign === 'middle'}
+            />
+          </Tooltip>
+          <Tooltip title="Align Bottom">
+            <RibbonButton
+              id="align-bottom"
+              layout="icon-only"
+              icon={<AlignBottomIcon />}
+              onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'bottom' })}
+              isOpen={verticalAlign === 'bottom'}
+              disabled={!canFormatCells}
+              aria-label="Align bottom"
+              aria-pressed={verticalAlign === 'bottom'}
+            />
+          </Tooltip>
         </div>
 
         <div className="w-px h-11 bg-ss-surface-tertiary" />
@@ -373,27 +367,23 @@ export const AlignmentGroup = React.memo(function AlignmentGroup() {
             />
           </Tooltip>
 
-          {/* Merge Cells Split Button: direct-action + dropdown.
- Main button toggles merge & center vs unmerge (matches MERGE_AND_CENTER
- handler's internal toggle behavior). */}
+          {/* Merge Cells split button: direct action plus menu options. */}
           <div className="relative inline-flex">
             <Tooltip title="Merge & Center" shortcut="Ctrl+Shift+M">
-              <RibbonButton
+              <SplitButton
                 id="merge-center"
-                layout="icon-only"
-                icon={
-                  <span className="flex items-center gap-[var(--ribbon-button-icon-gap)]">
-                    <MergeCellsIcon />
-                    <DropdownArrowIcon />
-                  </span>
-                }
+                icon={<MergeCellsIcon />}
+                variant="small"
                 isOpen={isMerged || mergeDropdownOpen}
                 disabled={!canFormatCells || (!canMerge && !canUnmerge)}
                 visibilityKey="mergeCenter"
                 aria-label="Merge & Center"
-                onClick={() => setMergeDropdownOpen(!mergeDropdownOpen)}
-                aria-expanded={mergeDropdownOpen}
-                aria-haspopup="menu"
+                onMainClick={() => {
+                  setMergeDropdownOpen(false);
+                  dispatch('MERGE_AND_CENTER');
+                }}
+                onDropdownClick={() => setMergeDropdownOpen(!mergeDropdownOpen)}
+                dropdownTestId="merge-dropdown-trigger"
               />
             </Tooltip>
             <RibbonDropdownPanel

--- a/apps/spreadsheet/src/chrome/toolbar/groups/AlignmentGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/AlignmentGroup.tsx
@@ -33,7 +33,7 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { useActiveSheetId, useFeatureGate, useUIStore, useWorkbook } from '../../../internal-api';
 
-import { SegmentedControl, Tooltip } from '@mog/shell';
+import { Tooltip } from '@mog/shell';
 import { ALIGNMENT_COLLAPSE_CONFIG } from '@mog-sdk/contracts/ribbon';
 import { useDispatch } from '../../../hooks/toolbar/use-action-dependencies';
 import { useSheetProtectionPermissions } from '../../../hooks/structure/use-sheet-protection';
@@ -51,7 +51,6 @@ import {
 } from '../primitives/HomeAlignmentIcons';
 import { RibbonButton } from '../primitives/RibbonButton';
 import { RibbonDropdownPanel } from '../primitives/RibbonDropdown';
-import { SplitButton } from '../primitives/SplitButton';
 import { ToolbarGroup } from '../primitives/ToolbarGroup';
 import { useRibbonVisibilityPathVisible } from '../visibility/RibbonVisibilityContext';
 import {
@@ -61,6 +60,7 @@ import {
   AlignMiddleIcon,
   AlignRightIcon,
   AlignTopIcon,
+  DropdownArrowIcon,
   MergeAcrossIcon,
   MergeAndCenterIcon,
   MergeCellsIcon,
@@ -72,7 +72,6 @@ import {
 // Types
 // =============================================================================
 
-type HorizontalAlign = 'left' | 'center' | 'right' | 'justify';
 type VerticalAlign = 'top' | 'middle' | 'bottom';
 
 // =============================================================================
@@ -266,33 +265,6 @@ export const AlignmentGroup = React.memo(function AlignmentGroup() {
   const showAlignCenter = useRibbonVisibilityPathVisible(['home', 'alignment', 'center']);
   const showAlignRight = useRibbonVisibilityPathVisible(['home', 'alignment', 'alignRight']);
 
-  const horizontalAlignmentOptions = [
-    {
-      value: 'left',
-      id: 'align-left',
-      ariaLabel: 'Align left',
-      tooltip: 'Align Left',
-      label: <AlignLeftIcon />,
-      visible: showAlignLeft,
-    },
-    {
-      value: 'center',
-      id: 'align-center',
-      ariaLabel: 'Align center',
-      tooltip: 'Align Center',
-      label: <AlignCenterIcon />,
-      visible: showAlignCenter,
-    },
-    {
-      value: 'right',
-      id: 'align-right',
-      ariaLabel: 'Align right',
-      tooltip: 'Align Right',
-      label: <AlignRightIcon />,
-      visible: showAlignRight,
-    },
-  ].filter((option) => option.visible);
-
   if (!isEnabled) return null;
 
   return (
@@ -304,23 +276,49 @@ export const AlignmentGroup = React.memo(function AlignmentGroup() {
       dialogLaunchTitle="Alignment Settings"
     >
       <div className="flex items-center gap-2">
-        <div className="flex flex-col gap-[var(--ribbon-button-gap)]">
-          {/* Bind to the *raw* alignment, not the mapped textAlign: Radix
- RadioGroup suppresses onValueChange when clicking the already-
- selected segment (radios don't uncheck on re-click), so mapping
- 'general' → 'left' would silence the keytip-driven synthetic
- click on `align-left`. Excel shows the unset state as no segment
- highlighted, which matches this binding by construction. */}
-          <SegmentedControl
-            id="horizontal-align"
-            ariaLabel="Horizontal alignment"
-            value={rawHAlign}
-            onChange={(v) => dispatch('SET_HORIZONTAL_ALIGN', { align: v as HorizontalAlign })}
-            disabled={!canFormatCells}
-            options={horizontalAlignmentOptions}
-          />
-
-          <div className="flex items-center gap-[var(--ribbon-button-inline-gap)]">
+        <div className="grid grid-cols-3 gap-[var(--ribbon-button-inline-gap)]">
+          {showAlignLeft && (
+            <Tooltip title="Align Left">
+              <RibbonButton
+                id="align-left"
+                layout="icon-only"
+                icon={<AlignLeftIcon />}
+                onClick={() => dispatch('SET_HORIZONTAL_ALIGN', { align: 'left' })}
+                isOpen={rawHAlign === 'left'}
+                disabled={!canFormatCells}
+                aria-label="Align left"
+                aria-pressed={rawHAlign === 'left'}
+              />
+            </Tooltip>
+          )}
+          {showAlignCenter && (
+            <Tooltip title="Align Center">
+              <RibbonButton
+                id="align-center"
+                layout="icon-only"
+                icon={<AlignCenterIcon />}
+                onClick={() => dispatch('SET_HORIZONTAL_ALIGN', { align: 'center' })}
+                isOpen={rawHAlign === 'center'}
+                disabled={!canFormatCells}
+                aria-label="Align center"
+                aria-pressed={rawHAlign === 'center'}
+              />
+            </Tooltip>
+          )}
+          {showAlignRight && (
+            <Tooltip title="Align Right">
+              <RibbonButton
+                id="align-right"
+                layout="icon-only"
+                icon={<AlignRightIcon />}
+                onClick={() => dispatch('SET_HORIZONTAL_ALIGN', { align: 'right' })}
+                isOpen={rawHAlign === 'right'}
+                disabled={!canFormatCells}
+                aria-label="Align right"
+                aria-pressed={rawHAlign === 'right'}
+              />
+            </Tooltip>
+          )}
             <Tooltip title="Align Top">
               <RibbonButton
                 id="align-top"
@@ -357,12 +355,11 @@ export const AlignmentGroup = React.memo(function AlignmentGroup() {
                 aria-pressed={verticalAlign === 'bottom'}
               />
             </Tooltip>
-          </div>
         </div>
 
         <div className="w-px h-11 bg-ss-surface-tertiary" />
 
-        <div className="grid grid-cols-3 items-center gap-x-1 gap-y-[var(--ribbon-button-gap)]">
+        <div className="grid grid-cols-[auto_auto] items-center gap-x-1.5 gap-y-[var(--ribbon-button-gap)]">
           <Tooltip title="Word Wrap">
             <RibbonButton
               id="word-wrap"
@@ -381,23 +378,22 @@ export const AlignmentGroup = React.memo(function AlignmentGroup() {
  handler's internal toggle behavior). */}
           <div className="relative inline-flex">
             <Tooltip title="Merge & Center" shortcut="Ctrl+Shift+M">
-              <SplitButton
+              <RibbonButton
                 id="merge-center"
-                icon={<MergeCellsIcon />}
-                variant="small"
+                layout="icon-only"
+                icon={
+                  <span className="flex items-center gap-[var(--ribbon-button-icon-gap)]">
+                    <MergeCellsIcon />
+                    <DropdownArrowIcon />
+                  </span>
+                }
                 isOpen={isMerged || mergeDropdownOpen}
                 disabled={!canFormatCells || (!canMerge && !canUnmerge)}
                 visibilityKey="mergeCenter"
                 aria-label="Merge & Center"
-                onMainClick={() => {
-                  if (isMerged || canUnmerge) {
-                    dispatch('UNMERGE_CELLS');
-                  } else if (canMerge) {
-                    dispatch('MERGE_AND_CENTER');
-                  }
-                }}
-                onDropdownClick={() => setMergeDropdownOpen(!mergeDropdownOpen)}
-                dropdownTestId="merge-dropdown-trigger"
+                onClick={() => setMergeDropdownOpen(!mergeDropdownOpen)}
+                aria-expanded={mergeDropdownOpen}
+                aria-haspopup="menu"
               />
             </Tooltip>
             <RibbonDropdownPanel
@@ -674,29 +670,31 @@ export const AlignmentGroup = React.memo(function AlignmentGroup() {
             </RibbonDropdownPanel>
           </div>
 
-          {/* Decrease Indent */}
-          <Tooltip title="Decrease Indent">
-            <RibbonButton
-              id="decrease-indent"
-              layout="icon-only"
-              icon={<DecreaseIndentIcon />}
-              onClick={() => dispatch('DECREASE_INDENT')}
-              disabled={!canFormatCells || indent === 0}
-              aria-label="Decrease indent"
-            />
-          </Tooltip>
+          <div className="flex items-center gap-[var(--ribbon-button-inline-gap)]">
+            {/* Decrease Indent */}
+            <Tooltip title="Decrease Indent">
+              <RibbonButton
+                id="decrease-indent"
+                layout="icon-only"
+                icon={<DecreaseIndentIcon />}
+                onClick={() => dispatch('DECREASE_INDENT')}
+                disabled={!canFormatCells || indent === 0}
+                aria-label="Decrease indent"
+              />
+            </Tooltip>
 
-          {/* Increase Indent */}
-          <Tooltip title="Increase Indent">
-            <RibbonButton
-              id="increase-indent"
-              layout="icon-only"
-              icon={<IncreaseIndentIcon />}
-              onClick={() => dispatch('INCREASE_INDENT')}
-              disabled={!canFormatCells}
-              aria-label="Increase indent"
-            />
-          </Tooltip>
+            {/* Increase Indent */}
+            <Tooltip title="Increase Indent">
+              <RibbonButton
+                id="increase-indent"
+                layout="icon-only"
+                icon={<IncreaseIndentIcon />}
+                onClick={() => dispatch('INCREASE_INDENT')}
+                disabled={!canFormatCells}
+                aria-label="Increase indent"
+              />
+            </Tooltip>
+          </div>
         </div>
       </div>
     </ToolbarGroup>

--- a/apps/spreadsheet/src/chrome/toolbar/groups/AlignmentGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/AlignmentGroup.tsx
@@ -303,9 +303,8 @@ export const AlignmentGroup = React.memo(function AlignmentGroup() {
       onDialogLaunch={() => dispatch('OPEN_FORMAT_CELLS_DIALOG', { initialTab: 'alignment' })}
       dialogLaunchTitle="Alignment Settings"
     >
-      <div className="flex flex-col gap-[var(--ribbon-button-gap)]">
-        {/* Row 1: Horizontal alignment + Vertical alignment */}
-        <div className="flex items-center gap-[var(--ribbon-button-inline-gap)]">
+      <div className="flex items-center gap-2">
+        <div className="flex flex-col gap-[var(--ribbon-button-gap)]">
           {/* Bind to the *raw* alignment, not the mapped textAlign: Radix
  RadioGroup suppresses onValueChange when clicking the already-
  selected segment (radios don't uncheck on re-click), so mapping
@@ -321,48 +320,49 @@ export const AlignmentGroup = React.memo(function AlignmentGroup() {
             options={horizontalAlignmentOptions}
           />
 
-          <div className="w-px h-5 bg-ss-surface-tertiary mx-0.5" />
-
-          <Tooltip title="Align Top">
-            <RibbonButton
-              id="align-top"
-              layout="icon-only"
-              icon={<AlignTopIcon />}
-              onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'top' })}
-              isOpen={verticalAlign === 'top'}
-              disabled={!canFormatCells}
-              aria-label="Align top"
-              aria-pressed={verticalAlign === 'top'}
-            />
-          </Tooltip>
-          <Tooltip title="Align Middle">
-            <RibbonButton
-              id="align-middle"
-              layout="icon-only"
-              icon={<AlignMiddleIcon />}
-              onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'middle' })}
-              isOpen={verticalAlign === 'middle'}
-              disabled={!canFormatCells}
-              aria-label="Align middle"
-              aria-pressed={verticalAlign === 'middle'}
-            />
-          </Tooltip>
-          <Tooltip title="Align Bottom">
-            <RibbonButton
-              id="align-bottom"
-              layout="icon-only"
-              icon={<AlignBottomIcon />}
-              onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'bottom' })}
-              isOpen={verticalAlign === 'bottom'}
-              disabled={!canFormatCells}
-              aria-label="Align bottom"
-              aria-pressed={verticalAlign === 'bottom'}
-            />
-          </Tooltip>
+          <div className="flex items-center gap-[var(--ribbon-button-inline-gap)]">
+            <Tooltip title="Align Top">
+              <RibbonButton
+                id="align-top"
+                layout="icon-only"
+                icon={<AlignTopIcon />}
+                onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'top' })}
+                isOpen={verticalAlign === 'top'}
+                disabled={!canFormatCells}
+                aria-label="Align top"
+                aria-pressed={verticalAlign === 'top'}
+              />
+            </Tooltip>
+            <Tooltip title="Align Middle">
+              <RibbonButton
+                id="align-middle"
+                layout="icon-only"
+                icon={<AlignMiddleIcon />}
+                onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'middle' })}
+                isOpen={verticalAlign === 'middle'}
+                disabled={!canFormatCells}
+                aria-label="Align middle"
+                aria-pressed={verticalAlign === 'middle'}
+              />
+            </Tooltip>
+            <Tooltip title="Align Bottom">
+              <RibbonButton
+                id="align-bottom"
+                layout="icon-only"
+                icon={<AlignBottomIcon />}
+                onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'bottom' })}
+                isOpen={verticalAlign === 'bottom'}
+                disabled={!canFormatCells}
+                aria-label="Align bottom"
+                aria-pressed={verticalAlign === 'bottom'}
+              />
+            </Tooltip>
+          </div>
         </div>
 
-        {/* Row 2: Wrap + Merge + Orientation + Indent */}
-        <div className="flex items-center gap-[var(--ribbon-button-inline-gap)]">
+        <div className="w-px h-11 bg-ss-surface-tertiary" />
+
+        <div className="grid grid-cols-3 items-center gap-x-1 gap-y-[var(--ribbon-button-gap)]">
           <Tooltip title="Word Wrap">
             <RibbonButton
               id="word-wrap"
@@ -673,8 +673,6 @@ export const AlignmentGroup = React.memo(function AlignmentGroup() {
               </div>
             </RibbonDropdownPanel>
           </div>
-
-          <div className="w-px h-5 bg-ss-surface-tertiary mx-0.5" />
 
           {/* Decrease Indent */}
           <Tooltip title="Decrease Indent">

--- a/apps/spreadsheet/src/chrome/toolbar/groups/AlignmentGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/AlignmentGroup.tsx
@@ -269,398 +269,404 @@ export const AlignmentGroup = React.memo(function AlignmentGroup() {
       collapseConfig={ALIGNMENT_COLLAPSE_CONFIG}
       dropdownIcon={<AlignCenterIcon />}
     >
-      <div className="flex items-center gap-2">
-        <div className="grid grid-cols-3 gap-[var(--ribbon-button-inline-gap)]">
-          {showAlignLeft && (
-            <Tooltip title="Align Left">
+      <div className="flex h-full items-start gap-2">
+        <div className="flex h-[calc(var(--ribbon-content-height)-4px)] flex-col justify-between">
+          <div className="flex h-7 items-center gap-[var(--ribbon-button-inline-gap)]">
+            {showAlignLeft && (
+              <Tooltip title="Align Left">
+                <RibbonButton
+                  id="align-left"
+                  layout="icon-only"
+                  icon={<AlignLeftIcon />}
+                  onClick={() => dispatch('SET_HORIZONTAL_ALIGN', { align: 'left' })}
+                  isOpen={rawHAlign === 'left'}
+                  disabled={!canFormatCells}
+                  aria-label="Align left"
+                  aria-pressed={rawHAlign === 'left'}
+                />
+              </Tooltip>
+            )}
+            {showAlignCenter && (
+              <Tooltip title="Align Center">
+                <RibbonButton
+                  id="align-center"
+                  layout="icon-only"
+                  icon={<AlignCenterIcon />}
+                  onClick={() => dispatch('SET_HORIZONTAL_ALIGN', { align: 'center' })}
+                  isOpen={rawHAlign === 'center'}
+                  disabled={!canFormatCells}
+                  aria-label="Align center"
+                  aria-pressed={rawHAlign === 'center'}
+                />
+              </Tooltip>
+            )}
+            {showAlignRight && (
+              <Tooltip title="Align Right">
+                <RibbonButton
+                  id="align-right"
+                  layout="icon-only"
+                  icon={<AlignRightIcon />}
+                  onClick={() => dispatch('SET_HORIZONTAL_ALIGN', { align: 'right' })}
+                  isOpen={rawHAlign === 'right'}
+                  disabled={!canFormatCells}
+                  aria-label="Align right"
+                  aria-pressed={rawHAlign === 'right'}
+                />
+              </Tooltip>
+            )}
+          </div>
+          <div className="flex h-[var(--ribbon-button-height-third)] items-center gap-[var(--ribbon-button-inline-gap)]">
+            <Tooltip title="Align Top">
               <RibbonButton
-                id="align-left"
+                id="align-top"
                 layout="icon-only"
-                icon={<AlignLeftIcon />}
-                onClick={() => dispatch('SET_HORIZONTAL_ALIGN', { align: 'left' })}
-                isOpen={rawHAlign === 'left'}
+                icon={<AlignTopIcon />}
+                onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'top' })}
+                isOpen={verticalAlign === 'top'}
                 disabled={!canFormatCells}
-                aria-label="Align left"
-                aria-pressed={rawHAlign === 'left'}
+                aria-label="Align top"
+                aria-pressed={verticalAlign === 'top'}
               />
             </Tooltip>
-          )}
-          {showAlignCenter && (
-            <Tooltip title="Align Center">
+            <Tooltip title="Align Middle">
               <RibbonButton
-                id="align-center"
+                id="align-middle"
                 layout="icon-only"
-                icon={<AlignCenterIcon />}
-                onClick={() => dispatch('SET_HORIZONTAL_ALIGN', { align: 'center' })}
-                isOpen={rawHAlign === 'center'}
+                icon={<AlignMiddleIcon />}
+                onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'middle' })}
+                isOpen={verticalAlign === 'middle'}
                 disabled={!canFormatCells}
-                aria-label="Align center"
-                aria-pressed={rawHAlign === 'center'}
+                aria-label="Align middle"
+                aria-pressed={verticalAlign === 'middle'}
               />
             </Tooltip>
-          )}
-          {showAlignRight && (
-            <Tooltip title="Align Right">
+            <Tooltip title="Align Bottom">
               <RibbonButton
-                id="align-right"
+                id="align-bottom"
                 layout="icon-only"
-                icon={<AlignRightIcon />}
-                onClick={() => dispatch('SET_HORIZONTAL_ALIGN', { align: 'right' })}
-                isOpen={rawHAlign === 'right'}
+                icon={<AlignBottomIcon />}
+                onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'bottom' })}
+                isOpen={verticalAlign === 'bottom'}
                 disabled={!canFormatCells}
-                aria-label="Align right"
-                aria-pressed={rawHAlign === 'right'}
+                aria-label="Align bottom"
+                aria-pressed={verticalAlign === 'bottom'}
               />
             </Tooltip>
-          )}
-          <Tooltip title="Align Top">
-            <RibbonButton
-              id="align-top"
-              layout="icon-only"
-              icon={<AlignTopIcon />}
-              onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'top' })}
-              isOpen={verticalAlign === 'top'}
-              disabled={!canFormatCells}
-              aria-label="Align top"
-              aria-pressed={verticalAlign === 'top'}
-            />
-          </Tooltip>
-          <Tooltip title="Align Middle">
-            <RibbonButton
-              id="align-middle"
-              layout="icon-only"
-              icon={<AlignMiddleIcon />}
-              onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'middle' })}
-              isOpen={verticalAlign === 'middle'}
-              disabled={!canFormatCells}
-              aria-label="Align middle"
-              aria-pressed={verticalAlign === 'middle'}
-            />
-          </Tooltip>
-          <Tooltip title="Align Bottom">
-            <RibbonButton
-              id="align-bottom"
-              layout="icon-only"
-              icon={<AlignBottomIcon />}
-              onClick={() => dispatch('SET_VERTICAL_ALIGN', { align: 'bottom' })}
-              isOpen={verticalAlign === 'bottom'}
-              disabled={!canFormatCells}
-              aria-label="Align bottom"
-              aria-pressed={verticalAlign === 'bottom'}
-            />
-          </Tooltip>
+          </div>
         </div>
 
-        <div className="w-px h-11 bg-ss-surface-tertiary" />
+        <div className="w-px h-11 self-center bg-ss-surface-tertiary" />
 
-        <div className="grid grid-cols-[auto_auto] items-center gap-x-1.5 gap-y-[var(--ribbon-button-gap)]">
-          <Tooltip title="Word Wrap">
-            <RibbonButton
-              id="word-wrap"
-              layout="icon-only"
-              icon={<WordWrapIcon />}
-              onClick={() => dispatch('TOGGLE_WRAP_TEXT')}
-              isOpen={wordWrap}
-              disabled={!canFormatCells}
-              aria-label="Word wrap"
-              aria-pressed={wordWrap}
-            />
-          </Tooltip>
-
-          {/* Merge Cells split button: direct action plus menu options. */}
-          <div className="relative inline-flex">
-            <Tooltip title="Merge & Center" shortcut="Ctrl+Shift+M">
-              <SplitButton
-                id="merge-center"
-                icon={<MergeCellsIcon />}
-                variant="small"
-                isOpen={isMerged || mergeDropdownOpen}
-                disabled={!canFormatCells || (!canMerge && !canUnmerge)}
-                visibilityKey="mergeCenter"
-                aria-label="Merge & Center"
-                onMainClick={() => {
-                  setMergeDropdownOpen(false);
-                  dispatch('MERGE_AND_CENTER');
-                }}
-                onDropdownClick={() => setMergeDropdownOpen(!mergeDropdownOpen)}
-                dropdownTestId="merge-dropdown-trigger"
+        <div className="flex h-[calc(var(--ribbon-content-height)-4px)] flex-col justify-between">
+          <div className="flex h-7 items-center gap-1.5">
+            <Tooltip title="Word Wrap">
+              <RibbonButton
+                id="word-wrap"
+                layout="icon-only"
+                icon={<WordWrapIcon />}
+                onClick={() => dispatch('TOGGLE_WRAP_TEXT')}
+                isOpen={wordWrap}
+                disabled={!canFormatCells}
+                aria-label="Word wrap"
+                aria-pressed={wordWrap}
               />
             </Tooltip>
-            <RibbonDropdownPanel
-              open={mergeDropdownOpen}
-              onClose={() => setMergeDropdownOpen(false)}
-            >
-              <div data-testid="ribbon-dropdown-menu-merge" className="py-1 min-w-[180px]">
-                {/* Merge & Center */}
-                <button
-                  type="button"
-                  data-value="merge-and-center"
-                  className={`
+
+            {/* Merge Cells split button: direct action plus menu options. */}
+            <div className="relative inline-flex">
+              <Tooltip title="Merge & Center" shortcut="Ctrl+Shift+M">
+                <SplitButton
+                  id="merge-center"
+                  icon={<MergeCellsIcon />}
+                  variant="small"
+                  isOpen={isMerged || mergeDropdownOpen}
+                  disabled={!canFormatCells || (!canMerge && !canUnmerge)}
+                  visibilityKey="mergeCenter"
+                  aria-label="Merge & Center"
+                  onMainClick={() => {
+                    setMergeDropdownOpen(false);
+                    dispatch('MERGE_AND_CENTER');
+                  }}
+                  onDropdownClick={() => setMergeDropdownOpen(!mergeDropdownOpen)}
+                  dropdownTestId="merge-dropdown-trigger"
+                />
+              </Tooltip>
+              <RibbonDropdownPanel
+                open={mergeDropdownOpen}
+                onClose={() => setMergeDropdownOpen(false)}
+              >
+                <div data-testid="ribbon-dropdown-menu-merge" className="py-1 min-w-[180px]">
+                  {/* Merge & Center */}
+                  <button
+                    type="button"
+                    data-value="merge-and-center"
+                    className={`
  w-full px-3 py-2 text-left text-dropdown
  flex items-center gap-2
  transition-colors
                   ${canFormatCells && canMerge ? 'hover:bg-ss-surface-hover text-text-ss-primary' : 'text-ss-text-disabled cursor-not-allowed'}
  `}
-                  onClick={() => {
-                    if (canFormatCells && canMerge) {
-                      dispatch('MERGE_AND_CENTER');
-                      setMergeDropdownOpen(false);
-                    }
-                  }}
-                  disabled={!canFormatCells || !canMerge}
-                >
-                  <MergeAndCenterIcon />
-                  <span>Merge & Center</span>
-                </button>
-                {/* Merge Across */}
-                <button
-                  type="button"
-                  data-value="merge-across"
-                  className={`
+                    onClick={() => {
+                      if (canFormatCells && canMerge) {
+                        dispatch('MERGE_AND_CENTER');
+                        setMergeDropdownOpen(false);
+                      }
+                    }}
+                    disabled={!canFormatCells || !canMerge}
+                  >
+                    <MergeAndCenterIcon />
+                    <span>Merge & Center</span>
+                  </button>
+                  {/* Merge Across */}
+                  <button
+                    type="button"
+                    data-value="merge-across"
+                    className={`
  w-full px-3 py-2 text-left text-dropdown
  flex items-center gap-2
  transition-colors
                   ${canFormatCells && canMerge ? 'hover:bg-ss-surface-hover text-text-ss-primary' : 'text-ss-text-disabled cursor-not-allowed'}
  `}
-                  onClick={() => {
-                    if (canFormatCells && canMerge) {
-                      dispatch('MERGE_ACROSS');
-                      setMergeDropdownOpen(false);
-                    }
-                  }}
-                  disabled={!canFormatCells || !canMerge}
-                >
-                  <MergeAcrossIcon />
-                  <span>Merge Across</span>
-                </button>
-                {/* Merge Cells (plain — no center alignment) */}
-                <button
-                  type="button"
-                  data-value="merge-cells"
-                  className={`
+                    onClick={() => {
+                      if (canFormatCells && canMerge) {
+                        dispatch('MERGE_ACROSS');
+                        setMergeDropdownOpen(false);
+                      }
+                    }}
+                    disabled={!canFormatCells || !canMerge}
+                  >
+                    <MergeAcrossIcon />
+                    <span>Merge Across</span>
+                  </button>
+                  {/* Merge Cells (plain — no center alignment) */}
+                  <button
+                    type="button"
+                    data-value="merge-cells"
+                    className={`
  w-full px-3 py-2 text-left text-dropdown
  flex items-center gap-2
  transition-colors
                   ${canFormatCells && canMerge ? 'hover:bg-ss-surface-hover text-text-ss-primary' : 'text-ss-text-disabled cursor-not-allowed'}
  `}
-                  onClick={() => {
-                    if (canFormatCells && canMerge) {
-                      dispatch('MERGE_CELLS');
-                      setMergeDropdownOpen(false);
-                    }
-                  }}
-                  disabled={!canFormatCells || !canMerge}
-                >
-                  <MergeCellsIcon />
-                  <span>Merge Cells</span>
-                </button>
-                {/* Divider */}
-                <div className="h-px bg-ss-surface-tertiary my-1" />
-                {/* Unmerge Cells */}
-                <button
-                  type="button"
-                  data-value="unmerge"
-                  className={`
+                    onClick={() => {
+                      if (canFormatCells && canMerge) {
+                        dispatch('MERGE_CELLS');
+                        setMergeDropdownOpen(false);
+                      }
+                    }}
+                    disabled={!canFormatCells || !canMerge}
+                  >
+                    <MergeCellsIcon />
+                    <span>Merge Cells</span>
+                  </button>
+                  {/* Divider */}
+                  <div className="h-px bg-ss-surface-tertiary my-1" />
+                  {/* Unmerge Cells */}
+                  <button
+                    type="button"
+                    data-value="unmerge"
+                    className={`
  w-full px-3 py-2 text-left text-dropdown
  flex items-center gap-2
  transition-colors
                   ${canFormatCells && canUnmerge ? 'hover:bg-ss-surface-hover text-text-ss-primary' : 'text-ss-text-disabled cursor-not-allowed'}
  `}
-                  onClick={() => {
-                    if (canFormatCells && canUnmerge) {
-                      dispatch('UNMERGE_CELLS');
-                      setMergeDropdownOpen(false);
+                    onClick={() => {
+                      if (canFormatCells && canUnmerge) {
+                        dispatch('UNMERGE_CELLS');
+                        setMergeDropdownOpen(false);
+                      }
+                    }}
+                    disabled={!canFormatCells || !canUnmerge}
+                  >
+                    <UnmergeCellsIcon />
+                    <span>Unmerge Cells</span>
+                  </button>
+                  {/* Center Across Selection */}
+                  <button
+                    type="button"
+                    data-value="center-across-selection"
+                    data-testid="merge-menu-center-across-selection"
+                    aria-describedby={
+                      !centerAcrossAvailability.enabled
+                        ? 'merge-center-across-disabled-reason'
+                        : undefined
                     }
-                  }}
-                  disabled={!canFormatCells || !canUnmerge}
-                >
-                  <UnmergeCellsIcon />
-                  <span>Unmerge Cells</span>
-                </button>
-                {/* Center Across Selection */}
-                <button
-                  type="button"
-                  data-value="center-across-selection"
-                  data-testid="merge-menu-center-across-selection"
-                  aria-describedby={
-                    !centerAcrossAvailability.enabled
-                      ? 'merge-center-across-disabled-reason'
-                      : undefined
-                  }
-                  data-disabled-reason={centerAcrossAvailability.reason}
-                  className={`
+                    data-disabled-reason={centerAcrossAvailability.reason}
+                    className={`
  w-full px-3 py-2 text-left text-dropdown
  flex items-center gap-2
  transition-colors
  ${centerAcrossAvailability.enabled ? 'hover:bg-ss-surface-hover text-text-ss-primary' : 'text-ss-text-disabled cursor-not-allowed'}
  `}
-                  onClick={() => {
-                    if (centerAcrossAvailability.enabled) {
-                      dispatch('SET_HORIZONTAL_ALIGN', { align: 'centerContinuous' });
-                      setMergeDropdownOpen(false);
-                    }
-                  }}
-                  disabled={!centerAcrossAvailability.enabled}
-                >
-                  <AlignCenterIcon />
-                  <span>Center Across Selection</span>
-                </button>
-                {!centerAcrossAvailability.enabled && (
-                  <span id="merge-center-across-disabled-reason" className="sr-only">
-                    {centerAcrossAvailability.reason}
-                  </span>
-                )}
-              </div>
-            </RibbonDropdownPanel>
+                    onClick={() => {
+                      if (centerAcrossAvailability.enabled) {
+                        dispatch('SET_HORIZONTAL_ALIGN', { align: 'centerContinuous' });
+                        setMergeDropdownOpen(false);
+                      }
+                    }}
+                    disabled={!centerAcrossAvailability.enabled}
+                  >
+                    <AlignCenterIcon />
+                    <span>Center Across Selection</span>
+                  </button>
+                  {!centerAcrossAvailability.enabled && (
+                    <span id="merge-center-across-disabled-reason" className="sr-only">
+                      {centerAcrossAvailability.reason}
+                    </span>
+                  )}
+                </div>
+              </RibbonDropdownPanel>
+            </div>
           </div>
 
-          {/* Text Orientation Dropdown */}
-          <div className="relative inline-flex">
-            <Tooltip title="Orientation">
-              <RibbonButton
-                id="orientation"
-                layout="icon-only"
-                data-testid="ribbon-dropdown-orientation"
-                icon={<TextOrientationIcon />}
-                onClick={() => setOrientationDropdownOpen(!orientationDropdownOpen)}
-                isOpen={orientationDropdownOpen}
-                hasDropdown
-                disabled={!canFormatCells}
-                aria-label="Text orientation"
-                aria-expanded={orientationDropdownOpen}
-              />
-            </Tooltip>
-            <RibbonDropdownPanel
-              open={orientationDropdownOpen}
-              onClose={() => setOrientationDropdownOpen(false)}
-            >
-              <div data-testid="ribbon-dropdown-menu-orientation" className="py-1 min-w-[180px]">
-                <button
-                  type="button"
-                  data-value="angle-counterclockwise"
-                  className={`
+          <div className="flex h-[var(--ribbon-button-height-third)] items-center gap-[var(--ribbon-button-inline-gap)]">
+            {/* Text Orientation Dropdown */}
+            <div className="relative inline-flex">
+              <Tooltip title="Orientation">
+                <RibbonButton
+                  id="orientation"
+                  layout="icon-only"
+                  data-testid="ribbon-dropdown-orientation"
+                  icon={<TextOrientationIcon />}
+                  onClick={() => setOrientationDropdownOpen(!orientationDropdownOpen)}
+                  isOpen={orientationDropdownOpen}
+                  hasDropdown
+                  disabled={!canFormatCells}
+                  aria-label="Text orientation"
+                  aria-expanded={orientationDropdownOpen}
+                />
+              </Tooltip>
+              <RibbonDropdownPanel
+                open={orientationDropdownOpen}
+                onClose={() => setOrientationDropdownOpen(false)}
+              >
+                <div data-testid="ribbon-dropdown-menu-orientation" className="py-1 min-w-[180px]">
+                  <button
+                    type="button"
+                    data-value="angle-counterclockwise"
+                    className={`
  w-full px-3 py-2 text-left text-dropdown
  flex items-center gap-2
  transition-colors
  ${canFormatCells ? 'hover:bg-ss-surface-hover' : 'text-ss-text-disabled cursor-not-allowed'}
  ${textRotation === 45 ? 'bg-ss-surface-selected' : ''}
  `}
-                  onClick={() => {
-                    if (!canFormatCells) return;
-                    dispatch('SET_TEXT_ROTATION', { rotation: 45 });
-                    setOrientationDropdownOpen(false);
-                  }}
-                  disabled={!canFormatCells}
-                >
-                  <AngleCounterclockwiseIcon />
-                  <span>Angle Counterclockwise</span>
-                </button>
-                <button
-                  type="button"
-                  data-value="angle-clockwise"
-                  className={`
+                    onClick={() => {
+                      if (!canFormatCells) return;
+                      dispatch('SET_TEXT_ROTATION', { rotation: 45 });
+                      setOrientationDropdownOpen(false);
+                    }}
+                    disabled={!canFormatCells}
+                  >
+                    <AngleCounterclockwiseIcon />
+                    <span>Angle Counterclockwise</span>
+                  </button>
+                  <button
+                    type="button"
+                    data-value="angle-clockwise"
+                    className={`
  w-full px-3 py-2 text-left text-dropdown
  flex items-center gap-2
  transition-colors
  ${canFormatCells ? 'hover:bg-ss-surface-hover' : 'text-ss-text-disabled cursor-not-allowed'}
  ${textRotation === -45 ? 'bg-ss-surface-selected' : ''}
  `}
-                  onClick={() => {
-                    if (!canFormatCells) return;
-                    dispatch('SET_TEXT_ROTATION', { rotation: -45 });
-                    setOrientationDropdownOpen(false);
-                  }}
-                  disabled={!canFormatCells}
-                >
-                  <AngleClockwiseIcon />
-                  <span>Angle Clockwise</span>
-                </button>
-                <button
-                  type="button"
-                  data-value="vertical-text"
-                  className={`
+                    onClick={() => {
+                      if (!canFormatCells) return;
+                      dispatch('SET_TEXT_ROTATION', { rotation: -45 });
+                      setOrientationDropdownOpen(false);
+                    }}
+                    disabled={!canFormatCells}
+                  >
+                    <AngleClockwiseIcon />
+                    <span>Angle Clockwise</span>
+                  </button>
+                  <button
+                    type="button"
+                    data-value="vertical-text"
+                    className={`
  w-full px-3 py-2 text-left text-dropdown
  flex items-center gap-2
  transition-colors
  ${canFormatCells ? 'hover:bg-ss-surface-hover' : 'text-ss-text-disabled cursor-not-allowed'}
  ${textRotation === 255 ? 'bg-ss-surface-selected' : ''}
  `}
-                  onClick={() => {
-                    if (!canFormatCells) return;
-                    dispatch('SET_TEXT_ROTATION', { rotation: 255 });
-                    setOrientationDropdownOpen(false);
-                  }}
-                  disabled={!canFormatCells}
-                >
-                  <VerticalTextIcon />
-                  <span>Vertical Text</span>
-                </button>
-                <button
-                  type="button"
-                  data-value="rotate-text-up"
-                  className={`
+                    onClick={() => {
+                      if (!canFormatCells) return;
+                      dispatch('SET_TEXT_ROTATION', { rotation: 255 });
+                      setOrientationDropdownOpen(false);
+                    }}
+                    disabled={!canFormatCells}
+                  >
+                    <VerticalTextIcon />
+                    <span>Vertical Text</span>
+                  </button>
+                  <button
+                    type="button"
+                    data-value="rotate-text-up"
+                    className={`
  w-full px-3 py-2 text-left text-dropdown
  flex items-center gap-2
  transition-colors
  ${canFormatCells ? 'hover:bg-ss-surface-hover' : 'text-ss-text-disabled cursor-not-allowed'}
  ${textRotation === 90 ? 'bg-ss-surface-selected' : ''}
  `}
-                  onClick={() => {
-                    if (!canFormatCells) return;
-                    dispatch('SET_TEXT_ROTATION', { rotation: 90 });
-                    setOrientationDropdownOpen(false);
-                  }}
-                  disabled={!canFormatCells}
-                >
-                  <RotateTextUpIcon />
-                  <span>Rotate Text Up</span>
-                </button>
-                <button
-                  type="button"
-                  data-value="rotate-text-down"
-                  className={`
+                    onClick={() => {
+                      if (!canFormatCells) return;
+                      dispatch('SET_TEXT_ROTATION', { rotation: 90 });
+                      setOrientationDropdownOpen(false);
+                    }}
+                    disabled={!canFormatCells}
+                  >
+                    <RotateTextUpIcon />
+                    <span>Rotate Text Up</span>
+                  </button>
+                  <button
+                    type="button"
+                    data-value="rotate-text-down"
+                    className={`
  w-full px-3 py-2 text-left text-dropdown
  flex items-center gap-2
  transition-colors
  ${canFormatCells ? 'hover:bg-ss-surface-hover' : 'text-ss-text-disabled cursor-not-allowed'}
  ${textRotation === -90 ? 'bg-ss-surface-selected' : ''}
  `}
-                  onClick={() => {
-                    if (!canFormatCells) return;
-                    dispatch('SET_TEXT_ROTATION', { rotation: -90 });
-                    setOrientationDropdownOpen(false);
-                  }}
-                  disabled={!canFormatCells}
-                >
-                  <RotateTextDownIcon />
-                  <span>Rotate Text Down</span>
-                </button>
-                <div className="h-px bg-ss-surface-tertiary my-1" />
-                <button
-                  type="button"
-                  data-value="no-rotation"
-                  className={`
+                    onClick={() => {
+                      if (!canFormatCells) return;
+                      dispatch('SET_TEXT_ROTATION', { rotation: -90 });
+                      setOrientationDropdownOpen(false);
+                    }}
+                    disabled={!canFormatCells}
+                  >
+                    <RotateTextDownIcon />
+                    <span>Rotate Text Down</span>
+                  </button>
+                  <div className="h-px bg-ss-surface-tertiary my-1" />
+                  <button
+                    type="button"
+                    data-value="no-rotation"
+                    className={`
  w-full px-3 py-2 text-left text-dropdown
  flex items-center gap-2
  transition-colors
  ${canFormatCells ? 'hover:bg-ss-surface-hover' : 'text-ss-text-disabled cursor-not-allowed'}
  ${textRotation === 0 ? 'bg-ss-surface-selected' : ''}
  `}
-                  onClick={() => {
-                    if (!canFormatCells) return;
-                    dispatch('SET_TEXT_ROTATION', { rotation: 0 });
-                    setOrientationDropdownOpen(false);
-                  }}
-                  disabled={!canFormatCells}
-                >
-                  <span className="w-4" />
-                  <span>No Rotation</span>
-                </button>
-              </div>
-            </RibbonDropdownPanel>
-          </div>
+                    onClick={() => {
+                      if (!canFormatCells) return;
+                      dispatch('SET_TEXT_ROTATION', { rotation: 0 });
+                      setOrientationDropdownOpen(false);
+                    }}
+                    disabled={!canFormatCells}
+                  >
+                    <span className="w-4" />
+                    <span>No Rotation</span>
+                  </button>
+                </div>
+              </RibbonDropdownPanel>
+            </div>
 
-          <div className="flex items-center gap-[var(--ribbon-button-inline-gap)]">
             {/* Decrease Indent */}
             <Tooltip title="Decrease Indent">
               <RibbonButton

--- a/apps/spreadsheet/src/chrome/toolbar/groups/CellsGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/CellsGroup.tsx
@@ -20,7 +20,6 @@ import React, { useCallback, useEffect } from 'react';
 import { useSelector } from '@xstate/react';
 import {
   dispatch,
-  useActionDependencies,
   useActiveSheetId,
   useCoordinator,
   useFeatureGate,
@@ -78,10 +77,9 @@ export const CellsGroup = React.memo(function CellsGroup() {
   const isEnabled = useFeatureGate('groups', 'cells');
 
   // ===========================================================================
-  // Action Dependencies for Dialog Launcher + dispatch hook
+  // Action dispatch and workbook state
   // ===========================================================================
 
-  const deps = useActionDependencies();
   const dispatchAction = useDispatch();
   const coordinator = useCoordinator();
   const activeSheetId = useActiveSheetId();
@@ -153,8 +151,6 @@ export const CellsGroup = React.memo(function CellsGroup() {
       label="Cells"
       collapseConfig={CELLS_COLLAPSE_CONFIG}
       dropdownIcon={<InsertCellsIcon />}
-      onDialogLaunch={() => dispatch('OPEN_FORMAT_CELLS_DIALOG', deps)}
-      dialogLaunchTitle="Format Cells"
     >
       {/* Vertical stack of three dropdown rows - matches Excel's Cells group layout */}
       <div className="flex flex-col gap-[var(--ribbon-button-gap)]">

--- a/apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx
@@ -141,6 +141,10 @@ const DEFAULT_BORDER: { borders: CellBorders; preset: BorderPresetMode } = {
   preset: null,
 };
 
+const FONT_SIZE_STEP_ICON_STYLE = {
+  '--ribbon-icon-size': '15px',
+} as React.CSSProperties;
+
 // =============================================================================
 // Component
 // =============================================================================
@@ -579,7 +583,11 @@ export const FontGroup = React.memo(function FontGroup() {
           <Tooltip title="Increase Font Size">
             <RibbonButton
               layout="icon-only"
-              icon={<FontSizeIncreaseIcon />}
+              icon={
+                <span className="translate-y-px" style={FONT_SIZE_STEP_ICON_STYLE}>
+                  <FontSizeIncreaseIcon />
+                </span>
+              }
               onClick={() => dispatch('INCREASE_FONT_SIZE')}
               disabled={!canFormatCells}
               id="increase-font-size"
@@ -591,7 +599,11 @@ export const FontGroup = React.memo(function FontGroup() {
           <Tooltip title="Decrease Font Size">
             <RibbonButton
               layout="icon-only"
-              icon={<FontSizeDecreaseIcon />}
+              icon={
+                <span className="translate-y-px" style={FONT_SIZE_STEP_ICON_STYLE}>
+                  <FontSizeDecreaseIcon />
+                </span>
+              }
               onClick={() => dispatch('DECREASE_FONT_SIZE')}
               disabled={!canFormatCells}
               id="decrease-font-size"

--- a/apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx
@@ -480,13 +480,7 @@ export const FontGroup = React.memo(function FontGroup() {
   if (!isEnabled) return null;
 
   return (
-    <ToolbarGroup
-      label="Font"
-      collapseConfig={FONT_COLLAPSE_CONFIG}
-      dropdownIcon={<FontIcon />}
-      onDialogLaunch={() => dispatch('OPEN_FORMAT_CELLS_DIALOG', { initialTab: 'font' })}
-      dialogLaunchTitle="Font Settings"
-    >
+    <ToolbarGroup label="Font" collapseConfig={FONT_COLLAPSE_CONFIG} dropdownIcon={<FontIcon />}>
       <div className="flex flex-col gap-[var(--ribbon-button-gap)]">
         {/* Row 1: Font family & size */}
         <div className="flex items-center gap-1">

--- a/apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx
@@ -521,12 +521,12 @@ export const FontGroup = React.memo(function FontGroup() {
                   className={`
  h-7 px-2 ${isCompactMode ? 'min-w-[80px] max-w-[100px]' : 'min-w-[100px] max-w-[130px]'}
  flex items-center justify-between
- border border-transparent rounded
- bg-transparent text-ss-text-secondary text-ribbon
+ border rounded
+ bg-ss-surface text-ss-text-secondary text-ribbon
  cursor-pointer outline-none disabled:opacity-50 disabled:grayscale disabled:cursor-not-allowed disabled:pointer-events-none
  transition-colors duration-ss-fast
  hover:bg-ss-surface-hover
- ${fontPickerOpen ? 'bg-ss-primary-light text-ss-primary' : ''}
+ ${fontPickerOpen ? 'border-ss-primary ring-1 ring-ss-primary' : 'border-ss-border'}
  `}
                   style={{ fontFamily: `"${fontFamily ?? DEFAULT_FONT_FAMILY}", sans-serif` }}
                   title="Font family"

--- a/apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx
@@ -521,12 +521,12 @@ export const FontGroup = React.memo(function FontGroup() {
                   className={`
  h-7 px-2 ${isCompactMode ? 'min-w-[80px] max-w-[100px]' : 'min-w-[100px] max-w-[130px]'}
  flex items-center justify-between
- border rounded
- bg-ss-surface text-ss-text-secondary text-ribbon
+ border border-transparent rounded
+ bg-transparent text-ss-text-secondary text-ribbon
  cursor-pointer outline-none disabled:opacity-50 disabled:grayscale disabled:cursor-not-allowed disabled:pointer-events-none
  transition-colors duration-ss-fast
  hover:bg-ss-surface-hover
- ${fontPickerOpen ? 'border-ss-primary ring-1 ring-ss-primary' : 'border-ss-border'}
+ ${fontPickerOpen ? 'bg-ss-primary-light text-ss-primary' : ''}
  `}
                   style={{ fontFamily: `"${fontFamily ?? DEFAULT_FONT_FAMILY}", sans-serif` }}
                   title="Font family"

--- a/apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/FontGroup.tsx
@@ -489,7 +489,7 @@ export const FontGroup = React.memo(function FontGroup() {
     >
       <div className="flex flex-col gap-[var(--ribbon-button-gap)]">
         {/* Row 1: Font family & size */}
-        <div className="flex gap-1">
+        <div className="flex items-center gap-1">
           {/* Font Family Picker */}
           <RibbonVisibilityItem item="fontFamily">
             <div id="font-family-picker" className="relative inline-flex">

--- a/apps/spreadsheet/src/chrome/toolbar/groups/NumberGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/NumberGroup.tsx
@@ -275,8 +275,6 @@ export const NumberGroup = React.memo(function NumberGroup() {
       label="Number"
       collapseConfig={NUMBER_COLLAPSE_CONFIG}
       dropdownIcon={<NumberFormatIcon />}
-      onDialogLaunch={() => dispatch('OPEN_FORMAT_CELLS_DIALOG')}
-      dialogLaunchTitle="Number Format Settings"
     >
       <div className="flex flex-col gap-[var(--ribbon-button-gap)]">
         {/* Row 1: Number format dropdown */}

--- a/apps/spreadsheet/src/chrome/toolbar/groups/NumberGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/NumberGroup.tsx
@@ -313,14 +313,14 @@ export const NumberGroup = React.memo(function NumberGroup() {
                   className={`
  h-7 px-2 ${isCompactMode ? 'min-w-[70px]' : 'min-w-[90px]'}
  flex items-center justify-between gap-1
- border border-transparent rounded
+ border rounded
  text-ss-text-secondary text-ribbon
  cursor-pointer outline-none disabled:opacity-50 disabled:grayscale disabled:cursor-not-allowed disabled:pointer-events-none
  transition-colors duration-ss-fast
  ${
    numberFormatOpen
-     ? 'bg-ss-primary-light text-ss-primary'
-     : 'bg-transparent hover:bg-ss-surface-hover'
+     ? 'bg-ss-primary-light border-ss-primary ring-1 ring-ss-primary text-ss-primary'
+     : 'bg-ss-surface border-ss-border hover:bg-ss-surface-hover'
  }
  `}
                   aria-label="Number format"

--- a/apps/spreadsheet/src/chrome/toolbar/groups/NumberGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/NumberGroup.tsx
@@ -313,14 +313,14 @@ export const NumberGroup = React.memo(function NumberGroup() {
                   className={`
  h-7 px-2 ${isCompactMode ? 'min-w-[70px]' : 'min-w-[90px]'}
  flex items-center justify-between gap-1
- border rounded
+ border border-transparent rounded
  text-ss-text-secondary text-ribbon
  cursor-pointer outline-none disabled:opacity-50 disabled:grayscale disabled:cursor-not-allowed disabled:pointer-events-none
  transition-colors duration-ss-fast
  ${
    numberFormatOpen
-     ? 'bg-ss-primary-light border-ss-primary ring-1 ring-ss-primary text-ss-primary'
-     : 'bg-ss-surface border-ss-border hover:bg-ss-surface-hover'
+     ? 'bg-ss-primary-light text-ss-primary'
+     : 'bg-transparent hover:bg-ss-surface-hover'
  }
  `}
                   aria-label="Number format"

--- a/apps/spreadsheet/src/chrome/toolbar/groups/PageSetupGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/PageSetupGroup.tsx
@@ -245,8 +245,6 @@ export function PageSetupGroup() {
       label="Page Setup"
       collapseConfig={PAGE_SETUP_COLLAPSE_CONFIG}
       dropdownIcon={<MarginsIcon />}
-      onDialogLaunch={() => dispatch('OPEN_PAGE_SETUP_DIALOG')}
-      dialogLaunchTitle="Page Setup"
     >
       <div className="flex items-center gap-[var(--ribbon-group-items-gap)]">
         {/* Margins Dropdown */}

--- a/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.test.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.test.ts
@@ -13,14 +13,32 @@ describe('StylesGroup responsive layout', () => {
     expect(STYLES_COLLAPSE_CONFIG.levels[2]).toBe('dropdown');
   });
 
-  test('style preview chips include horizontal padding and stable text wrapping', () => {
+  test('stacked commands keep stable keytip and test anchors', () => {
     const source = readFileSync(
       nodePath.resolve(APP_ROOT, 'src/chrome/toolbar/groups/StylesGroup.tsx'),
       'utf8',
     );
+    const conditionalSource = readFileSync(
+      nodePath.resolve(APP_ROOT, 'src/chrome/toolbar/galleries/ConditionalFormattingMenu.tsx'),
+      'utf8',
+    );
 
-    expect(source).toContain('min-w-[36px] h-[20px] px-1.5');
-    expect(source).toContain('flex flex-wrap content-start gap-0.5 w-[92px]');
+    expect(source).toContain('<ConditionalFormattingMenu variant="stacked" />');
+    expect(conditionalSource).toContain('id="conditional-formatting"');
+    expect(conditionalSource).toContain('testId="ribbon-dropdown-conditional-formatting"');
+    expect(source).toContain('id="format-as-table"');
+    expect(source).toContain('testId="ribbon-dropdown-format-as-table"');
+    expect(source).toContain('id="cell-styles"');
+    expect(source).toContain('testId="ribbon-dropdown-cell-styles"');
+  });
+
+  test('stacked command primitive preserves compact non-wrapping rows', () => {
+    const source = readFileSync(
+      nodePath.resolve(APP_ROOT, 'src/chrome/toolbar/primitives/StackedRibbonMenuButton.tsx'),
+      'utf8',
+    );
+
+    expect(source).toContain('h-5 min-w-[132px]');
     expect(source).toContain('whitespace-nowrap');
   });
 });

--- a/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.test.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.test.ts
@@ -26,10 +26,16 @@ describe('StylesGroup responsive layout', () => {
     expect(source).toContain('<ConditionalFormattingMenu variant="stacked" />');
     expect(conditionalSource).toContain('id="conditional-formatting"');
     expect(conditionalSource).toContain('testId="ribbon-dropdown-conditional-formatting"');
+    expect(conditionalSource).toContain('visibilityKey="conditionalFormatting"');
+    expect(conditionalSource).toContain('<RibbonVisibilityItem item="conditionalFormatting">');
     expect(source).toContain('id="format-as-table"');
     expect(source).toContain('testId="ribbon-dropdown-format-as-table"');
+    expect(source).toContain('visibilityKey="formatAsTable"');
+    expect(source).toContain('<RibbonVisibilityItem item="formatAsTable">');
     expect(source).toContain('id="cell-styles"');
     expect(source).toContain('testId="ribbon-dropdown-cell-styles"');
+    expect(source).toContain('visibilityKey="cellStyles"');
+    expect(source).toContain('<RibbonVisibilityItem item="cellStyles">');
   });
 
   test('stacked command primitive preserves compact non-wrapping rows', () => {
@@ -40,5 +46,6 @@ describe('StylesGroup responsive layout', () => {
 
     expect(source).toContain('h-5 min-w-[132px]');
     expect(source).toContain('whitespace-nowrap');
+    expect(source).toContain('useRibbonButtonVisible');
   });
 });

--- a/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.tsx
@@ -42,6 +42,7 @@ import { RibbonDropdownPanel } from '../primitives/RibbonDropdown';
 import { StackedRibbonMenuButton } from '../primitives/StackedRibbonMenuButton';
 import { ToolbarGroup } from '../primitives/ToolbarGroup';
 import { ConditionalFormatIcon } from '../primitives/ToolbarIcons';
+import { RibbonVisibilityItem } from '../visibility/RibbonVisibilityContext';
 
 // =============================================================================
 // Icons
@@ -190,57 +191,63 @@ export const StylesGroup = React.memo(function StylesGroup() {
       <div className="flex flex-col justify-center gap-0.5">
         <ConditionalFormattingMenu variant="stacked" />
 
-        <div className="relative inline-flex">
-          <StackedRibbonMenuButton
-            id="format-as-table"
-            testId="ribbon-dropdown-format-as-table"
-            icon={<FormatAsTableIcon />}
-            label="Format as Table"
-            isOpen={tableStyleGalleryOpen}
-            onClick={() => setTableStyleGalleryOpen(!tableStyleGalleryOpen)}
-          />
-          <RibbonDropdownPanel
-            open={tableStyleGalleryOpen}
-            onClose={() => setTableStyleGalleryOpen(false)}
-            position="bottom-right"
-          >
-            <div data-testid="ribbon-dropdown-menu-format-as-table">
-              <TableStyleGallery
-                onSelectStyle={(styleId) => {
-                  formatAsTable(styleId);
-                  setTableStyleGalleryOpen(false);
-                }}
-                onClose={() => setTableStyleGalleryOpen(false)}
-              />
-            </div>
-          </RibbonDropdownPanel>
-        </div>
+        <RibbonVisibilityItem item="formatAsTable">
+          <div className="relative inline-flex">
+            <StackedRibbonMenuButton
+              id="format-as-table"
+              testId="ribbon-dropdown-format-as-table"
+              icon={<FormatAsTableIcon />}
+              label="Format as Table"
+              visibilityKey="formatAsTable"
+              isOpen={tableStyleGalleryOpen}
+              onClick={() => setTableStyleGalleryOpen(!tableStyleGalleryOpen)}
+            />
+            <RibbonDropdownPanel
+              open={tableStyleGalleryOpen}
+              onClose={() => setTableStyleGalleryOpen(false)}
+              position="bottom-right"
+            >
+              <div data-testid="ribbon-dropdown-menu-format-as-table">
+                <TableStyleGallery
+                  onSelectStyle={(styleId) => {
+                    formatAsTable(styleId);
+                    setTableStyleGalleryOpen(false);
+                  }}
+                  onClose={() => setTableStyleGalleryOpen(false)}
+                />
+              </div>
+            </RibbonDropdownPanel>
+          </div>
+        </RibbonVisibilityItem>
 
-        <div className="relative inline-flex">
-          <StackedRibbonMenuButton
-            id="cell-styles"
-            testId="ribbon-dropdown-cell-styles"
-            icon={<CellStylesIcon />}
-            label="Cell Styles"
-            isOpen={styleGalleryOpen}
-            onClick={() => setStyleGalleryOpen(!styleGalleryOpen)}
-          />
-          <RibbonDropdownPanel
-            open={styleGalleryOpen}
-            onClose={() => setStyleGalleryOpen(false)}
-            position="bottom-right"
-          >
-            <div data-testid="ribbon-dropdown-menu-cell-styles">
-              <StyleGallery
-                onSelectStyle={(styleId) => {
-                  applyStyle(styleId);
-                  setStyleGalleryOpen(false);
-                }}
-                onClose={() => setStyleGalleryOpen(false)}
-              />
-            </div>
-          </RibbonDropdownPanel>
-        </div>
+        <RibbonVisibilityItem item="cellStyles">
+          <div className="relative inline-flex">
+            <StackedRibbonMenuButton
+              id="cell-styles"
+              testId="ribbon-dropdown-cell-styles"
+              icon={<CellStylesIcon />}
+              label="Cell Styles"
+              visibilityKey="cellStyles"
+              isOpen={styleGalleryOpen}
+              onClick={() => setStyleGalleryOpen(!styleGalleryOpen)}
+            />
+            <RibbonDropdownPanel
+              open={styleGalleryOpen}
+              onClose={() => setStyleGalleryOpen(false)}
+              position="bottom-right"
+            >
+              <div data-testid="ribbon-dropdown-menu-cell-styles">
+                <StyleGallery
+                  onSelectStyle={(styleId) => {
+                    applyStyle(styleId);
+                    setStyleGalleryOpen(false);
+                  }}
+                  onClose={() => setStyleGalleryOpen(false)}
+                />
+              </div>
+            </RibbonDropdownPanel>
+          </div>
+        </RibbonVisibilityItem>
       </div>
     </ToolbarGroup>
   );

--- a/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.tsx
@@ -36,12 +36,14 @@ import { StyleGallery } from '../../../components/pickers/StyleGallery';
 import { TableStyleGallery } from '../../../components/pickers/TableStyleGallery';
 import { useDispatch } from '../../../hooks/toolbar/use-action-dependencies';
 import { useToolbarActions } from '../../../hooks/toolbar/use-toolbar-actions';
-import { ConditionalFormattingMenu } from '../galleries/ConditionalFormattingMenu';
+import {
+  ConditionalFormattingMenu,
+  ConditionalFormattingStackIcon,
+} from '../galleries/ConditionalFormattingMenu';
 import { keyTipRegistry } from '../keytips';
 import { RibbonDropdownPanel } from '../primitives/RibbonDropdown';
 import { StackedRibbonMenuButton } from '../primitives/StackedRibbonMenuButton';
 import { ToolbarGroup } from '../primitives/ToolbarGroup';
-import { ConditionalFormatIcon } from '../primitives/ToolbarIcons';
 import { RibbonVisibilityItem } from '../visibility/RibbonVisibilityContext';
 
 // =============================================================================
@@ -53,7 +55,13 @@ import { RibbonVisibilityItem } from '../visibility/RibbonVisibilityContext';
  */
 function FormatAsTableIcon() {
   return (
-    <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg
+      width="var(--ribbon-icon-size)"
+      height="var(--ribbon-icon-size)"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
       {/* Table icon with header */}
       <rect x="2" y="2" width="16" height="4" fill="#4472c4" rx="1" />
       <rect x="2" y="7" width="16" height="3" fill="#d6dce5" stroke="#8faadc" strokeWidth="0.3" />
@@ -65,7 +73,13 @@ function FormatAsTableIcon() {
 
 function CellStylesIcon() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <svg
+      width="var(--ribbon-icon-size)"
+      height="var(--ribbon-icon-size)"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+    >
       <rect x="1.5" y="2" width="11" height="12" rx="1" fill="#ffffff" stroke="#6b7280" />
       <path d="M5.2 2v12M8.9 2v12M1.5 6h11M1.5 10h11" stroke="#9ca3af" strokeWidth="0.7" />
       <rect x="2.3" y="2.8" width="2.2" height="2.5" fill="#d8eadc" />
@@ -186,7 +200,7 @@ export const StylesGroup = React.memo(function StylesGroup() {
     <ToolbarGroup
       label="Styles"
       collapseConfig={STYLES_COLLAPSE_CONFIG}
-      dropdownIcon={<ConditionalFormatIcon />}
+      dropdownIcon={<ConditionalFormattingStackIcon />}
     >
       <div className="flex flex-col justify-center gap-0.5">
         <ConditionalFormattingMenu variant="stacked" />

--- a/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.tsx
@@ -5,17 +5,13 @@
  * Excel layout: compact three-row command stack for Conditional Formatting,
  * Format as Table, and Cell Styles.
  *
- * Text formatting dispatch: clearFormat (the "Normal" quick-pick chip)
- * routes through `useDispatch()`/`dispatch('CLEAR_FORMATS')`. The
- * applyStyle / formatAsTable code paths still call non-dispatch helpers
- * (`useToolbarActions().handleApplyStyle` and `ws.tables.add` directly) —
- * those need APPLY_CELL_STYLE / FORMAT_AS_TABLE handlers which are out of
- * scope for text formatting. It does not add new ActionTypes here.
+ * Text formatting dispatch: Format as Table routes through INSERT_TABLE.
+ * Cell Styles still delegates named styles to the existing toolbar action
+ * helper until a typed APPLY_CELL_STYLE handler exists.
  *
  * Features:
  * - Conditional Formatting dropdown (Excel-like menu with quick rules, presets, and manager)
  * - Format as Table dropdown (creates table with selected style)
- * - Quick-pick style chips for one-click style application
  * - Cell Styles dropdown (applies built-in cell styles)
  *
  * COLLAPSE SUPPORT (
@@ -34,7 +30,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { useFeatureGate, useUIStore } from '../../../internal-api';
 
-import { Tooltip } from '@mog/shell';
 import type { TableStylePreset } from '@mog-sdk/contracts/tables';
 import { STYLES_COLLAPSE_CONFIG } from '@mog-sdk/contracts/ribbon';
 import { StyleGallery } from '../../../components/pickers/StyleGallery';
@@ -44,8 +39,9 @@ import { useToolbarActions } from '../../../hooks/toolbar/use-toolbar-actions';
 import { ConditionalFormattingMenu } from '../galleries/ConditionalFormattingMenu';
 import { keyTipRegistry } from '../keytips';
 import { RibbonDropdownPanel } from '../primitives/RibbonDropdown';
+import { StackedRibbonMenuButton } from '../primitives/StackedRibbonMenuButton';
 import { ToolbarGroup } from '../primitives/ToolbarGroup';
-import { ConditionalFormatIcon, DropdownArrowIcon } from '../primitives/ToolbarIcons';
+import { ConditionalFormatIcon } from '../primitives/ToolbarIcons';
 
 // =============================================================================
 // Icons
@@ -84,32 +80,6 @@ function CellStylesIcon() {
   );
 }
 
-interface StyleStackButtonProps {
-  icon: React.ReactNode;
-  label: string;
-  onClick: () => void;
-  isOpen: boolean;
-}
-
-function StyleStackButton({ icon, label, onClick, isOpen }: StyleStackButtonProps) {
-  return (
-    <Tooltip title={label}>
-      <button
-        type="button"
-        onClick={onClick}
-        className="flex h-5 min-w-[132px] items-center gap-1.5 rounded px-1.5 text-ribbon-compact leading-none text-ss-text-secondary transition-colors duration-ss-fast hover:bg-ss-surface-hover focus:outline-none focus-visible:ring-1 focus-visible:ring-ss-primary"
-        aria-label={label}
-        aria-expanded={isOpen}
-        aria-haspopup="menu"
-      >
-        <span className="flex h-4 w-4 shrink-0 items-center justify-center">{icon}</span>
-        <span className="flex-1 whitespace-nowrap text-left">{label}</span>
-        <DropdownArrowIcon className={isOpen ? 'rotate-180' : ''} />
-      </button>
-    </Tooltip>
-  );
-}
-
 // =============================================================================
 // Component
 // =============================================================================
@@ -117,10 +87,10 @@ function StyleStackButton({ icon, label, onClick, isOpen }: StyleStackButtonProp
 /**
  * Styles toolbar group - self-sufficient, no props required.
  *
- * Layout matches Excel:
- * - Conditional Formatting (large button with dropdown)
- * - Format as Table (large button with gallery dropdown)
- * - Quick-pick style chips (2x2 grid: Normal, Bad, Good, Neutral) with Cell Styles dropdown
+ * Compact three-row command stack:
+ * - Conditional Formatting
+ * - Format as Table
+ * - Cell Styles
  *
  * Memoized to prevent re-renders when parent re-renders.
  */
@@ -216,14 +186,14 @@ export const StylesGroup = React.memo(function StylesGroup() {
       label="Styles"
       collapseConfig={STYLES_COLLAPSE_CONFIG}
       dropdownIcon={<ConditionalFormatIcon />}
-      onDialogLaunch={() => dispatch('OPEN_FORMAT_CELLS_DIALOG')}
-      dialogLaunchTitle="Cell Styles Settings"
     >
       <div className="flex flex-col justify-center gap-0.5">
         <ConditionalFormattingMenu variant="stacked" />
 
         <div className="relative inline-flex">
-          <StyleStackButton
+          <StackedRibbonMenuButton
+            id="format-as-table"
+            testId="ribbon-dropdown-format-as-table"
             icon={<FormatAsTableIcon />}
             label="Format as Table"
             isOpen={tableStyleGalleryOpen}
@@ -247,7 +217,9 @@ export const StylesGroup = React.memo(function StylesGroup() {
         </div>
 
         <div className="relative inline-flex">
-          <StyleStackButton
+          <StackedRibbonMenuButton
+            id="cell-styles"
+            testId="ribbon-dropdown-cell-styles"
             icon={<CellStylesIcon />}
             label="Cell Styles"
             isOpen={styleGalleryOpen}

--- a/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.tsx
@@ -97,7 +97,7 @@ function StyleStackButton({ icon, label, onClick, isOpen }: StyleStackButtonProp
       <button
         type="button"
         onClick={onClick}
-        className="flex h-5 min-w-[134px] items-center gap-1.5 rounded px-1.5 text-ribbon leading-none text-ss-text-secondary transition-colors duration-ss-fast hover:bg-ss-surface-hover focus:outline-none focus-visible:ring-1 focus-visible:ring-ss-primary"
+        className="flex h-5 min-w-[132px] items-center gap-1.5 rounded px-1.5 text-ribbon-compact leading-none text-ss-text-secondary transition-colors duration-ss-fast hover:bg-ss-surface-hover focus:outline-none focus-visible:ring-1 focus-visible:ring-ss-primary"
         aria-label={label}
         aria-expanded={isOpen}
         aria-haspopup="menu"

--- a/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/StylesGroup.tsx
@@ -2,8 +2,8 @@
  * Styles Group
  *
  * Self-sufficient toolbar group for styling operations.
- * Excel layout: Conditional Formatting, Format as Table, then a 2x2 grid of
- * quick-pick style chips (Normal, Good, Bad, Neutral) with Cell Styles dropdown.
+ * Excel layout: compact three-row command stack for Conditional Formatting,
+ * Format as Table, and Cell Styles.
  *
  * Text formatting dispatch: clearFormat (the "Normal" quick-pick chip)
  * routes through `useDispatch()`/`dispatch('CLEAR_FORMATS')`. The
@@ -43,11 +43,9 @@ import { useDispatch } from '../../../hooks/toolbar/use-action-dependencies';
 import { useToolbarActions } from '../../../hooks/toolbar/use-toolbar-actions';
 import { ConditionalFormattingMenu } from '../galleries/ConditionalFormattingMenu';
 import { keyTipRegistry } from '../keytips';
-import { RibbonButton } from '../primitives/RibbonButton';
 import { RibbonDropdownPanel } from '../primitives/RibbonDropdown';
 import { ToolbarGroup } from '../primitives/ToolbarGroup';
 import { ConditionalFormatIcon, DropdownArrowIcon } from '../primitives/ToolbarIcons';
-import { RibbonVisibilityItem } from '../visibility/RibbonVisibilityContext';
 
 // =============================================================================
 // Icons
@@ -58,7 +56,7 @@ import { RibbonVisibilityItem } from '../visibility/RibbonVisibilityContext';
  */
 function FormatAsTableIcon() {
   return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+    <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
       {/* Table icon with header */}
       <rect x="2" y="2" width="16" height="4" fill="#4472c4" rx="1" />
       <rect x="2" y="7" width="16" height="3" fill="#d6dce5" stroke="#8faadc" strokeWidth="0.3" />
@@ -68,77 +66,45 @@ function FormatAsTableIcon() {
   );
 }
 
-// =============================================================================
-// Quick-Pick Style Chips
-// =============================================================================
-
-/**
- * Quick-pick style definitions.
- * These match Excel's 2x2 grid of Normal, Good, Bad, Neutral.
- * "Normal" clears formatting (represented as null styleId).
- */
-const QUICK_PICK_STYLES = [
-  { id: null, name: 'Normal', bgColor: '#ffffff', textColor: '#000000', borderColor: '#d4d4d4' },
-  { id: 'bad', name: 'Bad', bgColor: '#ffc7ce', textColor: '#9c0006', borderColor: '#9c0006' },
-  { id: 'good', name: 'Good', bgColor: '#c6efce', textColor: '#006100', borderColor: '#006100' },
-  {
-    id: 'neutral',
-    name: 'Neutral',
-    bgColor: '#ffeb9c',
-    textColor: '#9c5700',
-    borderColor: '#9c5700',
-  },
-] as const;
-
-interface StylePreviewChipProps {
-  /** Style ID or null for "Normal" (clear formatting) */
-  styleId: string | null;
-  /** Display name */
-  name: string;
-  /** Background color */
-  bgColor: string;
-  /** Text/border color for the chip */
-  textColor: string;
-  /** Border color */
-  borderColor: string;
-  /** Click handler */
-  onClick: () => void;
+function CellStylesIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <rect x="1.5" y="2" width="11" height="12" rx="1" fill="#ffffff" stroke="#6b7280" />
+      <path d="M5.2 2v12M8.9 2v12M1.5 6h11M1.5 10h11" stroke="#9ca3af" strokeWidth="0.7" />
+      <rect x="2.3" y="2.8" width="2.2" height="2.5" fill="#d8eadc" />
+      <rect x="6" y="6.8" width="2.2" height="2.5" fill="#dbeafe" />
+      <rect x="9.7" y="10.8" width="2" height="2.3" fill="#f8d7da" />
+      <path
+        d="M9.8 13.8 14 9.6l1.1 1.1-4.2 4.2-1.4.3.3-1.4z"
+        fill="#2f7d59"
+        stroke="#ffffff"
+        strokeWidth="0.45"
+      />
+    </svg>
+  );
 }
 
-/**
- * Small colored preview chip for quick style application.
- * Shows a preview of the style with the style name.
- */
-function StylePreviewChip({
-  name,
-  bgColor,
-  textColor,
-  borderColor,
-  onClick,
-}: StylePreviewChipProps) {
+interface StyleStackButtonProps {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  isOpen: boolean;
+}
+
+function StyleStackButton({ icon, label, onClick, isOpen }: StyleStackButtonProps) {
   return (
-    <Tooltip title={name} description={`Apply ${name} style`}>
+    <Tooltip title={label}>
       <button
         type="button"
         onClick={onClick}
-        className="
- flex items-center justify-center
- min-w-[36px] h-[20px] px-1.5
- text-ribbon-chip leading-none font-medium
- whitespace-nowrap
- rounded-ss-sm cursor-pointer
- border transition-all duration-ss-fast
- hover:ring-1 hover:ring-ss-primary hover:ring-offset-1
- focus:outline-none focus-visible:ring-2 focus-visible:ring-ss-primary
- "
-        style={{
-          backgroundColor: bgColor,
-          color: textColor,
-          borderColor: borderColor,
-        }}
-        aria-label={`Apply ${name} style`}
+        className="flex h-5 min-w-[134px] items-center gap-1.5 rounded px-1.5 text-ribbon leading-none text-ss-text-secondary transition-colors duration-ss-fast hover:bg-ss-surface-hover focus:outline-none focus-visible:ring-1 focus-visible:ring-ss-primary"
+        aria-label={label}
+        aria-expanded={isOpen}
+        aria-haspopup="menu"
       >
-        {name}
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center">{icon}</span>
+        <span className="flex-1 whitespace-nowrap text-left">{label}</span>
+        <DropdownArrowIcon className={isOpen ? 'rotate-180' : ''} />
       </button>
     </Tooltip>
   );
@@ -239,18 +205,6 @@ export const StylesGroup = React.memo(function StylesGroup() {
   // Handlers
   // ===========================================================================
 
-  /**
-   * Handle quick-pick style chip click.
-   * null id means "Normal" (CLEAR_FORMATS), otherwise apply the named style.
-   */
-  const handleQuickStyleClick = (styleId: string | null) => {
-    if (styleId === null) {
-      dispatch('CLEAR_FORMATS');
-    } else {
-      applyStyle(styleId);
-    }
-  };
-
   // ===========================================================================
   // Render
   // ===========================================================================
@@ -265,26 +219,16 @@ export const StylesGroup = React.memo(function StylesGroup() {
       onDialogLaunch={() => dispatch('OPEN_FORMAT_CELLS_DIALOG')}
       dialogLaunchTitle="Cell Styles Settings"
     >
-      <div className="flex items-start gap-1">
-        {/* Conditional Formatting - Dropdown Menu (Excel-like) */}
-        <ConditionalFormattingMenu />
+      <div className="flex flex-col justify-center gap-0.5">
+        <ConditionalFormattingMenu variant="stacked" />
 
-        {/* Format as Table - Large Button with Gallery */}
         <div className="relative inline-flex">
-          <Tooltip title="Format as Table" description="Convert data to a table with formatting">
-            <RibbonButton
-              layout="vertical"
-              height="full"
-              data-testid="ribbon-dropdown-format-as-table"
-              icon={<FormatAsTableIcon />}
-              label="Table"
-              hasDropdown
-              dropdownPosition="inline"
-              isOpen={tableStyleGalleryOpen}
-              onClick={() => setTableStyleGalleryOpen(!tableStyleGalleryOpen)}
-              aria-label="Format as Table"
-            />
-          </Tooltip>
+          <StyleStackButton
+            icon={<FormatAsTableIcon />}
+            label="Format as Table"
+            isOpen={tableStyleGalleryOpen}
+            onClick={() => setTableStyleGalleryOpen(!tableStyleGalleryOpen)}
+          />
           <RibbonDropdownPanel
             open={tableStyleGalleryOpen}
             onClose={() => setTableStyleGalleryOpen(false)}
@@ -302,64 +246,29 @@ export const StylesGroup = React.memo(function StylesGroup() {
           </RibbonDropdownPanel>
         </div>
 
-        {/* Quick-Pick Style Chips + Cell Styles Dropdown */}
-        <RibbonVisibilityItem item="cellStyles">
-          <div className="relative inline-flex flex-col items-start h-[var(--ribbon-content-height)] justify-between py-1">
-            {/* 2x2 Grid of style preview chips */}
-            <div className="flex flex-wrap content-start gap-0.5 w-[92px]">
-              {QUICK_PICK_STYLES.map((style) => (
-                <StylePreviewChip
-                  key={style.name}
-                  styleId={style.id}
-                  name={style.name}
-                  bgColor={style.bgColor}
-                  textColor={style.textColor}
-                  borderColor={style.borderColor}
-                  onClick={() => handleQuickStyleClick(style.id)}
-                />
-              ))}
+        <div className="relative inline-flex">
+          <StyleStackButton
+            icon={<CellStylesIcon />}
+            label="Cell Styles"
+            isOpen={styleGalleryOpen}
+            onClick={() => setStyleGalleryOpen(!styleGalleryOpen)}
+          />
+          <RibbonDropdownPanel
+            open={styleGalleryOpen}
+            onClose={() => setStyleGalleryOpen(false)}
+            position="bottom-right"
+          >
+            <div data-testid="ribbon-dropdown-menu-cell-styles">
+              <StyleGallery
+                onSelectStyle={(styleId) => {
+                  applyStyle(styleId);
+                  setStyleGalleryOpen(false);
+                }}
+                onClose={() => setStyleGalleryOpen(false)}
+              />
             </div>
-
-            {/* Cell Styles dropdown button */}
-            <Tooltip title="Cell Styles" description="Apply predefined cell styles">
-              <button
-                type="button"
-                data-testid="ribbon-dropdown-cell-styles"
-                onClick={() => setStyleGalleryOpen(!styleGalleryOpen)}
-                className="
- flex items-center gap-0.5 px-1 py-0.5
- text-ribbon text-ss-text-secondary
- rounded cursor-pointer
- hover:bg-ss-surface-hover
- transition-all duration-ss-fast
- "
-                aria-label="Cell Styles"
-                aria-expanded={styleGalleryOpen}
-                aria-haspopup="menu"
-              >
-                <span>Cell Styles</span>
-                <DropdownArrowIcon className={styleGalleryOpen ? 'rotate-180' : ''} />
-              </button>
-            </Tooltip>
-
-            {/* Cell Styles Gallery Dropdown */}
-            <RibbonDropdownPanel
-              open={styleGalleryOpen}
-              onClose={() => setStyleGalleryOpen(false)}
-              position="bottom-right"
-            >
-              <div data-testid="ribbon-dropdown-menu-cell-styles">
-                <StyleGallery
-                  onSelectStyle={(styleId) => {
-                    applyStyle(styleId);
-                    setStyleGalleryOpen(false);
-                  }}
-                  onClose={() => setStyleGalleryOpen(false)}
-                />
-              </div>
-            </RibbonDropdownPanel>
-          </div>
-        </RibbonVisibilityItem>
+          </RibbonDropdownPanel>
+        </div>
       </div>
     </ToolbarGroup>
   );

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/CollapsedGroupDropdown.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/CollapsedGroupDropdown.tsx
@@ -147,9 +147,6 @@ export const CollapsedGroupDropdown = React.memo(function CollapsedGroupDropdown
         </PopoverContent>
       </Popover>
 
-      {/* Label area - matches non-collapsed groups for vertical alignment */}
-      <div className="h-[var(--ribbon-label-height)]" />
-
       {/* Separator - matches ToolbarGroup */}
       {!isLast && (
         <div

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/RibbonButton.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/RibbonButton.tsx
@@ -468,11 +468,15 @@ function IconOnlyButton({
     >
       {hasDropdown ? (
         <span className="flex items-center justify-center gap-[var(--ribbon-button-icon-gap)]">
-          <span className="flex items-center justify-center w-4 h-4 overflow-visible">{icon}</span>
+          <span className="flex h-[var(--ribbon-icon-size)] w-[var(--ribbon-icon-size)] items-center justify-center overflow-visible">
+            {icon}
+          </span>
           <DropdownArrowIcon className={isOpen ? 'rotate-180' : ''} />
         </span>
       ) : (
-        <span className="flex items-center justify-center w-4 h-4 overflow-visible">{icon}</span>
+        <span className="flex h-[var(--ribbon-icon-size)] w-[var(--ribbon-icon-size)] items-center justify-center overflow-visible">
+          {icon}
+        </span>
       )}
     </button>
   );
@@ -526,7 +530,9 @@ function VerticalButton({
   const isBottomDropdown = hasDropdown && dropdownPosition === 'bottom' && isFullHeight;
 
   // Icon size: 20x20 for full height, 16x16 for half/third
-  const iconSize = isFullHeight ? 'w-5 h-5' : 'w-4 h-4';
+  const iconSize = isFullHeight
+    ? 'h-5 w-5'
+    : 'h-[var(--ribbon-icon-size)] w-[var(--ribbon-icon-size)]';
 
   // Text size: normal for full height, compact for half/third
   const textClass = isFullHeight ? 'text-ribbon' : 'text-ribbon-compact';
@@ -659,7 +665,9 @@ function HorizontalButton({
       {...buttonProps}
     >
       {/* Icon container - 16x16 */}
-      <span className="flex items-center justify-center w-4 h-4">{icon}</span>
+      <span className="flex h-[var(--ribbon-icon-size)] w-[var(--ribbon-icon-size)] items-center justify-center">
+        {icon}
+      </span>
 
       {/* Label */}
       <span className={`${textClass} leading-tight ${labelWhitespaceClass} text-center`}>

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/RibbonLayoutTokens.test.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/RibbonLayoutTokens.test.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 
-const RIBBON_TOP_BORDER_PX = 1;
 const APP_ROOT = process.cwd().endsWith(`${nodePath.sep}apps${nodePath.sep}spreadsheet`)
   ? process.cwd()
   : nodePath.resolve(process.cwd(), 'apps/spreadsheet');
@@ -36,6 +35,6 @@ describe('ribbon layout tokens', () => {
     const paddingY = readPxToken(css, 'ribbon-padding-y');
 
     expect(paddingY).toBeGreaterThan(0);
-    expect(ribbonHeight).toBe(contentHeight + labelHeight + paddingY * 2 + RIBBON_TOP_BORDER_PX);
+    expect(ribbonHeight).toBe(contentHeight + labelHeight + paddingY * 2);
   });
 });

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/SplitButton.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/SplitButton.tsx
@@ -33,6 +33,7 @@ import { useRibbonButtonVisible } from '../visibility/RibbonVisibilityContext';
 import { DropdownArrowIcon } from './ToolbarIcons';
 
 type SplitButtonVariant = 'small' | 'large';
+type SplitButtonWidth = 'normal' | 'narrow';
 
 interface SplitButtonProps {
   /** Optional ID for keytip positioning */
@@ -43,6 +44,8 @@ interface SplitButtonProps {
   label?: string;
   /** Size variant */
   variant?: SplitButtonVariant;
+  /** Width variant for large ribbon buttons. */
+  width?: SplitButtonWidth;
   /** Whether the dropdown is currently open */
   isOpen?: boolean;
   /** Whether the entire button is disabled */
@@ -118,6 +121,7 @@ export const SplitButton = React.memo(function SplitButton({
   icon,
   label,
   variant = 'small',
+  width = 'normal',
   isOpen = false,
   disabled = false,
   title,
@@ -168,9 +172,17 @@ export const SplitButton = React.memo(function SplitButton({
     // Adjust sizing based on collapse mode
     // In icons mode, use more compact sizing
     const isCompact = groupMode === 'icons' || groupMode === 'compact';
+    const isNarrow = width === 'narrow';
     const mainButtonClasses = isCompact
       ? 'px-2 py-1 min-w-[32px]' // Compact sizing
-      : 'px-3 py-1 min-w-[44px]'; // Full sizing
+      : isNarrow
+        ? 'px-2 py-1 min-w-[38px]'
+        : 'px-3 py-1 min-w-[44px]'; // Full sizing
+    const iconSizeClasses = isNarrow
+      ? 'h-[var(--ribbon-icon-size)] w-[var(--ribbon-icon-size)]'
+      : 'h-5 w-5';
+    const dropdownButtonClasses = isNarrow ? 'px-0.5 min-w-[14px]' : 'px-1 min-w-[16px]';
+    const labelTextClasses = isNarrow ? 'text-ribbon-compact' : 'text-ribbon';
 
     return (
       <div id={id} className={`group/split-button flex flex-row items-stretch ${className}`}>
@@ -194,9 +206,9 @@ export const SplitButton = React.memo(function SplitButton({
  ${activeStyles}
  `}
         >
-          <span className="flex items-center justify-center w-5 h-5">{icon}</span>
+          <span className={`flex items-center justify-center ${iconSizeClasses}`}>{icon}</span>
           {showLabel && (
-            <span className="text-ribbon leading-tight whitespace-nowrap">{label}</span>
+            <span className={`${labelTextClasses} leading-tight whitespace-nowrap`}>{label}</span>
           )}
         </button>
 
@@ -212,7 +224,7 @@ export const SplitButton = React.memo(function SplitButton({
           data-testid={dropdownTestId}
           className={`
  ${buttonBase}
- px-1 min-w-[16px]
+ ${dropdownButtonClasses}
  h-[var(--ribbon-content-height)]
  border border-l rounded-r
  cursor-pointer select-none
@@ -247,7 +259,9 @@ export const SplitButton = React.memo(function SplitButton({
  ${activeStyles}
  `}
       >
-        {icon}
+        <span className="flex h-[var(--ribbon-icon-size)] w-[var(--ribbon-icon-size)] items-center justify-center">
+          {icon}
+        </span>
       </button>
 
       {/* Dropdown Trigger - Small */}

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/SplitButton.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/SplitButton.tsx
@@ -155,7 +155,13 @@ export const SplitButton = React.memo(function SplitButton({
  disabled:opacity-50 disabled:grayscale disabled:cursor-not-allowed disabled:pointer-events-none disabled:shadow-none
  `;
 
-  const hoverStyles = 'hover:bg-ss-surface-hover hover:shadow-ss-button-hover';
+  const quietSplitStyles = `
+ bg-transparent text-ss-text-secondary border-transparent
+ group-hover/split-button:bg-ss-surface-hover
+ group-hover/split-button:border-ss-border-button-hover
+ group-hover/split-button:shadow-ss-button-hover
+ `;
+  const openSplitStyles = 'bg-ss-primary-light text-ss-primary border-ss-primary-light';
   const activeStyles = 'active:bg-ss-surface-active active:shadow-ss-button-active';
 
   if (variant === 'large') {
@@ -167,7 +173,7 @@ export const SplitButton = React.memo(function SplitButton({
       : 'px-3 py-1 min-w-[44px]'; // Full sizing
 
     return (
-      <div id={id} className={`flex flex-row items-stretch ${className}`}>
+      <div id={id} className={`group/split-button flex flex-row items-stretch ${className}`}>
         {/* Main Button - Large */}
         <button
           type="button"
@@ -182,9 +188,9 @@ export const SplitButton = React.memo(function SplitButton({
  ${mainButtonClasses}
  h-[var(--ribbon-content-height)]
  text-ss-text-secondary
- border border-ss-border rounded-l
+ border border-r-0 rounded-l
  cursor-pointer select-none
- ${hoverStyles}
+ ${isOpen ? openSplitStyles : quietSplitStyles}
  ${activeStyles}
  `}
         >
@@ -208,9 +214,9 @@ export const SplitButton = React.memo(function SplitButton({
  ${buttonBase}
  px-1 min-w-[16px]
  h-[var(--ribbon-content-height)]
- border border-l-0 border-ss-border rounded-r
+ border border-l rounded-r
  cursor-pointer select-none
- ${isOpen ? 'bg-ss-primary-light text-ss-primary' : `text-ss-text-secondary ${hoverStyles}`}
+ ${isOpen ? openSplitStyles : quietSplitStyles}
  ${activeStyles}
  `}
         >
@@ -222,7 +228,7 @@ export const SplitButton = React.memo(function SplitButton({
 
   // Small variant (default)
   return (
-    <div id={id} className={`flex flex-row items-stretch ${className}`}>
+    <div id={id} className={`group/split-button flex flex-row items-stretch ${className}`}>
       {/* Main Button - Small */}
       <button
         type="button"
@@ -235,9 +241,9 @@ export const SplitButton = React.memo(function SplitButton({
  ${buttonBase}
  w-6 h-7
  text-ss-text-secondary
- border border-ss-border rounded-l
+ border border-r-0 rounded-l
  cursor-pointer select-none
- ${hoverStyles}
+ ${isOpen ? openSplitStyles : quietSplitStyles}
  ${activeStyles}
  `}
       >
@@ -257,9 +263,9 @@ export const SplitButton = React.memo(function SplitButton({
         className={`
  ${buttonBase}
  px-0.5 min-w-[14px] h-7
- border border-l-0 border-ss-border rounded-r
+ border border-l rounded-r
  cursor-pointer select-none
- ${isOpen ? 'bg-ss-primary-light text-ss-primary' : `text-ss-text-secondary ${hoverStyles}`}
+ ${isOpen ? openSplitStyles : quietSplitStyles}
  ${activeStyles}
  `}
       >

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/StackedRibbonMenuButton.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/StackedRibbonMenuButton.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from 'react';
+
+import { Tooltip } from '@mog/shell';
+import { DropdownArrowIcon } from './ToolbarIcons';
+
+interface StackedRibbonMenuButtonProps {
+  id: string;
+  testId: string;
+  icon: ReactNode;
+  label: string;
+  isOpen: boolean;
+  onClick: () => void;
+}
+
+export function StackedRibbonMenuButton({
+  id,
+  testId,
+  icon,
+  label,
+  isOpen,
+  onClick,
+}: StackedRibbonMenuButtonProps) {
+  return (
+    <Tooltip title={label}>
+      <button
+        id={id}
+        type="button"
+        data-testid={testId}
+        onClick={onClick}
+        className="flex h-5 min-w-[132px] items-center gap-1.5 rounded px-1.5 text-ribbon-compact leading-none text-ss-text-secondary transition-colors duration-ss-fast hover:bg-ss-surface-hover focus:outline-none focus-visible:ring-1 focus-visible:ring-ss-primary"
+        aria-label={label}
+        aria-expanded={isOpen}
+        aria-haspopup="menu"
+      >
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center">{icon}</span>
+        <span className="flex-1 whitespace-nowrap text-left">{label}</span>
+        <DropdownArrowIcon className={isOpen ? 'rotate-180' : ''} />
+      </button>
+    </Tooltip>
+  );
+}

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/StackedRibbonMenuButton.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/StackedRibbonMenuButton.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 
 import { Tooltip } from '@mog/shell';
+import { useRibbonButtonVisible } from '../visibility/RibbonVisibilityContext';
 import { DropdownArrowIcon } from './ToolbarIcons';
 
 interface StackedRibbonMenuButtonProps {
@@ -8,6 +9,7 @@ interface StackedRibbonMenuButtonProps {
   testId: string;
   icon: ReactNode;
   label: string;
+  visibilityKey: string;
   isOpen: boolean;
   onClick: () => void;
 }
@@ -17,9 +19,16 @@ export function StackedRibbonMenuButton({
   testId,
   icon,
   label,
+  visibilityKey,
   isOpen,
   onClick,
 }: StackedRibbonMenuButtonProps) {
+  const visible = useRibbonButtonVisible({ visibilityKey, label, testId });
+
+  if (!visible) {
+    return null;
+  }
+
   return (
     <Tooltip title={label}>
       <button

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/TabBar.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/TabBar.tsx
@@ -390,7 +390,7 @@ function TabBarImpl<T extends string>({
         )}
       </div>
 
-      {/* Tabs - Excel-like appearance where active tab connects to ribbon */}
+      {/* Tabs */}
       {/*
  Expose the ribbon tab strip via WAI-ARIA tablist semantics so `readActiveRibbonTab`
  resolves the *ribbon* active tab. Without `role="tab"` on the
@@ -416,13 +416,12 @@ function TabBarImpl<T extends string>({
           type="button"
           onClick={onFileClick}
           className={`
- px-[var(--tabbar-tab-padding-x)] py-[var(--tabbar-tab-padding-y)]
+ relative px-[var(--tabbar-tab-padding-x)] py-[var(--tabbar-tab-padding-y)]
  flex-shrink-0 whitespace-nowrap
  cursor-pointer text-tab font-normal
  transition-all duration-ss-fast
- border-t border-l border-r border-transparent
+ border border-transparent
  bg-[var(--tab-inactive-bg)] text-[var(--tab-inactive-text)]
- rounded-t-[var(--tab-border-radius)]
  hover:bg-[var(--tab-hover-bg)] hover:text-text
  `}
         >
@@ -449,22 +448,15 @@ function TabBarImpl<T extends string>({
               aria-selected={isActive}
               onClick={(event) => handleTabClick(tab.id, event)}
               className={`
- px-[var(--tabbar-tab-padding-x)] py-[var(--tabbar-tab-padding-y)]
+ relative px-[var(--tabbar-tab-padding-x)] py-[var(--tabbar-tab-padding-y)]
  flex-shrink-0 whitespace-nowrap
  cursor-pointer text-tab font-normal
  transition-all duration-ss-fast
- border-t border-l border-r border-transparent
+ border border-transparent
  ${
    isActive
-     ? // Active tab: "lifts" and connects to ribbon content
-       `bg-[var(--tab-active-bg)] text-[var(--tab-active-text)] font-medium
- rounded-t-[var(--tab-border-radius)]
- border-t-border-light border-l-border-light border-r-border-light
- relative -mb-px z-ss-sticky`
-     : // Inactive tab: subtle hover, stays "recessed"
-       `bg-[var(--tab-inactive-bg)] text-[var(--tab-inactive-text)]
- rounded-t-[var(--tab-border-radius)]
- hover:bg-[var(--tab-hover-bg)] hover:text-text`
+     ? `bg-[var(--tab-active-bg)] text-[var(--tab-active-text)] font-medium`
+     : `bg-[var(--tab-inactive-bg)] text-[var(--tab-inactive-text)] hover:bg-[var(--tab-hover-bg)] hover:text-text`
  }
  ${
    // Contextual tab accent (e.g., Table Design)
@@ -474,6 +466,13 @@ function TabBarImpl<T extends string>({
  `}
             >
               {tab.label}
+              {isActive && (
+                <span
+                  className="absolute left-[var(--tabbar-tab-padding-x)] right-[var(--tabbar-tab-padding-x)] bottom-0 bg-[var(--tab-active-text)]"
+                  style={{ height: 'var(--tab-active-underline)' }}
+                  aria-hidden="true"
+                />
+              )}
             </button>
           );
         })}

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/TabbedToolbar.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/TabbedToolbar.tsx
@@ -469,8 +469,8 @@ export const TabbedToolbar = React.memo(function TabbedToolbar({
               ref={ribbonContentRef}
               data-testid="panel-ribbon"
               className={`
- flex items-stretch px-[var(--ribbon-padding-x)] py-[var(--ribbon-padding-y)]
- bg-ss-surface gap-[var(--ribbon-section-gap)] h-[var(--ribbon-height)]
+ flex items-center px-[var(--ribbon-padding-x)] py-[var(--ribbon-padding-y)]
+ bg-ss-surface-secondary gap-[var(--ribbon-section-gap)] h-[var(--ribbon-height)]
  border-t border-ss-border-light overflow-hidden min-w-0
  ${temporaryShow ? 'shadow-ss-lg' : ''}
  `}

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarGroup.tsx
@@ -19,44 +19,13 @@
 import type { ReactNode } from 'react';
 import React from 'react';
 
-import { Tooltip } from '@mog/shell';
 import type { GroupCollapseConfig, GroupRenderMode } from '@mog-sdk/contracts/ribbon';
 import { GroupRenderModeProvider, useRibbonCollapseLevel } from '../collapse';
 import {
   RibbonVisibilityGroup,
-  RibbonVisibilityItem,
   useRibbonGroupVisibility,
 } from '../visibility/RibbonVisibilityContext';
 import { CollapsedGroupDropdown } from './CollapsedGroupDropdown';
-
-// =============================================================================
-// Dialog Launcher Icon
-// =============================================================================
-
-/**
- * Small diagonal arrow icon for dialog launcher.
- * Matches Excel's visual style - subtle, small (10x10).
- * Points to bottom-right to indicate "more options".
- */
-function DialogLauncherIcon() {
-  return (
-    <svg
-      width="10"
-      height="10"
-      viewBox="0 0 10 10"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.25"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      {/* Diagonal arrow pointing to bottom-right corner */}
-      <path d="M3 3L7 7" />
-      <path d="M7 4V7H4" />
-    </svg>
-  );
-}
 
 // =============================================================================
 // Types
@@ -110,8 +79,6 @@ export const ToolbarGroup = React.memo(function ToolbarGroup({
   label,
   isLast = false,
   children,
-  onDialogLaunch,
-  dialogLaunchTitle,
   collapseConfig,
   dropdownIcon,
   dropdownContent,
@@ -145,55 +112,13 @@ export const ToolbarGroup = React.memo(function ToolbarGroup({
     );
   }
 
-  // Full/Compact/Icons mode - render normal group with mode context
-  // Default tooltip title if not provided
-  const launchTitle = dialogLaunchTitle ?? `${label} Settings`;
-
   return (
     <RibbonVisibilityGroup group={groupVisibility.groupKey}>
       <GroupRenderModeProvider value={renderMode}>
-        <div className="relative flex flex-col px-[var(--ribbon-group-padding-x)] group/toolbar-group">
+        <div className="relative flex px-[var(--ribbon-group-padding-x)] group/toolbar-group">
           {/* Content area - fixed height from design token */}
           <div className="flex items-center justify-center gap-[var(--ribbon-group-items-gap)] h-[var(--ribbon-content-height)]">
             {children}
-          </div>
-          {/* Label area - fixed height from design token */}
-          {/* Excel uses UPPERCASE group labels */}
-          {/* Position relative to allow dialog launcher positioning */}
-          <div
-            className="relative flex items-center justify-center h-[var(--ribbon-label-height)] text-ribbon-group leading-none text-ss-text-tertiary whitespace-nowrap uppercase"
-            style={{ letterSpacing: 'var(--ribbon-group-label-letter-spacing)' }}
-          >
-            <span className="sr-only"> </span>
-            {label}
-            {/* Dialog Launcher - Excel-style small arrow in bottom-right corner */}
-            {/* Only rendered when onDialogLaunch is provided */}
-            {onDialogLaunch && (
-              <RibbonVisibilityItem item="dialogLauncher">
-                <Tooltip title={launchTitle}>
-                  <button
-                    type="button"
-                    onClick={onDialogLaunch}
-                    className="
- absolute right-0 bottom-0
- w-3 h-3
- flex items-center justify-center
- text-ss-text-tertiary
- opacity-50 group-hover/toolbar-group:opacity-100
- hover:!opacity-100 hover:text-ss-primary
- transition-opacity duration-ss-fast
- cursor-pointer
- bg-transparent border-none outline-none
- rounded-ss-sm
- focus-visible:ring-1 focus-visible:ring-ss-primary focus-visible:opacity-100
- "
-                    aria-label={launchTitle}
-                  >
-                    <DialogLauncherIcon />
-                  </button>
-                </Tooltip>
-              </RibbonVisibilityItem>
-            )}
           </div>
           {/* E2: Gradient fade separator - softer than solid border */}
           {/* Extended fade region (10%-90%) for more visible separator while keeping soft edges */}

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarGroup.tsx
@@ -38,17 +38,6 @@ export interface ToolbarGroupProps {
   isLast?: boolean;
   /** Group content - rendered when not collapsed to dropdown */
   children: ReactNode;
-  /**
-   * Optional callback when dialog launcher is clicked.
-   * When provided, renders a small diagonal arrow icon in the bottom-right
-   * corner that opens a related dialog (Excel-style dialog launcher).
-   */
-  onDialogLaunch?: () => void;
-  /**
-   * Tooltip text for the dialog launcher icon.
-   * Defaults to "{label} Settings" if not provided.
-   */
-  dialogLaunchTitle?: string;
 
   // === Collapse configuration (NEW) ===
 

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarIcons.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarIcons.tsx
@@ -259,7 +259,7 @@ type SvgComponent = ComponentType<SVGProps<SVGSVGElement>>;
 // Icon Wrapper Utilities
 // =============================================================================
 
-const iconStyle = { width: 16, height: 16 };
+const iconStyle = { width: 'var(--ribbon-icon-size)', height: 'var(--ribbon-icon-size)' };
 const iconStyleLarge = { width: 20, height: 20 };
 const iconStyleXL = { width: 24, height: 24 };
 

--- a/apps/spreadsheet/src/components/pickers/FontSizePicker.tsx
+++ b/apps/spreadsheet/src/components/pickers/FontSizePicker.tsx
@@ -306,11 +306,11 @@ export function FontSizePicker({
  ${
    error
      ? 'border-ss-error ring-1 ring-ss-error/20'
-   : isSmallFont
+     : isSmallFont
        ? 'border-ss-warning ring-1 ring-ss-warning/20 bg-ss-warning-bg'
-   : isOpen
-        ? 'border-ss-primary ring-1 ring-ss-primary/20'
-        : 'border-ss-border'
+       : isOpen
+         ? 'border-ss-primary ring-1 ring-ss-primary/20'
+         : 'border-ss-border'
  }
  `}
         title={

--- a/apps/spreadsheet/src/components/pickers/FontSizePicker.tsx
+++ b/apps/spreadsheet/src/components/pickers/FontSizePicker.tsx
@@ -298,19 +298,19 @@ export function FontSizePicker({
         onFocus={handleFocus}
         className={`
  ${isCompact ? 'w-10' : 'w-12'} h-7 px-1
- border rounded
- bg-ss-surface text-ss-text-secondary text-ribbon text-center
+ border border-transparent rounded
+ bg-transparent text-ss-text-secondary text-ribbon text-center
  cursor-pointer outline-none
  transition-colors duration-ss-fast
  hover:bg-ss-surface-hover
  ${
    error
      ? 'border-ss-error ring-1 ring-ss-error/20'
-     : isSmallFont
+   : isSmallFont
        ? 'border-ss-warning ring-1 ring-ss-warning/20 bg-ss-warning-bg'
-       : isOpen
-         ? 'border-ss-primary ring-1 ring-ss-primary/20'
-         : 'border-ss-border'
+   : isOpen
+        ? 'bg-ss-primary-light text-ss-primary'
+        : ''
  }
  `}
         title={

--- a/apps/spreadsheet/src/components/pickers/FontSizePicker.tsx
+++ b/apps/spreadsheet/src/components/pickers/FontSizePicker.tsx
@@ -298,8 +298,8 @@ export function FontSizePicker({
         onFocus={handleFocus}
         className={`
  ${isCompact ? 'w-10' : 'w-12'} h-7 px-1
- border border-transparent rounded
- bg-transparent text-ss-text-secondary text-ribbon text-center
+ border rounded
+ bg-ss-surface text-ss-text-secondary text-ribbon text-center
  cursor-pointer outline-none
  transition-colors duration-ss-fast
  hover:bg-ss-surface-hover
@@ -309,8 +309,8 @@ export function FontSizePicker({
    : isSmallFont
        ? 'border-ss-warning ring-1 ring-ss-warning/20 bg-ss-warning-bg'
    : isOpen
-        ? 'bg-ss-primary-light text-ss-primary'
-        : ''
+        ? 'border-ss-primary ring-1 ring-ss-primary/20'
+        : 'border-ss-border'
  }
  `}
         title={

--- a/apps/spreadsheet/src/index.tsx
+++ b/apps/spreadsheet/src/index.tsx
@@ -866,12 +866,6 @@ function SpreadsheetContent(): React.JSX.Element {
  the panel detaches from the DOM. The panel root carries
  `data-testid="panel-status-bar"` for the chrome-symmetry
  contract. */}
-          {showStatusBar && (
-            <div data-testid="panel-status-bar" className="shrink-0 border-t border-ss-border">
-              <StatusBar />
-            </div>
-          )}
-
           {/* Sheet Tabs - app-owned chrome (gated by capabilities.sheetTabs) */}
           {showSheetTabs && (
             <div className="shrink-0">
@@ -890,6 +884,12 @@ function SpreadsheetContent(): React.JSX.Element {
                 hiddenSheets={hiddenSheets}
                 readOnly={readOnly}
               />
+            </div>
+          )}
+
+          {showStatusBar && (
+            <div data-testid="panel-status-bar" className="shrink-0 border-t border-ss-border">
+              <StatusBar />
             </div>
           )}
         </div>

--- a/apps/spreadsheet/src/index.tsx
+++ b/apps/spreadsheet/src/index.tsx
@@ -512,7 +512,10 @@ export default function SpreadsheetApp({
   );
 }
 
-function effectiveWorkbookFeatureGates(readOnly: boolean, featureGates: FeatureGates): FeatureGates {
+function effectiveWorkbookFeatureGates(
+  readOnly: boolean,
+  featureGates: FeatureGates,
+): FeatureGates {
   return readOnly ? { ...featureGates, editing: false } : featureGates;
 }
 

--- a/apps/spreadsheet/src/infra/styles/globals.css
+++ b/apps/spreadsheet/src/infra/styles/globals.css
@@ -575,6 +575,7 @@
     appearance: none;
     width: 10px;
     height: 8px;
+    margin-top: -2px;
     border-radius: 4px;
     border: 1px solid var(--color-ss-text-tertiary);
     background: var(--color-ss-surface);

--- a/apps/spreadsheet/src/infra/styles/globals.css
+++ b/apps/spreadsheet/src/infra/styles/globals.css
@@ -147,10 +147,9 @@
   --qat-gap: 2px;
   --qat-padding-x: 4px;
 
-  /* Ribbon structure - explicit heights for predictable layout */
-  /* Tightened to match Excel's vertical density (was 80px/66px) */
-  /* Note: 77px = 60px content + 14px label + 2px padding-y + 1px border-t */
-  --ribbon-height: 68px; /* total ribbon height (includes 1px border) */
+  /* Ribbon structure - explicit border-box heights for predictable layout */
+  /* 68px = 56px content + 0px footer label + 12px vertical padding */
+  --ribbon-height: 68px; /* total ribbon height */
   --ribbon-content-height: 56px; /* height of button/content area */
   --ribbon-label-height: 0px; /* group footer labels are hidden */
   --ribbon-padding-x: 6px;
@@ -185,9 +184,8 @@
     (var(--ribbon-content-height) - 2 * var(--ribbon-button-gap)) / 3
   );
 
-  /* Ribbon group separators & labels */
+  /* Ribbon group separators */
   --ribbon-group-separator-width: 1px;
-  --ribbon-group-label-letter-spacing: 0.03em;
 
   /* Tooltip timing */
   --tooltip-delay: 500ms;

--- a/apps/spreadsheet/src/infra/styles/globals.css
+++ b/apps/spreadsheet/src/infra/styles/globals.css
@@ -126,12 +126,13 @@
   --tabbar-section-margin: 8px; /* margin between major sections */
 
   /* Tab styling - Excel-like appearance */
-  --tab-active-bg: var(--color-ss-surface);
+  --tab-active-bg: transparent;
   --tab-inactive-bg: transparent;
   --tab-hover-bg: rgba(0, 0, 0, 0.04);
   --tab-active-text: var(--color-ss-primary);
   --tab-inactive-text: var(--color-ss-text-secondary);
   --tab-border-radius: 3px;
+  --tab-active-underline: 2px;
   /* Contextual tab accent (Table Design = green) */
   --tab-contextual-accent: #217346;
 
@@ -149,11 +150,11 @@
   /* Ribbon structure - explicit heights for predictable layout */
   /* Tightened to match Excel's vertical density (was 80px/66px) */
   /* Note: 77px = 60px content + 14px label + 2px padding-y + 1px border-t */
-  --ribbon-height: 77px; /* total ribbon height (includes 1px border) */
-  --ribbon-content-height: 60px; /* height of button/content area */
-  --ribbon-label-height: 14px; /* height of group label area */
+  --ribbon-height: 68px; /* total ribbon height (includes 1px border) */
+  --ribbon-content-height: 56px; /* height of button/content area */
+  --ribbon-label-height: 0px; /* group footer labels are hidden */
   --ribbon-padding-x: 6px;
-  --ribbon-padding-y: 1px;
+  --ribbon-padding-y: 6px;
 
   /* Ribbon groups */
   --ribbon-section-gap: 4px; /* gap between ribbon groups */
@@ -167,16 +168,16 @@
 
   /* Ribbon button heights - CONSTRAINT-BASED SYSTEM
  * ================================================
- * All heights derive from --ribbon-content-height (60px).
+ * All heights derive from --ribbon-content-height (56px).
  * Formula: (content-height - (N-1) * gap) / N
  *
  * This guarantees N stacked buttons ALWAYS fit their container.
  * Overflow is impossible by construction.
  *
- * Calculated values (60px content, 2px gap):
- * full = 60px
- * half = (60 - 2) / 2 = 29px
- * third = (60 - 4) / 3 = 18.67px
+ * Calculated values (56px content, 2px gap):
+ * full = 56px
+ * half = (56 - 2) / 2 = 27px
+ * third = (56 - 4) / 3 = 17.33px
  */
   --ribbon-button-height-full: var(--ribbon-content-height);
   --ribbon-button-height-half: calc((var(--ribbon-content-height) - var(--ribbon-button-gap)) / 2);
@@ -570,6 +571,37 @@
  * Base utilities (.no-select) are inherited from shell
  * ============================================ */
 @layer utilities {
+  .mog-zoom-slider::-webkit-slider-thumb {
+    appearance: none;
+    width: 10px;
+    height: 8px;
+    border-radius: 4px;
+    border: 1px solid var(--color-ss-text-tertiary);
+    background: var(--color-ss-surface);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.03);
+  }
+
+  .mog-zoom-slider::-moz-range-thumb {
+    width: 10px;
+    height: 8px;
+    border-radius: 4px;
+    border: 1px solid var(--color-ss-text-tertiary);
+    background: var(--color-ss-surface);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.03);
+  }
+
+  .mog-zoom-slider::-webkit-slider-runnable-track {
+    height: 4px;
+    border-radius: 999px;
+    background: var(--color-ss-surface-hover);
+  }
+
+  .mog-zoom-slider::-moz-range-track {
+    height: 4px;
+    border-radius: 999px;
+    background: var(--color-ss-surface-hover);
+  }
+
   /* F6 Pane Focus Indicator
  *
  * Visual indicator showing which pane is focused during F6 navigation.

--- a/apps/spreadsheet/src/infra/styles/globals.css
+++ b/apps/spreadsheet/src/infra/styles/globals.css
@@ -161,6 +161,7 @@
   --ribbon-group-items-gap: 3px; /* gap between items horizontally within a group */
 
   /* Ribbon buttons */
+  --ribbon-icon-size: 14px;
   --ribbon-button-gap: 2px; /* gap between button rows vertically */
   --ribbon-button-icon-gap: 2px; /* gap between icon and label within a button */
   --ribbon-button-inline-gap: 1px; /* tight gap between adjacent icon buttons (B/I/U row) */

--- a/apps/spreadsheet/src/infra/styles/tokens.css
+++ b/apps/spreadsheet/src/infra/styles/tokens.css
@@ -25,12 +25,13 @@
   --tabbar-section-margin: 8px; /* margin between major sections */
 
   /* Tab styling - Excel-like appearance */
-  --tab-active-bg: var(--color-ss-surface);
+  --tab-active-bg: transparent;
   --tab-inactive-bg: transparent;
   --tab-hover-bg: rgba(0, 0, 0, 0.04);
   --tab-active-text: var(--color-ss-primary);
   --tab-inactive-text: var(--color-ss-text-secondary);
   --tab-border-radius: 3px;
+  --tab-active-underline: 2px;
   /* Contextual tab accent (Table Design = green) */
   --tab-contextual-accent: #217346;
 
@@ -48,11 +49,11 @@
   /* Ribbon structure - explicit heights for predictable layout */
   /* Tightened to match Excel's vertical density (was 80px/66px) */
   /* Note: 77px = 60px content + 14px label + 2px padding-y + 1px border-t */
-  --ribbon-height: 77px; /* total ribbon height (includes 1px border) */
-  --ribbon-content-height: 60px; /* height of button/content area */
-  --ribbon-label-height: 14px; /* height of group label area */
+  --ribbon-height: 68px; /* total ribbon height (includes 1px border) */
+  --ribbon-content-height: 56px; /* height of button/content area */
+  --ribbon-label-height: 0px; /* group footer labels are hidden */
   --ribbon-padding-x: 6px;
-  --ribbon-padding-y: 1px;
+  --ribbon-padding-y: 6px;
 
   /* Ribbon groups */
   --ribbon-section-gap: 4px; /* gap between ribbon groups */
@@ -66,16 +67,16 @@
 
   /* Ribbon button heights - CONSTRAINT-BASED SYSTEM
  * ================================================
- * All heights derive from --ribbon-content-height (60px).
+ * All heights derive from --ribbon-content-height (56px).
  * Formula: (content-height - (N-1) * gap) / N
  *
  * This guarantees N stacked buttons ALWAYS fit their container.
  * Overflow is impossible by construction.
  *
- * Calculated values (60px content, 2px gap):
- * full = 60px
- * half = (60 - 2) / 2 = 29px
- * third = (60 - 4) / 3 = 18.67px
+ * Calculated values (56px content, 2px gap):
+ * full = 56px
+ * half = (56 - 2) / 2 = 27px
+ * third = (56 - 4) / 3 = 17.33px
  */
   --ribbon-button-height-full: var(--ribbon-content-height);
   --ribbon-button-height-half: calc((var(--ribbon-content-height) - var(--ribbon-button-gap)) / 2);
@@ -459,6 +460,37 @@
   .no-select {
     user-select: none;
     -webkit-user-select: none;
+  }
+
+  .mog-zoom-slider::-webkit-slider-thumb {
+    appearance: none;
+    width: 10px;
+    height: 8px;
+    border-radius: 4px;
+    border: 1px solid var(--color-ss-text-tertiary);
+    background: var(--color-ss-surface);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.03);
+  }
+
+  .mog-zoom-slider::-moz-range-thumb {
+    width: 10px;
+    height: 8px;
+    border-radius: 4px;
+    border: 1px solid var(--color-ss-text-tertiary);
+    background: var(--color-ss-surface);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.03);
+  }
+
+  .mog-zoom-slider::-webkit-slider-runnable-track {
+    height: 4px;
+    border-radius: 999px;
+    background: var(--color-ss-surface-hover);
+  }
+
+  .mog-zoom-slider::-moz-range-track {
+    height: 4px;
+    border-radius: 999px;
+    background: var(--color-ss-surface-hover);
   }
 
   /* F6 Pane Focus Indicator

--- a/apps/spreadsheet/src/infra/styles/tokens.css
+++ b/apps/spreadsheet/src/infra/styles/tokens.css
@@ -60,6 +60,7 @@
   --ribbon-group-items-gap: 3px; /* gap between items horizontally within a group */
 
   /* Ribbon buttons */
+  --ribbon-icon-size: 14px;
   --ribbon-button-gap: 2px; /* gap between button rows vertically */
   --ribbon-button-icon-gap: 2px; /* gap between icon and label within a button */
   --ribbon-button-inline-gap: 1px; /* tight gap between adjacent icon buttons (B/I/U row) */

--- a/apps/spreadsheet/src/infra/styles/tokens.css
+++ b/apps/spreadsheet/src/infra/styles/tokens.css
@@ -46,10 +46,9 @@
   --qat-gap: 2px;
   --qat-padding-x: 4px;
 
-  /* Ribbon structure - explicit heights for predictable layout */
-  /* Tightened to match Excel's vertical density (was 80px/66px) */
-  /* Note: 77px = 60px content + 14px label + 2px padding-y + 1px border-t */
-  --ribbon-height: 68px; /* total ribbon height (includes 1px border) */
+  /* Ribbon structure - explicit border-box heights for predictable layout */
+  /* 68px = 56px content + 0px footer label + 12px vertical padding */
+  --ribbon-height: 68px; /* total ribbon height */
   --ribbon-content-height: 56px; /* height of button/content area */
   --ribbon-label-height: 0px; /* group footer labels are hidden */
   --ribbon-padding-x: 6px;
@@ -84,9 +83,8 @@
     (var(--ribbon-content-height) - 2 * var(--ribbon-button-gap)) / 3
   );
 
-  /* Ribbon group separators & labels */
+  /* Ribbon group separators */
   --ribbon-group-separator-width: 1px;
-  --ribbon-group-label-letter-spacing: 0.03em;
 
   /* Tooltip timing */
   --tooltip-delay: 500ms;
@@ -460,37 +458,6 @@
   .no-select {
     user-select: none;
     -webkit-user-select: none;
-  }
-
-  .mog-zoom-slider::-webkit-slider-thumb {
-    appearance: none;
-    width: 10px;
-    height: 8px;
-    border-radius: 4px;
-    border: 1px solid var(--color-ss-text-tertiary);
-    background: var(--color-ss-surface);
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.03);
-  }
-
-  .mog-zoom-slider::-moz-range-thumb {
-    width: 10px;
-    height: 8px;
-    border-radius: 4px;
-    border: 1px solid var(--color-ss-text-tertiary);
-    background: var(--color-ss-surface);
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.03);
-  }
-
-  .mog-zoom-slider::-webkit-slider-runnable-track {
-    height: 4px;
-    border-radius: 999px;
-    background: var(--color-ss-surface-hover);
-  }
-
-  .mog-zoom-slider::-moz-range-track {
-    height: 4px;
-    border-radius: 999px;
-    background: var(--color-ss-surface-hover);
   }
 
   /* F6 Pane Focus Indicator

--- a/canvas/grid-renderer/src/coordinates/__tests__/get-click-position-in-cell.test.ts
+++ b/canvas/grid-renderer/src/coordinates/__tests__/get-click-position-in-cell.test.ts
@@ -123,17 +123,17 @@ describe('CoordinateSystem.getClickPositionInCell', () => {
     });
 
     it('returns correct position for cell (0, 0) at center of cell', () => {
-      // Cell (0,0) starts at (50, 24), size (100, 21)
-      // Center is at (100, 34.5)
-      const clickPos = coords.getClickPositionInCell(TEST_SHEET_ID, viewportPoint(100, 34), {
+      const clickX = ROW_HEADER_WIDTH + DEFAULT_COL_WIDTH / 2;
+      const clickY = COL_HEADER_HEIGHT + 10;
+      const clickPos = coords.getClickPositionInCell(TEST_SHEET_ID, viewportPoint(clickX, clickY), {
         row: 0,
         col: 0,
       });
 
       expect(clickPos).not.toBeNull();
       if (clickPos) {
-        expect(clickPos.x).toBe(50); // 100 - 50 (header offset)
-        expect(clickPos.y).toBe(10); // 34 - 24 (header offset)
+        expect(clickPos.x).toBe(DEFAULT_COL_WIDTH / 2);
+        expect(clickPos.y).toBe(10);
         expect(clickPos.width).toBe(DEFAULT_COL_WIDTH);
         expect(clickPos.height).toBe(DEFAULT_ROW_HEIGHT);
       }

--- a/canvas/grid-renderer/src/coordinates/__tests__/hidden-headers.test.ts
+++ b/canvas/grid-renderer/src/coordinates/__tests__/hidden-headers.test.ts
@@ -616,9 +616,9 @@ describe('CoordinateSystem with hidden headers', () => {
       const vpRect = coords.documentToViewport(TEST_SHEET_ID, docRect);
 
       expect(vpRect).not.toBeNull();
-      // x: 100 * 2 + ROW_HEADER_WIDTH = 200 + 50 = 250
+      // x: 100 * 2 + ROW_HEADER_WIDTH
       // y: 50 * 2 = 100 (no column header offset)
-      expect(vpRect!.x).toBe(250);
+      expect(vpRect!.x).toBe(100 * 2 + ROW_HEADER_WIDTH);
       expect(vpRect!.y).toBe(100);
     });
 
@@ -665,9 +665,9 @@ describe('CoordinateSystem with hidden headers', () => {
       const vpRect = coords.documentToViewport(TEST_SHEET_ID, docRect);
 
       expect(vpRect).not.toBeNull();
-      // x: (300 - 200 scroll) + ROW_HEADER_WIDTH = 100 + 50 = 150
+      // x: (300 - 200 scroll) + ROW_HEADER_WIDTH
       // y: (150 - 100 scroll) = 50 (no column header offset)
-      expect(vpRect!.x).toBe(150);
+      expect(vpRect!.x).toBe(300 - 200 + ROW_HEADER_WIDTH);
       expect(vpRect!.y).toBe(50);
     });
 

--- a/canvas/grid-renderer/src/layers/headers.ts
+++ b/canvas/grid-renderer/src/layers/headers.ts
@@ -492,20 +492,16 @@ export class HeadersLayer extends BaseLayer implements OnceLayerWithChrome {
     ctx.lineTo(totalRowHeaderWidth, cornerBottomY);
     ctx.stroke();
 
-    // Small diagonal arrow icon in corner (select all indicator)
-    const centerX = totalRowHeaderWidth / 2;
-    const centerY = totalColHeaderHeight / 2;
-    const arrowSize = 5;
-
-    ctx.strokeStyle = this.config.textColor;
-    ctx.lineWidth = 1;
+    // Excel-style select-all corner mark: a right triangle scaled to the
+    // rectangular header corner rather than a square icon.
+    const inset = 5;
+    ctx.fillStyle = this.config.highlightBgColor;
     ctx.beginPath();
-    ctx.moveTo(centerX - arrowSize, centerY + arrowSize);
-    ctx.lineTo(centerX + arrowSize, centerY - arrowSize);
-    ctx.moveTo(centerX + arrowSize - 3, centerY - arrowSize);
-    ctx.lineTo(centerX + arrowSize, centerY - arrowSize);
-    ctx.lineTo(centerX + arrowSize, centerY - arrowSize + 3);
-    ctx.stroke();
+    ctx.moveTo(inset, totalColHeaderHeight - inset);
+    ctx.lineTo(totalRowHeaderWidth - inset, totalColHeaderHeight - inset);
+    ctx.lineTo(totalRowHeaderWidth - inset, inset);
+    ctx.closePath();
+    ctx.fill();
   }
 
   // ===========================================================================

--- a/contracts/src/rendering/__tests__/constants.test.ts
+++ b/contracts/src/rendering/__tests__/constants.test.ts
@@ -1,9 +1,13 @@
-import { DEFAULT_ROW_HEIGHT } from '../constants';
+import { DEFAULT_ROW_HEIGHT, ROW_HEADER_WIDTH } from '../constants';
 
 describe('rendering constants', () => {
   test('DEFAULT_ROW_HEIGHT matches OOXML spec (15pt at 96 DPI)', () => {
     // OOXML default row height is 15pt. At 96 DPI: 15 × 96/72 = 20px.
     // This must match the Rust compute engine's points_to_pixels(15.0) = 20.0.
     expect(DEFAULT_ROW_HEIGHT).toBe(20);
+  });
+
+  test('ROW_HEADER_WIDTH matches the compact app chrome contract', () => {
+    expect(ROW_HEADER_WIDTH).toBe(28);
   });
 });

--- a/contracts/src/rendering/constants.ts
+++ b/contracts/src/rendering/constants.ts
@@ -55,7 +55,7 @@ export const MIN_ROW_HEIGHT = 16;
 // =============================================================================
 
 /** Width of row header column (shows row numbers) */
-export const ROW_HEADER_WIDTH = 50;
+export const ROW_HEADER_WIDTH = 28;
 
 /** Height of column header row (shows column letters) */
 export const COL_HEADER_HEIGHT = 24;

--- a/infra/icons/src/wrappers.tsx
+++ b/infra/icons/src/wrappers.tsx
@@ -15,7 +15,7 @@ import type { ComponentType, CSSProperties, SVGProps } from 'react';
 
 // Standard icon sizes used across the application
 export const ICON_SIZES = {
-  toolbar: 16,
+  toolbar: 14,
   toolbarLarge: 20,
   menu: 20,
   dialog: 24,

--- a/kernel/src/api/worksheet/tables.ts
+++ b/kernel/src/api/worksheet/tables.ts
@@ -142,10 +142,7 @@ export class WorksheetTablesImpl implements WorksheetTables {
     this.ctx.writeGate.assertWritable(op);
   }
 
-  private _tableMutationOptions(
-    operationIdPrefix: string,
-    groupId?: string,
-  ): TableMutationOptions {
+  private _tableMutationOptions(operationIdPrefix: string, groupId?: string): TableMutationOptions {
     return createTableMutationOptions(this.ctx, operationIdPrefix, this.sheetId, groupId);
   }
 
@@ -247,9 +244,12 @@ export class WorksheetTablesImpl implements WorksheetTables {
 
   private tableInfoWithMethods(table: TableInfo): TableInfo {
     return attachTableInfoMethods(table, {
-      setTotalsRow: (tableName, visible) => this.setShowTotals(tableName, visible),
-      setTotalsFunction: (tableName, columnName, func) =>
-        this.setColumnTotalsFunction(tableName, columnName, func as TotalsFunction),
+      setTotalsRow: async (tableName, visible) => {
+        await this.setShowTotals(tableName, visible);
+      },
+      setTotalsFunction: async (tableName, columnName, func) => {
+        await this.setColumnTotalsFunction(tableName, columnName, func as TotalsFunction);
+      },
     });
   }
 
@@ -2002,7 +2002,6 @@ export class WorksheetTablesImpl implements WorksheetTables {
     });
     return toDisposable(unsub);
   }
-
 }
 
 /**

--- a/shell/src/components/ui/radix/SegmentedControl.tsx
+++ b/shell/src/components/ui/radix/SegmentedControl.tsx
@@ -56,17 +56,18 @@ export interface SegmentedControlProps {
 
 const groupClasses = [
   'inline-flex items-center',
-  'rounded-ss-sm border border-transparent',
-  'bg-transparent overflow-hidden',
+  'rounded-ss-sm border border-ss-border',
+  'bg-ss-surface overflow-hidden',
 ].join(' ');
 
 const itemClasses = [
   'relative inline-flex items-center justify-center',
   'px-2 h-6 text-ribbon font-medium',
+  'border-r border-ss-border last:border-r-0',
   'cursor-pointer select-none',
   'transition-colors duration-100',
   // Inactive state
-  'bg-transparent text-ss-text-secondary',
+  'bg-ss-surface text-ss-text-secondary',
   'hover:bg-ss-surface-hover hover:text-ss-text',
   // Active state — Radix sets data-state="checked" on the active item
   'data-[state=checked]:bg-ss-primary',

--- a/shell/src/components/ui/radix/SegmentedControl.tsx
+++ b/shell/src/components/ui/radix/SegmentedControl.tsx
@@ -56,18 +56,17 @@ export interface SegmentedControlProps {
 
 const groupClasses = [
   'inline-flex items-center',
-  'rounded-ss-sm border border-ss-border',
-  'bg-ss-surface overflow-hidden',
+  'rounded-ss-sm border border-transparent',
+  'bg-transparent overflow-hidden',
 ].join(' ');
 
 const itemClasses = [
   'relative inline-flex items-center justify-center',
   'px-2 h-6 text-ribbon font-medium',
-  'border-r border-ss-border last:border-r-0',
   'cursor-pointer select-none',
   'transition-colors duration-100',
   // Inactive state
-  'bg-ss-surface text-ss-text-secondary',
+  'bg-transparent text-ss-text-secondary',
   'hover:bg-ss-surface-hover hover:text-ss-text',
   // Active state — Radix sets data-state="checked" on the active item
   'data-[state=checked]:bg-ss-primary',


### PR DESCRIPTION
## Summary
- refines Home ribbon spacing, active-tab underline, and shared ribbon/formula-bar background
- removes ribbon group footer labels/launch affordances for a tighter command surface
- compacts Styles into a three-row icon/list layout and balances Font/Alignment controls
- moves sheet tabs above the Ready/zoom status row
- narrows the row header gutter to 28px and replaces the select-all arrow with an Excel-style triangle
- restyles the zoom thumb and removes green formula-bar focus chrome / blue edit selection styling

## Verification
- pnpm --filter @mog/platform-memory typecheck
- pnpm --filter @mog/kernel-host-internal typecheck
- pnpm --filter @mog/app-spreadsheet typecheck
- manually verified http://127.0.0.1:3101/?new opens a blank workbook, renders the polished ribbon, supports cell typing, and shows no browser console errors