### PR TITLE
fix(screenshot): render hard line breaks as physical lines

### DIFF
--- a/compute/core/crates/compute-screenshot/src/cells.rs
+++ b/compute/core/crates/compute-screenshot/src/cells.rs
@@ -221,44 +221,49 @@ fn render_cell_text(canvas: &mut SheetCanvas, cell_text: CellText<'_>) {
         })
         .unwrap_or(colors::BLACK);
 
-    let text_w = text::measure_text_advance(&buzz_face, font_size, cell_text.text);
+    let lines = text::hard_lines(cell_text.text);
+    let line_widths: Vec<f32> = lines
+        .iter()
+        .map(|line| text::measure_text_advance(&buzz_face, font_size, line))
+        .collect();
+    let text_w = line_widths.iter().copied().fold(0.0, f32::max);
     let ascender = text::ascender_px(&buzz_face, font_size);
     let line_h = text::line_height_px(&buzz_face, font_size);
+    let text_h = line_h * lines.len() as f32;
     let clip_rect = text_clip_rect(&cell_text, text_w);
 
-    // Horizontal alignment
     use domain_types::CellVerticalAlign;
     use ooxml_types::styles::HorizontalAlign;
     let h_align = format.horizontal_align.unwrap_or(HorizontalAlign::General);
-    let text_x = match h_align {
-        HorizontalAlign::Center | HorizontalAlign::CenterContinuous => {
-            rect.x + (rect.w - text_w) / 2.0
-        }
-        HorizontalAlign::Right => rect.x + rect.w - text_w - CELL_PADDING,
-        _ => rect.x + CELL_PADDING, // Left, General, Fill, Justify, Distributed
-    };
-
-    // Vertical alignment
     let v_align = format.vertical_align.unwrap_or(CellVerticalAlign::Bottom);
-    let text_y = match v_align {
+    let first_baseline_y = match v_align {
         CellVerticalAlign::Top => rect.y + ascender + 2.0,
-        CellVerticalAlign::Middle => rect.y + (rect.h - line_h) / 2.0 + ascender,
-        _ => rect.y + rect.h - (line_h - ascender) - 2.0, // Bottom default, Justify, Distributed
+        CellVerticalAlign::Middle => rect.y + (rect.h - text_h) / 2.0 + ascender,
+        _ => rect.y + rect.h - (text_h - ascender) - 2.0,
     };
 
     canvas.set_clip(clip_rect.x, clip_rect.y, clip_rect.w, clip_rect.h);
-    text::render_text(
-        canvas,
-        &buzz_face,
-        &ttf_face,
-        text::TextRun {
-            font_size,
-            text: cell_text.text,
-            x: text_x,
-            y: text_y,
-            color: text_color,
-        },
-    );
+    for (index, (line, line_width)) in lines.iter().zip(line_widths).enumerate() {
+        let text_x = match h_align {
+            HorizontalAlign::Center | HorizontalAlign::CenterContinuous => {
+                rect.x + (rect.w - line_width) / 2.0
+            }
+            HorizontalAlign::Right => rect.x + rect.w - line_width - CELL_PADDING,
+            _ => rect.x + CELL_PADDING,
+        };
+        text::render_text(
+            canvas,
+            &buzz_face,
+            &ttf_face,
+            text::TextRun {
+                font_size,
+                text: line,
+                x: text_x,
+                y: first_baseline_y + index as f32 * line_h,
+                color: text_color,
+            },
+        );
+    }
     canvas.clear_clip();
 }
 
