### PR TITLE
fix(xlsx): allocate unique generated sheet IDs

### DIFF
--- a/file-io/xlsx/parser/src/write/from_parse_output/workbook_parts.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/workbook_parts.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use domain_types::{ParseOutput, WorkbookSheetKind};
 
 use super::WriteError;
@@ -200,7 +202,8 @@ fn add_generated_sheet_defs(
     package_graph: &ResolvedPackageGraph,
     workbook_writer: &mut WorkbookWriter,
 ) -> Result<(), WriteError> {
-    for (idx, sheet_data) in output.sheets.iter().enumerate() {
+    let sheet_ids = allocate_generated_sheet_ids(output)?;
+    for (idx, (sheet_data, sheet_id)) in output.sheets.iter().zip(sheet_ids).enumerate() {
         let sheet_target = format!("worksheets/sheet{}.xml", idx + 1);
         let r_id = package_graph
             .relationship_id(&PackageOwner::Workbook, REL_WORKSHEET, &sheet_target)
@@ -211,7 +214,6 @@ fn add_generated_sheet_defs(
                 ))
             })?
             .to_string();
-        let sheet_id = sheet_data.sheet_id.unwrap_or(idx as u32 + 1);
         workbook_writer.add_sheet_def(SheetDef::with_state(
             &sheet_data.name,
             sheet_id,
@@ -220,6 +222,49 @@ fn add_generated_sheet_defs(
         ));
     }
     Ok(())
+}
+
+fn allocate_generated_sheet_ids(output: &ParseOutput) -> Result<Vec<u32>, WriteError> {
+    let mut used = BTreeSet::new();
+    for sheet in &output.sheets {
+        let Some(sheet_id) = sheet.sheet_id else {
+            continue;
+        };
+        if sheet_id == 0 {
+            return Err(WriteError::PackageIntegrity(format!(
+                "worksheet {:?} has invalid sheetId 0",
+                sheet.name
+            )));
+        }
+        if !used.insert(sheet_id) {
+            return Err(WriteError::PackageIntegrity(format!(
+                "duplicate worksheet sheetId {sheet_id}"
+            )));
+        }
+    }
+
+    let mut allocated = Vec::with_capacity(output.sheets.len());
+    for sheet in &output.sheets {
+        if let Some(sheet_id) = sheet.sheet_id {
+            allocated.push(sheet_id);
+            continue;
+        }
+
+        let sheet_id = used
+            .last()
+            .copied()
+            .unwrap_or(0)
+            .checked_add(1)
+            .ok_or_else(|| {
+                WriteError::PackageIntegrity(
+                    "cannot allocate a positive worksheet sheetId".to_string(),
+                )
+            })?;
+        used.insert(sheet_id);
+        allocated.push(sheet_id);
+    }
+
+    Ok(allocated)
 }
 
 fn add_inventory_sheet_defs(
@@ -280,4 +325,42 @@ fn workbook_relative_target(path: &str) -> String {
         .unwrap_or(path)
         .trim_start_matches('/')
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use domain_types::SheetData;
+
+    use super::*;
+
+    fn output_with_sheet_ids(sheet_ids: &[Option<u32>]) -> ParseOutput {
+        ParseOutput {
+            sheets: sheet_ids
+                .iter()
+                .enumerate()
+                .map(|(index, sheet_id)| SheetData {
+                    name: format!("Sheet {}", index + 1),
+                    sheet_id: *sheet_id,
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn generated_sheet_ids_reject_zero() {
+        let error = allocate_generated_sheet_ids(&output_with_sheet_ids(&[Some(0)]))
+            .expect_err("sheetId 0 must fail export");
+
+        assert!(error.to_string().contains("invalid sheetId 0"));
+    }
+
+    #[test]
+    fn generated_sheet_ids_reject_preserved_duplicates() {
+        let error = allocate_generated_sheet_ids(&output_with_sheet_ids(&[Some(4), Some(4)]))
+            .expect_err("duplicate preserved sheet IDs must fail export");
+
+        assert!(error.to_string().contains("duplicate worksheet sheetId 4"));
+    }
 }

--- a/file-io/xlsx/parser/tests/roundtrip_parse_output/workbook.rs
+++ b/file-io/xlsx/parser/tests/roundtrip_parse_output/workbook.rs
@@ -514,6 +514,58 @@ fn roundtrip_many_sheets() {
 }
 
 #[test]
+fn generated_sheet_ids_are_unique_for_sparse_imports_at_every_insertion_position() {
+    for insertion_index in [0, 2, 3] {
+        let mut sheets = vec![
+            SheetData {
+                name: "Imported 4".to_string(),
+                sheet_id: Some(4),
+                ..Default::default()
+            },
+            SheetData {
+                name: "Imported 3".to_string(),
+                sheet_id: Some(3),
+                ..Default::default()
+            },
+            SheetData {
+                name: "Imported 1".to_string(),
+                sheet_id: Some(1),
+                ..Default::default()
+            },
+        ];
+        sheets.insert(
+            insertion_index,
+            SheetData {
+                name: "Inserted".to_string(),
+                sheet_id: None,
+                ..Default::default()
+            },
+        );
+
+        let round_tripped = roundtrip(&ParseOutput {
+            sheets,
+            ..Default::default()
+        });
+        let sheet_ids: Vec<u32> = round_tripped
+            .sheets
+            .iter()
+            .map(|sheet| sheet.sheet_id.expect("exported worksheet has a sheetId"))
+            .collect();
+
+        assert_eq!(sheet_ids[insertion_index], 5);
+        assert_eq!(
+            sheet_ids
+                .iter()
+                .copied()
+                .collect::<std::collections::BTreeSet<_>>()
+                .len(),
+            sheet_ids.len(),
+            "sheet IDs must stay unique when inserting at position {insertion_index}"
+        );
+    }
+}
+
+#[test]
 fn roundtrip_sheet_name_special_chars() {
     let output = make_single_sheet(
         "My Sheet (1)",


### PR DESCRIPTION
Fixes #334.

## What changed

- Preserve valid imported worksheet IDs.
- Allocate each generated worksheet ID above the maximum preserved/allocated ID instead of deriving it from sheet position.
- Fail export when the generated-sheet path receives `sheetId=0` or duplicate preserved IDs.

## Regression coverage

The regression test starts from preserved IDs `4, 3, 1`, inserts a generated sheet at the beginning, middle, and end, and verifies that the inserted sheet receives `5` with no duplicates in every case.

## Verification

- `cargo fmt --check`
- `cargo test -p xlsx-parser generated_sheet_ids --locked`

All focused checks pass. Existing unrelated compiler warnings remain unchanged.