### PR TITLE
Release v0.10.6

### DIFF
--- a/compute/core/crates/compute-screenshot/src/cells.rs
+++ b/compute/core/crates/compute-screenshot/src/cells.rs
@@ -221,44 +221,49 @@ fn render_cell_text(canvas: &mut SheetCanvas, cell_text: CellText<'_>) {
         })
         .unwrap_or(colors::BLACK);
 
-    let text_w = text::measure_text_advance(&buzz_face, font_size, cell_text.text);
+    let lines = text::hard_lines(cell_text.text);
+    let line_widths: Vec<f32> = lines
+        .iter()
+        .map(|line| text::measure_text_advance(&buzz_face, font_size, line))
+        .collect();
+    let text_w = line_widths.iter().copied().fold(0.0, f32::max);
     let ascender = text::ascender_px(&buzz_face, font_size);
     let line_h = text::line_height_px(&buzz_face, font_size);
+    let text_h = line_h * lines.len() as f32;
     let clip_rect = text_clip_rect(&cell_text, text_w);
 
-    // Horizontal alignment
     use domain_types::CellVerticalAlign;
     use ooxml_types::styles::HorizontalAlign;
     let h_align = format.horizontal_align.unwrap_or(HorizontalAlign::General);
-    let text_x = match h_align {
-        HorizontalAlign::Center | HorizontalAlign::CenterContinuous => {
-            rect.x + (rect.w - text_w) / 2.0
-        }
-        HorizontalAlign::Right => rect.x + rect.w - text_w - CELL_PADDING,
-        _ => rect.x + CELL_PADDING, // Left, General, Fill, Justify, Distributed
-    };
-
-    // Vertical alignment
     let v_align = format.vertical_align.unwrap_or(CellVerticalAlign::Bottom);
-    let text_y = match v_align {
+    let first_baseline_y = match v_align {
         CellVerticalAlign::Top => rect.y + ascender + 2.0,
-        CellVerticalAlign::Middle => rect.y + (rect.h - line_h) / 2.0 + ascender,
-        _ => rect.y + rect.h - (line_h - ascender) - 2.0, // Bottom default, Justify, Distributed
+        CellVerticalAlign::Middle => rect.y + (rect.h - text_h) / 2.0 + ascender,
+        _ => rect.y + rect.h - (text_h - ascender) - 2.0,
     };
 
     canvas.set_clip(clip_rect.x, clip_rect.y, clip_rect.w, clip_rect.h);
-    text::render_text(
-        canvas,
-        &buzz_face,
-        &ttf_face,
-        text::TextRun {
-            font_size,
-            text: cell_text.text,
-            x: text_x,
-            y: text_y,
-            color: text_color,
-        },
-    );
+    for (index, (line, line_width)) in lines.iter().zip(line_widths).enumerate() {
+        let text_x = match h_align {
+            HorizontalAlign::Center | HorizontalAlign::CenterContinuous => {
+                rect.x + (rect.w - line_width) / 2.0
+            }
+            HorizontalAlign::Right => rect.x + rect.w - line_width - CELL_PADDING,
+            _ => rect.x + CELL_PADDING,
+        };
+        text::render_text(
+            canvas,
+            &buzz_face,
+            &ttf_face,
+            text::TextRun {
+                font_size,
+                text: line,
+                x: text_x,
+                y: first_baseline_y + index as f32 * line_h,
+                color: text_color,
+            },
+        );
+    }
     canvas.clear_clip();
 }
 
