### PR TITLE
Promote dev-v0.10.4 to main

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -250,7 +250,7 @@ jobs:
             artifact: native-linux-arm64-musl
             npm-dir: compute/napi/npm/linux-arm64-musl
           - target: x86_64-pc-windows-msvc
-            os: windows-latest
+            os: windows-2025-8core
             artifact: native-win32-x64-msvc
             npm-dir: compute/napi/npm/win32-x64-msvc
     steps:

--- a/apps/spreadsheet/src/chrome/toolbar/collapse/collapse-ladder.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/collapse/collapse-ladder.ts
@@ -1,0 +1,75 @@
+/**
+ * Collapse ladder derivation.
+ *
+ * Progressive collapse treats each group as a ladder of render modes ordered
+ * from most-expanded to most-collapsed. The coordinator collapses groups one
+ * rung at a time, least-important first, until the ribbon fits — instead of
+ * moving the whole ribbon through discrete global levels in lock-step.
+ *
+ * We DERIVE the ladder from the group's existing GroupCollapseConfig.levels so
+ * the per-group progression stays authored in one place (collapse-configs.ts):
+ * the distinct render modes, in order, become the rungs. `hidden` is pulled out
+ * of the rung list into `canHide`, because hiding a group is a LAST RESORT used
+ * only when every group is already at its most-compact non-hidden rung and the
+ * ribbon still overflows — "important buttons never disappear unless it is
+ * physically impossible to fit them".
+ */
+
+import type { CollapseLevel, GroupCollapseConfig, GroupRenderMode } from '@mog-sdk/contracts/ribbon';
+
+const LEVELS: readonly CollapseLevel[] = [0, 1, 2, 3, 4];
+
+export interface CollapseLadder {
+  /** Lower number = more important = collapses later. */
+  priority: number;
+  /**
+   * Render modes from most-expanded (`rungs[0]`, always the mode the group
+   * shows when nothing needs to collapse) to most-collapsed, EXCLUDING
+   * `hidden`. Always has at least one entry.
+   */
+  rungs: GroupRenderMode[];
+  /** Whether the group may be hidden as an absolute last resort. */
+  canHide: boolean;
+}
+
+/**
+ * Derive a group's collapse ladder from its collapse config.
+ *
+ * A group with no config never collapses (single `full` rung, never hidden).
+ */
+export function deriveCollapseLadder(config: GroupCollapseConfig | undefined): CollapseLadder {
+  if (!config) {
+    return { priority: 0, rungs: ['full'], canHide: false };
+  }
+
+  const rungs: GroupRenderMode[] = [];
+  let canHide = false;
+
+  for (const level of LEVELS) {
+    const mode = config.levels[level];
+    if (!mode) continue;
+    if (mode === 'hidden') {
+      canHide = true;
+      continue;
+    }
+    if (rungs[rungs.length - 1] !== mode) {
+      rungs.push(mode);
+    }
+  }
+
+  if (rungs.length === 0) rungs.push('full');
+
+  return { priority: config.priority, rungs, canHide };
+}
+
+/**
+ * Serialize a ladder into the compact form stored on the group's DOM element as
+ * data attributes, so the (DOM-driven) coordinator can read each visible
+ * group's priority/rungs without a React registration handshake.
+ */
+export const LADDER_DATA_ATTRS = {
+  key: 'data-ribbon-group-key',
+  priority: 'data-ribbon-priority',
+  rungs: 'data-ribbon-rungs',
+  canHide: 'data-ribbon-can-hide',
+} as const;

--- a/apps/spreadsheet/src/chrome/toolbar/collapse/collapse-ladder.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/collapse/collapse-ladder.ts
@@ -15,7 +15,11 @@
  * physically impossible to fit them".
  */
 
-import type { CollapseLevel, GroupCollapseConfig, GroupRenderMode } from '@mog-sdk/contracts/ribbon';
+import type {
+  CollapseLevel,
+  GroupCollapseConfig,
+  GroupRenderMode,
+} from '@mog-sdk/contracts/ribbon';
 
 const LEVELS: readonly CollapseLevel[] = [0, 1, 2, 3, 4];
 

--- a/apps/spreadsheet/src/chrome/toolbar/collapse/context.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/collapse/context.tsx
@@ -17,30 +17,32 @@
 
 import { createContext, useContext } from 'react';
 
-import type {
-  CollapseLevel,
-  GroupRenderMode,
-  RibbonCollapseState,
-} from '@mog-sdk/contracts/ribbon';
+import type { GroupRenderMode } from '@mog-sdk/contracts/ribbon';
 // =============================================================================
 // Ribbon Collapse Context (provided by TabbedToolbar)
 // =============================================================================
 