@@ -270,6 +275,7 @@ fn text_clip_rect(cell_text: &CellText<'_>, text_w: f32) -> CssRect {
         || !cell_value_can_overflow(cell_text.cell)
         || cell_text.format.wrap_text.unwrap_or(false)
         || cell_text.format.shrink_to_fit.unwrap_or(false)
+        || cell_text.text.contains(['\n', '\r'])
         || cell_in_merge(cell_text.data, cell_text.cell.row, cell_text.cell.col)
     {
         return rect;
@@ -563,6 +569,37 @@ mod tests {
             find_text_horizontal_bounds(&canvas, 0, 20, 66, 128, 200).is_none(),
             "no text should leak into cell B1"
         );
+    }
+
+    #[test]
+    fn hard_line_breaks_render_as_separate_physical_lines() {
+        let db = shared_font_db();
+        let format = CellFormat {
+            vertical_align: Some(domain_types::CellVerticalAlign::Top),
+            ..Default::default()
+        };
+        let mut data =
+            make_viewport_data(vec![make_cell_with_format(0, 0, "Alpha\nBeta\r\nGamma", 1)]);
+        data.format_palette.push(format);
+        data.row_positions = vec![0.0, 60.0, 80.0, 100.0, 120.0, 140.0];
+        let mut canvas = SheetCanvas::new(320, 140, 1.0);
+
+        render_cells(
+            &mut canvas,
+            &data,
+            &data.row_positions,
+            &data.col_positions,
+            0.0,
+            0.0,
+            db,
+        );
+
+        for (top, bottom) in [(0, 15), (15, 30), (30, 45)] {
+            assert!(
+                find_text_horizontal_bounds(&canvas, top, bottom, 0, 64, 200).is_some(),
+                "expected a rendered line in y={top}..{bottom}"
+            );
+        }
     }
 
     #[test]

--- a/compute/core/crates/compute-screenshot/src/merges.rs
+++ b/compute/core/crates/compute-screenshot/src/merges.rs
@@ -169,39 +169,45 @@ fn render_merge_text(canvas: &mut SheetCanvas, merge_text: MergeText<'_>) {
         })
         .unwrap_or(colors::BLACK);
 
-    let text_w = text::measure_text_advance(&buzz_face, font_size, merge_text.text);
+    let lines = text::hard_lines(merge_text.text);
+    let line_widths: Vec<f32> = lines
+        .iter()
+        .map(|line| text::measure_text_advance(&buzz_face, font_size, line))
+        .collect();
     let ascender = text::ascender_px(&buzz_face, font_size);
     let line_h = text::line_height_px(&buzz_face, font_size);
+    let text_h = line_h * lines.len() as f32;
 
     use domain_types::CellVerticalAlign;
     use ooxml_types::styles::HorizontalAlign;
     let h_align = format.horizontal_align.unwrap_or(HorizontalAlign::Center);
-    let text_x = match h_align {
-        HorizontalAlign::Left | HorizontalAlign::General => rect.x + CELL_PADDING,
-        HorizontalAlign::Right => rect.x + rect.w - text_w - CELL_PADDING,
-        _ => rect.x + (rect.w - text_w) / 2.0, // center for merges by default
-    };
-
     let v_align = format.vertical_align.unwrap_or(CellVerticalAlign::Middle);
-    let text_y = match v_align {
+    let first_baseline_y = match v_align {
         CellVerticalAlign::Top => rect.y + ascender + 2.0,
-        CellVerticalAlign::Bottom => rect.y + rect.h - (line_h - ascender) - 2.0,
-        _ => rect.y + (rect.h - line_h) / 2.0 + ascender, // center
+        CellVerticalAlign::Bottom => rect.y + rect.h - (text_h - ascender) - 2.0,
+        _ => rect.y + (rect.h - text_h) / 2.0 + ascender,
     };
 
     canvas.set_clip(rect.x, rect.y, rect.w, rect.h);
-    text::render_text(
-        canvas,
-        &buzz_face,
-        &ttf_face,
-        text::TextRun {
-            font_size,
-            text: merge_text.text,
-            x: text_x,
-            y: text_y,
-            color: text_color,
-        },
-    );
+    for (index, (line, line_width)) in lines.iter().zip(line_widths).enumerate() {
+        let text_x = match h_align {
+            HorizontalAlign::Left | HorizontalAlign::General => rect.x + CELL_PADDING,
+            HorizontalAlign::Right => rect.x + rect.w - line_width - CELL_PADDING,
+            _ => rect.x + (rect.w - line_width) / 2.0,
+        };
+        text::render_text(
+            canvas,
+            &buzz_face,
+            &ttf_face,
+            text::TextRun {
+                font_size,
+                text: line,
+                x: text_x,
+                y: first_baseline_y + index as f32 * line_h,
+                color: text_color,
+            },
+        );
+    }
     canvas.clear_clip();
 }
 