@@ -270,6 +275,7 @@ fn text_clip_rect(cell_text: &CellText<'_>, text_w: f32) -> CssRect {
         || !cell_value_can_overflow(cell_text.cell)
         || cell_text.format.wrap_text.unwrap_or(false)
         || cell_text.format.shrink_to_fit.unwrap_or(false)
+        || cell_text.text.contains(['\n', '\r'])
         || cell_in_merge(cell_text.data, cell_text.cell.row, cell_text.cell.col)
     {
         return rect;
@@ -563,6 +569,37 @@ mod tests {
             find_text_horizontal_bounds(&canvas, 0, 20, 66, 128, 200).is_none(),
             "no text should leak into cell B1"
         );
+    }
+
+    #[test]
+    fn hard_line_breaks_render_as_separate_physical_lines() {
+        let db = shared_font_db();
+        let format = CellFormat {
+            vertical_align: Some(domain_types::CellVerticalAlign::Top),
+            ..Default::default()
+        };
+        let mut data =
+            make_viewport_data(vec![make_cell_with_format(0, 0, "Alpha\nBeta\r\nGamma", 1)]);
+        data.format_palette.push(format);
+        data.row_positions = vec![0.0, 60.0, 80.0, 100.0, 120.0, 140.0];
+        let mut canvas = SheetCanvas::new(320, 140, 1.0);
+
+        render_cells(
+            &mut canvas,
+            &data,
+            &data.row_positions,
+            &data.col_positions,
+            0.0,
+            0.0,
+            db,
+        );
+
+        for (top, bottom) in [(0, 15), (15, 30), (30, 45)] {
+            assert!(
+                find_text_horizontal_bounds(&canvas, top, bottom, 0, 64, 200).is_some(),
+                "expected a rendered line in y={top}..{bottom}"
+            );
+        }
     }
 
     #[test]

--- a/compute/core/crates/compute-screenshot/src/merges.rs
+++ b/compute/core/crates/compute-screenshot/src/merges.rs
@@ -169,39 +169,45 @@ fn render_merge_text(canvas: &mut SheetCanvas, merge_text: MergeText<'_>) {
         })
         .unwrap_or(colors::BLACK);
 
-    let text_w = text::measure_text_advance(&buzz_face, font_size, merge_text.text);
+    let lines = text::hard_lines(merge_text.text);
+    let line_widths: Vec<f32> = lines
+        .iter()
+        .map(|line| text::measure_text_advance(&buzz_face, font_size, line))
+        .collect();
     let ascender = text::ascender_px(&buzz_face, font_size);
     let line_h = text::line_height_px(&buzz_face, font_size);
+    let text_h = line_h * lines.len() as f32;
 
     use domain_types::CellVerticalAlign;
     use ooxml_types::styles::HorizontalAlign;
     let h_align = format.horizontal_align.unwrap_or(HorizontalAlign::Center);
-    let text_x = match h_align {
-        HorizontalAlign::Left | HorizontalAlign::General => rect.x + CELL_PADDING,
-        HorizontalAlign::Right => rect.x + rect.w - text_w - CELL_PADDING,
-        _ => rect.x + (rect.w - text_w) / 2.0, // center for merges by default
-    };
-
     let v_align = format.vertical_align.unwrap_or(CellVerticalAlign::Middle);
-    let text_y = match v_align {
+    let first_baseline_y = match v_align {
         CellVerticalAlign::Top => rect.y + ascender + 2.0,
-        CellVerticalAlign::Bottom => rect.y + rect.h - (line_h - ascender) - 2.0,
-        _ => rect.y + (rect.h - line_h) / 2.0 + ascender, // center
+        CellVerticalAlign::Bottom => rect.y + rect.h - (text_h - ascender) - 2.0,
+        _ => rect.y + (rect.h - text_h) / 2.0 + ascender,
     };
 
     canvas.set_clip(rect.x, rect.y, rect.w, rect.h);
-    text::render_text(
-        canvas,
-        &buzz_face,
-        &ttf_face,
-        text::TextRun {
-            font_size,
-            text: merge_text.text,
-            x: text_x,
-            y: text_y,
-            color: text_color,
-        },
-    );
+    for (index, (line, line_width)) in lines.iter().zip(line_widths).enumerate() {
+        let text_x = match h_align {
+            HorizontalAlign::Left | HorizontalAlign::General => rect.x + CELL_PADDING,
+            HorizontalAlign::Right => rect.x + rect.w - line_width - CELL_PADDING,
+            _ => rect.x + (rect.w - line_width) / 2.0,
+        };
+        text::render_text(
+            canvas,
+            &buzz_face,
+            &ttf_face,
+            text::TextRun {
+                font_size,
+                text: line,
+                x: text_x,
+                y: first_baseline_y + index as f32 * line_h,
+                color: text_color,
+            },
+        );
+    }
     canvas.clear_clip();
 }
 
@@ -343,6 +349,27 @@ mod tests {
             text_center_y.abs_diff(20) <= 5,
             "text center_y={text_center_y}, expected near 20 (merge center)"
         );
