### PR TITLE
fix(xlsx): emit workbook children in schema order

### DIFF
--- a/file-io/xlsx/parser/src/domain/workbook/write/root.rs
+++ b/file-io/xlsx/parser/src/domain/workbook/write/root.rs
@@ -1,5 +1,4 @@
 use crate::write::xml_writer::XmlWriter;
-use std::collections::HashSet;
 
 use super::attrs::{RELATIONSHIPS_NS, SPREADSHEET_NS};
 use super::writer::WorkbookWriter;
@@ -52,65 +51,36 @@ pub(super) fn write_workbook(writer: &WorkbookWriter) -> Vec<u8> {
 }
 
 fn write_workbook_children(w: &mut XmlWriter, writer: &WorkbookWriter) {
-    let mut emitted = HashSet::new();
-
-    if let Some(fidelity) = writer.workbook_xml_fidelity.as_ref() {
-        for slot in &fidelity.slots {
-            if !matches!(
-                slot.fallback_action,
-                WorkbookXmlFallbackAction::Regenerate | WorkbookXmlFallbackAction::Preserve
-            ) {
-                continue;
-            }
-            if emitted.contains(&slot.kind) && is_singleton_child(slot.kind) {
-                continue;
-            }
-
-            let did_emit = match slot.kind {
-                WorkbookXmlChildKind::FunctionGroups
-                | WorkbookXmlChildKind::OleSize
-                | WorkbookXmlChildKind::SmartTagPr
-                | WorkbookXmlChildKind::SmartTagTypes
-                | WorkbookXmlChildKind::FileRecoveryPr
-                | WorkbookXmlChildKind::WebPublishObjects => slot
-                    .payload_id
-                    .as_deref()
-                    .and_then(|payload_id| raw_child_xml(fidelity, payload_id))
-                    .map(|xml| {
-                        let xml = String::from_utf8_lossy(xml);
-                        w.raw_str(&xml);
-                    })
-                    .is_some(),
-                WorkbookXmlChildKind::ExtLst => {
-                    if writer.ext_lst_entries.is_empty() {
-                        slot.payload_id
-                            .as_deref()
-                            .and_then(|payload_id| raw_child_xml(fidelity, payload_id))
-                            .map(|xml| {
-                                let xml = String::from_utf8_lossy(xml);
-                                w.raw_str(&xml);
-                            })
-                            .is_some()
-                    } else {
-                        write_generated_ext_lst(w, writer);
-                        true
-                    }
-                }
-                kind => write_modeled_child(w, writer, kind),
-            };
-
-            if did_emit && is_singleton_child(slot.kind) {
-                emitted.insert(slot.kind);
-            }
-        }
-    }
-
     for kind in CANONICAL_CHILD_ORDER {
-        if emitted.contains(kind) && is_singleton_child(*kind) {
-            continue;
-        }
-        if write_modeled_child(w, writer, *kind) && is_singleton_child(*kind) {
-            emitted.insert(*kind);
+        let emitted_from_fidelity = writer
+            .workbook_xml_fidelity
+            .as_ref()
+            .and_then(|fidelity| {
+                fidelity
+                    .slots
+                    .iter()
+                    .find(|slot| {
+                        slot.kind == *kind
+                            && matches!(
+                                slot.fallback_action,
+                                WorkbookXmlFallbackAction::Regenerate
+                                    | WorkbookXmlFallbackAction::Preserve
+                            )
+                    })
+                    .map(|slot| {
+                        write_fidelity_child(
+                            w,
+                            writer,
+                            fidelity,
+                            slot.kind,
+                            slot.payload_id.as_deref(),
+                        )
+                    })
+            })
+            .unwrap_or(false);
+
+        if !emitted_from_fidelity {
+            write_modeled_child(w, writer, *kind);
         }
     }
 }
@@ -119,17 +89,48 @@ const CANONICAL_CHILD_ORDER: &[WorkbookXmlChildKind] = &[
     WorkbookXmlChildKind::FileVersion,
     WorkbookXmlChildKind::FileSharing,
     WorkbookXmlChildKind::WorkbookPr,
-    WorkbookXmlChildKind::BookViews,
-    WorkbookXmlChildKind::CustomWorkbookViews,
-    WorkbookXmlChildKind::Sheets,
     WorkbookXmlChildKind::WorkbookProtection,
+    WorkbookXmlChildKind::BookViews,
+    WorkbookXmlChildKind::Sheets,
+    WorkbookXmlChildKind::FunctionGroups,
     WorkbookXmlChildKind::ExternalReferences,
     WorkbookXmlChildKind::DefinedNames,
     WorkbookXmlChildKind::CalcPr,
+    WorkbookXmlChildKind::OleSize,
+    WorkbookXmlChildKind::CustomWorkbookViews,
     WorkbookXmlChildKind::PivotCaches,
+    WorkbookXmlChildKind::SmartTagPr,
+    WorkbookXmlChildKind::SmartTagTypes,
     WorkbookXmlChildKind::WebPublishing,
+    WorkbookXmlChildKind::FileRecoveryPr,
+    WorkbookXmlChildKind::WebPublishObjects,
     WorkbookXmlChildKind::ExtLst,
 ];
+
+fn write_fidelity_child(
+    w: &mut XmlWriter,
+    writer: &WorkbookWriter,
+    fidelity: &domain_types::WorkbookXmlFidelity,
+    kind: WorkbookXmlChildKind,
+    payload_id: Option<&str>,
+) -> bool {
+    match kind {
+        WorkbookXmlChildKind::FunctionGroups
+        | WorkbookXmlChildKind::OleSize
+        | WorkbookXmlChildKind::SmartTagPr
+        | WorkbookXmlChildKind::SmartTagTypes
+        | WorkbookXmlChildKind::FileRecoveryPr
+        | WorkbookXmlChildKind::WebPublishObjects => payload_id
+            .and_then(|payload_id| raw_child_xml(fidelity, payload_id))
+            .map(|xml| w.raw_str(&String::from_utf8_lossy(xml)))
+            .is_some(),
+        WorkbookXmlChildKind::ExtLst if writer.ext_lst_entries.is_empty() => payload_id
+            .and_then(|payload_id| raw_child_xml(fidelity, payload_id))
+            .map(|xml| w.raw_str(&String::from_utf8_lossy(xml)))
+            .is_some(),
+        kind => write_modeled_child(w, writer, kind),
+    }
+}
 
 fn write_modeled_child(
     w: &mut XmlWriter,
@@ -153,9 +154,8 @@ fn write_modeled_child(
             present
         }
         WorkbookXmlChildKind::BookViews => {
-            let present = !writer.workbook_views.is_empty();
             super::views::write_book_views(w, &writer.workbook_views);
-            present
+            true
         }
         WorkbookXmlChildKind::CustomWorkbookViews => {
             if let Some(xml) = writer.custom_workbook_views_xml.as_ref() {
@@ -236,10 +236,6 @@ fn raw_child_xml<'a>(
         .iter()
         .find(|raw| raw.payload_id == payload_id)
         .map(|raw| raw.xml.as_slice())
-}
-
-fn is_singleton_child(kind: WorkbookXmlChildKind) -> bool {
-    !matches!(kind, WorkbookXmlChildKind::Unknown)
 }
 
 fn workbook_conformance_to_emit(writer: &WorkbookWriter) -> Option<&str> {

--- a/file-io/xlsx/parser/src/domain/workbook/write/tests.rs
+++ b/file-io/xlsx/parser/src/domain/workbook/write/tests.rs
@@ -264,6 +264,102 @@ fn test_complete_workbook_xml() {
 }
 
 #[test]
+fn fidelity_merge_emits_generated_and_preserved_children_in_schema_order() {
+    use domain_types::{
+        WorkbookXmlChildKind, WorkbookXmlChildSlot, WorkbookXmlFallbackAction, WorkbookXmlFidelity,
+        WorkbookXmlOwnerPolicy, WorkbookXmlProvenanceStatus, WorkbookXmlRawChild,
+    };
+
+    let regenerated = |kind| WorkbookXmlChildSlot {
+        kind,
+        owner_policy: WorkbookXmlOwnerPolicy::TypedRegenerated,
+        provenance_status: WorkbookXmlProvenanceStatus::Current,
+        fallback_action: WorkbookXmlFallbackAction::Regenerate,
+        payload_id: None,
+        reason: None,
+    };
+    let function_groups_payload = "function-groups".to_string();
+    let function_groups = WorkbookXmlChildSlot {
+        kind: WorkbookXmlChildKind::FunctionGroups,
+        owner_policy: WorkbookXmlOwnerPolicy::InertDirectChildPayload,
+        provenance_status: WorkbookXmlProvenanceStatus::SafeInert,
+        fallback_action: WorkbookXmlFallbackAction::Preserve,
+        payload_id: Some(function_groups_payload.clone()),
+        reason: None,
+    };
+    let mut writer = WorkbookWriter::new();
+    writer.set_file_version(domain_types::domain::workbook::FileVersion {
+        app_name: Some("Mog".to_string()),
+        ..Default::default()
+    });
+    writer.set_workbook_xml_fidelity(WorkbookXmlFidelity {
+        // Deliberately omit bookViews, put functionGroups before sheets, and
+        // place fileVersion last to model malformed imported ordering.
+        slots: vec![
+            function_groups,
+            regenerated(WorkbookXmlChildKind::Sheets),
+            regenerated(WorkbookXmlChildKind::CalcPr),
+            WorkbookXmlChildSlot {
+                kind: WorkbookXmlChildKind::FileVersion,
+                owner_policy: WorkbookXmlOwnerPolicy::TypedWithValidatedProvenance,
+                provenance_status: WorkbookXmlProvenanceStatus::Current,
+                fallback_action: WorkbookXmlFallbackAction::Regenerate,
+                payload_id: None,
+                reason: None,
+            },
+        ],
+        raw_children: vec![WorkbookXmlRawChild {
+            payload_id: function_groups_payload,
+            kind: WorkbookXmlChildKind::FunctionGroups,
+            q_name: "functionGroups".to_string(),
+            local_name: "functionGroups".to_string(),
+            xml: br#"<functionGroups builtInGroupCount="16"/>"#.to_vec(),
+            relationship_ids: Vec::new(),
+        }],
+        diagnostics: Vec::new(),
+    });
+
+    let xml = String::from_utf8(writer.to_xml()).unwrap();
+    let file_version_pos = xml.find("<fileVersion").unwrap();
+    let book_views_pos = xml.find("<bookViews>").unwrap();
+    let sheets_pos = xml.find("<sheets>").unwrap();
+    let function_groups_pos = xml.find("<functionGroups").unwrap();
+    let calc_pos = xml.find("<calcPr").unwrap();
+
+    assert!(file_version_pos < book_views_pos);
+    assert!(book_views_pos < sheets_pos);
+    assert!(sheets_pos < function_groups_pos);
+    assert!(function_groups_pos < calc_pos);
+    assert_eq!(xml.matches("<bookViews>").count(), 1);
+}
+
+#[test]
+fn fidelity_book_views_slot_emits_one_default_view() {
+    use domain_types::{
+        WorkbookXmlChildKind, WorkbookXmlChildSlot, WorkbookXmlFallbackAction, WorkbookXmlFidelity,
+        WorkbookXmlOwnerPolicy, WorkbookXmlProvenanceStatus,
+    };
+
+    let mut writer = WorkbookWriter::new();
+    writer.set_workbook_xml_fidelity(WorkbookXmlFidelity {
+        slots: vec![WorkbookXmlChildSlot {
+            kind: WorkbookXmlChildKind::BookViews,
+            owner_policy: WorkbookXmlOwnerPolicy::TypedRegenerated,
+            provenance_status: WorkbookXmlProvenanceStatus::Current,
+            fallback_action: WorkbookXmlFallbackAction::Regenerate,
+            payload_id: None,
+            reason: None,
+        }],
+        ..Default::default()
+    });
+
+    let xml = String::from_utf8(writer.to_xml()).unwrap();
+
+    assert_eq!(xml.matches("<bookViews>").count(), 1);
+    assert_eq!(xml.matches("<workbookView").count(), 1);
+}
+
+#[test]
 fn test_no_defined_names() {
     let mut writer = WorkbookWriter::new();
     writer.add_sheet("Sheet1", "rId1");


### PR DESCRIPTION
## Problem

Workbook fidelity replay currently emits imported child slots first, then appends modeled children that were absent from the import. If an imported workbook has no `bookViews`, the writer generates it after existing `sheets` and `calcPr`, violating the `CT_Workbook` child sequence. The same replay behavior preserves other malformed modeled-child positions such as a trailing `fileVersion`.

A minimal writer repro with fidelity slots for `sheets` and `calcPr` emits `bookViews` after both on `main`.

## What changed

- Merge regenerated and preserved workbook children through the complete supported `CT_Workbook` schema order.
- Keep inert raw child payloads, but place them at their schema-defined positions.
- Treat the always-generated default `bookViews` block as emitted so a fidelity slot cannot duplicate it.

This is intentionally limited to workbook root child ordering. It does not change worksheet namespace/MCE handling.

## Verification

- `cargo fmt --check`
- `cargo test -p xlsx-parser domain::workbook::write::tests --lib --locked` — 31 passed

I also ran `cargo test -p xlsx-parser --lib --locked`; the 3,370-test process was terminated by the OS with `SIGKILL` after progressing through the suite, without an assertion failure. I am not claiming that resource-limited run as passing.