### PR TITLE
fix(xlsx): preserve grouped chart ownership on export

### DIFF
--- a/domain-types/src/domain/chart/spec.rs
+++ b/domain-types/src/domain/chart/spec.rs
@@ -781,6 +781,7 @@ impl ChartSpec {
             client_data_prints_with_sheet: self.client_data_prints_with_sheet,
             relationship_id: None,
             relationship_target: None,
+            nested_in_group: false,
             raw_alternate_content: None,
         })
     }

--- a/domain-types/src/domain/floating_object/ooxml.rs
+++ b/domain-types/src/domain/floating_object/ooxml.rs
@@ -198,6 +198,12 @@ pub struct ChartDrawingFrameOoxmlProps {
     pub relationship_id: Option<String>,
     /// Original drawing relationship target for the chart part.
     pub relationship_target: Option<String>,
+    /// Whether the graphic frame is owned by a group shape rather than by the
+    /// worksheet drawing anchor directly. Group-owned charts keep their chart
+    /// parts and relationships, but must not be emitted as additional top-level
+    /// drawing anchors during export.
+    #[serde(default, skip_serializing_if = "crate::is_false")]
+    pub nested_in_group: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub raw_alternate_content: Option<String>,
 }

--- a/file-io/xlsx/parser/src/output/to_parse_output/features/charts/chart_frames.rs
+++ b/file-io/xlsx/parser/src/output/to_parse_output/features/charts/chart_frames.rs
@@ -281,6 +281,7 @@ fn append_chart_drawing_frames_from_anchor(
         client_data,
         raw_alternate_content.as_deref(),
         anchor_index,
+        false,
         chart_ex,
         frames,
     );