+    }
+
+    #[test]
+    fn merge_hard_line_breaks_render_as_separate_physical_lines() {
+        let db = shared_font_db();
+        let mut data = make_merge_data();
+        data.cells[0].formatted = Some("First\nSecond".to_string());
+        let mut canvas = SheetCanvas::new(320, 100, 1.0);
+
+        render_merges(
+            &mut canvas,
+            &data,
+            &data.row_positions,
+            &data.col_positions,
+            0.0,
+            0.0,
+            db,
+        );
+
+        assert!(find_text_horizontal_bounds(&canvas, 3, 20, 0, 192, 200).is_some());
+        assert!(find_text_horizontal_bounds(&canvas, 20, 37, 0, 192, 200).is_some());
     }
 
     #[test]

--- a/compute/core/crates/compute-screenshot/src/text.rs
+++ b/compute/core/crates/compute-screenshot/src/text.rs
@@ -13,6 +13,15 @@ pub struct TextRun<'a> {
     pub color: Color,
 }
 
+/// Split spreadsheet text into physical lines, accepting both LF and CRLF.
+/// Empty segments are retained so consecutive and trailing hard breaks still
+/// consume line height.
+pub fn hard_lines(text: &str) -> Vec<&str> {
+    text.split('\n')
+        .map(|line| line.strip_suffix('\r').unwrap_or(line))
+        .collect()
+}
+
 /// Outline builder adapter: converts ttf-parser glyph outlines to tiny-skia paths.
 struct OutlineAdapter {
     builder: PathBuilder,
@@ -164,6 +173,33 @@ mod tests {
         let (_, entry) = db.resolve("Carlito").unwrap();
         let face = entry.face().unwrap();
         assert_eq!(measure_text_advance(&face, 11.0, ""), 0.0);
+    }
+
+    #[test]
+    fn hard_lines_preserve_physical_line_count() {
+        assert_eq!(hard_lines("A\nB\r\n\n"), vec!["A", "B", "", ""]);
+
+        let synthetic_repro_cases = [
+            (
+                "Workforce/Source Data: service, operating and admin roles.\nNo dedicated sales function.\nQoE commissions lack a service-vs-acquisition split.\nConclusion: retain 0% special S&M\npending role-level confirmation.",
+                5,
+            ),
+            (
+                "62-person roster:\nno dedicated sales or\ntechnology team.",
+                3,
+            ),
+            (
+                "#2 QoE column DU;\n#1 standalone base\nforecast.\nRevenue: QoE share.\nBAG overhead:\nQoE share.\nEBITDA scaled\nannually.",
+                8,
+            ),
+            (
+                "QoE PF-adjusted TTM\ncontext.\nForecast revenue and\nEBITDA reconcile to\nmanagement forecast.\nUS$000s.",
+                6,
+            ),
+        ];
+        for (text, expected_lines) in synthetic_repro_cases {
+            assert_eq!(hard_lines(text).len(), expected_lines);
+        }
     }
 
     #[test]

--- a/file-io/xlsx/parser/src/domain/workbook/write/root.rs
+++ b/file-io/xlsx/parser/src/domain/workbook/write/root.rs
@@ -1,5 +1,4 @@
 use crate::write::xml_writer::XmlWriter;
-use std::collections::HashSet;
 
 use super::attrs::{RELATIONSHIPS_NS, SPREADSHEET_NS};
 use super::writer::WorkbookWriter;
@@ -52,65 +51,36 @@ pub(super) fn write_workbook(writer: &WorkbookWriter) -> Vec<u8> {
 }
 
 fn write_workbook_children(w: &mut XmlWriter, writer: &WorkbookWriter) {
-    let mut emitted = HashSet::new();
-
-    if let Some(fidelity) = writer.workbook_xml_fidelity.as_ref() {
-        for slot in &fidelity.slots {
-            if !matches!(
-                slot.fallback_action,
-                WorkbookXmlFallbackAction::Regenerate | WorkbookXmlFallbackAction::Preserve
-            ) {
-                continue;
-            }
-            if emitted.contains(&slot.kind) && is_singleton_child(slot.kind) {
-                continue;
-            }
-
-            let did_emit = match slot.kind {
-                WorkbookXmlChildKind::FunctionGroups
-                | WorkbookXmlChildKind::OleSize
-                | WorkbookXmlChildKind::SmartTagPr
-                | WorkbookXmlChildKind::SmartTagTypes
-                | WorkbookXmlChildKind::FileRecoveryPr
-                | WorkbookXmlChildKind::WebPublishObjects => slot
-                    .payload_id
-                    .as_deref()
-                    .and_then(|payload_id| raw_child_xml(fidelity, payload_id))
-                    .map(|xml| {
-                        let xml = String::from_utf8_lossy(xml);
-                        w.raw_str(&xml);
-                    })
-                    .is_some(),
-                WorkbookXmlChildKind::ExtLst => {
-                    if writer.ext_lst_entries.is_empty() {
-                        slot.payload_id
-                            .as_deref()
-                            .and_then(|payload_id| raw_child_xml(fidelity, payload_id))
-                            .map(|xml| {
-                                let xml = String::from_utf8_lossy(xml);
-                                w.raw_str(&xml);
-                            })
-                            .is_some()
-                    } else {
-                        write_generated_ext_lst(w, writer);
-                        true
-                    }
-                }
-                kind => write_modeled_child(w, writer, kind),
-            };
-
-            if did_emit && is_singleton_child(slot.kind) {
-                emitted.insert(slot.kind);
-            }
-        }
-    }
-
     for kind in CANONICAL_CHILD_ORDER {
-        if emitted.contains(kind) && is_singleton_child(*kind) {
-            continue;
-        }
-        if write_modeled_child(w, writer, *kind) && is_singleton_child(*kind) {
-            emitted.insert(*kind);
+        let emitted_from_fidelity = writer
+            .workbook_xml_fidelity
+            .as_ref()
+            .and_then(|fidelity| {
+                fidelity
+                    .slots
+                    .iter()
+                    .find(|slot| {
+                        slot.kind == *kind
+                            && matches!(
+                                slot.fallback_action,
+                                WorkbookXmlFallbackAction::Regenerate
+                                    | WorkbookXmlFallbackAction::Preserve
+                            )
+                    })
+                    .map(|slot| {
+                        write_fidelity_child(
+                            w,
+                            writer,
+                            fidelity,
+                            slot.kind,
+                            slot.payload_id.as_deref(),
+                        )
+                    })
+            })
+            .unwrap_or(false);
+
+        if !emitted_from_fidelity {
+            write_modeled_child(w, writer, *kind);
         }
     }
 }
@@ -119,17 +89,48 @@ const CANONICAL_CHILD_ORDER: &[WorkbookXmlChildKind] = &[
     WorkbookXmlChildKind::FileVersion,
     WorkbookXmlChildKind::FileSharing,
     WorkbookXmlChildKind::WorkbookPr,
-    WorkbookXmlChildKind::BookViews,
-    WorkbookXmlChildKind::CustomWorkbookViews,
-    WorkbookXmlChildKind::Sheets,
     WorkbookXmlChildKind::WorkbookProtection,
+    WorkbookXmlChildKind::BookViews,
+    WorkbookXmlChildKind::Sheets,
+    WorkbookXmlChildKind::FunctionGroups,
     WorkbookXmlChildKind::ExternalReferences,
     WorkbookXmlChildKind::DefinedNames,
     WorkbookXmlChildKind::CalcPr,
+    WorkbookXmlChildKind::OleSize,
+    WorkbookXmlChildKind::CustomWorkbookViews,
     WorkbookXmlChildKind::PivotCaches,
+    WorkbookXmlChildKind::SmartTagPr,
+    WorkbookXmlChildKind::SmartTagTypes,
     WorkbookXmlChildKind::WebPublishing,
+    WorkbookXmlChildKind::FileRecoveryPr,
+    WorkbookXmlChildKind::WebPublishObjects,
     WorkbookXmlChildKind::ExtLst,
 ];
+
+fn write_fidelity_child(
+    w: &mut XmlWriter,
+    writer: &WorkbookWriter,
+    fidelity: &domain_types::WorkbookXmlFidelity,
+    kind: WorkbookXmlChildKind,
+    payload_id: Option<&str>,
+) -> bool {
+    match kind {
+        WorkbookXmlChildKind::FunctionGroups
+        | WorkbookXmlChildKind::OleSize
+        | WorkbookXmlChildKind::SmartTagPr
+        | WorkbookXmlChildKind::SmartTagTypes
+        | WorkbookXmlChildKind::FileRecoveryPr
+        | WorkbookXmlChildKind::WebPublishObjects => payload_id
+            .and_then(|payload_id| raw_child_xml(fidelity, payload_id))
+            .map(|xml| w.raw_str(&String::from_utf8_lossy(xml)))
+            .is_some(),
+        WorkbookXmlChildKind::ExtLst if writer.ext_lst_entries.is_empty() => payload_id
+            .and_then(|payload_id| raw_child_xml(fidelity, payload_id))
+            .map(|xml| w.raw_str(&String::from_utf8_lossy(xml)))
+            .is_some(),
+        kind => write_modeled_child(w, writer, kind),
+    }
+}
 
 fn write_modeled_child(
     w: &mut XmlWriter,
@@ -153,9 +154,8 @@ fn write_modeled_child(
             present
         }
         WorkbookXmlChildKind::BookViews => {
-            let present = !writer.workbook_views.is_empty();
             super::views::write_book_views(w, &writer.workbook_views);
-            present
+            true
         }
         WorkbookXmlChildKind::CustomWorkbookViews => {
             if let Some(xml) = writer.custom_workbook_views_xml.as_ref() {
@@ -236,10 +236,6 @@ fn raw_child_xml<'a>(
         .iter()
         .find(|raw| raw.payload_id == payload_id)
         .map(|raw| raw.xml.as_slice())
-}
-
-fn is_singleton_child(kind: WorkbookXmlChildKind) -> bool {
-    !matches!(kind, WorkbookXmlChildKind::Unknown)
 }
 
 fn workbook_conformance_to_emit(writer: &WorkbookWriter) -> Option<&str> {

--- a/file-io/xlsx/parser/src/domain/workbook/write/tests.rs
+++ b/file-io/xlsx/parser/src/domain/workbook/write/tests.rs
@@ -264,6 +264,102 @@ fn test_complete_workbook_xml() {
 }
 
 #[test]
+fn fidelity_merge_emits_generated_and_preserved_children_in_schema_order() {
+    use domain_types::{
+        WorkbookXmlChildKind, WorkbookXmlChildSlot, WorkbookXmlFallbackAction, WorkbookXmlFidelity,
+        WorkbookXmlOwnerPolicy, WorkbookXmlProvenanceStatus, WorkbookXmlRawChild,
+    };
+
+    let regenerated = |kind| WorkbookXmlChildSlot {
+        kind,
+        owner_policy: WorkbookXmlOwnerPolicy::TypedRegenerated,
+        provenance_status: WorkbookXmlProvenanceStatus::Current,
+        fallback_action: WorkbookXmlFallbackAction::Regenerate,
+        payload_id: None,
+        reason: None,
+    };
+    let function_groups_payload = "function-groups".to_string();
+    let function_groups = WorkbookXmlChildSlot {
+        kind: WorkbookXmlChildKind::FunctionGroups,
+        owner_policy: WorkbookXmlOwnerPolicy::InertDirectChildPayload,
+        provenance_status: WorkbookXmlProvenanceStatus::SafeInert,
+        fallback_action: WorkbookXmlFallbackAction::Preserve,
+        payload_id: Some(function_groups_payload.clone()),
+        reason: None,
+    };
+    let mut writer = WorkbookWriter::new();
+    writer.set_file_version(domain_types::domain::workbook::FileVersion {
+        app_name: Some("Mog".to_string()),
+        ..Default::default()
+    });
+    writer.set_workbook_xml_fidelity(WorkbookXmlFidelity {
+        // Deliberately omit bookViews, put functionGroups before sheets, and
+        // place fileVersion last to model malformed imported ordering.
+        slots: vec![
+            function_groups,
+            regenerated(WorkbookXmlChildKind::Sheets),
+            regenerated(WorkbookXmlChildKind::CalcPr),
+            WorkbookXmlChildSlot {
+                kind: WorkbookXmlChildKind::FileVersion,
+                owner_policy: WorkbookXmlOwnerPolicy::TypedWithValidatedProvenance,
+                provenance_status: WorkbookXmlProvenanceStatus::Current,
+                fallback_action: WorkbookXmlFallbackAction::Regenerate,
+                payload_id: None,
+                reason: None,
+            },
+        ],
+        raw_children: vec![WorkbookXmlRawChild {
+            payload_id: function_groups_payload,
+            kind: WorkbookXmlChildKind::FunctionGroups,
+            q_name: "functionGroups".to_string(),
+            local_name: "functionGroups".to_string(),
+            xml: br#"<functionGroups builtInGroupCount="16"/>"#.to_vec(),
+            relationship_ids: Vec::new(),
+        }],
+        diagnostics: Vec::new(),
+    });
+
+    let xml = String::from_utf8(writer.to_xml()).unwrap();
+    let file_version_pos = xml.find("<fileVersion").unwrap();
+    let book_views_pos = xml.find("<bookViews>").unwrap();
+    let sheets_pos = xml.find("<sheets>").unwrap();
+    let function_groups_pos = xml.find("<functionGroups").unwrap();
+    let calc_pos = xml.find("<calcPr").unwrap();
+
+    assert!(file_version_pos < book_views_pos);
+    assert!(book_views_pos < sheets_pos);
+    assert!(sheets_pos < function_groups_pos);
+    assert!(function_groups_pos < calc_pos);
+    assert_eq!(xml.matches("<bookViews>").count(), 1);
+}
+
+#[test]
+fn fidelity_book_views_slot_emits_one_default_view() {
+    use domain_types::{
+        WorkbookXmlChildKind, WorkbookXmlChildSlot, WorkbookXmlFallbackAction, WorkbookXmlFidelity,
+        WorkbookXmlOwnerPolicy, WorkbookXmlProvenanceStatus,
+    };
+
+    let mut writer = WorkbookWriter::new();
+    writer.set_workbook_xml_fidelity(WorkbookXmlFidelity {
+        slots: vec![WorkbookXmlChildSlot {
+            kind: WorkbookXmlChildKind::BookViews,
+            owner_policy: WorkbookXmlOwnerPolicy::TypedRegenerated,
+            provenance_status: WorkbookXmlProvenanceStatus::Current,
+            fallback_action: WorkbookXmlFallbackAction::Regenerate,
+            payload_id: None,
+            reason: None,
+        }],
+        ..Default::default()
+    });
+
+    let xml = String::from_utf8(writer.to_xml()).unwrap();
+
+    assert_eq!(xml.matches("<bookViews>").count(), 1);
+    assert_eq!(xml.matches("<workbookView").count(), 1);
+}
+
+#[test]
 fn test_no_defined_names() {
     let mut writer = WorkbookWriter::new();
     writer.add_sheet("Sheet1", "rId1");

--- a/file-io/xlsx/parser/src/write/from_parse_output/workbook_parts.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/workbook_parts.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use domain_types::{ParseOutput, WorkbookSheetKind};
 
 use super::WriteError;
@@ -200,7 +202,8 @@ fn add_generated_sheet_defs(
     package_graph: &ResolvedPackageGraph,
     workbook_writer: &mut WorkbookWriter,
 ) -> Result<(), WriteError> {
-    for (idx, sheet_data) in output.sheets.iter().enumerate() {
+    let sheet_ids = allocate_generated_sheet_ids(output)?;
+    for (idx, (sheet_data, sheet_id)) in output.sheets.iter().zip(sheet_ids).enumerate() {
         let sheet_target = format!("worksheets/sheet{}.xml", idx + 1);
         let r_id = package_graph
             .relationship_id(&PackageOwner::Workbook, REL_WORKSHEET, &sheet_target)
@@ -211,7 +214,6 @@ fn add_generated_sheet_defs(
                 ))
             })?
             .to_string();
-        let sheet_id = sheet_data.sheet_id.unwrap_or(idx as u32 + 1);
         workbook_writer.add_sheet_def(SheetDef::with_state(
             &sheet_data.name,
             sheet_id,
@@ -220,6 +222,49 @@ fn add_generated_sheet_defs(
         ));
     }
     Ok(())
+}
+
+fn allocate_generated_sheet_ids(output: &ParseOutput) -> Result<Vec<u32>, WriteError> {
+    let mut used = BTreeSet::new();
+    for sheet in &output.sheets {
+        let Some(sheet_id) = sheet.sheet_id else {
+            continue;
+        };
+        if sheet_id == 0 {
+            return Err(WriteError::PackageIntegrity(format!(
+                "worksheet {:?} has invalid sheetId 0",
+                sheet.name
+            )));
+        }
+        if !used.insert(sheet_id) {
+            return Err(WriteError::PackageIntegrity(format!(
+                "duplicate worksheet sheetId {sheet_id}"
+            )));
+        }
+    }
+
+    let mut allocated = Vec::with_capacity(output.sheets.len());
+    for sheet in &output.sheets {
+        if let Some(sheet_id) = sheet.sheet_id {
+            allocated.push(sheet_id);
+            continue;
+        }
+
+        let sheet_id = used
+            .last()
+            .copied()
+            .unwrap_or(0)
+            .checked_add(1)
+            .ok_or_else(|| {
+                WriteError::PackageIntegrity(
+                    "cannot allocate a positive worksheet sheetId".to_string(),
+                )
+            })?;
+        used.insert(sheet_id);
+        allocated.push(sheet_id);
+    }
+
+    Ok(allocated)
 }
 
 fn add_inventory_sheet_defs(
@@ -280,4 +325,42 @@ fn workbook_relative_target(path: &str) -> String {
         .unwrap_or(path)
         .trim_start_matches('/')
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use domain_types::SheetData;
+
+    use super::*;
+
+    fn output_with_sheet_ids(sheet_ids: &[Option<u32>]) -> ParseOutput {
+        ParseOutput {
+            sheets: sheet_ids
+                .iter()
+                .enumerate()
+                .map(|(index, sheet_id)| SheetData {
+                    name: format!("Sheet {}", index + 1),
+                    sheet_id: *sheet_id,
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn generated_sheet_ids_reject_zero() {
+        let error = allocate_generated_sheet_ids(&output_with_sheet_ids(&[Some(0)]))
+            .expect_err("sheetId 0 must fail export");
+
+        assert!(error.to_string().contains("invalid sheetId 0"));
+    }
+
+    #[test]
+    fn generated_sheet_ids_reject_preserved_duplicates() {
+        let error = allocate_generated_sheet_ids(&output_with_sheet_ids(&[Some(4), Some(4)]))
+            .expect_err("duplicate preserved sheet IDs must fail export");
+
+        assert!(error.to_string().contains("duplicate worksheet sheetId 4"));
+    }
 }

--- a/file-io/xlsx/parser/tests/roundtrip_parse_output/workbook.rs
+++ b/file-io/xlsx/parser/tests/roundtrip_parse_output/workbook.rs
@@ -514,6 +514,58 @@ fn roundtrip_many_sheets() {
 }
 
 #[test]
+fn generated_sheet_ids_are_unique_for_sparse_imports_at_every_insertion_position() {
+    for insertion_index in [0, 2, 3] {
+        let mut sheets = vec![
+            SheetData {
+                name: "Imported 4".to_string(),
+                sheet_id: Some(4),
+                ..Default::default()
+            },
+            SheetData {
+                name: "Imported 3".to_string(),
+                sheet_id: Some(3),
+                ..Default::default()
+            },
+            SheetData {
+                name: "Imported 1".to_string(),
+                sheet_id: Some(1),
+                ..Default::default()
+            },
+        ];
+        sheets.insert(
+            insertion_index,
+            SheetData {
+                name: "Inserted".to_string(),
+                sheet_id: None,
+                ..Default::default()
+            },
+        );
+
+        let round_tripped = roundtrip(&ParseOutput {
+            sheets,
+            ..Default::default()
+        });
+        let sheet_ids: Vec<u32> = round_tripped
+            .sheets
+            .iter()
+            .map(|sheet| sheet.sheet_id.expect("exported worksheet has a sheetId"))
+            .collect();
+
+        assert_eq!(sheet_ids[insertion_index], 5);
+        assert_eq!(
+            sheet_ids
+                .iter()
+                .copied()
+                .collect::<std::collections::BTreeSet<_>>()
+                .len(),
+            sheet_ids.len(),
+            "sheet IDs must stay unique when inserting at position {insertion_index}"
+        );
+    }
+}
+
+#[test]
 fn roundtrip_sheet_name_special_chars() {
     let output = make_single_sheet(
         "My Sheet (1)",


### PR DESCRIPTION
## Summary

Promote the v0.10.6 development branch to main.

## Included fixes

- Allocate unique OOXML worksheet IDs when inserting sheets into imported workbooks with sparse or non-sequential IDs.
- Emit workbook XML children in schema order.
- Render explicit hard line breaks as separate physical lines in screenshots.

## Verification

- Focused regression tests pass on the combined dev-v0.10.6 head.
- Touched-crate clippy checks pass.
- pnpm check:publish-readiness:fast passes.
- Durable production-path app-eval coverage is merged in fundamental-research-labs/mog-internal#251.

This PR promotes source changes only. Package publication occurs separately from release/v0.10.6.