@@ -343,6 +349,27 @@ mod tests {
             text_center_y.abs_diff(20) <= 5,
             "text center_y={text_center_y}, expected near 20 (merge center)"
         );
+    }
+
+    #[test]
+    fn merge_hard_line_breaks_render_as_separate_physical_lines() {
+        let db = shared_font_db();
+        let mut data = make_merge_data();
+        data.cells[0].formatted = Some("First\nSecond".to_string());
+        let mut canvas = SheetCanvas::new(320, 100, 1.0);
+
+        render_merges(
+            &mut canvas,
+            &data,
+            &data.row_positions,
+            &data.col_positions,
+            0.0,
+            0.0,
+            db,
+        );
+
+        assert!(find_text_horizontal_bounds(&canvas, 3, 20, 0, 192, 200).is_some());
+        assert!(find_text_horizontal_bounds(&canvas, 20, 37, 0, 192, 200).is_some());
     }
 
     #[test]

--- a/compute/core/crates/compute-screenshot/src/text.rs
+++ b/compute/core/crates/compute-screenshot/src/text.rs
@@ -13,6 +13,15 @@ pub struct TextRun<'a> {
     pub color: Color,
 }
 
+/// Split spreadsheet text into physical lines, accepting both LF and CRLF.
+/// Empty segments are retained so consecutive and trailing hard breaks still
+/// consume line height.
+pub fn hard_lines(text: &str) -> Vec<&str> {
+    text.split('\n')
+        .map(|line| line.strip_suffix('\r').unwrap_or(line))
+        .collect()
+}
+
 /// Outline builder adapter: converts ttf-parser glyph outlines to tiny-skia paths.
 struct OutlineAdapter {
     builder: PathBuilder,
@@ -164,6 +173,33 @@ mod tests {
         let (_, entry) = db.resolve("Carlito").unwrap();
         let face = entry.face().unwrap();
         assert_eq!(measure_text_advance(&face, 11.0, ""), 0.0);
+    }
+
+    #[test]
+    fn hard_lines_preserve_physical_line_count() {
+        assert_eq!(hard_lines("A\nB\r\n\n"), vec!["A", "B", "", ""]);
+
+        let synthetic_repro_cases = [
+            (
+                "Workforce/Source Data: service, operating and admin roles.\nNo dedicated sales function.\nQoE commissions lack a service-vs-acquisition split.\nConclusion: retain 0% special S&M\npending role-level confirmation.",
+                5,
+            ),
+            (
+                "62-person roster:\nno dedicated sales or\ntechnology team.",
+                3,
+            ),
+            (
+                "#2 QoE column DU;\n#1 standalone base\nforecast.\nRevenue: QoE share.\nBAG overhead:\nQoE share.\nEBITDA scaled\nannually.",
+                8,
+            ),
+            (
+                "QoE PF-adjusted TTM\ncontext.\nForecast revenue and\nEBITDA reconcile to\nmanagement forecast.\nUS$000s.",
+                6,
+            ),
+        ];
+        for (text, expected_lines) in synthetic_repro_cases {
+            assert_eq!(hard_lines(text).len(), expected_lines);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The headless screenshot renderer passes an entire cell string, including literal LF characters, to the text shaper as one run. The LF is therefore rendered as a control/replacement glyph and the remaining text stays on one horizontal line, producing false clipping findings.

This is reproducible with a synthetic XLSX whose expected physical line counts are `5/3/8/6`; the raw PNG is already incorrect before OCR or model interpretation.

## What changed

- Split LF and CRLF into physical lines before shaping while preserving empty/trailing lines.
- Measure and vertically align the complete multiline text block.
- Horizontally align each physical line independently.
- Clip hard-line-break content to its source cell instead of overflowing into adjacent cells.
- Apply the same behavior to ordinary and merged cells.

## Regression coverage

- Exact synthetic `5/3/8/6` strings retain their physical line counts.
- Pixel-level renderer tests verify distinct vertical text bands for ordinary and merged cells.
- Existing overflow, alignment, border, and renderer coverage remains green.

## Verification

- `cargo fmt --check`
- `cargo test -p compute-screenshot --locked` — 75 passed

The public repository does not include the external app-eval runner; these tests exercise the Rust screenshot implementation that the dev app and app-eval call.