### PR TITLE
fix(xlsx): preserve grouped connector ownership

### DIFF
--- a/compute/core/src/storage/engine/tests/test_xlsx_export.rs
+++ b/compute/core/src/storage/engine/tests/test_xlsx_export.rs
@@ -214,6 +214,109 @@ fn xlsx_export_preserves_imported_form_control_order_through_yrs_storage() {
     );
 }
 
+#[test]
+fn grouped_connector_ownership_survives_yrs_without_duplicate_top_level_anchor() {
+    use domain_types::domain::{
+        drawings::{DrawingContent, GroupShapeData},
+        floating_object::{
+            AnchorMode, ConnectorData, ConnectorOoxmlProps, FloatingObject, FloatingObjectAnchor,
+            FloatingObjectCommon, FloatingObjectData, ShapeData, ShapeOoxmlProps,
+        },
+    };
+
+    let grouped_connector = ooxml_types::drawings::SpreadsheetConnector::default();
+    let group = FloatingObject {
+        common: FloatingObjectCommon {
+            id: "group-1".to_string(),
+            name: "Group 1".to_string(),
+            width: 240.0,
+            height: 120.0,
+            anchor: FloatingObjectAnchor {
+                anchor_mode: AnchorMode::TwoCell,
+                end_row: Some(8),
+                end_col: Some(5),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        data: FloatingObjectData::Shape(ShapeData {
+            shape_type: "group".to_string(),
+            ooxml: Some(ShapeOoxmlProps {
+                anchor_index: Some(0),
+                group_shape: Some(GroupShapeData {
+                    children: vec![DrawingContent::Connector(grouped_connector.clone())],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+    };
+    let projected_connector = FloatingObject {
+        common: FloatingObjectCommon {
+            id: "connector-1".to_string(),
+            name: "Grouped line".to_string(),
+            width: 120.0,
+            height: 40.0,
+            anchor: FloatingObjectAnchor {
+                anchor_mode: AnchorMode::TwoCell,
+                end_row: Some(4),
+                end_col: Some(3),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        data: FloatingObjectData::Connector(ConnectorData {
+            shape_type: "line".to_string(),
+            fill: None,
+            outline: None,
+            start_connection: None,
+            end_connection: None,
+            adjustments: None,
+            ooxml: Some(ConnectorOoxmlProps {
+                connector: grouped_connector,
+                anchor_index: Some(0),
+                nested_in_group: true,
+                ..Default::default()
+            }),
+        }),
+    };
+    let input = ParseOutput {
+        sheets: vec![SheetData {
+            name: "Grouped connector".to_string(),
+            rows: 10,
+            cols: 8,
+            floating_objects: vec![group, projected_connector],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let engine = engine_from_parse_output_normal(&input);
+    let hydrated = engine
+        .export_to_parse_output()
+        .expect("Yrs export should succeed")
+        .parse_output;
+    let connector_ooxml = hydrated.sheets[0]
+        .floating_objects
+        .iter()
+        .find_map(|object| match &object.data {
+            FloatingObjectData::Connector(connector) => connector.ooxml.as_ref(),
+            _ => None,
+        })
+        .expect("projected connector should survive Yrs hydration");
+    assert!(connector_ooxml.nested_in_group);
+
+    let exported_bytes = engine.export_to_xlsx_bytes().expect("export xlsx bytes");
+    let drawing_xml = archive_text(&exported_bytes, "xl/drawings/drawing1.xml")
+        .expect("drawing XML should exist");
+    assert_eq!(
+        drawing_xml.matches("<xdr:twoCellAnchor").count(),
+        1,
+        "the connector already owned by the group must not be duplicated as a worksheet anchor"
+    );
+}
+
 fn ole_owner_parse_output() -> ParseOutput {
     use domain_types::domain::floating_object::{
         AnchorMode, FloatingObject, FloatingObjectAnchor, FloatingObjectCommon, FloatingObjectData,

--- a/domain-types/src/domain/floating_object/ooxml.rs
+++ b/domain-types/src/domain/floating_object/ooxml.rs
@@ -128,6 +128,12 @@ pub struct ConnectorOoxmlProps {
     pub client_data_prints_with_sheet: Option<bool>,
     /// Raw XML for mc:AlternateContent.
     pub mc_alternate_content_raw_xml: Option<String>,
+    /// Whether the connector is owned by a group shape rather than by the
+    /// worksheet drawing anchor directly. Group-owned connectors remain
+    /// available to the runtime model, but must not be emitted as additional
+    /// top-level drawing anchors during export.
+    #[serde(default, skip_serializing_if = "crate::is_false")]
+    pub nested_in_group: bool,
 }
 
 /// OOXML round-trip properties for drawing objects that are not projected into

--- a/file-io/xlsx/parser/src/domain/charts/read/connectors.rs
+++ b/file-io/xlsx/parser/src/domain/charts/read/connectors.rs
@@ -101,7 +101,7 @@ pub fn parse_connectors_for_sheet(
         };
 
         // Recursively extract connectors from content (handles group shapes too)
-        extract_connectors_from_content(content, anchor, &mut connectors);
+        extract_connectors_from_content(content, anchor, false, &mut connectors);
     }
 
     connectors
@@ -111,6 +111,7 @@ pub fn parse_connectors_for_sheet(
 fn extract_connectors_from_content(
     content: &crate::domain::drawings::DrawingContent,
     anchor: ConnectorAnchor,
+    nested_in_group: bool,
     out: &mut Vec<crate::output::results::ConnectorOutput>,
 ) {
     use crate::domain::drawings::DrawingContent;
@@ -164,14 +165,54 @@ fn extract_connectors_from_content(
                 width: anchor.width,
                 height: anchor.height,
                 raw_json,
+                nested_in_group,
             });
         }
         DrawingContent::GroupShape(group) => {
             // Recurse into group children
             for child in &group.children {
-                extract_connectors_from_content(child, anchor, out);
+                extract_connectors_from_content(child, anchor, true, out);
             }
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::drawings::{DrawingContent, GroupShape};
+
+    fn anchor() -> ConnectorAnchor {
+        ConnectorAnchor {
+            anchor_row: Some(1),
+            anchor_col: Some(2),
+            anchor_row_offset: 0,
+            anchor_col_offset: 0,
+            end_row: None,
+            end_col: None,
+            end_row_offset: None,
+            end_col_offset: None,
+            width: Some(100),
+            height: Some(200),
+        }
+    }
+
+    #[test]
+    fn connector_extraction_tracks_group_ownership() {
+        let connector = DrawingContent::Connector(Default::default());
+        let mut direct = Vec::new();
+        extract_connectors_from_content(&connector, anchor(), false, &mut direct);
+        assert_eq!(direct.len(), 1);
+        assert!(!direct[0].nested_in_group);
+
+        let grouped = DrawingContent::GroupShape(GroupShape {
+            children: vec![connector],
+            ..Default::default()
+        });
+        let mut nested = Vec::new();
+        extract_connectors_from_content(&grouped, anchor(), false, &mut nested);
+        assert_eq!(nested.len(), 1);
+        assert!(nested[0].nested_in_group);
     }
 }

--- a/file-io/xlsx/parser/src/output/results/workbook.rs
+++ b/file-io/xlsx/parser/src/output/results/workbook.rs
@@ -485,6 +485,10 @@ pub struct ConnectorOutput {
     pub height: Option<i64>,
     /// Full connector data as JSON for roundtrip fidelity.
     pub raw_json: Option<String>,
+    /// Whether this connector is owned by a group shape rather than directly
+    /// by the worksheet drawing anchor.
+    #[serde(default)]
+    pub nested_in_group: bool,
 }
 
 /// Connector endpoint referencing a shape and connection site.

--- a/file-io/xlsx/parser/src/output/to_parse_output/features/legacy_objects.rs
+++ b/file-io/xlsx/parser/src/output/to_parse_output/features/legacy_objects.rs
@@ -448,6 +448,7 @@ pub(crate) fn convert_connectors(connectors: &[ConnectorOutput]) -> Vec<Floating
                     client_data_locks_with_sheet: None,
                     client_data_prints_with_sheet: None,
                     mc_alternate_content_raw_xml: None,
+                    nested_in_group: c.nested_in_group,
                 });
             FloatingObject {
                 common: FloatingObjectCommon {

--- a/file-io/xlsx/parser/src/write/drawing_writer_helpers.rs
+++ b/file-io/xlsx/parser/src/write/drawing_writer_helpers.rs
@@ -148,6 +148,13 @@ pub fn build_sheet_drawing_data(floating_objects: &[FloatingObject]) -> SheetDra
                 }
             }
             FloatingObjectData::Connector(conn_data) => {
+                if conn_data
+                    .ooxml
+                    .as_ref()
+                    .is_some_and(|ooxml| ooxml.nested_in_group)
+                {
+                    continue;
+                }
                 let mut anchor =
                     connectors::convert_unified_connector_to_anchor(&obj.common, conn_data);
                 hyperlinks::register_anchor_hyperlink_relationships(

--- a/file-io/xlsx/parser/src/write/drawing_writer_helpers/tests.rs
+++ b/file-io/xlsx/parser/src/write/drawing_writer_helpers/tests.rs
@@ -684,6 +684,28 @@ fn connector_anchor_index_is_carried_without_anchor_level_ooxml_restoration() {
 }
 
 #[test]
+fn group_owned_connector_is_not_emitted_as_a_top_level_anchor() {
+    let conn = FloatingObject {
+        common: make_common("Grouped line"),
+        data: FloatingObjectData::Connector(ConnectorData {
+            shape_type: "line".to_string(),
+            fill: None,
+            outline: None,
+            start_connection: None,
+            end_connection: None,
+            adjustments: None,
+            ooxml: Some(ConnectorOoxmlProps {
+                nested_in_group: true,
+                ..Default::default()
+            }),
+        }),
+    };
+
+    let result = build_sheet_drawing_data(&[conn]);
+    assert!(result.anchors.is_empty());
+}
+
+#[test]
 fn unknown_mime_type_defaults_to_png_extension() {
     let parsed = parse_data_url("data:application/octet-stream;base64,AQIDBA==")
         .expect("unknown mime should still decode");


### PR DESCRIPTION
## Problem

A no-op XLSX roundtrip duplicates connectors owned by group shapes as additional top-level drawing anchors. In the PV23 cashflow breakeven workbook, three valid grouped vertical lines become three groups plus three zero-length connector objects at H75, M75, and R75, with duplicate cNvPr IDs 12, 4, and 6.

The parser recursively projected group-owned connectors into the editable floating-object model without retaining their group ownership. Export then wrote both the preserved group child and the projected connector.

## Fix

- Mark connectors discovered inside a group as `nestedInGroup`.
- Preserve that marker through parse output and Yrs hydration.
- Skip only group-owned connector projections when creating top-level drawing anchors.
- Keep ordinary top-level connectors unchanged.

This applies the same ownership contract already used for nested chart frames.

## Verification

- Connector extraction distinguishes direct and group-owned connectors.
- Drawing writer suppresses only group-owned connector projections.
- Engine-level ParseOutput -> Yrs -> XLSX regression proves one worksheet anchor is emitted.
- Focused parser/writer connector suite: 54 passed, 0 failed.
- Focused engine regression: 1 passed, 0 failed.
- Real PV23 workbook through the fixed engine: 3 anchors, cNvPr IDs 2/3/4/5/6/12, no duplicates.