### PR TITLE
fix(xlsx): export refresh-safe PivotTable metadata

### DIFF
--- a/compute/core/src/storage/engine/export.rs
+++ b/compute/core/src/storage/engine/export.rs
@@ -382,7 +382,11 @@ impl YrsComputeEngine {
     fn export_workbook_parsed_pivot_tables(
         &self,
     ) -> Vec<domain_types::domain::pivot::ParsedPivotTable> {
-        super::services::export::export_workbook_parsed_pivot_tables(&self.stores)
+        super::services::export::export_workbook_parsed_pivot_tables(
+            &self.stores,
+            &self.mirror,
+            None,
+        )
     }
 }
 

--- a/compute/core/src/storage/engine/services/export/mod.rs
+++ b/compute/core/src/storage/engine/services/export/mod.rs
@@ -835,7 +835,8 @@ pub(in crate::storage::engine) fn build_parse_output_from_yrs(
     let persons = export_workbook_threaded_comment_persons(stores);
     let has_persons_part = !persons.is_empty()
         || workbook::export_workbook_threaded_comment_persons_part_present(stores);
-    let pivot_tables = export_workbook_parsed_pivot_tables(stores);
+    let pivot_tables =
+        export_workbook_parsed_pivot_tables(stores, mirror, default_pivot_style.as_deref());
 
     let output = ParseOutput {
         sheets: output_sheets,

--- a/compute/core/src/storage/engine/services/export/workbook.rs
+++ b/compute/core/src/storage/engine/services/export/workbook.rs
@@ -19,6 +19,7 @@ use domain_types::{
 };
 use yrs::{Any, Map, Out, Transact};
 
+use crate::mirror::CellMirror;
 use crate::snapshot::{CalcMode, CalculationSettings};
 use crate::storage::engine::stores::EngineStores;
 use crate::storage::sheet::pivots;
@@ -777,6 +778,8 @@ pub(in crate::storage::engine) fn export_workbook_timeline_caches(
 /// pivotTables maps using imported-pivot associations as the authority.
 pub(in crate::storage::engine) fn export_workbook_parsed_pivot_tables(
     stores: &EngineStores,
+    mirror: &CellMirror,
+    default_pivot_style: Option<&str>,
 ) -> Vec<domain_types::domain::pivot::ParsedPivotTable> {
     let doc = stores.storage.doc();
     let sheets_ref = stores.storage.sheets();
@@ -790,7 +793,11 @@ pub(in crate::storage::engine) fn export_workbook_parsed_pivot_tables(
         .collect::<std::collections::HashMap<_, _>>();
 
     if associations.is_empty() {
-        return export_workbook_parsed_pivot_tables_legacy_name_dedup(stores);
+        return export_workbook_parsed_pivot_tables_legacy_name_dedup(
+            stores,
+            mirror,
+            default_pivot_style,
+        );
     }
 
     let specs_by_key: std::collections::HashMap<String, ParsedPivotTable> = specs
@@ -857,7 +864,13 @@ pub(in crate::storage::engine) fn export_workbook_parsed_pivot_tables(
                         &cache_sources_by_id,
                     );
                 result.push(ParsedPivotTable {
-                    config: live_config,
+                    config: project_live_pivot_export_metadata(
+                        live_config,
+                        &output_sheet_id,
+                        mirror,
+                        None,
+                        false,
+                    ),
                     initial_expansion_state: original.initial_expansion_state.clone(),
                     ooxml_preservation,
                 });
@@ -873,6 +886,13 @@ pub(in crate::storage::engine) fn export_workbook_parsed_pivot_tables(
             if associated_native_ids.contains(&config.id) {
                 continue;
             }
+            let config = project_live_pivot_export_metadata(
+                config,
+                sheet_id,
+                mirror,
+                default_pivot_style,
+                true,
+            );
             result.push(ParsedPivotTable {
                 config,
                 initial_expansion_state: None,
@@ -886,6 +906,8 @@ pub(in crate::storage::engine) fn export_workbook_parsed_pivot_tables(
 
 fn export_workbook_parsed_pivot_tables_legacy_name_dedup(
     stores: &EngineStores,
+    mirror: &CellMirror,
+    default_pivot_style: Option<&str>,
 ) -> Vec<domain_types::domain::pivot::ParsedPivotTable> {
     let doc = stores.storage.doc();
     let sheets_ref = stores.storage.sheets();
@@ -907,6 +929,13 @@ fn export_workbook_parsed_pivot_tables_legacy_name_dedup(
             if existing_names.contains(&config.name) {
                 continue; // Imported pivot — keep original workbook-level spec
             }
+            let config = project_live_pivot_export_metadata(
+                config,
+                sheet_id,
+                mirror,
+                default_pivot_style,
+                true,
+            );
             result.push(ParsedPivotTable {
                 config,
                 initial_expansion_state: None,
@@ -916,6 +945,50 @@ fn export_workbook_parsed_pivot_tables_legacy_name_dedup(
     }
 
     result
+}
+
+fn project_live_pivot_export_metadata(
+    mut config: domain_types::domain::pivot::PivotTableConfig,
+    storage_sheet_id: &SheetId,
+    mirror: &CellMirror,
+    default_pivot_style: Option<&str>,
+    apply_default_style: bool,
+) -> domain_types::domain::pivot::PivotTableConfig {
+    let output_sheet_id = config
+        .output_sheet_id
+        .as_deref()
+        .and_then(|value| SheetId::from_uuid_str(value).ok())
+        .or_else(|| mirror.sheet_by_name(&config.output_sheet_name))
+        .unwrap_or(*storage_sheet_id);
+    if let Some(def) =
+        mirror.find_pivot_table_def(&config.id, &config.name, &output_sheet_id.to_uuid_string())
+        && !def.is_empty_rendered_region()
+    {
+        config.ref_range = Some(format!(
+            "{}:{}",
+            crate::range_manager::pos_to_a1(def.start_row, def.start_col),
+            crate::range_manager::pos_to_a1(def.end_row, def.end_col),
+        ));
+        config.first_data_row = Some(def.first_data_row);
+        config.first_data_col = Some(def.first_data_col);
+    }
+
+    if apply_default_style && config.style.is_none() {
+        config.style = Some(domain_types::domain::pivot::PivotTableStyle {
+            style_name: Some(
+                default_pivot_style
+                    .unwrap_or("PivotStyleLight16")
+                    .to_string(),
+            ),
+            show_row_headers: Some(true),
+            show_column_headers: Some(true),
+            show_row_stripes: Some(false),
+            show_column_stripes: Some(false),
+            show_last_column: Some(true),
+        });
+    }
+
+    config
 }
 
 fn read_workbook_pivot_specs(

--- a/compute/core/src/storage/engine/tests/test_pivot_materialization.rs
+++ b/compute/core/src/storage/engine/tests/test_pivot_materialization.rs
@@ -96,14 +96,25 @@ fn pivot_history_snapshot(sid: SheetId) -> WorkbookSnapshot {
 }
 
 fn create_region_sales_pivot(engine: &mut YrsComputeEngine, sid: SheetId, name: &str) -> String {
+    create_region_sales_pivot_on_sheet(engine, sid, sid, "Sheet1", name)
+}
+
+fn create_region_sales_pivot_on_sheet(
+    engine: &mut YrsComputeEngine,
+    source_sid: SheetId,
+    output_sid: SheetId,
+    output_sheet_name: &str,
+    name: &str,
+) -> String {
     engine
         .pivot_create(json!({
             "id": name,
             "name": name,
-            "sourceSheetId": sid.to_uuid_string(),
+            "sourceSheetId": source_sid.to_uuid_string(),
             "sourceSheetName": "Sheet1",
             "sourceRange": { "startRow": 0, "startCol": 0, "endRow": 2, "endCol": 1 },
-            "outputSheetName": "Sheet1",
+            "outputSheetId": output_sid.to_uuid_string(),
+            "outputSheetName": output_sheet_name,
             "outputLocation": { "row": 0, "col": 4 },
             "fields": [
                 { "id": "Region", "name": "Region", "sourceColumn": 0, "dataType": "string" },
@@ -122,11 +133,72 @@ fn create_region_sales_pivot(engine: &mut YrsComputeEngine, sid: SheetId, name: 
         }))
         .expect("create pivot");
     engine
-        .pivot_get_all(&sid)
+        .pivot_get_all(&output_sid)
         .into_iter()
         .find(|config| config.name == name)
         .expect("created pivot")
         .id
+}
+
+#[test]
+fn api_created_pivot_exports_refresh_safe_ooxml_metadata() {
+    let sid = sheet_id();
+    let snap = pivot_history_snapshot(sid);
+    let (mut engine, _) = YrsComputeEngine::from_snapshot(snap).unwrap();
+    let (output_sheet_hex, _) = engine
+        .create_sheet("PivotOutput")
+        .expect("create separate pivot output sheet");
+    let output_sid = SheetId::from_uuid_str(&output_sheet_hex).expect("output sheet id");
+    let pivot_id = create_region_sales_pivot_on_sheet(
+        &mut engine,
+        sid,
+        output_sid,
+        "PivotOutput",
+        "ExportSafePivot",
+    );
+    engine.recalculate().expect("materialize pivot");
+
+    let def = engine
+        .mirror()
+        .find_pivot_table_def(&pivot_id, "ExportSafePivot", &output_sid.to_uuid_string())
+        .expect("materialized pivot definition")
+        .clone();
+    let expected_range = format!(
+        "{}:{}",
+        crate::range_manager::pos_to_a1(def.start_row, def.start_col),
+        crate::range_manager::pos_to_a1(def.end_row, def.end_col),
+    );
+
+    let exported = engine
+        .export_to_parse_output()
+        .expect("export parse output")
+        .parse_output;
+    let pivot = exported
+        .pivot_tables
+        .iter()
+        .find(|pivot| pivot.config.id == pivot_id)
+        .expect("exported pivot");
+    assert_eq!(
+        pivot.config.ref_range.as_deref(),
+        Some(expected_range.as_str())
+    );
+    assert_eq!(pivot.config.first_data_row, Some(def.first_data_row));
+    assert_eq!(pivot.config.first_data_col, Some(def.first_data_col));
+    assert_eq!(
+        pivot
+            .config
+            .style
+            .as_ref()
+            .and_then(|style| style.style_name.as_deref()),
+        Some("PivotStyleLight16")
+    );
+
+    let bytes = engine.export_to_xlsx_bytes().expect("export xlsx bytes");
+    let pivot_xml =
+        archive_text(&bytes, "xl/pivotTables/pivotTable1.xml").expect("pivot table part");
+    assert!(pivot_xml.contains(&format!("ref=\"{expected_range}\"")));
+    assert!(pivot_xml.contains("<items count=\"1\"><item t=\"default\"/></items>"));
+    assert!(pivot_xml.contains("name=\"PivotStyleLight16\""));
 }
 
 #[test]

--- a/file-io/xlsx/parser/src/write/pivot_writer/config_to_def.rs
+++ b/file-io/xlsx/parser/src/write/pivot_writer/config_to_def.rs
@@ -63,6 +63,26 @@ pub(super) fn parsed_pivot_to_def(pt: &ParsedPivotTable) -> domain_types::PivotT
                 })
                 .unwrap_or((true, true));
 
+            let mut items = pivot_items_for_field_filters(
+                field.id.as_str(),
+                field_idx,
+                &field.items,
+                &config.filters,
+                &pt.ooxml_preservation.cache_shared_items,
+                page_fields.iter().any(|page_field| {
+                    page_field.field_index == field_idx as i32 && page_field.item.is_some()
+                }),
+            );
+            if items.is_empty() && matches!(axis, Some(PivotAxis::Row | PivotAxis::Col)) {
+                items.push(PivotFieldItem {
+                    item_type: PivotItemType::Default,
+                    value: None,
+                    hidden: false,
+                    show_details: true,
+                    s: None,
+                });
+            }
+
             PivotFieldDef {
                 name: Some(pivot_field_ooxml_name(field.name.as_str(), axis_placement)),
                 axis,
@@ -82,16 +102,7 @@ pub(super) fn parsed_pivot_to_def(pt: &ParsedPivotTable) -> domain_types::PivotT
                 subtotal_top: field.subtotal_top.unwrap_or(true),
                 default_subtotal: field.default_subtotal.unwrap_or(true),
                 subtotals: field.subtotals.clone(),
-                items: pivot_items_for_field_filters(
-                    field.id.as_str(),
-                    field_idx,
-                    &field.items,
-                    &config.filters,
-                    &pt.ooxml_preservation.cache_shared_items,
-                    page_fields.iter().any(|page_field| {
-                        page_field.field_index == field_idx as i32 && page_field.item.is_some()
-                    }),
-                ),
+                items,
             }
         })
         .collect();
@@ -667,6 +678,25 @@ mod tests {
             },
             initial_expansion_state: None,
             ooxml_preservation: Default::default(),
+        }
+    }
+
+    #[test]
+    fn empty_row_and_column_axis_fields_emit_a_default_item() {
+        for area in [PivotFieldArea::Row, PivotFieldArea::Column] {
+            let mut pt = parsed_pivot_with_category_filter(PivotFilter {
+                field_id: FieldId::from("Category"),
+                include_values: None,
+                exclude_values: None,
+                condition: None,
+                top_bottom: None,
+                show_items_with_no_data: None,
+            });
+            pt.config.placements[0].area = area;
+
+            let def = parsed_pivot_to_def(&pt);
+
+            assert_eq!(def.fields[0].items, vec![default_item()]);
         }
     }
 


### PR DESCRIPTION
## Problem

API-created PivotTables exported structurally incomplete OOXML:

- row/column axis fields with no modeled item list were emitted as self-closing `<pivotField .../>` elements;
- `<location>` used a fixed three-row estimate instead of the pivot materializer's real rendered bounds;
- no `pivotTableStyleInfo` was emitted when the API config omitted an explicit style.

On the pv23 PivotTable simulation workbook, Excel for Mac terminated in `mbukernel` while refreshing the exported pivots. Adding only default axis items prevented the crash, but the undersized declared location left Mog's already-materialized cells outside PivotTable ownership and refresh produced `#SPILL!`. Applying the real rendered range removed the spill. Applying the workbook default PivotTable style restored native PivotTable formatting.

## Fix

- Emit one OOXML default item for otherwise-empty row/column axis fields.
- Project live PivotTable bounds and first-data offsets from the existing `CellMirror` materialization definition into export metadata.
- Give API-created pivots the workbook's declared default PivotTable style (falling back to `PivotStyleLight16`) when no explicit style was requested.
- Preserve imported PivotTable style metadata and unsupported imported pivots unchanged.

## Verification

- Added a writer regression covering empty row and column axis fields.
- Added an engine-to-XLSX regression covering rendered range, first-data offsets, default axis items, and default style.
- Exact affected workbook probe, retaining Mog's original cache:
  - opens in Microsoft Excel 16.112 without repair or crash;
  - automatic refresh completes;
  - explicit **Refresh All** completes;
  - both PivotTables remain intact;
  - no `#SPILL!`;
  - default PivotTable styling is applied.
- `cargo fmt --all -- --check`
- Clean compilation/tests delegated to CI because the local Rust target was cold and full builds are intentionally kept off the developer laptop.

No customer workbook is included in this PR.
