### PR TITLE
fix(xlsx): normalize malformed chart color styles

### DIFF
--- a/compute/core/src/storage/engine/tests/test_xlsx_export_charts.rs
+++ b/compute/core/src/storage/engine/tests/test_xlsx_export_charts.rs
@@ -19,13 +19,12 @@ fn sdk_authored_chart_palette_exports_chart_color_style_part() {
     let cases = [
         (
             serde_json::json!({ "colors": ["#4472C4"] }),
-            r#"id="0""#,
+            None,
             Some(r#"<a:srgbClr val="4472C4"/>"#),
         ),
-        (serde_json::json!({ "colorScheme": 1 }), r#"id="1""#, None),
         (
             serde_json::json!({ "colors": ["#4472C4"], "colorScheme": 1 }),
-            r#"id="1""#,
+            Some(r#"id="1""#),
             Some(r#"<a:srgbClr val="4472C4"/>"#),
         ),
     ];
@@ -41,7 +40,7 @@ fn sdk_authored_chart_palette_exports_chart_color_style_part() {
 
 fn assert_sdk_authored_chart_color_style_export(
     appearance_config: serde_json::Value,
-    expected_scheme: &str,
+    expected_scheme: Option<&str>,
     expected_color: Option<&str>,
 ) {
     let (mut engine, _) = YrsComputeEngine::from_snapshot(simple_snapshot()).unwrap();
@@ -84,10 +83,42 @@ fn assert_sdk_authored_chart_color_style_export(
             .contains("http://schemas.microsoft.com/office/2011/relationships/chartColorStyle")
     );
     assert!(chart_rels.contains(r#"Target="colors1.xml""#));
-    assert!(color_style.contains(expected_scheme));
+    if let Some(expected_scheme) = expected_scheme {
+        assert!(color_style.contains(expected_scheme));
+    } else {
+        assert!(!color_style.contains(r#" id="#));
+    }
     if let Some(expected_color) = expected_color {
         assert!(color_style.contains(expected_color));
     }
+}
+
+#[test]
+fn sdk_authored_chart_color_scheme_without_palette_omits_invalid_sidecar() {
+    let (mut engine, _) = YrsComputeEngine::from_snapshot(simple_snapshot()).unwrap();
+    let sheet_id = sheet_id();
+    engine
+        .create_chart(
+            &sheet_id,
+            &serde_json::json!({
+                "type": "area",
+                "name": "Scheme-only Contract",
+                "dataRange": "A1:B2",
+                "anchorRow": 7,
+                "anchorCol": 1,
+                "width": 480.0,
+                "height": 320.0,
+                "colorScheme": 1
+            }),
+        )
+        .expect("chart creation should succeed");
+
+    let exported_bytes = engine.export_to_xlsx_bytes().expect("export xlsx bytes");
+    assert!(archive_text(&exported_bytes, "xl/charts/colors1.xml").is_none());
+    let chart_rels = archive_text(&exported_bytes, "xl/charts/_rels/chart1.xml.rels");
+    assert!(chart_rels.as_deref().is_none_or(|rels| {
+        !rels.contains("http://schemas.microsoft.com/office/2011/relationships/chartColorStyle")
+    }));
 }
 
 #[test]
@@ -163,6 +194,49 @@ fn imported_standard_chart_metadata_survives_yrs_with_current_package_replay() {
     assert!(archive.contains("xl/charts/_rels/chart2.xml.rels"));
     assert!(archive.contains("xl/charts/style2.xml"));
     assert!(archive.contains("xl/charts/colors2.xml"));
+}
+
+#[test]
+fn historical_nested_chart_palette_is_regenerated_during_current_replay() {
+    let mut chart = imported_current_standard_chart2();
+    chart.colors = Some(vec!["AAD7E2".to_string()]);
+    chart.color_scheme = None;
+    chart.chart_auxiliary_files[1].1 = br#"<cs:colorStyle xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" meth="cycle" id="0"><cs:variation><a:srgbClr val="AAD7E2"/></cs:variation></cs:colorStyle>"#.to_vec();
+    let fingerprint = standard_chart_projection_fingerprint(&chart);
+    chart
+        .standard_chart_provenance
+        .as_mut()
+        .expect("import provenance")
+        .projection_fingerprint = Some(fingerprint.clone());
+    chart
+        .standard_chart_export_authority
+        .as_mut()
+        .expect("export authority")
+        .projection_fingerprint = Some(fingerprint);
+
+    let input = ParseOutput {
+        sheets: vec![SheetData {
+            name: "Data".to_string(),
+            rows: 20,
+            cols: 8,
+            charts: vec![chart],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let engine = engine_from_parse_output_normal(&input);
+    let exported_bytes = engine.export_to_xlsx_bytes().expect("export xlsx bytes");
+    let color_style = archive_text(&exported_bytes, "xl/charts/colors2.xml")
+        .expect("repaired chart color style should exist");
+    let chart_rels = archive_text(&exported_bytes, "xl/charts/_rels/chart2.xml.rels")
+        .expect("chart relationships should exist");
+
+    assert!(color_style.contains(r#"<a:srgbClr val="AAD7E2"/><cs:variation/>"#));
+    assert!(!color_style.contains(r#"id="0""#));
+    assert!(!color_style.contains(r#"<cs:variation><a:srgbClr"#));
+    assert!(chart_rels.contains(r#"Id="rId2""#));
+    assert!(chart_rels.contains(r#"Target="colors2.xml""#));
+    assert!(archive_text(&exported_bytes, "xl/charts/style2.xml").is_some());
 }
 
 #[test]
@@ -419,7 +493,7 @@ fn imported_current_standard_chart2() -> ChartSpec {
         ),
         (
             "xl/charts/colors2.xml".to_string(),
-            br#"<cs:colorStyle xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle"/>"#
+            br#"<cs:colorStyle xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" meth="cycle"><a:schemeClr val="accent1"/><cs:variation/></cs:colorStyle>"#
                 .to_vec(),
         ),
     ];

--- a/file-io/xlsx/parser/src/domain/charts/color_style.rs
+++ b/file-io/xlsx/parser/src/domain/charts/color_style.rs
@@ -1,5 +1,20 @@
 use crate::infra::scanner::{extract_quoted_value, find_attr_simd, find_tag_simd};
 use crate::write::xml_writer::XmlWriter;
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::name::{Namespace, ResolveResult};
+use quick_xml::reader::NsReader;
+
+const CHART_STYLE_NS: &[u8] = b"http://schemas.microsoft.com/office/drawing/2012/chartStyle";
+const DRAWINGML_NS: &[u8] = b"http://schemas.openxmlformats.org/drawingml/2006/main";
+
+#[derive(Default)]
+struct ColorStyleStructure {
+    valid_root: bool,
+    has_method: bool,
+    has_direct_base_color: bool,
+    direct_child_phase: u8,
+    direct_child_order_valid: bool,
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ChartColorStyleProjection {
@@ -16,7 +31,9 @@ pub(crate) fn build_chart_color_style_xml(
         .iter()
         .filter_map(|color| normalize_hex_color(color))
         .collect();
-    if normalized_colors.is_empty() && color_scheme.is_none() {
+    // CT_ColorStyle requires one or more direct EG_ColorChoice children. An
+    // identifier by itself cannot form a conformant chart color style part.
+    if normalized_colors.is_empty() {
         return None;
     }
 
@@ -31,17 +48,20 @@ pub(crate) fn build_chart_color_style_xml(
             "xmlns:a",
             "http://schemas.openxmlformats.org/drawingml/2006/main",
         )
-        .attr("meth", "cycle")
-        .attr_num("id", color_scheme.unwrap_or(0))
-        .end_attrs();
+        .attr("meth", "cycle");
+    if let Some(color_scheme) = color_scheme {
+        w.attr_num("id", color_scheme);
+    }
+    w.end_attrs();
 
     for color in normalized_colors {
-        w.start_element("cs:variation").end_attrs();
         w.start_element("a:srgbClr")
             .attr("val", &color)
             .self_close();
-        w.end_element("cs:variation");
     }
+    // An empty variation applies the base colors without transforms and is the
+    // interoperable Office representation of a direct palette.
+    w.start_element("cs:variation").self_close();
 
     w.end_element("cs:colorStyle");
     Some(w.finish())
@@ -67,6 +87,108 @@ pub(crate) fn parse_chart_color_style_xml(xml: &[u8]) -> ChartColorStyleProjecti
     }
 }
 
+/// Return whether an imported chart color style satisfies the package-level
+/// shape required for safe opaque replay. Historical Mog builds emitted palette
+/// colors inside `cs:variation`; those parts are well-formed XML but violate
+/// CT_ColorStyle and cause Excel for Mac to remove the owning drawing.
+pub(crate) fn chart_color_style_xml_is_replay_safe(xml: &[u8]) -> bool {
+    let mut reader = NsReader::from_reader(xml);
+    reader.config_mut().trim_text(true);
+    reader.config_mut().expand_empty_elements = false;
+    let mut buf = Vec::new();
+    let mut depth = 0usize;
+    let mut structure = ColorStyleStructure {
+        direct_child_order_valid: true,
+        ..Default::default()
+    };
+
+    loop {
+        let (namespace, event) = match reader.read_resolved_event_into(&mut buf) {
+            Ok(value) => value,
+            Err(_) => return false,
+        };
+        match event {
+            Event::Start(start) => {
+                inspect_color_style_element(&namespace, &start, depth, &mut structure);
+                depth = depth.saturating_add(1);
+            }
+            Event::Empty(start) => {
+                inspect_color_style_element(&namespace, &start, depth, &mut structure)
+            }
+            Event::End(_) => depth = depth.saturating_sub(1),
+            Event::Eof => break,
+            Event::Text(_)
+            | Event::CData(_)
+            | Event::Comment(_)
+            | Event::Decl(_)
+            | Event::PI(_)
+            | Event::DocType(_) => {}
+        }
+        buf.clear();
+    }
+
+    structure.valid_root
+        && structure.has_method
+        && structure.has_direct_base_color
+        && structure.direct_child_order_valid
+}
+
+fn inspect_color_style_element(
+    namespace: &ResolveResult<'_>,
+    start: &BytesStart<'_>,
+    depth: usize,
+    structure: &mut ColorStyleStructure,
+) {
+    if depth == 0 {
+        structure.valid_root =
+            start.local_name().as_ref() == b"colorStyle" && namespace_is(namespace, CHART_STYLE_NS);
+        structure.has_method = attr_value(start, b"meth").is_some_and(|method| {
+            matches!(
+                method.as_str(),
+                "cycle"
+                    | "withinLinear"
+                    | "withinLinearReversed"
+                    | "acrossLinear"
+                    | "acrossLinearReversed"
+            )
+        });
+    } else if depth == 1 {
+        let local_name = start.local_name();
+        let local_name = local_name.as_ref();
+        if namespace_is(namespace, DRAWINGML_NS)
+            && matches!(
+                local_name,
+                b"scrgbClr" | b"srgbClr" | b"hslClr" | b"sysClr" | b"schemeClr" | b"prstClr"
+            )
+        {
+            structure.has_direct_base_color = true;
+            structure.direct_child_order_valid &= structure.direct_child_phase == 0;
+        } else if namespace_is(namespace, CHART_STYLE_NS) && local_name == b"variation" {
+            structure.direct_child_order_valid &=
+                structure.has_direct_base_color && structure.direct_child_phase <= 1;
+            structure.direct_child_phase = 1;
+        } else if namespace_is(namespace, CHART_STYLE_NS) && local_name == b"extLst" {
+            structure.direct_child_order_valid &=
+                structure.has_direct_base_color && structure.direct_child_phase <= 1;
+            structure.direct_child_phase = 2;
+        } else {
+            structure.direct_child_order_valid = false;
+        }
+    }
+}
+
+fn namespace_is(namespace: &ResolveResult<'_>, expected: &[u8]) -> bool {
+    matches!(namespace, ResolveResult::Bound(Namespace(uri)) if *uri == expected)
+}
+
+fn attr_value(start: &BytesStart<'_>, name: &[u8]) -> Option<String> {
+    start.attributes().flatten().find_map(|attr| {
+        (attr.key.local_name().as_ref() == name)
+            .then(|| attr.unescape_value().ok().map(|value| value.into_owned()))
+            .flatten()
+    })
+}
+
 fn normalize_hex_color(value: &str) -> Option<String> {
     let hex = value.trim().strip_prefix('#').unwrap_or(value.trim());
     (hex.len() == 6 && hex.bytes().all(|byte| byte.is_ascii_hexdigit()))
@@ -89,7 +211,10 @@ fn parse_string_attr(xml: &[u8], attr: &[u8]) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_chart_color_style_xml, parse_chart_color_style_xml};
+    use super::{
+        build_chart_color_style_xml, chart_color_style_xml_is_replay_safe,
+        parse_chart_color_style_xml,
+    };
 
     #[test]
     fn chart_color_style_xml_round_trips_direct_palette() {
@@ -103,14 +228,44 @@ mod tests {
             Some(vec!["4472C4".to_string(), "ED7D31".to_string()])
         );
         assert_eq!(projection.color_scheme, None);
+        assert!(chart_color_style_xml_is_replay_safe(&xml));
+        let xml = String::from_utf8(xml).unwrap();
+        assert!(
+            xml.contains(r#"<a:srgbClr val="4472C4"/><a:srgbClr val="ED7D31"/><cs:variation/>"#)
+        );
+        assert!(!xml.contains(r#"id="0""#));
     }
 
     #[test]
-    fn chart_color_style_xml_preserves_color_scheme_id() {
-        let xml = build_chart_color_style_xml(None, Some(1)).expect("color style xml");
+    fn chart_color_style_xml_preserves_color_scheme_id_with_a_palette() {
+        let xml = build_chart_color_style_xml(Some(&["4472C4".to_string()]), Some(1))
+            .expect("color style xml");
         let projection = parse_chart_color_style_xml(&xml);
 
-        assert_eq!(projection.colors, None);
+        assert_eq!(projection.colors, Some(vec!["4472C4".to_string()]));
         assert_eq!(projection.color_scheme, Some(1));
+        assert!(chart_color_style_xml_is_replay_safe(&xml));
+    }
+
+    #[test]
+    fn chart_color_style_xml_rejects_identifier_without_base_colors() {
+        assert_eq!(build_chart_color_style_xml(None, Some(1)), None);
+    }
+
+    #[test]
+    fn historical_nested_palette_is_salvaged_but_not_replay_safe() {
+        let xml = br#"<cs:colorStyle xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" meth="cycle" id="0"><cs:variation><a:srgbClr val="AAD7E2"/></cs:variation></cs:colorStyle>"#;
+        let projection = parse_chart_color_style_xml(xml);
+
+        assert_eq!(projection.colors, Some(vec!["AAD7E2".to_string()]));
+        assert_eq!(projection.color_scheme, None);
+        assert!(!chart_color_style_xml_is_replay_safe(xml));
+    }
+
+    #[test]
+    fn color_style_with_base_color_after_variation_is_not_replay_safe() {
+        let xml = br#"<cs:colorStyle xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" meth="cycle"><cs:variation/><a:srgbClr val="AAD7E2"/></cs:colorStyle>"#;
+
+        assert!(!chart_color_style_xml_is_replay_safe(xml));
     }
 }

--- a/file-io/xlsx/parser/src/write/from_parse_output/chart_auxiliary.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/chart_auxiliary.rs
@@ -34,7 +34,7 @@ pub(super) struct GeneratedChartColorStyle {
     pub(super) path: String,
     pub(super) data: Vec<u8>,
     pub(super) relationship_type: &'static str,
-    pub(super) relationship_id_hint: &'static str,
+    pub(super) relationship_id_hint: String,
 }
 
 pub(super) fn chart_auxiliary_data(chart_spec: &ChartSpec) -> Option<ChartAuxiliaryDataRef<'_>> {
@@ -131,12 +131,34 @@ pub(super) fn generated_chart_color_style_data(
         chart_spec.color_scheme,
     )?;
     let number = chart_number(chart_path)?;
+    let imported_identity = imported_chart_color_style(chart_spec, chart_path)
+        .map(|(relationship, path, _)| (relationship.r_id.clone(), path));
+    let (relationship_id_hint, path) = imported_identity.unwrap_or_else(|| {
+        (
+            "rIdChartColorStyle".to_string(),
+            format!("xl/charts/colors{number}.xml"),
+        )
+    });
     Some(GeneratedChartColorStyle {
-        path: format!("xl/charts/colors{number}.xml"),
+        path,
         data,
         relationship_type: REL_CHART_COLOR_STYLE,
-        relationship_id_hint: "rIdChartColorStyle",
+        relationship_id_hint,
     })
+}
+
+pub(super) fn should_generate_chart_color_style(
+    chart_spec: &ChartSpec,
+    chart_path: &str,
+    allows_current_auxiliary_replay: bool,
+) -> bool {
+    !allows_current_auxiliary_replay
+        || matches!(
+            imported_chart_color_style(chart_spec, chart_path).map(|(_, _, data)| {
+                crate::domain::charts::color_style::chart_color_style_xml_is_replay_safe(data)
+            }),
+            Some(false)
+        )
 }
 
 pub(super) fn standard_chart_number(aux: &ChartAuxiliaryDataRef<'_>) -> Option<usize> {
@@ -162,7 +184,20 @@ pub(super) fn supported_auxiliary_file_paths(
         .iter()
         .map(|(path, _)| normalize_path(path))
         .filter(|path| relationship_targets.contains(path))
+        .filter(|path| auxiliary_file_is_replay_safe(aux, path))
         .collect()
+}
+
+fn auxiliary_file_is_replay_safe(aux: &ChartAuxiliaryDataRef<'_>, path: &str) -> bool {
+    if !matches!(auxiliary_kind(path), Some(AuxiliaryKind::ColorStyle)) {
+        return true;
+    }
+    aux.auxiliary_files
+        .iter()
+        .find(|(candidate, _)| normalize_path(candidate) == path)
+        .is_some_and(|(_, data)| {
+            crate::domain::charts::color_style::chart_color_style_xml_is_replay_safe(data)
+        })
 }
 
 pub(super) fn supported_auxiliary_relationship_targets<'a>(
@@ -189,6 +224,27 @@ pub(super) fn is_supported_auxiliary_relationship(rel_type: &str, target_path: &
         Some(AuxiliaryKind::UserShapes) => rel_type == REL_CHART_USER_SHAPES,
         None => false,
     }
+}
+
+fn imported_chart_color_style<'a>(
+    chart_spec: &'a ChartSpec,
+    chart_path: &str,
+) -> Option<(&'a ChartRelationshipData, String, &'a [u8])> {
+    let relationship = chart_spec.chart_relationships.iter().find(|relationship| {
+        relationship.relationship_type.as_deref() == Some(REL_CHART_COLOR_STYLE)
+            && !crate::write::package_graph::is_external_target_mode(
+                relationship.target_mode.as_deref(),
+            )
+    })?;
+    let target = relationship.target.as_deref()?;
+    let path = crate::infra::opc::resolve_relationship_target(Some(chart_path), target)
+        .ok()
+        .map(|path| normalize_path(&path))?;
+    let (_, data) = chart_spec
+        .chart_auxiliary_files
+        .iter()
+        .find(|(candidate, _)| normalize_path(candidate) == path)?;
+    Some((relationship, path, data.as_slice()))
 }
 
 fn chart_identity_path(chart_spec: &ChartSpec) -> Option<String> {

--- a/file-io/xlsx/parser/src/write/from_parse_output/chart_auxiliary_registration.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/chart_auxiliary_registration.rs
@@ -9,14 +9,20 @@ pub(super) fn register_generated_chart_color_style(
     chart_auxiliary_relationships: &mut Vec<ChartAuxiliaryRelationshipGraphEntry>,
     chart_spec: &domain_types::ChartSpec,
     chart_path: &str,
-) -> Result<bool, WriteError> {
-    if chart_replay::chart_allows_current_auxiliary_replay(chart_spec, chart_path) {
-        return Ok(false);
+) -> Result<(), WriteError> {
+    let allows_current_auxiliary_replay =
+        chart_replay::chart_allows_current_auxiliary_replay(chart_spec, chart_path);
+    if !chart_auxiliary::should_generate_chart_color_style(
+        chart_spec,
+        chart_path,
+        allows_current_auxiliary_replay,
+    ) {
+        return Ok(());
     }
     let Some(color_style) =
         chart_auxiliary::generated_chart_color_style_data(chart_spec, chart_path)
     else {
-        return Ok(false);
+        return Ok(());
     };
     if registered_chart_auxiliary_parts.insert(color_style.path.clone()) {
         crate::write::package_graph::register_chart_auxiliary_part(
@@ -28,7 +34,7 @@ pub(super) fn register_generated_chart_color_style(
         chart_path: chart_path.to_string(),
         rel_type: color_style.relationship_type.to_string(),
         target_path: color_style.path,
-        relationship_id_hint: color_style.relationship_id_hint.to_string(),
+        relationship_id_hint: color_style.relationship_id_hint,
     });
-    Ok(true)
+    Ok(())
 }

--- a/file-io/xlsx/parser/src/write/from_parse_output/mod.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/mod.rs
@@ -1415,13 +1415,14 @@ pub fn write_xlsx_from_parse_output(output: &ParseOutput) -> Result<Vec<u8>, Wri
                 entry.global_idx,
             )?;
             let chart_spec = &output.sheets[sheet_idx].charts[entry.source_idx];
-            if !chart_auxiliary_registration::register_generated_chart_color_style(
+            chart_auxiliary_registration::register_generated_chart_color_style(
                 &mut package_graph_builder,
                 &mut registered_chart_auxiliary_parts,
                 &mut chart_auxiliary_relationships,
                 chart_spec,
                 &chart_path,
-            )? && chart_replay::chart_allows_current_auxiliary_replay(chart_spec, &chart_path)
+            )?;
+            if chart_replay::chart_allows_current_auxiliary_replay(chart_spec, &chart_path)
                 && let Some(aux) = chart_auxiliary::chart_auxiliary_data(chart_spec)
             {
                 let auxiliary_paths =
@@ -1479,13 +1480,14 @@ pub fn write_xlsx_from_parse_output(output: &ParseOutput) -> Result<Vec<u8>, Wri
                 entry.global_idx,
             )?;
             let chart_spec = &output.sheets[sheet_idx].charts[entry.source_idx];
-            if !chart_auxiliary_registration::register_generated_chart_color_style(
+            chart_auxiliary_registration::register_generated_chart_color_style(
                 &mut package_graph_builder,
                 &mut registered_chart_auxiliary_parts,
                 &mut chart_auxiliary_relationships,
                 chart_spec,
                 &chart_path,
-            )? && chart_replay::chart_allows_current_auxiliary_replay(chart_spec, &chart_path)
+            )?;
+            if chart_replay::chart_allows_current_auxiliary_replay(chart_spec, &chart_path)
                 && let Some(aux) = chart_auxiliary::chart_auxiliary_data(chart_spec)
             {
                 let auxiliary_paths =

--- a/file-io/xlsx/parser/src/write/from_parse_output/tests/chart_ex_replay.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/tests/chart_ex_replay.rs
@@ -57,7 +57,7 @@ fn imported_rich_title_chart_ex(original_number: usize, family_marker: &str) -> 
         (
             color_path,
             format!(
-                r#"<cs:colorStyle xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle"><!--COLOR-{family_marker}--></cs:colorStyle>"#
+                r#"<cs:colorStyle xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" meth="cycle"><a:schemeClr val="accent1"/><cs:variation/><!--COLOR-{family_marker}--></cs:colorStyle>"#
             )
             .into_bytes(),
         ),

--- a/file-io/xlsx/parser/src/write/from_parse_output/tests/charts.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/tests/charts.rs
@@ -1474,7 +1474,7 @@ fn chart_ex_family_with_replay(
         (
             color_path,
             format!(
-                r#"<cs:colorStyle xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle"><!--COLOR-{family_marker}--></cs:colorStyle>"#
+                r#"<cs:colorStyle xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" meth="cycle"><a:schemeClr val="accent1"/><cs:variation/><!--COLOR-{family_marker}--></cs:colorStyle>"#
             )
             .into_bytes(),
         ),

--- a/file-io/xlsx/parser/src/write/from_parse_output/zip_assembly.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/zip_assembly.rs
@@ -589,9 +589,14 @@ pub(super) fn write_zip_package(
                     chart_auxiliary::chart_user_shapes_data(chart_spec, &chart_path);
                 let mut written_auxiliary_paths = std::collections::BTreeSet::new();
 
-                if !chart_replay::chart_allows_current_auxiliary_replay(chart_spec, &chart_path)
-                    && let Some(color_style) =
-                        chart_auxiliary::generated_chart_color_style_data(chart_spec, &chart_path)
+                let allows_current_auxiliary_replay =
+                    chart_replay::chart_allows_current_auxiliary_replay(chart_spec, &chart_path);
+                if chart_auxiliary::should_generate_chart_color_style(
+                    chart_spec,
+                    &chart_path,
+                    allows_current_auxiliary_replay,
+                ) && let Some(color_style) =
+                    chart_auxiliary::generated_chart_color_style_data(chart_spec, &chart_path)
                 {
                     written_auxiliary_paths.insert(color_style.path.clone());
                     add_registered_part(
@@ -604,7 +609,7 @@ pub(super) fn write_zip_package(
 
                 // Write chart auxiliary files (style XML, colors XML) only
                 // when the current chart still carries imported chart identity.
-                if chart_replay::chart_allows_current_auxiliary_replay(chart_spec, &chart_path)
+                if allows_current_auxiliary_replay
                     && let Some(aux) = chart_auxiliary::chart_auxiliary_data(chart_spec)
                 {
                     let auxiliary_paths =
@@ -674,9 +679,14 @@ pub(super) fn write_zip_package(
                 // Write ChartEx auxiliary files only when the current chart
                 // still carries imported chart identity.
                 let chart_spec = &output.sheets[sheet_idx].charts[entry.source_idx];
-                if !chart_replay::chart_allows_current_auxiliary_replay(chart_spec, &chart_path)
-                    && let Some(color_style) =
-                        chart_auxiliary::generated_chart_color_style_data(chart_spec, &chart_path)
+                let allows_current_auxiliary_replay =
+                    chart_replay::chart_allows_current_auxiliary_replay(chart_spec, &chart_path);
+                if chart_auxiliary::should_generate_chart_color_style(
+                    chart_spec,
+                    &chart_path,
+                    allows_current_auxiliary_replay,
+                ) && let Some(color_style) =
+                    chart_auxiliary::generated_chart_color_style_data(chart_spec, &chart_path)
                 {
                     add_registered_part(
                         package_graph,
@@ -685,7 +695,7 @@ pub(super) fn write_zip_package(
                         color_style.data,
                     )?;
                 }
-                if chart_replay::chart_allows_current_auxiliary_replay(chart_spec, &chart_path)
+                if allows_current_auxiliary_replay
                     && let Some(aux) = chart_auxiliary::chart_auxiliary_data(chart_spec)
                 {
                     let auxiliary_paths =


### PR DESCRIPTION
## Summary

- emit conformant `CT_ColorStyle` parts with direct DrawingML base-color children
- validate imported chart-color sidecars before opaque replay and regenerate malformed historical Mog output from its parsed palette
- preserve the original color-part path and relationship ID while continuing to replay unrelated valid chart auxiliaries
- omit scheme-only sidecars that cannot satisfy the required base-color contract

## Root cause

Historical Mog exports placed `<a:srgbClr>` inside `<cs:variation>`. `CT_ColorStyle` requires one or more DrawingML color choices as direct children before optional variations. Excel can respond by removing the owning drawing during repair.

Schema reference: https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.office2013.drawing.chartstyle.colorstyle?view=openxml-3.0.1

## Verification

- `cargo fmt --all --check`
- `cargo test -p xlsx-parser chart --lib --locked -- --test-threads=2` (452 passed)
- `cargo test -p compute-core storage::engine::tests::test_xlsx_export_charts --locked` (6 passed)
- `cargo clippy -p xlsx-parser --lib --locked --no-deps` (passed; repository baseline warnings remain)
- confidential affected workbook, semantic import/export path: ZIP integrity passed, all XML parts parsed, all three chart-color relationship IDs and targets were preserved, and `xl/drawings/drawing2.xml` remained present
- Excel for Mac manual verification of the affected semantic-roundtrip workbook: opened normally with no repair warning

The customer workbook and temporary local harness are not included in this repository.