-export interface RibbonCollapseContextState extends RibbonCollapseState {
-  /**
-   * Collapse level derived from container width before content-aware overflow
-   * escalation. When omitted, consumers should treat it as equal to `level`.
-   */
-  widthLevel?: CollapseLevel;
+/**
+ * Collapse state broadcast to every group.
+ *
+ * Progressive collapse is PER-GROUP: `groupModes` maps a group's key to the
+ * render mode the coordinator has assigned it. A group missing from the map
+ * renders at its most-expanded rung (`full`-equivalent). There is no single
+ * global "level" anymore — the coordinator collapses groups independently,
+ * least-important first, so the ribbon fills the available width.
+ */
+export interface RibbonCollapseContextState {
+  /** Render mode assigned to each group, keyed by group key. */
+  groupModes: Record<string, GroupRenderMode>;
+  /** Container width in pixels (consumed by width-sensitive groups, e.g. Charts). */
+  containerWidth: number;
 }
 
 /**
- * Default state for collapse context.
- * Level 0 = full expansion (largest screens).
+ * Default state for collapse context: nothing collapsed.
  */
 const DEFAULT_COLLAPSE_STATE: RibbonCollapseContextState = {
-  level: 0,
-  widthLevel: 0,
+  groupModes: {},
   containerWidth: 1920,
 };
 
@@ -58,15 +60,15 @@ export const RibbonCollapseProvider = RibbonCollapseContext.Provider;
 /**
  * Hook to access the current ribbon collapse state.
  *
- * Used by ToolbarGroup to determine render mode based on collapse config.
+ * Used by ToolbarGroup to read the render mode the coordinator assigned to it.
  *
- * @returns Current collapse level and container width
+ * @returns Per-group render modes and container width
  *
  * @example
  * ```tsx
- * function ToolbarGroup({ collapseConfig, children }) {
- * const { level } = useRibbonCollapseLevel;
- * const renderMode = collapseConfig?.levels[level] ?? 'full';
+ * function ToolbarGroup({ groupKey, children }) {
+ * const { groupModes } = useRibbonCollapseLevel();
+ * const renderMode = groupModes[groupKey] ?? 'full';
  * // ...
  * }
  * ```

--- a/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.integration.test.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.integration.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Integration test for progressive, per-group ribbon collapse.
+ *
+ * Drives the full hook (ResizeObserver width observer + layout-effect
+ * convergence) in jsdom. Each mock group stamps the same ladder data attributes
+ * a real ToolbarGroup does and reports a width for its currently-assigned mode
+ * via `data-w`; the panel's mocked scrollWidth sums those widths. That lets us
+ * assert the exact per-group modes the coordinator settles on — the behavior
+ * jsdom's lack of real layout otherwise hides.
+ */
+import { useRef } from 'react';
+import { act, render } from '@testing-library/react';
+
+import type { GroupRenderMode } from '@mog-sdk/contracts/ribbon';
+import { RibbonCollapseProvider, useRibbonCollapseLevel } from './context';
+import { useRibbonCollapse } from './use-ribbon-collapse';
+
+// ---------------------------------------------------------------------------
+// Group model
+// ---------------------------------------------------------------------------
+
+interface GroupDef {
+  key: string;
+  priority: number;
+  rungs: GroupRenderMode[];
+  canHide: boolean;
+  widthByMode: Partial<Record<GroupRenderMode, number>>;
+}
+
+// A sparse Insert-like tab (as under the public visibility profile, plus the
+// low-priority groups the user said must not disappear).
+const INSERT_DEFS: GroupDef[] = [
+  { key: 'tables', priority: 2, rungs: ['full', 'compact', 'icons', 'dropdown'], canHide: false, widthByMode: { full: 180, compact: 140, icons: 110, dropdown: 70 } },
+  { key: 'charts', priority: 3, rungs: ['full', 'compact', 'icons', 'dropdown'], canHide: false, widthByMode: { full: 120, compact: 100, icons: 80, dropdown: 70 } },
+  { key: 'filters', priority: 4, rungs: ['full', 'dropdown'], canHide: true, widthByMode: { full: 110, dropdown: 70 } },
+  { key: 'links', priority: 4, rungs: ['full', 'dropdown'], canHide: true, widthByMode: { full: 70, dropdown: 60 } },
+  { key: 'comments', priority: 4, rungs: ['full', 'dropdown'], canHide: true, widthByMode: { full: 90, dropdown: 70 } },
+];
+
+// ---------------------------------------------------------------------------
+// DOM measurement mocks
+// ---------------------------------------------------------------------------
+
+let containerWidth = 1920;
+let resizeCallbacks: ResizeObserverCallback[] = [];
+
+const originalRO = globalThis.ResizeObserver;
+const originalGBCR = HTMLElement.prototype.getBoundingClientRect;
+const originalScrollWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollWidth');
+const originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+
+beforeEach(() => {
+  resizeCallbacks = [];
+  class MockResizeObserver {
+    constructor(cb: ResizeObserverCallback) {
+      resizeCallbacks.push(cb);
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
+  HTMLElement.prototype.getBoundingClientRect = function () {
+    return { width: containerWidth, height: 0, top: 0, left: 0, right: 0, bottom: 0, x: 0, y: 0, toJSON() {} } as DOMRect;
+  };
+  Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+    configurable: true,
+    get(this: HTMLElement) {
+      // Sum the reported widths of the visible group children.
+      let sum = 0;
+      for (const el of Array.from(this.querySelectorAll<HTMLElement>('[data-w]'))) {
+        sum += Number(el.getAttribute('data-w') ?? '0');
+      }
+      return sum;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get() {
+      return containerWidth;
+    },
+  });
+});
+
+afterEach(() => {
+  globalThis.ResizeObserver = originalRO;
+  HTMLElement.prototype.getBoundingClientRect = originalGBCR;
+  if (originalScrollWidth) Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalScrollWidth);
+  if (originalClientWidth) Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+});
+
+function resizeTo(width: number) {
+  containerWidth = width;
+  act(() => {
+    for (const cb of resizeCallbacks) {
+      cb([{ contentRect: { width } }] as unknown as ResizeObserverEntry[], {} as ResizeObserver);
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Harness (mini TabbedToolbar + ToolbarGroup)
+// ---------------------------------------------------------------------------
+
+let latestModes: Record<string, GroupRenderMode> = {};
+
+function MockGroup({ def }: { def: GroupDef }) {
+  const { groupModes } = useRibbonCollapseLevel();
+  const mode = groupModes[def.key] ?? def.rungs[0];
+  if (mode === 'hidden') return null; // hidden groups render no element
+  return (
+    <div
+      data-ribbon-group-key={def.key}
+      data-ribbon-priority={String(def.priority)}
+      data-ribbon-rungs={def.rungs.join(',')}
+      data-ribbon-can-hide={def.canHide ? '1' : '0'}
+      data-w={String(def.widthByMode[mode] ?? 0)}
+    />
+  );
+}
+
+function Harness({ defs, contentKey }: { defs: GroupDef[]; contentKey?: unknown }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const state = useRibbonCollapse(containerRef, panelRef, contentKey);
+  latestModes = state.groupModes;
+  return (
+    <div ref={containerRef}>
+      <RibbonCollapseProvider value={state}>
+        <div ref={panelRef} data-testid="panel">
+          {defs.map((d) => (
+            <MockGroup key={d.key} def={d} />
+          ))}
+        </div>
+      </RibbonCollapseProvider>
+    </div>
+  );
+}
+
+/** Resolve the effective mode for a group (absent assignment ⇒ most-expanded). */
+function modeOf(key: string): GroupRenderMode {
+  const def = INSERT_DEFS.find((d) => d.key === key)!;
+  return latestModes[key] ?? def.rungs[0];
+}
+
+describe('progressive per-group ribbon collapse', () => {
+  it('collapses one group at a time, least-important first, filling the space', () => {
+    // Full total = 570; container 560 overflows by only 10. A single low-priority
+    // group collapsing should be enough — the rest stay fully expanded.
+    containerWidth = 560;
+    render(<Harness defs={INSERT_DEFS} />);
+
+    expect(modeOf('tables')).toBe('full'); // major groups untouched
+    expect(modeOf('charts')).toBe('full');
+    expect(modeOf('filters')).toBe('full');
+    expect(modeOf('links')).toBe('full');
+    // Only the right-most least-important group collapses.
+    expect(modeOf('comments')).toBe('dropdown');
+    // Nothing disappears.
+    expect(Object.values(latestModes)).not.toContain('hidden');
+  });
+
+  it('never hides a group just because the window is narrow (degrades to dropdowns first)', () => {
+    containerWidth = 400;
+    render(<Harness defs={INSERT_DEFS} />);
+
+    // Every group is still present — low-priority ones as dropdowns, and even
+    // the most-important group only steps partway down its ladder.
+    expect(Object.values(latestModes)).not.toContain('hidden');
+    expect(modeOf('filters')).toBe('dropdown');
+    expect(modeOf('links')).toBe('dropdown');
+    expect(modeOf('comments')).toBe('dropdown');
+    expect(modeOf('charts')).toBe('dropdown');
+    expect(modeOf('tables')).toBe('icons'); // important group not fully collapsed
+  });
+
+  it('hides groups only when it is physically impossible to fit them, important ones last', () => {
+    // 200px cannot fit five dropdowns; low-priority groups get hidden, but the
+    // major groups (canHide=false) remain visible.
+    containerWidth = 200;
+    render(<Harness defs={INSERT_DEFS} />);
+
+    expect(modeOf('tables')).toBe('dropdown'); // never hidden
+    expect(modeOf('charts')).toBe('dropdown'); // never hidden
+    expect(latestModes.comments).toBe('hidden');
+    expect(latestModes.links).toBe('hidden');
+    expect(latestModes.filters).toBe('hidden');
+  });
+
+  it('keeps everything fully expanded when there is ample room', () => {
+    containerWidth = 2000;
+    render(<Harness defs={INSERT_DEFS} />);
+
+    expect(latestModes).toEqual({}); // no group collapsed
+  });
+
+  it('applies collapse immediately on tab switch, even from a fully-expanded tab (no resize needed)', () => {
+    containerWidth = 560;
+    // A sparse tab that fits fully → nothing collapsed (groupModes === {}).
+    const sparse: GroupDef[] = [
+      { key: 'a', priority: 2, rungs: ['full', 'dropdown'], canHide: false, widthByMode: { full: 180, dropdown: 70 } },
+      { key: 'b', priority: 3, rungs: ['full', 'dropdown'], canHide: false, widthByMode: { full: 120, dropdown: 70 } },
+    ];
+    const { rerender } = render(<Harness defs={sparse} contentKey="sparse-tab" />);
+    expect(latestModes).toEqual({});
+
+    // Switch to a denser tab (new contentKey) at the SAME width — no resize.
+    rerender(<Harness defs={INSERT_DEFS} contentKey="dense-tab" />);
+
+    // The dense tab overflows 560 and must collapse right away.
+    expect(modeOf('comments')).toBe('dropdown');
+    expect(Object.values(latestModes)).not.toContain('hidden');
+    // No stale keys from the previous tab leak in.
+    expect(latestModes.a).toBeUndefined();
+    expect(latestModes.b).toBeUndefined();
+  });
+
+  it('reclaims space for important groups when the window widens', () => {
+    containerWidth = 400;
+    render(<Harness defs={INSERT_DEFS} />);
+    expect(modeOf('tables')).toBe('icons');
+
+    resizeTo(2000);
+    expect(latestModes).toEqual({}); // fully expanded again
+
+    resizeTo(560);
+    // Back to the minimal collapse that fits 560.
+    expect(modeOf('comments')).toBe('dropdown');
+    expect(modeOf('tables')).toBe('full');
+  });
+});

--- a/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.integration.test.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.integration.test.tsx
@@ -30,11 +30,41 @@ interface GroupDef {
 // A sparse Insert-like tab (as under the public visibility profile, plus the
 // low-priority groups the user said must not disappear).
 const INSERT_DEFS: GroupDef[] = [
-  { key: 'tables', priority: 2, rungs: ['full', 'compact', 'icons', 'dropdown'], canHide: false, widthByMode: { full: 180, compact: 140, icons: 110, dropdown: 70 } },
-  { key: 'charts', priority: 3, rungs: ['full', 'compact', 'icons', 'dropdown'], canHide: false, widthByMode: { full: 120, compact: 100, icons: 80, dropdown: 70 } },
-  { key: 'filters', priority: 4, rungs: ['full', 'dropdown'], canHide: true, widthByMode: { full: 110, dropdown: 70 } },
-  { key: 'links', priority: 4, rungs: ['full', 'dropdown'], canHide: true, widthByMode: { full: 70, dropdown: 60 } },
-  { key: 'comments', priority: 4, rungs: ['full', 'dropdown'], canHide: true, widthByMode: { full: 90, dropdown: 70 } },
+  {
+    key: 'tables',
+    priority: 2,
+    rungs: ['full', 'compact', 'icons', 'dropdown'],
+    canHide: false,
+    widthByMode: { full: 180, compact: 140, icons: 110, dropdown: 70 },
+  },
+  {
+    key: 'charts',
+    priority: 3,
+    rungs: ['full', 'compact', 'icons', 'dropdown'],
+    canHide: false,
+    widthByMode: { full: 120, compact: 100, icons: 80, dropdown: 70 },
+  },
+  {
+    key: 'filters',
+    priority: 4,
+    rungs: ['full', 'dropdown'],
+    canHide: true,
+    widthByMode: { full: 110, dropdown: 70 },
+  },
+  {
+    key: 'links',
+    priority: 4,
+    rungs: ['full', 'dropdown'],
+    canHide: true,
+    widthByMode: { full: 70, dropdown: 60 },
+  },
+  {
+    key: 'comments',
+    priority: 4,
+    rungs: ['full', 'dropdown'],
+    canHide: true,
+    widthByMode: { full: 90, dropdown: 70 },
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -62,7 +92,17 @@ beforeEach(() => {
   globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
 
   HTMLElement.prototype.getBoundingClientRect = function () {
-    return { width: containerWidth, height: 0, top: 0, left: 0, right: 0, bottom: 0, x: 0, y: 0, toJSON() {} } as DOMRect;
+    return {
+      width: containerWidth,
+      height: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    } as DOMRect;
   };
   Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
     configurable: true,
@@ -86,8 +126,10 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.ResizeObserver = originalRO;
   HTMLElement.prototype.getBoundingClientRect = originalGBCR;
-  if (originalScrollWidth) Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalScrollWidth);
-  if (originalClientWidth) Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+  if (originalScrollWidth)
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalScrollWidth);
+  if (originalClientWidth)
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
 });
 
 function resizeTo(width: number) {
@@ -199,8 +241,20 @@ describe('progressive per-group ribbon collapse', () => {
     containerWidth = 560;
     // A sparse tab that fits fully → nothing collapsed (groupModes === {}).
     const sparse: GroupDef[] = [
-      { key: 'a', priority: 2, rungs: ['full', 'dropdown'], canHide: false, widthByMode: { full: 180, dropdown: 70 } },
-      { key: 'b', priority: 3, rungs: ['full', 'dropdown'], canHide: false, widthByMode: { full: 120, dropdown: 70 } },
+      {
+        key: 'a',
+        priority: 2,
+        rungs: ['full', 'dropdown'],
+        canHide: false,
+        widthByMode: { full: 180, dropdown: 70 },
+      },
+      {
+        key: 'b',
+        priority: 3,
+        rungs: ['full', 'dropdown'],
+        canHide: false,
+        widthByMode: { full: 120, dropdown: 70 },
+      },
     ];
     const { rerender } = render(<Harness defs={sparse} contentKey="sparse-tab" />);
     expect(latestModes).toEqual({});

--- a/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.test.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.test.ts
@@ -57,8 +57,10 @@ describe('deriveCollapseLadder', () => {
 });
 
 describe('pickCollapseStep — progressive, priority-ordered', () => {
-  const tables = () => group('tables', 2, ['full', 'compact', 'icons', 'dropdown'], false, 'full', 0);
-  const charts = () => group('charts', 3, ['full', 'compact', 'icons', 'dropdown'], false, 'full', 1);
+  const tables = () =>
+    group('tables', 2, ['full', 'compact', 'icons', 'dropdown'], false, 'full', 0);
+  const charts = () =>
+    group('charts', 3, ['full', 'compact', 'icons', 'dropdown'], false, 'full', 1);
   const links = () => group('links', 4, ['full', 'dropdown'], true, 'full', 2);
 
   it('collapses the least-important group first, one rung at a time', () => {
@@ -79,7 +81,14 @@ describe('pickCollapseStep — progressive, priority-ordered', () => {
   });
 
   it('advances one rung at a time (compact → icons), not straight to dropdown', () => {
-    const charts2 = group('charts', 3, ['full', 'compact', 'icons', 'dropdown'], false, 'compact', 1);
+    const charts2 = group(
+      'charts',
+      3,
+      ['full', 'compact', 'icons', 'dropdown'],
+      false,
+      'compact',
+      1,
+    );
     const links2 = group('links', 4, ['full', 'dropdown'], true, 'dropdown', 2);
     expect(pickCollapseStep([tables(), charts2, links2])).toEqual({
       key: 'charts',
@@ -88,7 +97,14 @@ describe('pickCollapseStep — progressive, priority-ordered', () => {
   });
 
   it('only touches the most-important group after all others are fully collapsed', () => {
-    const charts2 = group('charts', 3, ['full', 'compact', 'icons', 'dropdown'], false, 'dropdown', 1);
+    const charts2 = group(
+      'charts',
+      3,
+      ['full', 'compact', 'icons', 'dropdown'],
+      false,
+      'dropdown',
+      1,
+    );
     const links2 = group('links', 4, ['full', 'dropdown'], true, 'dropdown', 2);
     expect(pickCollapseStep([tables(), charts2, links2])).toEqual({
       key: 'tables',
@@ -97,8 +113,22 @@ describe('pickCollapseStep — progressive, priority-ordered', () => {
   });
 
   it('hides only as a last resort, after every group is at its tightest rung', () => {
-    const tables2 = group('tables', 2, ['full', 'compact', 'icons', 'dropdown'], false, 'dropdown', 0);
-    const charts2 = group('charts', 3, ['full', 'compact', 'icons', 'dropdown'], false, 'dropdown', 1);
+    const tables2 = group(
+      'tables',
+      2,
+      ['full', 'compact', 'icons', 'dropdown'],
+      false,
+      'dropdown',
+      0,
+    );
+    const charts2 = group(
+      'charts',
+      3,
+      ['full', 'compact', 'icons', 'dropdown'],
+      false,
+      'dropdown',
+      1,
+    );
     const links2 = group('links', 4, ['full', 'dropdown'], true, 'dropdown', 2);
     // Everything is at its last non-hidden rung → hide the least-important
     // hideable group (links). Tables/Charts (canHide=false) are never chosen.
@@ -109,8 +139,22 @@ describe('pickCollapseStep — progressive, priority-ordered', () => {
   });
 
   it('returns null when nothing can collapse further (physically impossible)', () => {
-    const tables2 = group('tables', 2, ['full', 'compact', 'icons', 'dropdown'], false, 'dropdown', 0);
-    const charts2 = group('charts', 3, ['full', 'compact', 'icons', 'dropdown'], false, 'dropdown', 1);
+    const tables2 = group(
+      'tables',
+      2,
+      ['full', 'compact', 'icons', 'dropdown'],
+      false,
+      'dropdown',
+      0,
+    );
+    const charts2 = group(
+      'charts',
+      3,
+      ['full', 'compact', 'icons', 'dropdown'],
+      false,
+      'dropdown',
+      1,
+    );
     // Both at last rung and neither can hide → nothing left to do.
     expect(pickCollapseStep([tables2, charts2])).toBeNull();
   });

--- a/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.test.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.test.ts
@@ -1,38 +1,126 @@
+import type { GroupRenderMode } from '@mog-sdk/contracts/ribbon';
+import {
+  CHARTS_COLLAPSE_CONFIG,
+  LINKS_COLLAPSE_CONFIG,
+  TABLES_INSERT_COLLAPSE_CONFIG,
+} from '@mog-sdk/contracts/ribbon';
+
+import { deriveCollapseLadder } from './collapse-ladder';
 import { __testing__ } from './use-ribbon-collapse';
 
-describe('ribbon collapse breakpoints', () => {
-  it('keeps the full ribbon mode for desktop widths', () => {
-    expect(__testing__.computeCollapseLevel(1600)).toBe(0);
-    expect(__testing__.computeCollapseLevel(1599)).toBe(1);
+const { pickCollapseStep } = __testing__;
+
+/** Build a group snapshot for pickCollapseStep tests. */
+function group(
+  key: string,
+  priority: number,
+  rungs: GroupRenderMode[],
+  canHide: boolean,
+  current: GroupRenderMode,
+  domIndex: number,
+) {
+  return { key, priority, rungs, canHide, current, domIndex };
+}
+
+describe('deriveCollapseLadder', () => {
+  it('derives distinct rungs in order and excludes hidden', () => {
+    // Tables: full, full, compact, icons, dropdown → never hidden.
+    expect(deriveCollapseLadder(TABLES_INSERT_COLLAPSE_CONFIG)).toEqual({
+      priority: 2,
+      rungs: ['full', 'compact', 'icons', 'dropdown'],
+      canHide: false,
+    });
   });
 
-  it('keeps existing lower-width collapse levels stable', () => {
-    expect(__testing__.computeCollapseLevel(1200)).toBe(1);
-    expect(__testing__.computeCollapseLevel(1024)).toBe(2);
-    expect(__testing__.computeCollapseLevel(900)).toBe(3);
-    expect(__testing__.computeCollapseLevel(640)).toBe(4);
+  it('marks low-priority groups as hideable with a short ladder', () => {
+    // Links: full, dropdown, dropdown, dropdown, hidden.
+    expect(deriveCollapseLadder(LINKS_COLLAPSE_CONFIG)).toEqual({
+      priority: 4,
+      rungs: ['full', 'dropdown'],
+      canHide: true,
+    });
   });
 
-  it('re-expands after a width-only collapse when no overflow escalation is pending', () => {
-    expect(
-      __testing__.resolveWidthCollapseLevel(
-        1800,
-        __testing__.computeCollapseLevel(1800),
-        3,
-        Number.POSITIVE_INFINITY,
-      ).level,
-    ).toBe(0);
+  it('keeps Charts collapsing to a dropdown but never hidden', () => {
+    const ladder = deriveCollapseLadder(CHARTS_COLLAPSE_CONFIG);
+    expect(ladder.rungs).toEqual(['full', 'compact', 'icons', 'dropdown']);
+    expect(ladder.canHide).toBe(false);
   });
 
-  it('keeps overflow escalation until the release width is crossed', () => {
-    expect(
-      __testing__.resolveWidthCollapseLevel(1400, __testing__.computeCollapseLevel(1400), 2, 1500)
-        .level,
-    ).toBe(2);
+  it('never-collapsing group when no config', () => {
+    expect(deriveCollapseLadder(undefined)).toEqual({
+      priority: 0,
+      rungs: ['full'],
+      canHide: false,
+    });
+  });
+});
 
-    expect(
-      __testing__.resolveWidthCollapseLevel(1608, __testing__.computeCollapseLevel(1608), 2, 1500)
-        .level,
-    ).toBe(0);
+describe('pickCollapseStep — progressive, priority-ordered', () => {
+  const tables = () => group('tables', 2, ['full', 'compact', 'icons', 'dropdown'], false, 'full', 0);
+  const charts = () => group('charts', 3, ['full', 'compact', 'icons', 'dropdown'], false, 'full', 1);
+  const links = () => group('links', 4, ['full', 'dropdown'], true, 'full', 2);
+
+  it('collapses the least-important group first, one rung at a time', () => {
+    // All full → the lowest-priority group (links, priority 4) steps first.
+    expect(pickCollapseStep([tables(), charts(), links()])).toEqual({
+      key: 'links',
+      mode: 'dropdown',
+    });
+  });
+
+  it('exhausts a group down its ladder before touching a more-important one', () => {
+    // links already at its last rung (dropdown); charts (3) is next before tables (2).
+    const links2 = group('links', 4, ['full', 'dropdown'], true, 'dropdown', 2);
+    expect(pickCollapseStep([tables(), charts(), links2])).toEqual({
+      key: 'charts',
+      mode: 'compact',
+    });
+  });
+
+  it('advances one rung at a time (compact → icons), not straight to dropdown', () => {
+    const charts2 = group('charts', 3, ['full', 'compact', 'icons', 'dropdown'], false, 'compact', 1);
+    const links2 = group('links', 4, ['full', 'dropdown'], true, 'dropdown', 2);
+    expect(pickCollapseStep([tables(), charts2, links2])).toEqual({
+      key: 'charts',
+      mode: 'icons',
+    });
+  });
+
+  it('only touches the most-important group after all others are fully collapsed', () => {
+    const charts2 = group('charts', 3, ['full', 'compact', 'icons', 'dropdown'], false, 'dropdown', 1);
+    const links2 = group('links', 4, ['full', 'dropdown'], true, 'dropdown', 2);
+    expect(pickCollapseStep([tables(), charts2, links2])).toEqual({
+      key: 'tables',
+      mode: 'compact',
+    });
+  });
+
+  it('hides only as a last resort, after every group is at its tightest rung', () => {
+    const tables2 = group('tables', 2, ['full', 'compact', 'icons', 'dropdown'], false, 'dropdown', 0);
+    const charts2 = group('charts', 3, ['full', 'compact', 'icons', 'dropdown'], false, 'dropdown', 1);
+    const links2 = group('links', 4, ['full', 'dropdown'], true, 'dropdown', 2);
+    // Everything is at its last non-hidden rung → hide the least-important
+    // hideable group (links). Tables/Charts (canHide=false) are never chosen.
+    expect(pickCollapseStep([tables2, charts2, links2])).toEqual({
+      key: 'links',
+      mode: 'hidden',
+    });
+  });
+
+  it('returns null when nothing can collapse further (physically impossible)', () => {
+    const tables2 = group('tables', 2, ['full', 'compact', 'icons', 'dropdown'], false, 'dropdown', 0);
+    const charts2 = group('charts', 3, ['full', 'compact', 'icons', 'dropdown'], false, 'dropdown', 1);
+    // Both at last rung and neither can hide → nothing left to do.
+    expect(pickCollapseStep([tables2, charts2])).toBeNull();
+  });
+
+  it('breaks priority ties by collapsing the right-most group first', () => {
+    const leftLink = group('linksA', 4, ['full', 'dropdown'], true, 'full', 0);
+    const rightLink = group('linksB', 4, ['full', 'dropdown'], true, 'full', 3);
+    expect(pickCollapseStep([leftLink, rightLink])).toEqual({
+      key: 'linksB',
+      mode: 'dropdown',
+    });
   });
 });

--- a/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.ts
@@ -2,102 +2,142 @@
  * useRibbonCollapse Hook
  *
  * The COORDINATOR for ribbon responsive collapse.
- * This is the SINGLE SOURCE OF TRUTH for collapse state.
  *
- * ARCHITECTURE:
- * - Observes ResizeObserver events on a STABLE ancestor (viewport-determined
- *   width). We deliberately do NOT observe the ribbon content panel: its width
- *   changes in response to collapse-level changes, which previously created an
- *   infinite ResizeObserver feedback loop (see ui/ribbon-tab-flicker.spec.ts).
- * - Computes a baseline collapse level from that width (width breakpoints).
- * - Then makes the level CONTENT-AWARE: width breakpoints are only an estimate
- *   of "does it fit". Some tabs (notably Formulas) have more controls than fit
- *   at the baseline level for a given width, so after layout we measure the
- *   panel's actual horizontal overflow and escalate the level until the content
- *   fits. This is what keeps the widest tab from clipping in the dead zone
- *   between two breakpoints.
+ * PROGRESSIVE, PER-GROUP COLLAPSE
+ * -------------------------------
+ * The ribbon does NOT move through discrete global levels in lock-step. Instead
+ * each group collapses INDEPENDENTLY, one rung at a time, in priority order:
+ *
+ *   - When the panel overflows, the LEAST-important group that still has a
+ *     tighter rung available is collapsed by ONE rung (full → compact → icons →
+ *     dropdown). We re-measure and repeat. So a group steps all the way down its
+ *     ladder before the next-least-important group starts collapsing, and
+ *     important groups (e.g. Tables) only collapse once everything below them
+ *     is exhausted.
+ *   - Hiding a group is a LAST RESORT: only after every group is already at its
+ *     most-compact non-hidden rung and the ribbon STILL overflows do we hide
+ *     groups (again least-important first). So a group never disappears merely
+ *     because the window is narrow — only when it is physically impossible to
+ *     fit every group even as a single dropdown button.
+ *   - When there is room (the window widened, or the tab changed), we rebase to
+ *     "everything expanded" and re-collapse from scratch, so freed space is
+ *     always reclaimed by the most-important groups first.
+ *
+ * The per-group metadata (priority + rungs) is read from data attributes each
+ * group stamps on its DOM element (see collapse-ladder.ts), so the coordinator
+ * stays DOM-driven and needs no React registration handshake.
+ *
+ * NO FEEDBACK LOOP
+ * ----------------
+ * We observe a STABLE ancestor (viewport-determined width) with a
+ * ResizeObserver — never the content panel, whose width changes with the
+ * collapse decisions and previously caused an infinite observer loop (see
+ * ui/ribbon-tab-flicker.spec.ts). Convergence runs in a layout effect (before
+ * paint) so the user never sees a clipped or mis-collapsed intermediate frame.
  *
  * This follows the coordinator pattern from docs/renderer/README.md:
  * "Machine Owns State, Coordinator Owns Execution"
- *
  */
 
 import { useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react';
 
-import type { CollapseLevel } from '@mog-sdk/contracts/ribbon';
+import type { GroupRenderMode } from '@mog-sdk/contracts/ribbon';
 import type { RibbonCollapseContextState } from './context';
+import { LADDER_DATA_ATTRS } from './collapse-ladder';
 
 // =============================================================================
-// Collapse Level Computation
+// Tuning constants
 // =============================================================================
 
 /**
- * Width breakpoints for each collapse level.
- *
- * | Level | Min Width | Description |
- * |-------|-----------|-------------|
- * | 0 | ≥1600px | Full: All groups expanded |
- * | 1 | ≥1200px | Compact: Some labels hidden |
- * | 2 | ≥1000px | Dense: Most buttons icon-only |
- * | 3 | ≥800px | Minimal: Low-priority groups collapsed |
- * | 4 | <800px | Mobile: Most groups collapsed |
- */
-const COLLAPSE_BREAKPOINTS: Record<CollapseLevel, number> = {
-  0: 1600,
-  1: 1200,
-  2: 1000,
-  3: 800,
-  4: 0, // Anything below 800
-};
-
-const MAX_COLLAPSE_LEVEL: CollapseLevel = 4;
-
-/**
- * Overflow past the panel's client width (in px) before we treat the ribbon as
- * clipped and escalate the collapse level. Matches the 1px tolerance used by
- * the app-eval density guard so the two agree on what "clipped" means.
+ * Overflow past the panel's client width (px) before the ribbon counts as
+ * clipped and we collapse another rung. Matches the 1px tolerance used by the
+ * app-eval density guard so the two agree on what "clipped" means.
  */
 const OVERFLOW_TOLERANCE_PX = 1;
 
 /**
- * Margin (px) added on top of a level's measured natural width before we allow
- * de-escalating back to it. This is the hysteresis band: we collapse when the
- * container drops below the content's natural width, but only expand again once
- * the container is comfortably wider, so a container hovering near the boundary
- * does not flip-flop between levels every frame.
+ * Width change (px) below which a ResizeObserver tick is treated as jitter and
+ * does not re-open the collapse search. A real resize (> this) rebases so a
+ * now-wider container expands the most-important groups back.
  */
-const RELEASE_MARGIN_PX = 8;
+const WIDTH_EPSILON_PX = 1;
 
-/**
- * Compute collapse level from container width.
- *
- * This is the SINGLE SOURCE OF TRUTH for the width → level mapping.
- *
- * @param width - Container width in pixels
- * @returns Collapse level (0-4)
- */
-function computeCollapseLevel(width: number): CollapseLevel {
-  if (width >= COLLAPSE_BREAKPOINTS[0]) return 0;
-  if (width >= COLLAPSE_BREAKPOINTS[1]) return 1;
-  if (width >= COLLAPSE_BREAKPOINTS[2]) return 2;
-  if (width >= COLLAPSE_BREAKPOINTS[3]) return 3;
-  return 4;
+// =============================================================================
+// Progressive collapse decision (pure, DOM-driven)
+// =============================================================================
+
+interface GroupSnapshot {
+  key: string;
+  priority: number;
+  rungs: GroupRenderMode[];
+  canHide: boolean;
+  current: GroupRenderMode;
+  domIndex: number;
 }
 
-function resolveWidthCollapseLevel(
-  width: number,
-  widthLevel: CollapseLevel,
-  previousLevel: CollapseLevel,
-  releaseWidth: number,
-): { level: CollapseLevel; releaseWidth: number } {
-  if (releaseWidth === Number.POSITIVE_INFINITY || width > releaseWidth) {
-    return { level: widthLevel, releaseWidth: Number.POSITIVE_INFINITY };
+/**
+ * Read the visible groups' collapse metadata + current assignment from the DOM.
+ * Groups that are currently `hidden` render no element and are simply absent —
+ * they stay hidden (via `assignments`) until the next rebase.
+ */
+function snapshotGroups(
+  panel: HTMLElement,
+  assignments: Record<string, GroupRenderMode>,
+): GroupSnapshot[] {
+  const els = Array.from(
+    panel.querySelectorAll<HTMLElement>(`[${LADDER_DATA_ATTRS.key}]`),
+  );
+  return els.map((el, domIndex) => {
+    const key = el.getAttribute(LADDER_DATA_ATTRS.key) ?? '';
+    const priority = Number(el.getAttribute(LADDER_DATA_ATTRS.priority) ?? '0');
+    const rungsRaw = el.getAttribute(LADDER_DATA_ATTRS.rungs) ?? 'full';
+    const rungs = rungsRaw.split(',') as GroupRenderMode[];
+    const canHide = el.getAttribute(LADDER_DATA_ATTRS.canHide) === '1';
+    const current = assignments[key] ?? rungs[0] ?? 'full';
+    return { key, priority, rungs, canHide, current, domIndex };
+  });
+}
+
+/**
+ * Order groups for collapsing: least-important first (higher priority number),
+ * and within equal priority the right-most group first (larger DOM index), so
+ * groups collapse from the trailing edge inward.
+ */
+function leastImportantFirst(a: GroupSnapshot, b: GroupSnapshot): number {
+  return b.priority - a.priority || b.domIndex - a.domIndex;
+}
+
+/**
+ * Pick the single next collapse step, or null when nothing can collapse further
+ * (the ribbon is at its most-compact possible layout and simply cannot fit).
+ */
+export function pickCollapseStep(
+  groups: GroupSnapshot[],
+): { key: string; mode: GroupRenderMode } | null {
+  // Phase 1 — shrink a rung (never hidden). Least-important group with a
+  // tighter rung remaining.
+  const shrinkable = groups
+    .filter((g) => {
+      const idx = Math.max(0, g.rungs.indexOf(g.current));
+      return idx < g.rungs.length - 1;
+    })
+    .sort(leastImportantFirst);
+  if (shrinkable.length > 0) {
+    const g = shrinkable[0];
+    const idx = Math.max(0, g.rungs.indexOf(g.current));
+    return { key: g.key, mode: g.rungs[idx + 1] };
   }
 
-  return {
-    level: Math.max(widthLevel, previousLevel) as CollapseLevel,
-    releaseWidth,
-  };
+  // Phase 2 — last resort: hide a group. Least-important hideable group.
+  const hideable = groups
+    .filter((g) => g.canHide && g.current !== 'hidden')
+    .sort(leastImportantFirst);
+  if (hideable.length > 0) {
+    return { key: hideable[0].key, mode: 'hidden' };
+  }
+
+  return null;
 }
 
 // =============================================================================
@@ -105,42 +145,18 @@ function resolveWidthCollapseLevel(
 // =============================================================================
 
 /**
- * Hook that observes container width and computes a content-aware collapse
- * level.
- *
- * This is the COORDINATOR for ribbon collapse:
- * - Observes ResizeObserver events on a stable ancestor
- * - Computes a baseline collapse level from width
- * - Escalates the level when the rendered panel actually overflows
- * - Broadcasts via context (components react)
+ * Coordinator hook for progressive, per-group ribbon collapse.
  *
  * @param containerRef - Ref to a STABLE ribbon ancestor (viewport-determined
- *   width). Must NOT be the element whose width changes with the collapse
- *   level, or the ResizeObserver will feed back on itself.
+ *   width). Must NOT be the element whose width changes with collapse, or the
+ *   ResizeObserver will feed back on itself.
  * @param panelRef - Ref to the ribbon content panel that can clip horizontally
- *   (`data-testid="panel-ribbon"`). Used to measure actual overflow. When
- *   omitted, the hook falls back to pure width-based collapse.
+ *   (`data-testid="panel-ribbon"`). Used to measure overflow and to read each
+ *   group's collapse metadata from its DOM element. When omitted, the hook
+ *   never collapses (all groups render expanded).
  * @param contentKey - Changes whenever the panel's content changes (e.g. the
- *   active tab). Lets the hook drop a previous tab's escalation and re-measure
- *   for the new content.
- * @returns Collapse state (level + width)
- *
- * @example
- * ```tsx
- * function TabbedToolbar() {
- * const containerRef = useRef<HTMLDivElement>(null);
- * const panelRef = useRef<HTMLDivElement>(null);
- * const collapseState = useRibbonCollapse(containerRef, panelRef, activeTab);
- *
- * return (
- * <RibbonCollapseProvider value={collapseState}>
- * <div ref={containerRef}>
- * <div ref={panelRef} data-testid="panel-ribbon">{/* groups *\/}</div>
- * </div>
- * </RibbonCollapseProvider>
- * );
- * }
- * ```
+ *   active tab). Rebases the collapse search for the new content.
+ * @returns Collapse state (per-group modes + container width).
  */
 export function useRibbonCollapse(
   containerRef: RefObject<HTMLElement | null>,
@@ -148,51 +164,39 @@ export function useRibbonCollapse(
   contentKey?: unknown,
 ): RibbonCollapseContextState {
   const [state, setState] = useState<RibbonCollapseContextState>({
-    level: 0,
-    widthLevel: 0,
-    containerWidth: 1920,
+    groupModes: {},
+    containerWidth: 0,
   });
 
-  // The container width at/above which the current escalation may be released.
-  // Set to the overflowing level's natural content width (+ margin) when we
-  // escalate; Infinity means "no escalation pending".
-  const releaseWidthRef = useRef<number>(Number.POSITIVE_INFINITY);
-
-  // Tracks the content the escalation was computed for, so a tab switch can
-  // re-baseline rather than inherit the previous tab's escalation.
+  // Width the current collapse assignment was computed for. A change > epsilon
+  // re-opens the search: a WIDER container rebases to fully-expanded and
+  // re-collapses (reclaiming space for important groups); a NARROWER container
+  // keeps the current assignment and just collapses further as needed.
+  const lastWidthRef = useRef<number>(0);
   const contentKeyRef = useRef<unknown>(contentKey);
 
   // ---------------------------------------------------------------------------
-  // 1. Width observer → baseline level (with hysteresis on release)
+  // 1. Width observer → keep containerWidth in sync so the convergence effect
+  //    re-runs on resize. Observes the STABLE container only (never the panel).
   // ---------------------------------------------------------------------------
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
     const applyWidth = (width: number) => {
-      const widthLevel = computeCollapseLevel(width);
-      setState((prev) => {
-        const resolved = resolveWidthCollapseLevel(
-          width,
-          widthLevel,
-          prev.level,
-          releaseWidthRef.current,
-        );
-        releaseWidthRef.current = resolved.releaseWidth;
-        const level = resolved.level;
-        if (prev.level === level && prev.widthLevel === widthLevel && prev.containerWidth === width)
-          return prev;
-        return { level, widthLevel, containerWidth: width };
-      });
+      setState((prev) =>
+        Math.abs(prev.containerWidth - width) < WIDTH_EPSILON_PX
+          ? prev
+          : { ...prev, containerWidth: width },
+      );
     };
 
     const observer = new ResizeObserver((entries) => {
-      const width = entries[0]?.contentRect.width ?? 1920;
+      const width = entries[0]?.contentRect.width ?? 0;
       applyWidth(width);
     });
 
     observer.observe(container);
-
     // Initial measurement (ResizeObserver may not fire immediately)
     applyWidth(container.getBoundingClientRect().width);
 
@@ -202,15 +206,15 @@ export function useRibbonCollapse(
   }, [containerRef]);
 
   // ---------------------------------------------------------------------------
-  // 2. Content-aware escalation → measure actual overflow and step down a level
-  //    until the panel fits. Runs in a layout effect (before paint) so the user
-  //    never sees a clipped intermediate frame.
+  // 2. Progressive convergence → measure overflow and collapse/expand one group
+  //    one rung per pass until the panel fits. Runs in a layout effect (before
+  //    paint) so intermediate frames are never shown.
   //
-  //    Convergence / no-feedback-loop guarantees:
-  //    - We do NOT observe the panel; clientWidth is viewport-determined and
-  //      stable across collapse levels, only scrollWidth (content) shrinks.
-  //    - Escalation is monotonic and bounded by MAX_COLLAPSE_LEVEL, and stops
-  //      as soon as the content fits, so it settles in ≤4 passes per change.
+  //    Convergence guarantees:
+  //    - Within a width bucket, collapsing is monotonic (we only ever tighten),
+  //      bounded by the finite total rungs across groups → it always settles.
+  //    - A wider container / new content rebases to expanded exactly once, then
+  //      re-collapses monotonically → no oscillation.
   // ---------------------------------------------------------------------------
   useLayoutEffect(() => {
     const panel = panelRef?.current;
@@ -218,42 +222,50 @@ export function useRibbonCollapse(
     if (!panel || !container) return;
 
     const width = container.getBoundingClientRect().width;
-    const widthLevel = computeCollapseLevel(width);
     const contentChanged = contentKeyRef.current !== contentKey;
+    const widthGrew = width > lastWidthRef.current + WIDTH_EPSILON_PX;
+    const widthShrank = width < lastWidthRef.current - WIDTH_EPSILON_PX;
 
-    // New content (e.g. tab switch): drop the previous content's escalation and
-    // re-baseline. We only need an explicit reset when the current level is
-    // *more* collapsed than the width baseline (i.e. an escalation is in
-    // effect); otherwise we can measure the new content immediately below.
-    if (contentChanged) {
+    // Rebase on new content or a wider container: expand everything, then
+    // re-collapse to fit. This is what reclaims freed space for the
+    // most-important groups.
+    if (contentChanged || widthGrew) {
       contentKeyRef.current = contentKey;
-      if (state.level > widthLevel) {
-        releaseWidthRef.current = Number.POSITIVE_INFINITY;
-        setState((prev) =>
-          prev.level === widthLevel && prev.widthLevel === widthLevel
-            ? prev
-            : { level: widthLevel, widthLevel, containerWidth: width },
-        );
-        // Re-baselined; the resulting re-render re-runs this effect to measure
-        // the new content at the baseline level.
+      lastWidthRef.current = width;
+      if (Object.keys(state.groupModes).length > 0) {
+        // Clear existing collapses; the resulting re-render re-runs this effect
+        // to measure from a fully-expanded baseline.
+        setState({ groupModes: {}, containerWidth: width });
         return;
       }
+      // Already fully expanded — the DOM (e.g. the just-switched-to tab) already
+      // reflects that, so fall through and measure it NOW. Returning here would
+      // be a no-op setState that never re-runs the effect, leaving a denser new
+      // tab clipped until the next resize.
+    } else if (widthShrank) {
+      // A narrower container keeps the current (already-collapsed) assignment
+      // and simply continues collapsing below if it now overflows.
+      lastWidthRef.current = width;
     }
 
-    const overflowing = panel.scrollWidth > panel.clientWidth + OVERFLOW_TOLERANCE_PX;
-
-    if (overflowing && state.level < MAX_COLLAPSE_LEVEL) {
-      // scrollWidth is the natural width of the *current* (overflowing) level —
-      // the container must exceed it (plus a hysteresis margin) before we allow
-      // de-escalating back to this level.
-      releaseWidthRef.current = panel.scrollWidth + RELEASE_MARGIN_PX;
-      setState((prev) => ({
-        level: Math.min(MAX_COLLAPSE_LEVEL, prev.level + 1) as CollapseLevel,
-        widthLevel,
-        containerWidth: width,
-      }));
+    const overflowPx = panel.scrollWidth - panel.clientWidth;
+    if (overflowPx > OVERFLOW_TOLERANCE_PX) {
+      const step = pickCollapseStep(snapshotGroups(panel, state.groupModes));
+      if (step) {
+        setState((prev) => ({
+          groupModes: { ...prev.groupModes, [step.key]: step.mode },
+          containerWidth: width,
+        }));
+        return;
+      }
+      // Nothing left to collapse: physically cannot fit. Settle (content clips).
     }
-  }, [containerRef, panelRef, contentKey, state.level, state.containerWidth]);
+
+    // Settled. Keep containerWidth in sync without touching assignments.
+    if (state.containerWidth !== width) {
+      setState((prev) => ({ ...prev, containerWidth: width }));
+    }
+  }, [containerRef, panelRef, contentKey, state.groupModes, state.containerWidth]);
 
   return state;
 }
@@ -264,10 +276,10 @@ export function useRibbonCollapse(
 
 /**
  * Exported for testing purposes only.
- * Use useRibbonCollapse hook in production code.
+ * Use the useRibbonCollapse hook in production code.
  */
 export const __testing__ = {
-  computeCollapseLevel,
-  resolveWidthCollapseLevel,
-  COLLAPSE_BREAKPOINTS,
+  pickCollapseStep,
+  OVERFLOW_TOLERANCE_PX,
+  WIDTH_EPSILON_PX,
 };

--- a/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/collapse/use-ribbon-collapse.ts
@@ -85,9 +85,7 @@ function snapshotGroups(
   panel: HTMLElement,
   assignments: Record<string, GroupRenderMode>,
 ): GroupSnapshot[] {
-  const els = Array.from(
-    panel.querySelectorAll<HTMLElement>(`[${LADDER_DATA_ATTRS.key}]`),
-  );
+  const els = Array.from(panel.querySelectorAll<HTMLElement>(`[${LADDER_DATA_ATTRS.key}]`));
   return els.map((el, domIndex) => {
     const key = el.getAttribute(LADDER_DATA_ATTRS.key) ?? '';
     const priority = Number(el.getAttribute(LADDER_DATA_ATTRS.priority) ?? '0');

--- a/apps/spreadsheet/src/chrome/toolbar/groups/CellsGroup.test.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/groups/CellsGroup.test.ts
@@ -1,28 +1,21 @@
 import { CELLS_COLLAPSE_CONFIG } from '@mog-sdk/contracts/ribbon';
-import { resolveToolbarGroupRenderMode } from '../primitives/ToolbarGroup';
+
+import { deriveCollapseLadder } from '../collapse/collapse-ladder';
 
 describe('CellsGroup responsive layout', () => {
-  test('keeps Cells hidden only for true width-derived mobile collapse', () => {
+  test('collapse config still hides Cells only at the mobile level', () => {
     expect(CELLS_COLLAPSE_CONFIG.levels[2]).toBe('dropdown');
     expect(CELLS_COLLAPSE_CONFIG.levels[3]).toBe('dropdown');
     expect(CELLS_COLLAPSE_CONFIG.levels[4]).toBe('hidden');
   });
 
-  test('keeps Cells reachable when overflow escalation compacts a wider ribbon', () => {
-    expect(
-      resolveToolbarGroupRenderMode(CELLS_COLLAPSE_CONFIG, {
-        level: 4,
-        widthLevel: 3,
-        containerWidth: 900,
-      }),
-    ).toBe('dropdown');
-
-    expect(
-      resolveToolbarGroupRenderMode(CELLS_COLLAPSE_CONFIG, {
-        level: 4,
-        widthLevel: 4,
-        containerWidth: 640,
-      }),
-    ).toBe('hidden');
+  test('progressive collapse degrades Cells to a dropdown before ever hiding it', () => {
+    // Under per-group progressive collapse, Cells collapses down to its most
+    // compact non-hidden rung (dropdown) and is only hidden as an absolute last
+    // resort — never merely because the window is narrow.
+    const ladder = deriveCollapseLadder(CELLS_COLLAPSE_CONFIG);
+    expect(ladder.rungs).toEqual(['full', 'compact', 'dropdown']);
+    expect(ladder.rungs[ladder.rungs.length - 1]).toBe('dropdown');
+    expect(ladder.canHide).toBe(true);
   });
 });

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/CollapsedGroupDropdown.test.ts
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/CollapsedGroupDropdown.test.ts
@@ -12,7 +12,7 @@ describe('CollapsedGroupDropdown dense layout', () => {
       'utf8',
     );
 
-    expect(source).toContain('const isDense = level >= 3');
+    expect(source).toContain('const isDense = containerWidth < 800');
     expect(source).toContain("isDense ? 'px-1' : 'px-[var(--ribbon-group-padding-x)]'");
     expect(source).toContain('text-ribbon-compact text-ss-text-secondary');
     expect(source).toContain('<span className={labelClassName}>{label}</span>');
@@ -31,6 +31,7 @@ describe('CollapsedGroupDropdown dense layout', () => {
     expect(source).toContain('groupKey?: string');
     expect(source).toContain('s.ribbonCollapsedGroups[groupKey] ?? false');
     expect(source).toContain('setRibbonCollapsedGroupOpen(groupKey, open)');
-    expect(toolbarGroupSource).toContain('groupKey={groupVisibility.groupKey}');
+    expect(toolbarGroupSource).toContain('const groupKey = groupVisibility.groupKey');
+    expect(toolbarGroupSource).toContain('groupKey={groupKey}');
   });
 });

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/CollapsedGroupDropdown.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/CollapsedGroupDropdown.tsx
@@ -101,8 +101,9 @@ export const CollapsedGroupDropdown = React.memo(function CollapsedGroupDropdown
       setLocalOpen(open);
     }
   };
-  const { level } = useRibbonCollapseLevel();
-  const isDense = level >= 3;
+  const { containerWidth } = useRibbonCollapseLevel();
+  // Denser collapsed button on narrow ribbons (mirrors the old level ≥ 3 cue).
+  const isDense = containerWidth < 800;
   const labelClassName = isDense
     ? 'text-ribbon-compact text-ss-text-secondary leading-none whitespace-nowrap max-w-[58px] overflow-hidden text-ellipsis'
     : 'text-ribbon text-ss-text-secondary whitespace-nowrap max-w-[68px] overflow-hidden text-ellipsis';

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/TabBar.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/TabBar.tsx
@@ -211,8 +211,7 @@ function TabBarImpl<T extends string>({
       // Whether the command area is currently on screen. This mirrors the
       // render gate in TabbedToolbar so the toggle below matches what the user
       // actually sees.
-      const commandsVisible =
-        !ribbonCollapsed && (displayMode === 'full' || temporaryShow);
+      const commandsVisible = !ribbonCollapsed && (displayMode === 'full' || temporaryShow);
 
       const revealCommands = () => {
         // A fully-collapsed ribbon (Ctrl+Shift+F1) is restored by un-collapsing;

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/TabBar.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/TabBar.tsx
@@ -4,9 +4,11 @@
  * Top bar with quick access buttons (undo/redo), tabs, and print/export actions.
  * Migrated to Tailwind CSS with UI primitives.
  *
- * Extended to support ribbon display modes:
- * - In tabs-only mode: clicking a tab shows ribbon temporarily
- * - Double-click on tabs toggles between full and tabs-only mode
+ * Tab-click semantics (single-click driven):
+ * - Clicking an inactive tab switches to it (and reveals the commands if the
+ *   ribbon was hidden).
+ * - Clicking the already-active tab toggles the command area (hide / show).
+ *   This is the same collapse toggle as Ctrl+Shift+F1.
  */
 
 import type { MouseEvent } from 'react';
@@ -176,11 +178,9 @@ function TabBarImpl<T extends string>({
   const { uiStore } = useDocumentContext();
   const displayMode = useStore(uiStore, (s) => s.displayMode);
   const ribbonCollapsed = useStore(uiStore, (s) => s.ribbonCollapsed);
+  const temporaryShow = useStore(uiStore, (s) => s.temporaryShow);
 
-  // Double-click tracking for tabs toggle
   const tabBarRootRef = useRef<HTMLDivElement>(null);
-  const lastClickTimeRef = useRef<number>(0);
-  const lastClickTabRef = useRef<string | null>(null);
   const [showCommandClusterForWidth, setShowCommandClusterForWidth] = useState(false);
 
   useEffect(() => {
@@ -199,47 +199,54 @@ function TabBarImpl<T extends string>({
 
     return () => observer.disconnect();
   }, []);
-  const DOUBLE_CLICK_THRESHOLD = 300; // ms
 
-  // Handle tab click with display mode awareness.
+  // Handle tab click. Single-click driven:
+  //   - inactive tab → switch to it, revealing the commands if they are hidden;
+  //   - active tab   → toggle the command area (hide if showing, reveal if hidden).
   // The File affordance is a standalone backstage-trigger button (rendered
   // outside the tab loop) with its own onClick — it never reaches this
   // handler, so there is no `isFileTab` branch here.
   const handleTabClick = useCallback(
-    (tabId: T, event: MouseEvent<HTMLButtonElement>) => {
-      // Only pointer-generated double-clicks should toggle ribbon tab mode.
-      // Keyboard activation produces click events too, but detail is 0.
-      const now = Date.now();
-      const isDoubleClick =
-        event.detail >= 2 &&
-        lastClickTabRef.current === tabId &&
-        now - lastClickTimeRef.current < DOUBLE_CLICK_THRESHOLD;
+    (tabId: T) => {
+      // Whether the command area is currently on screen. This mirrors the
+      // render gate in TabbedToolbar so the toggle below matches what the user
+      // actually sees.
+      const commandsVisible =
+        !ribbonCollapsed && (displayMode === 'full' || temporaryShow);
 
-      lastClickTimeRef.current = now;
-      lastClickTabRef.current = tabId as string;
-
-      if (isDoubleClick) {
-        // Double-click: toggle between full and tabs-only mode
-        // Only works in full or tabs-only mode (not auto-hide)
-        if (displayMode !== 'auto-hide') {
-          dispatch('TOGGLE_RIBBON_TABS_MODE', deps);
-        }
-      } else {
-        // Single click: switch tab
-        onTabChange(tabId);
-
+      const revealCommands = () => {
+        // A fully-collapsed ribbon (Ctrl+Shift+F1) is restored by un-collapsing;
+        // a tabs-only / auto-hide ribbon is revealed temporarily.
         if (ribbonCollapsed) {
           dispatch('TOGGLE_RIBBON', deps);
-          return;
-        }
-
-        // In tabs-only mode, also show ribbon temporarily
-        if (displayMode === 'tabs-only') {
+        } else {
           dispatch('SHOW_RIBBON_TEMPORARILY', deps);
         }
+      };
+
+      if (tabId !== activeTab) {
+        // Switching to a different tab; bring the commands back if hidden.
+        onTabChange(tabId);
+        if (!commandsVisible) {
+          revealCommands();
+        }
+        return;
+      }
+
+      // Re-clicking the active tab toggles the command area's visibility.
+      if (commandsVisible) {
+        // Hide: in full mode collapse the ribbon; otherwise drop the temporary
+        // reveal.
+        if (displayMode === 'full') {
+          dispatch('TOGGLE_RIBBON', deps);
+        } else {
+          dispatch('HIDE_RIBBON_TEMPORARILY', deps);
+        }
+      } else {
+        revealCommands();
       }
     },
-    [displayMode, ribbonCollapsed, onTabChange, deps],
+    [activeTab, displayMode, ribbonCollapsed, temporaryShow, onTabChange, deps],
   );
 
   const handleUndoClick = () => {
@@ -470,7 +477,7 @@ function TabBarImpl<T extends string>({
               type="button"
               role="tab"
               aria-selected={isActive}
-              onClick={(event) => handleTabClick(tab.id, event)}
+              onClick={() => handleTabClick(tab.id)}
               className={`
  relative px-[var(--tabbar-tab-padding-x)] py-[var(--tabbar-tab-padding-y)]
  flex-shrink-0 whitespace-nowrap

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/TabbedToolbar.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/TabbedToolbar.tsx
@@ -341,11 +341,20 @@ export const TabbedToolbar = React.memo(function TabbedToolbar({
   const displayMode = useStore(uiStore, (s) => s.displayMode);
   const temporaryShow = useStore(uiStore, (s) => s.temporaryShow);
 
-  // Ref for ribbon content area (used for auto-hide click-outside detection)
+  // Ref for ribbon content area (the command panel that clips/collapses).
   const ribbonContentRef = useRef<HTMLDivElement>(null);
 
-  // Set up auto-hide behavior
-  useAutoHideRibbon(ribbonContentRef);
+  // Ref for the whole ribbon chrome (tab strip + command panel). Declared here
+  // so auto-hide click-outside detection can scope to the entire ribbon, not
+  // just the command panel — otherwise clicking a ribbon *tab* (which lives in
+  // the tab strip, outside the panel) counts as an "outside" click and hides
+  // the temporarily-shown commands, producing a collapse-then-expand flicker
+  // when the tab handler immediately re-reveals them.
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Set up auto-hide behavior. Scope click-outside to the full ribbon chrome so
+  // interacting with the tab strip never triggers a hide.
+  useAutoHideRibbon(containerRef);
 
   // Get contextual tabs from the framework
   const contextualTabConfigs = useContextualTabs();
@@ -360,7 +369,6 @@ export const TabbedToolbar = React.memo(function TabbedToolbar({
 
   // Ribbon collapse coordinator - computes collapse level from container width
   // This is the SINGLE SOURCE OF TRUTH for collapse state
-  const containerRef = useRef<HTMLDivElement>(null);
   // Pass the content panel + active tab so collapse is content-aware: the width
   // breakpoints are only an estimate of "does it fit", and the widest tab
   // (Formulas) overflows in the dead zone between breakpoints unless we measure

--- a/apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarGroup.tsx
+++ b/apps/spreadsheet/src/chrome/toolbar/primitives/ToolbarGroup.tsx
@@ -17,15 +17,11 @@
  */
 
 import type { ReactNode } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
 
-import type {
-  CollapseLevel,
-  GroupCollapseConfig,
-  GroupRenderMode,
-} from '@mog-sdk/contracts/ribbon';
+import type { GroupCollapseConfig } from '@mog-sdk/contracts/ribbon';
 import { GroupRenderModeProvider, useRibbonCollapseLevel } from '../collapse';
-import type { RibbonCollapseContextState } from '../collapse/context';
+import { deriveCollapseLadder, LADDER_DATA_ATTRS } from '../collapse/collapse-ladder';
 import {
   RibbonVisibilityGroup,
   useRibbonGroupVisibility,
@@ -95,8 +91,19 @@ export const ToolbarGroup = React.memo(function ToolbarGroup({
   dialogLauncher,
 }: ToolbarGroupProps) {
   const groupVisibility = useRibbonGroupVisibility(label, visibilityKey);
-  const collapseState = useRibbonCollapseLevel();
-  const renderMode = resolveToolbarGroupRenderMode(collapseConfig, collapseState);
+  const { groupModes } = useRibbonCollapseLevel();
+  const ladder = useMemo(() => deriveCollapseLadder(collapseConfig), [collapseConfig]);
+  const groupKey = groupVisibility.groupKey;
+  // The coordinator assigns each group a render mode; absent → most-expanded
+  // rung. The ladder metadata below lets the (DOM-driven) coordinator know how
+  // far this group can collapse and how important it is.
+  const renderMode = groupModes[groupKey] ?? ladder.rungs[0];
+  const ladderAttrs = {
+    [LADDER_DATA_ATTRS.key]: groupKey,
+    [LADDER_DATA_ATTRS.priority]: String(ladder.priority),
+    [LADDER_DATA_ATTRS.rungs]: ladder.rungs.join(','),
+    [LADDER_DATA_ATTRS.canHide]: ladder.canHide ? '1' : '0',
+  };
 
   if (!groupVisibility.visible) {
     return null;
@@ -107,23 +114,27 @@ export const ToolbarGroup = React.memo(function ToolbarGroup({
     return null;
   }
 
-  // Dropdown mode - render collapsed button with dropdown
+  // Dropdown mode - render collapsed button with dropdown. The layout-transparent
+  // (`display: contents`) wrapper carries the ladder metadata for the coordinator
+  // without adding a box to the flex row.
   if (renderMode === 'dropdown') {
     return (
-      <RibbonVisibilityGroup group={groupVisibility.groupKey}>
-        <CollapsedGroupDropdown
-          label={label}
-          groupKey={groupVisibility.groupKey}
-          icon={dropdownIcon}
-          isLast={isLast}
-        >
-          {dialogLauncher && (
-            <div className="mb-2 flex justify-end border-b border-ss-border pb-2">
-              <DialogLauncherButton launcher={dialogLauncher} placement="dropdown" />
-            </div>
-          )}
-          {dropdownContent ?? children}
-        </CollapsedGroupDropdown>
+      <RibbonVisibilityGroup group={groupKey}>
+        <div className="contents" {...ladderAttrs}>
+          <CollapsedGroupDropdown
+            label={label}
+            groupKey={groupKey}
+            icon={dropdownIcon}
+            isLast={isLast}
+          >
+            {dialogLauncher && (
+              <div className="mb-2 flex justify-end border-b border-ss-border pb-2">
+                <DialogLauncherButton launcher={dialogLauncher} placement="dropdown" />
+              </div>
+            )}
+            {dropdownContent ?? children}
+          </CollapsedGroupDropdown>
+        </div>
       </RibbonVisibilityGroup>
     );
   }
@@ -136,12 +147,13 @@ export const ToolbarGroup = React.memo(function ToolbarGroup({
   ].join(' ');
 
   return (
-    <RibbonVisibilityGroup group={groupVisibility.groupKey}>
+    <RibbonVisibilityGroup group={groupKey}>
       <GroupRenderModeProvider value={renderMode}>
         <div
           className="relative flex px-[var(--ribbon-group-padding-x)] group/toolbar-group"
           role="group"
           aria-label={label}
+          {...ladderAttrs}
         >
           {/* Content area - fixed height from design token */}
           <div data-ribbon-group-content className={contentClassName}>
@@ -164,38 +176,6 @@ export const ToolbarGroup = React.memo(function ToolbarGroup({
     </RibbonVisibilityGroup>
   );
 });
-
-export function resolveToolbarGroupRenderMode(
-  collapseConfig: GroupCollapseConfig | undefined,
-  collapseState: RibbonCollapseContextState,
-): GroupRenderMode {
-  if (!collapseConfig) return 'full';
-
-  const { level } = collapseState;
-  const widthLevel = collapseState.widthLevel ?? level;
-  const renderMode = collapseConfig.levels[level] ?? 'full';
-
-  if (renderMode !== 'hidden' || level <= widthLevel) {
-    return renderMode;
-  }
-
-  // Content-aware overflow escalation can compact a desktop/tablet-width
-  // ribbon into level 4. Do not make commands unreachable in that case; use
-  // the most compact non-hidden mode reached while escalating from the
-  // width-derived level.
-  for (
-    let candidate = (level - 1) as CollapseLevel;
-    candidate >= widthLevel;
-    candidate = (candidate - 1) as CollapseLevel
-  ) {
-    const candidateMode = collapseConfig.levels[candidate];
-    if (candidateMode !== 'hidden') {
-      return candidateMode;
-    }
-  }
-
-  return renderMode;
-}
 
 function DialogLauncherButton({
   launcher,

--- a/apps/spreadsheet/src/ui-store/slices/ribbon/ribbon.ts
+++ b/apps/spreadsheet/src/ui-store/slices/ribbon/ribbon.ts
@@ -98,16 +98,23 @@ export const createRibbonSlice: StateCreator<RibbonSlice, [], [], RibbonSlice> =
   },
 
   toggleTabsMode: () => {
-    const { displayMode } = get();
+    const { displayMode, ribbonCollapsed } = get();
     // Only toggle between 'full' and 'tabs-only', not auto-hide
     if (displayMode === 'auto-hide') return;
 
     const newMode: RibbonDisplayMode = displayMode === 'full' ? 'tabs-only' : 'full';
     saveDisplayMode(newMode);
+    // Entering tabs-only mode should temporarily REVEAL the commands only when
+    // the ribbon was fully collapsed (Ctrl+Shift+F1) — i.e. this toggle is a
+    // "bring it back" gesture. When the commands are already visible (full
+    // mode), double-clicking a tab / Ctrl+F1 is a "collapse" gesture, so the
+    // commands must actually hide (temporaryShow=false). Previously this
+    // always set temporaryShow=true for tabs-only, so collapsing a visible
+    // ribbon by double-clicking a tab left the commands on screen.
     set({
       ribbonCollapsed: false,
       displayMode: newMode,
-      temporaryShow: newMode !== 'full',
+      temporaryShow: newMode === 'tabs-only' ? ribbonCollapsed : false,
     });
   },
 

--- a/compute/core/crates/compute-functions/src/statistical/regression.rs
+++ b/compute/core/crates/compute-functions/src/statistical/regression.rs
@@ -3,6 +3,7 @@
 //! LINEST, LOGEST, TREND, GROWTH,
 //! PROB
 
+use nalgebra::{DMatrix, DVector};
 use value_types::{CellError, CellValue};
 
 use super::correlation::FnCorrel;
@@ -178,6 +179,404 @@ impl PureFunction for FnSteyx {
 }
 
 pub(super) struct FnLinest;
+
+struct RegressionFit {
+    slopes: Vec<f64>,
+    intercept: f64,
+    slope_standard_errors: Vec<f64>,
+    intercept_standard_error: Option<f64>,
+    r_squared: f64,
+    standard_error_y: f64,
+    f_statistic: f64,
+    degrees_of_freedom: f64,
+    ss_regression: f64,
+    ss_residual: f64,
+}
+
+struct RegressionInput {
+    ys: Vec<f64>,
+    xs: Vec<Vec<f64>>,
+}
+
+#[derive(Clone, Copy)]
+enum DesignColumn {
+    Intercept,
+    Predictor(usize),
+}
+
+fn coerce_optional_bool(
+    args: &[CellValue],
+    index: usize,
+    default: bool,
+) -> Result<bool, CellError> {
+    match args.get(index) {
+        Some(value) => value.coerce_to_bool(),
+        None => Ok(default),
+    }
+}
+
+fn scalar_numbers_from_array(
+    value: &CellValue,
+    function_name: &str,
+) -> Result<Vec<f64>, CellValue> {
+    let flat = flatten_values(std::slice::from_ref(value));
+    match extract_numbers_strict(&flat) {
+        Ok(values) if values.is_empty() => Err(CellValue::error_with_message(
+            CellError::Na,
+            format!("{function_name}: known_ys array is empty"),
+        )),
+        Ok(values) => Ok(values),
+        Err(e) => Err(CellValue::Error(e, None)),
+    }
+}
+
+fn array_dimensions(value: &CellValue) -> Option<(usize, usize)> {
+    value.as_array().map(|array| (array.rows(), array.cols()))
+}
+
+fn numeric_rows(value: &CellValue) -> Result<Vec<Vec<f64>>, CellError> {
+    match value {
+        CellValue::Error(e, _) => Err(*e),
+        CellValue::Array(array) => {
+            let mut rows = Vec::with_capacity(array.rows());
+            for row in array.rows_iter() {
+                let mut values = Vec::with_capacity(row.len());
+                for cell in row {
+                    match cell {
+                        CellValue::Error(e, _) => return Err(*e),
+                        CellValue::Number(n) => values.push(n.get()),
+                        _ => {}
+                    }
+                }
+                rows.push(values);
+            }
+            Ok(rows)
+        }
+        CellValue::Number(n) => Ok(vec![vec![n.get()]]),
+        _ => Ok(vec![Vec::new()]),
+    }
+}
+
+fn build_regression_input(
+    args: &[CellValue],
+    function_name: &str,
+) -> Result<RegressionInput, CellValue> {
+    let ys = scalar_numbers_from_array(&args[0], function_name)?;
+    let n = ys.len();
+
+    let xs = if args.len() > 1 {
+        let x_rows = match numeric_rows(&args[1]) {
+            Ok(rows) => rows,
+            Err(e) => return Err(CellValue::Error(e, None)),
+        };
+        let (x_row_count, x_col_count) = array_dimensions(&args[1]).unwrap_or((1, 1));
+        let (y_row_count, y_col_count) = array_dimensions(&args[0]).unwrap_or((n, 1));
+
+        if x_row_count == n && x_col_count > 0 {
+            x_rows
+        } else if x_col_count == n && x_row_count > 0 {
+            (0..n)
+                .map(|observation| {
+                    x_rows
+                        .iter()
+                        .map(|row| row.get(observation).copied().unwrap_or(0.0))
+                        .collect::<Vec<_>>()
+                })
+                .collect()
+        } else if y_row_count == 1 && x_col_count == n && x_row_count > 0 {
+            (0..n)
+                .map(|observation| {
+                    x_rows
+                        .iter()
+                        .map(|row| row.get(observation).copied().unwrap_or(0.0))
+                        .collect::<Vec<_>>()
+                })
+                .collect()
+        } else if y_col_count == 1 && x_row_count == n && x_col_count > 0 {
+            x_rows
+        } else {
+            return Err(CellValue::error_with_message(
+                CellError::Na,
+                format!(
+                    "{function_name}: known_xs shape {x_row_count}x{x_col_count} must align with known_ys length {n}",
+                ),
+            ));
+        }
+    } else {
+        (1..=n).map(|i| vec![i as f64]).collect()
+    };
+
+    if xs.len() != n || xs.is_empty() || xs.iter().any(Vec::is_empty) {
+        return Err(CellValue::error_with_message(
+            CellError::Na,
+            format!(
+                "{function_name}: known_xs length ({}) must match known_ys length ({n}) and be >= 2",
+                xs.len(),
+            ),
+        ));
+    }
+    let predictor_count = xs[0].len();
+    if xs.iter().any(|row| row.len() != predictor_count) {
+        return Err(CellValue::error_with_message(
+            CellError::Na,
+            format!("{function_name}: known_xs rows must have consistent predictor counts"),
+        ));
+    }
+    if n < 2 || predictor_count == 0 {
+        return Err(CellValue::error_with_message(
+            CellError::Na,
+            format!(
+                "{function_name}: known_xs length ({}) must match known_ys length ({n}) and be >= 2",
+                xs.len(),
+            ),
+        ));
+    }
+
+    Ok(RegressionInput { ys, xs })
+}
+
+fn vector_dot(left: &[f64], right: &[f64]) -> f64 {
+    left.iter()
+        .zip(right.iter())
+        .map(|(a, b)| a * b)
+        .sum::<f64>()
+}
+
+fn vector_norm(values: &[f64]) -> f64 {
+    vector_dot(values, values).sqrt()
+}
+
+fn independent_design_columns(
+    input: &RegressionInput,
+    constant: bool,
+) -> Vec<(DesignColumn, Vec<f64>)> {
+    let n = input.ys.len();
+    let predictor_count = input.xs[0].len();
+    let mut candidates = Vec::with_capacity(predictor_count + usize::from(constant));
+    if constant {
+        candidates.push((DesignColumn::Intercept, vec![1.0; n]));
+    }
+    for predictor_index in 0..predictor_count {
+        candidates.push((
+            DesignColumn::Predictor(predictor_index),
+            input
+                .xs
+                .iter()
+                .map(|row| row[predictor_index])
+                .collect::<Vec<_>>(),
+        ));
+    }
+
+    let mut selected = Vec::new();
+    let mut orthonormal_basis: Vec<Vec<f64>> = Vec::new();
+    for (column, values) in candidates {
+        let original_norm = vector_norm(&values);
+        if original_norm <= 1e-12 {
+            continue;
+        }
+
+        let mut residual = values.clone();
+        for basis in &orthonormal_basis {
+            let projection = vector_dot(&residual, basis);
+            for (value, basis_value) in residual.iter_mut().zip(basis.iter()) {
+                *value -= projection * basis_value;
+            }
+        }
+
+        let residual_norm = vector_norm(&residual);
+        if residual_norm > 1e-10 * original_norm.max(1.0) {
+            for value in &mut residual {
+                *value /= residual_norm;
+            }
+            orthonormal_basis.push(residual);
+            selected.push((column, values));
+        }
+    }
+
+    selected
+}
+
+fn fit_linear_regression(
+    input: &RegressionInput,
+    constant: bool,
+) -> Result<RegressionFit, CellValue> {
+    let n = input.ys.len();
+    let predictor_count = input.xs[0].len();
+    let active_columns = independent_design_columns(input, constant);
+    let active_parameter_count = active_columns.len();
+    let active_predictor_count = active_columns
+        .iter()
+        .filter(|(column, _)| matches!(column, DesignColumn::Predictor(_)))
+        .count();
+    if active_parameter_count == 0 {
+        return Err(CellValue::error_with_message(
+            CellError::Div0,
+            "LINEST: known_xs columns are linearly dependent",
+        ));
+    }
+
+    let mut design_data = Vec::with_capacity(n * active_parameter_count);
+    for row_index in 0..n {
+        for (_, values) in &active_columns {
+            design_data.push(values[row_index]);
+        }
+    }
+
+    let design = DMatrix::from_row_slice(n, active_parameter_count, &design_data);
+    let y = DVector::from_row_slice(&input.ys);
+    let xtx = design.transpose() * &design;
+    let Some(xtx_inverse) = xtx.try_inverse() else {
+        return Err(CellValue::error_with_message(
+            CellError::Div0,
+            "LINEST: known_xs columns are linearly dependent",
+        ));
+    };
+
+    let beta = &xtx_inverse * design.transpose() * y;
+    let predictions = design * &beta;
+    let residuals: Vec<f64> = input
+        .ys
+        .iter()
+        .zip(predictions.iter())
+        .map(|(actual, predicted)| actual - predicted)
+        .collect();
+    let ss_residual: f64 = residuals.iter().map(|value| value * value).sum();
+
+    let (ss_total, ss_regression) = if constant {
+        let mean_y = input.ys.iter().sum::<f64>() / n as f64;
+        let ss_total = input
+            .ys
+            .iter()
+            .map(|value| (value - mean_y).powi(2))
+            .sum::<f64>();
+        (ss_total, ss_total - ss_residual)
+    } else {
+        let ss_total = input.ys.iter().map(|value| value * value).sum::<f64>();
+        (ss_total, ss_total - ss_residual)
+    };
+
+    let degrees_of_freedom = (n - active_parameter_count) as f64;
+    let mean_square_error = if degrees_of_freedom > 0.0 {
+        ss_residual / degrees_of_freedom
+    } else {
+        f64::NAN
+    };
+
+    let mut standard_errors = Vec::with_capacity(active_parameter_count);
+    for i in 0..active_parameter_count {
+        standard_errors.push((mean_square_error * xtx_inverse[(i, i)]).sqrt());
+    }
+
+    let mut slopes = vec![0.0; predictor_count];
+    let mut slope_standard_errors = vec![0.0; predictor_count];
+    let mut intercept = 0.0;
+    let mut intercept_standard_error = None;
+    for (active_index, (column, _)) in active_columns.iter().enumerate() {
+        match *column {
+            DesignColumn::Intercept => {
+                intercept = beta[active_index];
+                intercept_standard_error = Some(standard_errors[active_index]);
+            }
+            DesignColumn::Predictor(predictor_index) => {
+                slopes[predictor_index] = beta[active_index];
+                slope_standard_errors[predictor_index] = standard_errors[active_index];
+            }
+        }
+    }
+
+    let standard_error_y = mean_square_error.sqrt();
+    let r_squared = if ss_total.abs() > 1e-15 {
+        1.0 - ss_residual / ss_total
+    } else if ss_residual.abs() < 1e-15 {
+        1.0
+    } else {
+        f64::NAN
+    };
+    let regression_degrees_of_freedom = active_predictor_count as f64;
+    let f_statistic = if regression_degrees_of_freedom > 0.0
+        && degrees_of_freedom > 0.0
+        && ss_residual.abs() > 1e-15
+    {
+        (ss_regression / regression_degrees_of_freedom) / mean_square_error
+    } else if regression_degrees_of_freedom > 0.0
+        && degrees_of_freedom > 0.0
+        && ss_regression.abs() > 1e-15
+    {
+        f64::INFINITY
+    } else {
+        f64::NAN
+    };
+
+    Ok(RegressionFit {
+        slopes,
+        intercept: if constant { intercept } else { 0.0 },
+        slope_standard_errors,
+        intercept_standard_error: if constant {
+            intercept_standard_error
+        } else {
+            None
+        },
+        r_squared,
+        standard_error_y,
+        f_statistic,
+        degrees_of_freedom,
+        ss_regression,
+        ss_residual,
+    })
+}
+
+fn number_or_error(value: f64, error: CellError) -> CellValue {
+    if value.is_finite() {
+        CellValue::number(value)
+    } else {
+        CellValue::Error(error, None)
+    }
+}
+
+fn reversed_numbers(values: &[f64]) -> Vec<CellValue> {
+    values
+        .iter()
+        .rev()
+        .map(|value| number_or_error(*value, CellError::Num))
+        .collect()
+}
+
+fn linest_result(fit: &RegressionFit, stats: bool, output_columns: usize) -> CellValue {
+    let mut coefficient_row = reversed_numbers(&fit.slopes);
+    coefficient_row.push(number_or_error(fit.intercept, CellError::Num));
+
+    if !stats {
+        return CellValue::from_rows(vec![coefficient_row]);
+    }
+
+    let mut se_row = reversed_numbers(&fit.slope_standard_errors);
+    se_row.push(match fit.intercept_standard_error {
+        Some(value) => number_or_error(value, CellError::Div0),
+        None => CellValue::Error(CellError::Na, None),
+    });
+
+    let mut r2_row = vec![
+        number_or_error(fit.r_squared, CellError::Div0),
+        number_or_error(fit.standard_error_y, CellError::Div0),
+    ];
+    let mut f_row = vec![
+        number_or_error(fit.f_statistic, CellError::Div0),
+        number_or_error(fit.degrees_of_freedom, CellError::Div0),
+    ];
+    let mut ss_row = vec![
+        number_or_error(fit.ss_regression, CellError::Num),
+        number_or_error(fit.ss_residual, CellError::Num),
+    ];
+
+    for row in [&mut r2_row, &mut f_row, &mut ss_row] {
+        while row.len() < output_columns {
+            row.push(CellValue::Error(CellError::Na, None));
+        }
+    }
+
+    CellValue::from_rows(vec![coefficient_row, se_row, r2_row, f_row, ss_row])
+}
+
 impl PureFunction for FnLinest {
     fn name(&self) -> &'static str {
         "LINEST"
@@ -191,45 +590,31 @@ impl PureFunction for FnLinest {
     fn returns_array(&self) -> bool {
         true
     }
+    fn default_for_arg(&self, index: usize) -> Option<CellValue> {
+        match index {
+            2 => Some(CellValue::Boolean(true)),
+            3 => Some(CellValue::Boolean(false)),
+            _ => None,
+        }
+    }
     fn call(&self, args: &[CellValue]) -> CellValue {
-        let flat_y = flatten_values(&[args[0].clone()]);
-        let ys: Vec<f64> = match extract_numbers_strict(&flat_y) {
-            Ok(v) if v.is_empty() => {
-                return CellValue::error_with_message(
-                    CellError::Na,
-                    "LINEST: known_ys array is empty",
-                );
-            }
-            Ok(v) => v,
+        let constant = match coerce_optional_bool(args, 2, true) {
+            Ok(value) => value,
             Err(e) => return CellValue::Error(e, None),
         };
-        let xs: Vec<f64> = if args.len() > 1 {
-            let flat_x = flatten_values(&[args[1].clone()]);
-            match extract_numbers_strict(&flat_x) {
-                Ok(v) => v,
-                Err(e) => return CellValue::Error(e, None),
-            }
-        } else {
-            (1..=ys.len()).map(|i| i as f64).collect()
+        let stats = match coerce_optional_bool(args, 3, false) {
+            Ok(value) => value,
+            Err(e) => return CellValue::Error(e, None),
         };
-        if xs.len() != ys.len() || xs.len() < 2 {
-            return CellValue::error_with_message(
-                CellError::Na,
-                format!(
-                    "LINEST: known_xs length ({}) must match known_ys length ({}) and be >= 2",
-                    xs.len(),
-                    ys.len()
-                ),
-            );
-        }
-        match linear_regression(&xs, &ys) {
-            Some((slope, intercept)) => CellValue::from_rows(vec![vec![
-                CellValue::number(slope),
-                CellValue::number(intercept),
-            ]]),
-            None => {
-                CellValue::error_with_message(CellError::Div0, "LINEST: all x values are identical")
-            }
+
+        let input = match build_regression_input(args, "LINEST") {
+            Ok(input) => input,
+            Err(error) => return error,
+        };
+        let output_columns = input.xs[0].len() + 1;
+        match fit_linear_regression(&input, constant) {
+            Ok(fit) => linest_result(&fit, stats, output_columns),
+            Err(error) => error,
         }
     }
 }

--- a/compute/core/crates/compute-functions/src/statistical/tests/regression.rs
+++ b/compute/core/crates/compute-functions/src/statistical/tests/regression.rs
@@ -45,6 +45,14 @@ fn arr_get(result: &CellValue, row: usize, col: usize) -> CellValue {
         .clone()
 }
 
+fn assert_linest_shape(result: &CellValue, rows: usize, cols: usize, label: &str) {
+    let array = result
+        .as_array()
+        .unwrap_or_else(|| panic!("{label}: expected array, got {:?}", result));
+    assert_eq!(array.rows(), rows, "{label}: row count");
+    assert_eq!(array.cols(), cols, "{label}: column count");
+}
+
 #[test]
 fn test_slope_intercept() {
     // y = 2x + 1: points (1,3), (2,5), (3,7)
@@ -394,6 +402,7 @@ fn test_linest_perfect_linear() {
             arr(vec![1.0, 2.0, 3.0, 4.0, 5.0]),
         ],
     );
+    assert_linest_shape(&r, 1, 2, "LINEST perfect linear shape");
     assert_num(arr_get(&r, 0, 0), 2.0, 1e-10, "LINEST slope");
     assert_num(arr_get(&r, 0, 1), 0.0, 1e-10, "LINEST intercept");
 }
@@ -409,6 +418,7 @@ fn test_linest_hand_calculated() {
             arr(vec![1.0, 2.0, 3.0, 4.0, 5.0]),
         ],
     );
+    assert_linest_shape(&r, 1, 2, "LINEST hand-calculated shape");
     assert_num(arr_get(&r, 0, 0), 0.8, 1e-10, "LINEST hand slope");
     assert_num(arr_get(&r, 0, 1), 0.6, 1e-10, "LINEST hand intercept");
 }
@@ -418,8 +428,217 @@ fn test_linest_y_only_implicit_x() {
     // LINEST({2,4,6}) => implicit x={1,2,3} => slope=2, intercept=0
     let reg = crate::FunctionRegistry::new();
     let r = reg.call("LINEST", &[arr(vec![2.0, 4.0, 6.0])]);
+    assert_linest_shape(&r, 1, 2, "LINEST implicit x shape");
     assert_num(arr_get(&r, 0, 0), 2.0, 1e-10, "LINEST implicit slope");
     assert_num(arr_get(&r, 0, 1), 0.0, 1e-10, "LINEST implicit intercept");
+}
+
+#[test]
+fn test_linest_single_variable_stats_true_matches_excel_matrix() {
+    let reg = crate::FunctionRegistry::new();
+    let r = reg.call(
+        "LINEST",
+        &[
+            arr(vec![2.0, 4.0, 5.0, 4.0, 5.0]),
+            arr(vec![1.0, 2.0, 3.0, 4.0, 5.0]),
+            CellValue::Boolean(true),
+            CellValue::Boolean(true),
+        ],
+    );
+
+    assert_linest_shape(&r, 5, 2, "LINEST stats TRUE shape");
+    assert_num(arr_get(&r, 0, 0), 0.6, 1e-12, "LINEST stats slope");
+    assert_num(arr_get(&r, 0, 1), 2.2, 1e-12, "LINEST stats intercept");
+    assert_num(
+        arr_get(&r, 1, 0),
+        0.282_842_712_474_619,
+        1e-12,
+        "LINEST stats slope standard error",
+    );
+    assert_num(
+        arr_get(&r, 1, 1),
+        0.938_083_151_964_686,
+        1e-12,
+        "LINEST stats intercept standard error",
+    );
+    assert_num(arr_get(&r, 2, 0), 0.6, 1e-12, "LINEST stats r2");
+    assert_num(
+        arr_get(&r, 2, 1),
+        0.894_427_190_999_916,
+        1e-12,
+        "LINEST stats standard error y estimate",
+    );
+    assert_num(arr_get(&r, 3, 0), 4.5, 1e-12, "LINEST stats F");
+    assert_num(arr_get(&r, 3, 1), 3.0, 1e-12, "LINEST stats df");
+    assert_num(arr_get(&r, 4, 0), 3.6, 1e-12, "LINEST stats ssreg");
+    assert_num(arr_get(&r, 4, 1), 2.4, 1e-12, "LINEST stats ssresid");
+}
+
+#[test]
+fn test_linest_stats_false_or_omitted_returns_first_row_only() {
+    let reg = crate::FunctionRegistry::new();
+    let ys = arr(vec![2.0, 4.0, 5.0, 4.0, 5.0]);
+    let xs = arr(vec![1.0, 2.0, 3.0, 4.0, 5.0]);
+    let cases = vec![
+        (
+            "LINEST stats FALSE",
+            vec![
+                ys.clone(),
+                xs.clone(),
+                CellValue::Boolean(true),
+                CellValue::Boolean(false),
+            ],
+        ),
+        (
+            "LINEST stats omitted with const supplied",
+            vec![ys.clone(), xs.clone(), CellValue::Boolean(true)],
+        ),
+        ("LINEST const/stats omitted", vec![ys, xs]),
+    ];
+
+    for (label, args) in cases {
+        let r = reg.call("LINEST", &args);
+        assert_linest_shape(&r, 1, 2, label);
+        assert_num(arr_get(&r, 0, 0), 0.6, 1e-12, label);
+        assert_num(arr_get(&r, 0, 1), 2.2, 1e-12, label);
+    }
+}
+
+#[test]
+fn test_linest_omitted_arg_defaults_match_excel() {
+    let f = FnLinest;
+    assert_eq!(f.default_for_arg(2), Some(CellValue::Boolean(true)));
+    assert_eq!(f.default_for_arg(3), Some(CellValue::Boolean(false)));
+    assert_eq!(f.default_for_arg(1), None);
+}
+
+#[test]
+fn test_linest_const_false_forces_zero_intercept() {
+    let reg = crate::FunctionRegistry::new();
+    let r = reg.call(
+        "LINEST",
+        &[
+            arr(vec![2.0, 4.0, 5.0, 4.0, 5.0]),
+            arr(vec![1.0, 2.0, 3.0, 4.0, 5.0]),
+            CellValue::Boolean(false),
+            CellValue::Boolean(false),
+        ],
+    );
+
+    assert_linest_shape(&r, 1, 2, "LINEST const FALSE shape");
+    assert_num(arr_get(&r, 0, 0), 1.2, 1e-12, "LINEST const FALSE slope");
+    assert_num(
+        arr_get(&r, 0, 1),
+        0.0,
+        1e-12,
+        "LINEST const FALSE intercept",
+    );
+}
+
+#[test]
+fn test_linest_const_false_stats_reports_intercept_se_as_na() {
+    let reg = crate::FunctionRegistry::new();
+    let r = reg.call(
+        "LINEST",
+        &[
+            arr(vec![2.0, 4.0, 5.0, 4.0, 5.0]),
+            arr(vec![1.0, 2.0, 3.0, 4.0, 5.0]),
+            CellValue::Boolean(false),
+            CellValue::Boolean(true),
+        ],
+    );
+
+    assert_linest_shape(&r, 5, 2, "LINEST const FALSE stats shape");
+    assert_num(
+        arr_get(&r, 0, 0),
+        1.2,
+        1e-12,
+        "LINEST const FALSE stats slope",
+    );
+    assert_num(
+        arr_get(&r, 0, 1),
+        0.0,
+        1e-12,
+        "LINEST const FALSE stats intercept",
+    );
+    assert_err(
+        arr_get(&r, 1, 1),
+        CellError::Na,
+        "LINEST const FALSE intercept standard error",
+    );
+}
+
+#[test]
+fn test_linest_multi_variable_shape_and_excel_coefficient_order() {
+    let reg = crate::FunctionRegistry::new();
+    let ys = arr(vec![27.0, 33.0, 49.0, 51.0, 59.0]);
+    let xs = CellValue::from_rows(vec![
+        vec![num(1.0), num(5.0)],
+        vec![num(2.0), num(3.0)],
+        vec![num(3.0), num(6.0)],
+        vec![num(4.0), num(2.0)],
+        vec![num(5.0), num(1.0)],
+    ]);
+    let r = reg.call(
+        "LINEST",
+        &[ys, xs, CellValue::Boolean(true), CellValue::Boolean(false)],
+    );
+
+    assert_linest_shape(&r, 1, 3, "LINEST multi-variable shape");
+    assert_num(
+        arr_get(&r, 0, 0),
+        2.0,
+        1e-10,
+        "LINEST multi-variable rightmost x coefficient",
+    );
+    assert_num(
+        arr_get(&r, 0, 1),
+        10.0,
+        1e-10,
+        "LINEST multi-variable leftmost x coefficient",
+    );
+    assert_num(
+        arr_get(&r, 0, 2),
+        7.0,
+        1e-10,
+        "LINEST multi-variable intercept",
+    );
+}
+
+#[test]
+fn test_linest_removes_redundant_x_columns() {
+    let reg = crate::FunctionRegistry::new();
+    let ys = arr(vec![7.0, 9.0, 11.0, 13.0]);
+    let xs = CellValue::from_rows(vec![
+        vec![num(1.0), num(2.0)],
+        vec![num(2.0), num(4.0)],
+        vec![num(3.0), num(6.0)],
+        vec![num(4.0), num(8.0)],
+    ]);
+    let r = reg.call(
+        "LINEST",
+        &[ys, xs, CellValue::Boolean(true), CellValue::Boolean(false)],
+    );
+
+    assert_linest_shape(&r, 1, 3, "LINEST redundant-column shape");
+    assert_num(
+        arr_get(&r, 0, 0),
+        0.0,
+        1e-12,
+        "LINEST redundant rightmost x coefficient",
+    );
+    assert_num(
+        arr_get(&r, 0, 1),
+        2.0,
+        1e-12,
+        "LINEST retained leftmost x coefficient",
+    );
+    assert_num(
+        arr_get(&r, 0, 2),
+        5.0,
+        1e-12,
+        "LINEST redundant-column intercept",
+    );
 }
 
 #[test]

--- a/kernel/src/document/__tests__/deferred-hydration-scheduler.test.ts
+++ b/kernel/src/document/__tests__/deferred-hydration-scheduler.test.ts
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import type { SheetId } from '@mog-sdk/contracts/core';
 import { DocumentLifecycleSystem } from '../document-lifecycle-system';
+import { DocumentMaterializationTracker } from '../materialization-tracker';
 
 type SchedulerHarness = Pick<
   DocumentLifecycleSystem,
@@ -28,9 +29,23 @@ type SchedulerHarness = Pick<
   environment: 'browser' | 'headless';
   importDurabilityPending: boolean;
   materializationError: null;
+  materializationTracker: DocumentMaterializationTracker;
 };
 
-function createSchedulerHarness(completeDeferredHydration: jest.Mock): SchedulerHarness {
+function createSchedulerHarness(
+  completeDeferredHydration: jest.Mock,
+  options: {
+    readonly deferredImportSheetIds?: string[];
+    readonly materializedSheetIds?: string[];
+    readonly deferredHydrationPending?: boolean;
+  } = {},
+): SchedulerHarness {
+  const materializationTracker = new DocumentMaterializationTracker();
+  materializationTracker.markDeferredImport(
+    (options.deferredImportSheetIds ?? ['critical-sheet', 'secondary-sheet']) as SheetId[],
+    (options.materializedSheetIds ?? ['critical-sheet']) as SheetId[],
+  );
+
   const harness = Object.create(DocumentLifecycleSystem.prototype) as SchedulerHarness;
   harness.actor = {
     getSnapshot: () => ({
@@ -44,7 +59,7 @@ function createSchedulerHarness(completeDeferredHydration: jest.Mock): Scheduler
       value: 'ready',
     }),
   };
-  harness.deferredHydrationPending = true;
+  harness.deferredHydrationPending = options.deferredHydrationPending ?? true;
   harness.deferredHydrationPromise = null;
   harness.deferredHydrationTimer = null;
   harness.startDeferredHydrationNow = null;
@@ -52,6 +67,7 @@ function createSchedulerHarness(completeDeferredHydration: jest.Mock): Scheduler
   harness.environment = 'browser';
   harness.importDurabilityPending = false;
   harness.materializationError = null;
+  harness.materializationTracker = materializationTracker;
   return harness;
 }
 
@@ -100,6 +116,15 @@ describe('DocumentLifecycleSystem deferred hydration scheduling', () => {
     expect(completeDeferredHydration).toHaveBeenCalledTimes(1);
     expect(harness.deferredHydrationPending).toBe(false);
     expect(harness.importDurabilityPending).toBe(false);
+  });
+
+  it('does not force deferred import hydration for sheets outside the deferred scope', async () => {
+    const completeDeferredHydration = jest.fn().mockResolvedValue(undefined);
+    const harness = createSchedulerHarness(completeDeferredHydration);
+
+    await expect(harness.awaitMaterialized('added-sheet' as SheetId)).resolves.toBeUndefined();
+
+    expect(completeDeferredHydration).not.toHaveBeenCalled();
   });
 
   it('reports all-sheets hydrating once the full hydration run is scheduled', async () => {

--- a/kernel/src/document/__tests__/materialization-tracker.test.ts
+++ b/kernel/src/document/__tests__/materialization-tracker.test.ts
@@ -1,0 +1,55 @@
+import type { SheetId } from '@mog-sdk/contracts/core';
+import {
+  DocumentMaterializationTracker,
+  materializedSheetIdsForDeferredImport,
+} from '../materialization-tracker';
+
+const sheetId = (id: string) => id as SheetId;
+
+describe('DocumentMaterializationTracker', () => {
+  it('tracks only non-critical sheets from a deferred import', () => {
+    const tracker = new DocumentMaterializationTracker();
+
+    tracker.markDeferredImport([sheetId('critical'), sheetId('deferred')], [sheetId('critical')]);
+
+    expect(tracker.requiresDeferredHydration(sheetId('critical'))).toBe(false);
+    expect(tracker.requiresDeferredHydration(sheetId('deferred'))).toBe(true);
+    expect(tracker.requiresDeferredHydration(sheetId('added-after-import'))).toBe(false);
+    expect(tracker.requiresDeferredHydration('allSheets')).toBe(true);
+  });
+
+  it('clears deferred scope when all sheets are materialized or state resets', () => {
+    const tracker = new DocumentMaterializationTracker();
+    tracker.markDeferredImport([sheetId('critical'), sheetId('deferred')], [sheetId('critical')]);
+
+    tracker.markAllMaterialized();
+    expect(tracker.requiresDeferredHydration(sheetId('deferred'))).toBe(false);
+    expect(tracker.requiresDeferredHydration('allSheets')).toBe(false);
+
+    tracker.markDeferredImport([sheetId('critical'), sheetId('deferred')], [sheetId('critical')]);
+    tracker.reset();
+    expect(tracker.requiresDeferredHydration(sheetId('deferred'))).toBe(false);
+    expect(tracker.requiresDeferredHydration('allSheets')).toBe(false);
+  });
+
+  it('uses selected sheet ids as materialized deferred-import scope', () => {
+    const tracker = new DocumentMaterializationTracker();
+    tracker.markDeferredImport([sheetId('first'), sheetId('active')], [sheetId('active')]);
+    expect(tracker.requiresDeferredHydration(sheetId('first'))).toBe(true);
+    expect(tracker.requiresDeferredHydration(sheetId('active'))).toBe(false);
+
+    expect(
+      materializedSheetIdsForDeferredImport(
+        [sheetId('first'), sheetId('active')],
+        [sheetId('active')],
+      ),
+    ).toEqual([sheetId('active')]);
+
+    expect(materializedSheetIdsForDeferredImport([sheetId('first')], [])).toEqual([
+      sheetId('first'),
+    ]);
+    expect(materializedSheetIdsForDeferredImport([sheetId('first')], [sheetId('stale')])).toEqual([
+      sheetId('first'),
+    ]);
+  });
+});

--- a/kernel/src/document/document-lifecycle-system.ts
+++ b/kernel/src/document/document-lifecycle-system.ts
@@ -62,6 +62,10 @@ import {
 import { validateHostContext } from './validate-host-context';
 import { mapHostRuntimeToTransportConfig } from './host-runtime-transport';
 import { slog } from '../lib/slog';
+import {
+  DocumentMaterializationTracker,
+  materializedSheetIdsForDeferredImport,
+} from './materialization-tracker';
 
 import {
   documentLifecycleMachine,
@@ -342,6 +346,9 @@ export class DocumentLifecycleSystem {
   /** Last deferred hydration/materialization failure, if any. */
   private materializationError: MaterializationState['error'] | null = null;
 
+  /** Owns deferred-import sheet scope; not a sheet-existence registry. */
+  private readonly materializationTracker = new DocumentMaterializationTracker();
+
   /** Provider registry for the host-backed path (the storage provider lifecycle). */
   private readonly providerRegistry: StorageProviderRegistry;
 
@@ -531,6 +538,7 @@ export class DocumentLifecycleSystem {
         '[DocumentLifecycleSystem] Cannot create — system is disposed',
       );
     }
+    this.materializationTracker.reset();
     this.actor.send({ type: 'CREATE', docId, options });
   }
 
@@ -556,6 +564,7 @@ export class DocumentLifecycleSystem {
         `[DocumentLifecycleSystem] authorized room documentId mismatch: host=${this.hostLifecycleInput.documentId}, docId=${docId}, room=${options.authorizedRoomBootstrap.documentId}`,
       );
     }
+    this.materializationTracker.reset();
     this.authorizedRoomBootstrap = options.authorizedRoomBootstrap;
     this.actor.send({ type: 'CREATE', docId, options: { skipDefaultSheet: true } });
   }
@@ -575,6 +584,7 @@ export class DocumentLifecycleSystem {
         '[DocumentLifecycleSystem] Cannot create — system is disposed',
       );
     }
+    this.materializationTracker.reset();
     this.actor.send({
       type: 'CREATE_FROM_XLSX',
       docId,
@@ -599,6 +609,7 @@ export class DocumentLifecycleSystem {
         '[DocumentLifecycleSystem] Cannot create — system is disposed',
       );
     }
+    this.materializationTracker.reset();
     this.actor.send({
       type: 'CREATE_FROM_CSV',
       docId,
@@ -701,6 +712,7 @@ export class DocumentLifecycleSystem {
       );
     }
 
+    this.materializationTracker.reset();
     this.actor.send({ type: 'RECOVER', yrsState });
     return this.waitForReady();
   }
@@ -898,22 +910,12 @@ export class DocumentLifecycleSystem {
   }
 
   async awaitMaterialized(scope: SheetId | 'allSheets' = 'allSheets'): Promise<void> {
-    const initialActiveSheetId = this.getInitialActiveSheetId();
-
-    if (scope !== 'allSheets' && initialActiveSheetId === scope) {
-      return;
-    }
-
-    if (scope !== 'allSheets' && !this.isKnownSheetId(scope)) {
-      throw this.materializationFailure({
-        code: 'sheet_not_found',
-        scope,
-        message: `Sheet ${scope} is not part of this document.`,
-      });
-    }
-
     if (this.materializationError) {
       throw this.materializationFailure(this.materializationError);
+    }
+
+    if (scope !== 'allSheets' && !this.materializationTracker.requiresDeferredHydration(scope)) {
+      return;
     }
 
     await this.ensureDeferredHydration();
@@ -972,13 +974,6 @@ export class DocumentLifecycleSystem {
     return snap.context.initialSheetIds?.[0];
   }
 
-  private isKnownSheetId(sheetId: SheetId): boolean {
-    const snap = this.actor.getSnapshot();
-    if (!documentLifecycleSelectors.isReady(snap)) return true;
-    const ids = snap.context.initialSheetIds ?? [];
-    return ids.includes(sheetId);
-  }
-
   private materializationFailure(details: MaterializationState['error']): Error {
     const err = new Error(details?.message ?? 'XLSX materialization failed') as Error & {
       code?: string;
@@ -1007,6 +1002,7 @@ export class DocumentLifecycleSystem {
     if (!bridge) {
       this.deferredHydrationPending = false;
       this.importDurabilityPending = false;
+      this.materializationTracker.markAllMaterialized();
       return Promise.resolve();
     }
 
@@ -1047,6 +1043,7 @@ export class DocumentLifecycleSystem {
       }
 
       this.deferredHydrationPending = false;
+      this.materializationTracker.markAllMaterialized();
     };
 
     // Use a macrotask after the app's first paint. Host-backed browser imports
@@ -2135,6 +2132,13 @@ export class DocumentLifecycleSystem {
       // Get sheet IDs from the engine (populated by Rust import)
       await this.settleDeferredImportMirror(computeBridge);
       const sheetIds = await computeBridge.getAllSheetIds();
+      this.materializationTracker.markDeferredImport(
+        sheetIds,
+        materializedSheetIdsForDeferredImport(
+          sheetIds,
+          input.documentContext.mirror.getSelectedSheetIds(),
+        ),
+      );
 
       // Identity formula conversion is already done in Rust during
       // init_from_snapshot() → bulk_parse_and_register(). No TypeScript pass needed.
@@ -2205,6 +2209,13 @@ export class DocumentLifecycleSystem {
 
       await this.settleDeferredImportMirror(computeBridge);
       const sheetIds = await computeBridge.getAllSheetIds();
+      this.materializationTracker.markDeferredImport(
+        sheetIds,
+        materializedSheetIdsForDeferredImport(
+          sheetIds,
+          input.documentContext.mirror.getSelectedSheetIds(),
+        ),
+      );
 
       return {
         cellCount: 0, // cell count not available from single-call path

--- a/kernel/src/document/materialization-tracker.ts
+++ b/kernel/src/document/materialization-tracker.ts
@@ -24,10 +24,7 @@ export class DocumentMaterializationTracker {
     this.deferredSheetIds.clear();
   }
 
-  markDeferredImport(
-    sheetIds: readonly SheetId[],
-    materializedSheetIds: readonly SheetId[],
-  ): void {
+  markDeferredImport(sheetIds: readonly SheetId[], materializedSheetIds: readonly SheetId[]): void {
     this.deferredSheetIds.clear();
     const materialized = new Set(materializedSheetIds);
     for (const sheetId of sheetIds) {

--- a/kernel/src/document/materialization-tracker.ts
+++ b/kernel/src/document/materialization-tracker.ts
@@ -1,0 +1,48 @@
+import type { SheetId } from '@mog-sdk/contracts/core';
+
+export function materializedSheetIdsForDeferredImport(
+  sheetIds: readonly SheetId[],
+  selectedSheetIds: readonly SheetId[],
+): readonly SheetId[] {
+  const sheetIdSet = new Set(sheetIds);
+  const selectedImportedSheetIds = selectedSheetIds.filter((sheetId) => sheetIdSet.has(sheetId));
+  return selectedImportedSheetIds.length > 0 ? selectedImportedSheetIds : sheetIds.slice(0, 1);
+}
+
+/**
+ * Tracks only deferred-import materialization scope.
+ *
+ * This is deliberately not a sheet registry. Sheet existence belongs to the
+ * workbook/compute layer that dereferences sheets. The lifecycle only needs to
+ * know whether a requested scope is part of the imported workbook state that
+ * has not completed deferred hydration yet.
+ */
+export class DocumentMaterializationTracker {
+  private deferredSheetIds = new Set<SheetId>();
+
+  reset(): void {
+    this.deferredSheetIds.clear();
+  }
+
+  markDeferredImport(
+    sheetIds: readonly SheetId[],
+    materializedSheetIds: readonly SheetId[],
+  ): void {
+    this.deferredSheetIds.clear();
+    const materialized = new Set(materializedSheetIds);
+    for (const sheetId of sheetIds) {
+      if (!materialized.has(sheetId)) {
+        this.deferredSheetIds.add(sheetId);
+      }
+    }
+  }
+
+  markAllMaterialized(): void {
+    this.deferredSheetIds.clear();
+  }
+
+  requiresDeferredHydration(scope: SheetId | 'allSheets'): boolean {
+    if (scope === 'allSheets') return this.deferredSheetIds.size > 0;
+    return this.deferredSheetIds.has(scope);
+  }
+}


### PR DESCRIPTION
## Summary
- Promote `dev-v0.10.4` into `main`.
- Fix ribbon tab-click collapse/expand behavior and add progressive per-group responsive collapse.
- Fix deferred materialization scope for added sheets.
- Expand LINEST regression support in compute functions.

## Verification
- Not run locally; this PR only opens the already-pushed `dev-v0.10.4` branch for review.