@@ -296,6 +297,7 @@ fn append_chart_drawing_frames_from_content(
     client_data: &ClientData,
     raw_alternate_content: Option<&str>,
     anchor_index: usize,
+    nested_in_group: bool,
     chart_ex: bool,
     frames: &mut Vec<(AnchorPosition, ChartDrawingFrameOoxmlProps)>,
 ) {
@@ -310,6 +312,7 @@ fn append_chart_drawing_frames_from_content(
                 client_data,
                 raw_alternate_content,
                 anchor_index,
+                nested_in_group,
                 chart_ex,
             ) {
                 frames.push(frame);
@@ -326,6 +329,7 @@ fn append_chart_drawing_frames_from_content(
                     client_data,
                     raw_alternate_content,
                     anchor_index,
+                    true,
                     chart_ex,
                     frames,
                 );
@@ -345,6 +349,7 @@ fn chart_drawing_frame_from_graphic_frame(
     client_data: &ClientData,
     raw_alternate_content: Option<&str>,
     anchor_index: usize,
+    nested_in_group: bool,
     chart_ex: bool,
 ) -> Option<(AnchorPosition, ChartDrawingFrameOoxmlProps)> {
     let graphic_xml = gf.graphic_xml.as_deref().unwrap_or_default();
@@ -377,6 +382,7 @@ fn chart_drawing_frame_from_graphic_frame(
             client_data_prints_with_sheet,
             relationship_id,
             relationship_target,
+            nested_in_group,
             raw_alternate_content: raw_alternate_content.map(ToOwned::to_owned),
         },
     ))
@@ -562,6 +568,7 @@ mod tests {
                 .iter()
                 .all(|(_, frame)| frame.anchor_index == Some(0))
         );
+        assert!(frames.iter().all(|(_, frame)| frame.nested_in_group));
 
         let by_target = chart_frames_by_relationship_target(&frames);
         assert!(by_target.contains_key("xl/charts/chart8.xml"));

--- a/file-io/xlsx/parser/src/write/from_parse_output/mod.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/mod.rs
@@ -929,6 +929,10 @@ pub fn write_xlsx_from_parse_output(output: &ParseOutput) -> Result<Vec<u8>, Wri
                         .or(chart_spec.anchor_edit_as.as_deref())
                         .map(ooxml_types::drawings::EditAs::from_ooxml);
                     let chart_object = DrawingObject::ChartEx(cx_ref);
+                    if chart_frame.is_some_and(|frame| frame.nested_in_group) {
+                        cx_local_idx += 1;
+                        continue;
+                    }
                     let raw_alternate_content = chart_replay::chart_ex_raw_anchor_replay_xml(
                         chart_spec,
                         &cx_path,
@@ -1072,6 +1076,10 @@ pub fn write_xlsx_from_parse_output(output: &ParseOutput) -> Result<Vec<u8>, Wri
                         xfrm_flip_h: frame_transform.flip_h,
                         xfrm_flip_v: frame_transform.flip_v,
                     };
+                    if chart_frame.is_some_and(|frame| frame.nested_in_group) {
+                        regular_local_idx += 1;
+                        continue;
+                    }
                     if let (Some(x), Some(y)) = (
                         chart_spec.position.absolute_x,
                         chart_spec.position.absolute_y,

--- a/file-io/xlsx/parser/src/write/from_parse_output/tests/charts.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/tests/charts.rs
@@ -539,6 +539,38 @@ fn imported_chart_allocates_new_relationship_id_when_preferred_id_is_taken() {
 }
 
 #[test]
+fn grouped_chart_is_not_promoted_to_a_second_top_level_anchor() {
+    let mut chart = with_chart_identity(
+        make_chart(ChartType::Column, "Data!A1:B2"),
+        "../charts/chart1.xml",
+    );
+    chart.chart_frame.as_mut().unwrap().anchor_index = Some(0);
+    chart.chart_frame.as_mut().unwrap().nested_in_group = true;
+    let chart = with_current_standard_chart_authority(chart);
+
+    let output = make_parse_output(vec![SheetData {
+        name: "Data".to_string(),
+        cells: vec![
+            make_cell(0, 0, DomainValue::Text(Arc::from("Quarter"))),
+            make_cell(0, 1, DomainValue::Text(Arc::from("Revenue"))),
+            make_cell(1, 0, DomainValue::Text(Arc::from("Q1"))),
+            make_cell(1, 1, DomainValue::Number(FiniteF64::new(100.0).unwrap())),
+        ],
+        charts: vec![chart],
+        ..Default::default()
+    }]);
+
+    let bytes = write_xlsx_from_parse_output(&output).unwrap();
+    let archive = crate::XlsxArchive::new(&bytes).expect("exported XLSX should be readable");
+    let drawing_xml =
+        String::from_utf8(archive.read_file("xl/drawings/drawing1.xml").unwrap()).unwrap();
+
+    assert!(!drawing_xml.contains("<xdr:graphicFrame"), "{drawing_xml}");
+    assert!(archive.contains("xl/charts/chart1.xml"));
+    validate_archive_package_integrity(&archive).expect("exported package should be valid");
+}
+
+#[test]
 fn imported_chart_with_modeled_chart_property_does_not_replay_stale_raw_chart_xml() {
     let mut imported_chart = make_chart(ChartType::Column, "Data!A1:B2");
     imported_chart.title = None;


### PR DESCRIPTION
## Problem

When an imported drawing group contained charts, Mog modeled both the group and its nested chart frames. Export then wrote the group-owned chart frames again as worksheet-level anchors. The affected workbook gained 22 duplicate anchors across two drawing parts; Excel removed those drawing parts during repair.

## Fix

- Track whether an imported chart frame is owned by a group.
- Keep the nested chart part and relationship registered for group serialization.
- Do not promote that frame into a second top-level drawing anchor.
- Default and omit the new metadata field for backward-compatible serialized domain data.

## Verification

- `cargo fmt --check`
- `cargo check -p xlsx-parser --locked`
- `cargo test -p xlsx-parser chart_drawing_frames_include_graphic_frames_nested_in_groups --locked`
- `cargo test -p xlsx-parser grouped_chart_is_not_promoted_to_a_second_top_level_anchor --locked`
- Exact affected workbook: drawing4 restored from 23 to 13 anchors; drawing12 restored from 21 to 9; zero duplicate `cNvPr` IDs or drawing relationship IDs.
- Exported package passes ZIP integrity and opens in Microsoft Excel 16.112 without a repair prompt.

Confidential customer/eval workbooks are not included in the repository.