### PR TITLE
Prepare SDK release v0.10.6

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/cli",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Command-line interface for operating Mog workbooks with the headless SDK",
   "type": "module",
   "bin": {

--- a/compute/chart-render-wasm/npm/package.json
+++ b/compute/chart-render-wasm/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/chart-raster-wasm",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Mog chart raster backend for browsers, edge runtimes, and headless WASM hosts",
   "type": "module",
   "main": "compute_chart_render_wasm.js",

--- a/compute/napi/npm/darwin-arm64/package.json
+++ b/compute/napi/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/darwin-arm64",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "os": [
     "darwin"
   ],

--- a/compute/napi/npm/darwin-x64/package.json
+++ b/compute/napi/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/darwin-x64",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "os": [
     "darwin"
   ],

--- a/compute/napi/npm/linux-arm64-gnu/package.json
+++ b/compute/napi/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/linux-arm64-gnu",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "os": [
     "linux"
   ],

--- a/compute/napi/npm/linux-arm64-musl/package.json
+++ b/compute/napi/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/linux-arm64-musl",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "os": [
     "linux"
   ],

--- a/compute/napi/npm/linux-x64-gnu/package.json
+++ b/compute/napi/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/linux-x64-gnu",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "os": [
     "linux"
   ],

--- a/compute/napi/npm/linux-x64-musl/package.json
+++ b/compute/napi/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/linux-x64-musl",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "os": [
     "linux"
   ],

--- a/compute/napi/npm/win32-x64-msvc/package.json
+++ b/compute/napi/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/win32-x64-msvc",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "os": [
     "win32"
   ],

--- a/compute/wasm/npm/package.json
+++ b/compute/wasm/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/wasm",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Mog compute engine for browsers — WASM build of compute-core with full formula, formatting, and XLSX support",
   "type": "module",
   "main": "compute_core_wasm.js",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/contracts",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "license": "Apache-2.0",
   "repository": "https://github.com/fundamental-research-labs/mog",
   "private": false,

--- a/integrations/codex/package.json
+++ b/integrations/codex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mog/codex-plugin-build",
   "private": true,
-  "version": "0.10.5",
+  "version": "0.10.6",
   "type": "module",
   "scripts": {
     "build": "node scripts/build-plugin-dist.mjs",

--- a/integrations/codex/src/mcp/server.ts
+++ b/integrations/codex/src/mcp/server.ts
@@ -50,7 +50,7 @@ const browserRoot = resolve(runtimeRoot, 'browser');
 declare const MOG_PLUGIN_VERSION: string | undefined;
 declare const MOG_WASM_PACKAGE_BASE_URL: string | undefined;
 
-const pluginVersion = typeof MOG_PLUGIN_VERSION === 'string' ? MOG_PLUGIN_VERSION : '0.10.5';
+const pluginVersion = typeof MOG_PLUGIN_VERSION === 'string' ? MOG_PLUGIN_VERSION : '0.10.6';
 const wasmPackageBaseUrl =
   typeof MOG_WASM_PACKAGE_BASE_URL === 'string'
     ? MOG_WASM_PACKAGE_BASE_URL

--- a/integrations/vscode/mog-xlsx-editor/package.json
+++ b/integrations/vscode/mog-xlsx-editor/package.json
@@ -2,7 +2,7 @@
   "name": "mog-xlsx-editor",
   "displayName": "Mog Spreadsheet",
   "description": "Open, inspect, edit, and save XLSX workbooks in VS Code with Mog's spreadsheet runtime.",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "publisher": "FundamentalResearchLabs",
   "icon": "resources/icon.png",
   "license": "Apache-2.0",

--- a/plugins/mog/.codex-plugin/plugin.json
+++ b/plugins/mog/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mog",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Open, inspect, edit, and export Mog spreadsheets from Codex.",
   "author": {
     "name": "Mog",

--- a/plugins/mog/dist/browser/assets/import-map.json
+++ b/plugins/mog/dist/browser/assets/import-map.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "@mog-sdk/wasm": "https://cdn.jsdelivr.net/npm/@mog-sdk/wasm@0.10.5/compute_core_wasm.js"
+    "@mog-sdk/wasm": "https://cdn.jsdelivr.net/npm/@mog-sdk/wasm@0.10.6/compute_core_wasm.js"
   }
 }

--- a/plugins/mog/dist/browser/index.html
+++ b/plugins/mog/dist/browser/index.html
@@ -12,7 +12,7 @@
   <div id="root" data-mog-codex-state="loading"></div>
   <script type="importmap">{
   "imports": {
-    "@mog-sdk/wasm": "https://cdn.jsdelivr.net/npm/@mog-sdk/wasm@0.10.5/compute_core_wasm.js"
+    "@mog-sdk/wasm": "https://cdn.jsdelivr.net/npm/@mog-sdk/wasm@0.10.6/compute_core_wasm.js"
   }
 }</script>
   <script type="module" src="/assets/browser.js"></script>

--- a/plugins/mog/dist/mcp/server.mjs
+++ b/plugins/mog/dist/mcp/server.mjs
@@ -48,8 +48,8 @@ var hostServer = null;
 var hostPort = null;
 var runtimeRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 var browserRoot = resolve(runtimeRoot, "browser");
-var pluginVersion = true ? "0.10.5" : "0.10.5";
-var wasmPackageBaseUrl = true ? "https://cdn.jsdelivr.net/npm/@mog-sdk/wasm@0.10.5/" : `https://cdn.jsdelivr.net/npm/@mog-sdk/wasm@${pluginVersion}/`;
+var pluginVersion = true ? "0.10.6" : "0.10.6";
+var wasmPackageBaseUrl = true ? "https://cdn.jsdelivr.net/npm/@mog-sdk/wasm@0.10.6/" : `https://cdn.jsdelivr.net/npm/@mog-sdk/wasm@${pluginVersion}/`;
 function randomToken() {
   return randomBytes(32).toString("base64url");
 }

--- a/runtime/embed/package.json
+++ b/runtime/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/embed",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "license": "Apache-2.0",
   "repository": "https://github.com/fundamental-research-labs/mog",
   "description": "Embeddable read-only Mog spreadsheet component",

--- a/runtime/sdk/package.json
+++ b/runtime/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/sdk",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Headless spreadsheet engine with native Node and WASM runtime bindings",
   "type": "module",
   "main": "dist/index.cjs",

--- a/runtime/spreadsheet-app/package.json
+++ b/runtime/spreadsheet-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/spreadsheet-app",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "license": "Apache-2.0",
   "description": "Policy-driven full Mog spreadsheet app embed for trusted same-origin hosts",
   "type": "module",

--- a/views/sheet-view/package.json
+++ b/views/sheet-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mog-sdk/sheet-view",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "license": "Apache-2.0",
   "files": [
     "dist"


### PR DESCRIPTION
## Summary\n\n- bump the public SDK/package release metadata to 0.10.6\n- regenerate the SDK API specification and Codex plugin artifacts\n- prepare the immutable release candidate from main\n\n## Verification\n\n- focused regressions: sheet IDs 1/1, workbook ordering 31/31, hard-line rendering 3/3, explicit no-fill 1/1\n- public boundary checks passed\n- public artifact build passed\n- SDK publish verification: 45/45 passed\n- external consumer fixtures: 28 passed, 0 failed, 2 documented deferred kernel skips\n- GitHub publish dry-run: https://github.com/fundamental-research-labs/mog/actions/runs/32205425777 — passed\n- all release-platform builds passed; npm/PyPI/extension/tag/release production jobs were skipped\n\nCloud fleet production gate is planned against this exact commit; dispatch currently requires the missing operator IAM bindings.