### PR TITLE
fix(xlsx): preserve chart and comment package integrity

### DIFF
--- a/compute/core/src/storage/engine/tests/test_xlsx_export_charts.rs
+++ b/compute/core/src/storage/engine/tests/test_xlsx_export_charts.rs
@@ -197,6 +197,41 @@ fn imported_standard_chart_metadata_survives_yrs_with_current_package_replay() {
 }
 
 #[test]
+fn reconstructed_standard_chart_retains_imported_style_and_color_companions() {
+    let mut chart = imported_current_standard_chart2();
+    chart.title = Some("Edited Revenue".to_string());
+    let input = ParseOutput {
+        sheets: vec![SheetData {
+            name: "Data".to_string(),
+            rows: 20,
+            cols: 8,
+            charts: vec![chart],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let engine = engine_from_parse_output_normal(&input);
+    let exported_bytes = engine.export_to_xlsx_bytes().expect("export xlsx bytes");
+    let archive =
+        xlsx_parser::zip::XlsxArchive::new(&exported_bytes).expect("exported XLSX is readable");
+    let chart_rels = archive_text(&exported_bytes, "xl/charts/_rels/chart1.xml.rels")
+        .expect("reconstructed chart relationships should exist");
+    let content_types =
+        archive_text(&exported_bytes, "[Content_Types].xml").expect("content types should exist");
+
+    assert!(archive.contains("xl/charts/chart1.xml"));
+    assert!(archive.contains("xl/charts/style2.xml"));
+    assert!(archive.contains("xl/charts/colors2.xml"));
+    assert!(chart_rels.contains(xlsx_parser::infra::opc::REL_CHART_STYLE));
+    assert!(chart_rels.contains(r#"Target="style2.xml""#));
+    assert!(chart_rels.contains(xlsx_parser::infra::opc::REL_CHART_COLOR_STYLE));
+    assert!(chart_rels.contains(r#"Target="colors2.xml""#));
+    assert!(content_types.contains(r#"PartName="/xl/charts/style2.xml""#));
+    assert!(content_types.contains(r#"PartName="/xl/charts/colors2.xml""#));
+}
+
+#[test]
 fn historical_nested_chart_palette_is_regenerated_during_current_replay() {
     let mut chart = imported_current_standard_chart2();
     chart.colors = Some(vec!["AAD7E2".to_string()]);

--- a/compute/core/src/storage/engine/tests/test_xlsx_export_comments.rs
+++ b/compute/core/src/storage/engine/tests/test_xlsx_export_comments.rs
@@ -7,6 +7,81 @@ use domain_types::{
 };
 use value_types::CellValue;
 
+fn legacy_note_sheet(
+    name: &str,
+    cell_ref: &str,
+    content: &str,
+    comment_package: Option<SheetCommentPackageInfo>,
+) -> SheetData {
+    SheetData {
+        name: name.to_string(),
+        rows: 1,
+        cols: 1,
+        cells: vec![domain_types::CellData {
+            row: 0,
+            col: 0,
+            value: CellValue::Text(name.into()),
+            ..Default::default()
+        }],
+        comments: vec![Comment {
+            cell_ref: cell_ref.to_string(),
+            author: "Test User".to_string(),
+            content: Some(content.to_string()),
+            runs: vec![RichTextRun {
+                text: content.to_string(),
+                ..Default::default()
+            }],
+            comment_type: CommentType::Note,
+            ..Default::default()
+        }],
+        legacy_comment_authors: vec!["Test User".to_string()],
+        comment_package,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn l2_xlsx_export_reserves_all_imported_comment_paths_before_allocating_new_ones() {
+    let input = ParseOutput {
+        sheets: vec![
+            legacy_note_sheet("New comments", "A1", "new note", None),
+            legacy_note_sheet(
+                "Imported comments",
+                "A1",
+                "preserved note",
+                Some(SheetCommentPackageInfo {
+                    comments_path_hint: Some("xl/comments1.xml".to_string()),
+                    comments_relationship_id_hint: Some("rIdImportedComments".to_string()),
+                    vml_path_hint: Some("xl/drawings/vmlDrawing1.vml".to_string()),
+                    vml_relationship_id_hint: Some("rIdImportedVml".to_string()),
+                    ..Default::default()
+                }),
+            ),
+        ],
+        ..Default::default()
+    };
+
+    let engine = engine_from_parse_output_normal(&input);
+    let exported_bytes = engine.export_to_xlsx_bytes().expect("export xlsx bytes");
+
+    let imported_comments = archive_text(&exported_bytes, "xl/comments1.xml")
+        .expect("imported comments path should remain owned by the imported sheet");
+    let generated_comments = archive_text(&exported_bytes, "xl/comments2.xml")
+        .expect("new comments should use the next unreserved comments path");
+    assert!(imported_comments.contains("preserved note"));
+    assert!(!imported_comments.contains("new note"));
+    assert!(generated_comments.contains("new note"));
+
+    let new_sheet_rels = archive_text(&exported_bytes, "xl/worksheets/_rels/sheet1.xml.rels")
+        .expect("new-comments sheet relationships");
+    let imported_sheet_rels = archive_text(&exported_bytes, "xl/worksheets/_rels/sheet2.xml.rels")
+        .expect("imported-comments sheet relationships");
+    assert!(new_sheet_rels.contains(r#"Target="../comments2.xml""#));
+    assert!(imported_sheet_rels.contains(r#"Target="../comments1.xml""#));
+    assert!(new_sheet_rels.contains(r#"Target="../drawings/vmlDrawing2.vml""#));
+    assert!(imported_sheet_rels.contains(r#"Target="../drawings/vmlDrawing1.vml""#));
+}
+
 #[test]
 fn l2_xlsx_export_preserves_imported_comment_package_paths() {
     let thread_id = "{00000000-0000-0000-0000-000000000001}";

--- a/compute/core/src/storage/engine/tests/test_xlsx_export_comments.rs
+++ b/compute/core/src/storage/engine/tests/test_xlsx_export_comments.rs
@@ -46,14 +46,26 @@ fn l2_xlsx_export_reserves_all_imported_comment_paths_before_allocating_new_ones
         sheets: vec![
             legacy_note_sheet("New comments", "A1", "new note", None),
             legacy_note_sheet(
-                "Imported comments",
+                "Imported comments 1",
                 "A1",
-                "preserved note",
+                "preserved note 1",
                 Some(SheetCommentPackageInfo {
                     comments_path_hint: Some("xl/comments1.xml".to_string()),
                     comments_relationship_id_hint: Some("rIdImportedComments".to_string()),
                     vml_path_hint: Some("xl/drawings/vmlDrawing1.vml".to_string()),
                     vml_relationship_id_hint: Some("rIdImportedVml".to_string()),
+                    ..Default::default()
+                }),
+            ),
+            legacy_note_sheet(
+                "Imported comments 3",
+                "A1",
+                "preserved note 3",
+                Some(SheetCommentPackageInfo {
+                    comments_path_hint: Some("xl/comments3.xml".to_string()),
+                    comments_relationship_id_hint: Some("rIdImportedComments3".to_string()),
+                    vml_path_hint: Some("xl/drawings/vmlDrawing3.vml".to_string()),
+                    vml_relationship_id_hint: Some("rIdImportedVml3".to_string()),
                     ..Default::default()
                 }),
             ),
@@ -64,22 +76,30 @@ fn l2_xlsx_export_reserves_all_imported_comment_paths_before_allocating_new_ones
     let engine = engine_from_parse_output_normal(&input);
     let exported_bytes = engine.export_to_xlsx_bytes().expect("export xlsx bytes");
 
-    let imported_comments = archive_text(&exported_bytes, "xl/comments1.xml")
+    let imported_comments1 = archive_text(&exported_bytes, "xl/comments1.xml")
         .expect("imported comments path should remain owned by the imported sheet");
-    let generated_comments = archive_text(&exported_bytes, "xl/comments2.xml")
-        .expect("new comments should use the next unreserved comments path");
-    assert!(imported_comments.contains("preserved note"));
-    assert!(!imported_comments.contains("new note"));
+    let imported_comments3 = archive_text(&exported_bytes, "xl/comments3.xml")
+        .expect("sparse imported comments path should remain owned by the imported sheet");
+    let generated_comments = archive_text(&exported_bytes, "xl/comments4.xml")
+        .expect("new comments should use max imported path plus one");
+    assert!(imported_comments1.contains("preserved note 1"));
+    assert!(!imported_comments1.contains("new note"));
+    assert!(imported_comments3.contains("preserved note 3"));
+    assert!(!imported_comments3.contains("new note"));
     assert!(generated_comments.contains("new note"));
 
     let new_sheet_rels = archive_text(&exported_bytes, "xl/worksheets/_rels/sheet1.xml.rels")
         .expect("new-comments sheet relationships");
-    let imported_sheet_rels = archive_text(&exported_bytes, "xl/worksheets/_rels/sheet2.xml.rels")
-        .expect("imported-comments sheet relationships");
-    assert!(new_sheet_rels.contains(r#"Target="../comments2.xml""#));
-    assert!(imported_sheet_rels.contains(r#"Target="../comments1.xml""#));
-    assert!(new_sheet_rels.contains(r#"Target="../drawings/vmlDrawing2.vml""#));
-    assert!(imported_sheet_rels.contains(r#"Target="../drawings/vmlDrawing1.vml""#));
+    let imported_sheet1_rels = archive_text(&exported_bytes, "xl/worksheets/_rels/sheet2.xml.rels")
+        .expect("imported-comments1 sheet relationships");
+    let imported_sheet3_rels = archive_text(&exported_bytes, "xl/worksheets/_rels/sheet3.xml.rels")
+        .expect("imported-comments3 sheet relationships");
+    assert!(new_sheet_rels.contains(r#"Target="../comments4.xml""#));
+    assert!(imported_sheet1_rels.contains(r#"Target="../comments1.xml""#));
+    assert!(imported_sheet3_rels.contains(r#"Target="../comments3.xml""#));
+    assert!(new_sheet_rels.contains(r#"Target="../drawings/vmlDrawing4.vml""#));
+    assert!(imported_sheet1_rels.contains(r#"Target="../drawings/vmlDrawing1.vml""#));
+    assert!(imported_sheet3_rels.contains(r#"Target="../drawings/vmlDrawing3.vml""#));
 }
 
 #[test]

--- a/file-io/xlsx/parser/src/domain/charts/reconstruct/chart_groups.rs
+++ b/file-io/xlsx/parser/src/domain/charts/reconstruct/chart_groups.rs
@@ -19,7 +19,7 @@ use super::{
     formatting::{build_outline, build_shape_properties},
     ranges::series_for_export,
     series::{build_series, preserve_imported_series_text_body_properties},
-    text_body_fidelity::preserve_imported_optional_data_label_options_text_properties,
+    text_body_fidelity::preserve_imported_optional_data_label_options_fidelity,
 };
 
 // =============================================================================
@@ -65,7 +65,7 @@ pub(super) fn build_chart_groups(spec: &ChartSpec) -> Vec<ChartGroup> {
 
                     // Inject chart-level data labels
                     let mut d_lbls = spec.data_labels.as_ref().map(build_data_labels);
-                    preserve_imported_optional_data_label_options_text_properties(
+                    preserve_imported_optional_data_label_options_fidelity(
                         &mut d_lbls,
                         group.d_lbls.as_ref(),
                     );

--- a/file-io/xlsx/parser/src/domain/charts/reconstruct/series.rs
+++ b/file-io/xlsx/parser/src/domain/charts/reconstruct/series.rs
@@ -20,7 +20,7 @@ use super::{
     formatting::{build_drawing_color, build_outline, build_shape_properties, build_text_body},
     text_body_fidelity::{
         preserve_imported_data_label_text_properties,
-        preserve_imported_optional_data_label_options_text_properties,
+        preserve_imported_optional_data_label_options_fidelity,
     },
 };
 
@@ -208,7 +208,7 @@ pub(super) fn preserve_imported_series_text_body_properties(
     target: &mut charts::ChartSeries,
     imported: &charts::ChartSeries,
 ) {
-    preserve_imported_optional_data_label_options_text_properties(
+    preserve_imported_optional_data_label_options_fidelity(
         &mut target.d_lbls,
         imported.d_lbls.as_ref(),
     );

--- a/file-io/xlsx/parser/src/domain/charts/reconstruct/tests/data_label_fidelity.rs
+++ b/file-io/xlsx/parser/src/domain/charts/reconstruct/tests/data_label_fidelity.rs
@@ -297,6 +297,56 @@ fn imported_group_explicit_false_data_label_flags_survive_reconstruction() {
 }
 
 #[test]
+fn imported_series_explicit_false_data_label_flags_survive_reconstruction() {
+    let mut spec = minimal_chart_spec(DomainChartType::Pie, None);
+    spec.series = vec![modeled_series(0, None, "Composition", "Data!$B$2:$B$4")];
+    spec.definition = Some(ChartDefinition::Chart(ChartSpace {
+        chart: Chart {
+            plot_area: PlotArea {
+                chart_groups: vec![ChartGroup {
+                    chart_type: OoxmlChartType::Pie,
+                    config: ChartTypeConfig::Pie(PieChartConfig::default()),
+                    series: vec![ChartSeries {
+                        idx: 0,
+                        order: 0,
+                        d_lbls: Some(imported_explicit_false_data_label_options()),
+                        ..Default::default()
+                    }],
+                    d_lbls: None,
+                    ax_id: Vec::new(),
+                    raw_chart_type_attr: None,
+                    raw_chart_element_name: None,
+                    raw_chart_group_xml: None,
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    }));
+
+    let xml = chart_xml(&spec);
+    let series_xml = xml
+        .split_once("<c:ser>")
+        .and_then(|(_, remainder)| remainder.split_once("</c:ser>"))
+        .map(|(series, _)| series)
+        .expect("reconstructed series XML");
+
+    assert!(series_xml.contains(r#"<c:showVal val="0"/>"#), "{xml}");
+    assert!(series_xml.contains(r#"<c:showCatName val="0"/>"#), "{xml}");
+    assert!(series_xml.contains(r#"<c:showSerName val="0"/>"#), "{xml}");
+    assert!(series_xml.contains(r#"<c:showPercent val="0"/>"#), "{xml}");
+    assert!(
+        series_xml.contains(r#"<c:showLegendKey val="0"/>"#),
+        "{xml}"
+    );
+    assert!(
+        series_xml.contains(r#"<c:showBubbleSize val="0"/>"#),
+        "{xml}"
+    );
+}
+
+#[test]
 fn series_leader_line_alias_reconstructs_data_label_leader_lines() {
     let mut spec = minimal_chart_spec(DomainChartType::Pie, None);
     let mut series = modeled_series(0, None, "Composition", "Data!$B$2:$B$4");

--- a/file-io/xlsx/parser/src/domain/charts/reconstruct/tests/data_label_fidelity.rs
+++ b/file-io/xlsx/parser/src/domain/charts/reconstruct/tests/data_label_fidelity.rs
@@ -243,6 +243,60 @@ fn imported_group_data_label_text_properties_materialize_when_modeled_labels_abs
 }
 
 #[test]
+fn imported_group_explicit_false_data_label_flags_survive_reconstruction() {
+    let mut spec = minimal_chart_spec(DomainChartType::Pie, None);
+    spec.series = vec![modeled_series(0, None, "Composition", "Data!$B$2:$B$4")];
+    spec.definition = Some(ChartDefinition::Chart(ChartSpace {
+        chart: Chart {
+            plot_area: PlotArea {
+                chart_groups: vec![
+                    ChartGroup {
+                        chart_type: OoxmlChartType::Pie,
+                        config: ChartTypeConfig::Pie(PieChartConfig::default()),
+                        series: vec![ChartSeries {
+                            idx: 0,
+                            order: 0,
+                            ..Default::default()
+                        }],
+                        d_lbls: None,
+                        ax_id: Vec::new(),
+                        raw_chart_type_attr: None,
+                        raw_chart_element_name: None,
+                        raw_chart_group_xml: None,
+                    },
+                    ChartGroup {
+                        chart_type: OoxmlChartType::Pie,
+                        config: ChartTypeConfig::Pie(PieChartConfig::default()),
+                        series: vec![ChartSeries {
+                            idx: 0,
+                            order: 0,
+                            ..Default::default()
+                        }],
+                        d_lbls: Some(imported_explicit_false_data_label_options()),
+                        ax_id: Vec::new(),
+                        raw_chart_type_attr: None,
+                        raw_chart_element_name: None,
+                        raw_chart_group_xml: None,
+                    },
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    }));
+
+    let xml = chart_xml(&spec);
+
+    assert!(xml.contains(r#"<c:showVal val="0"/>"#), "{xml}");
+    assert!(xml.contains(r#"<c:showCatName val="0"/>"#), "{xml}");
+    assert!(xml.contains(r#"<c:showSerName val="0"/>"#), "{xml}");
+    assert!(xml.contains(r#"<c:showPercent val="0"/>"#), "{xml}");
+    assert!(xml.contains(r#"<c:showLegendKey val="0"/>"#), "{xml}");
+    assert!(xml.contains(r#"<c:showBubbleSize val="0"/>"#), "{xml}");
+}
+
+#[test]
 fn series_leader_line_alias_reconstructs_data_label_leader_lines() {
     let mut spec = minimal_chart_spec(DomainChartType::Pie, None);
     let mut series = modeled_series(0, None, "Composition", "Data!$B$2:$B$4");
@@ -302,6 +356,18 @@ fn imported_data_label_options() -> DataLabelOptions {
                 </a:p>
             </c:txPr>"#,
         )),
+        ..Default::default()
+    }
+}
+
+fn imported_explicit_false_data_label_options() -> DataLabelOptions {
+    DataLabelOptions {
+        show_value_present: true,
+        show_category_present: true,
+        show_series_name_present: true,
+        show_percent_present: true,
+        show_legend_key_present: true,
+        show_bubble_size_present: true,
         ..Default::default()
     }
 }

--- a/file-io/xlsx/parser/src/domain/charts/reconstruct/text_body_fidelity.rs
+++ b/file-io/xlsx/parser/src/domain/charts/reconstruct/text_body_fidelity.rs
@@ -33,13 +33,49 @@ pub(super) fn preserve_imported_text_body_properties(
     }
 }
 
-pub(super) fn preserve_imported_data_label_options_text_properties(
+pub(super) fn preserve_imported_data_label_options_fidelity(
     target: &mut DataLabelOptions,
     imported: Option<&DataLabelOptions>,
 ) {
     let Some(imported) = imported else {
         return;
     };
+    preserve_imported_display_flag(
+        &mut target.show_value,
+        &mut target.show_value_present,
+        imported.show_value,
+        imported.show_value_present,
+    );
+    preserve_imported_display_flag(
+        &mut target.show_category,
+        &mut target.show_category_present,
+        imported.show_category,
+        imported.show_category_present,
+    );
+    preserve_imported_display_flag(
+        &mut target.show_series_name,
+        &mut target.show_series_name_present,
+        imported.show_series_name,
+        imported.show_series_name_present,
+    );
+    preserve_imported_display_flag(
+        &mut target.show_percent,
+        &mut target.show_percent_present,
+        imported.show_percent,
+        imported.show_percent_present,
+    );
+    preserve_imported_display_flag(
+        &mut target.show_legend_key,
+        &mut target.show_legend_key_present,
+        imported.show_legend_key,
+        imported.show_legend_key_present,
+    );
+    preserve_imported_display_flag(
+        &mut target.show_bubble_size,
+        &mut target.show_bubble_size_present,
+        imported.show_bubble_size,
+        imported.show_bubble_size_present,
+    );
     preserve_imported_text_body_properties(&mut target.tx_pr, imported.tx_pr.as_ref());
 
     for label in &mut target.d_lbl {
@@ -51,18 +87,38 @@ pub(super) fn preserve_imported_data_label_options_text_properties(
     }
 }
 
-pub(super) fn preserve_imported_optional_data_label_options_text_properties(
+pub(super) fn preserve_imported_optional_data_label_options_fidelity(
     target: &mut Option<DataLabelOptions>,
     imported: Option<&DataLabelOptions>,
 ) {
     let Some(imported) = imported else {
         return;
     };
-    if target.is_none() && imported.tx_pr.is_some() {
+    if target.is_none()
+        && (imported.tx_pr.is_some()
+            || imported.show_value_present
+            || imported.show_category_present
+            || imported.show_series_name_present
+            || imported.show_percent_present
+            || imported.show_legend_key_present
+            || imported.show_bubble_size_present)
+    {
         *target = Some(DataLabelOptions::default());
     }
     if let Some(target) = target.as_mut() {
-        preserve_imported_data_label_options_text_properties(target, Some(imported));
+        preserve_imported_data_label_options_fidelity(target, Some(imported));
+    }
+}
+
+fn preserve_imported_display_flag(
+    target_value: &mut bool,
+    target_present: &mut bool,
+    imported_value: bool,
+    imported_present: bool,
+) {
+    if !*target_present && imported_present {
+        *target_value = imported_value;
+        *target_present = true;
     }
 }
 

--- a/file-io/xlsx/parser/src/write/from_parse_output/chart_auxiliary.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/chart_auxiliary.rs
@@ -188,6 +188,33 @@ pub(super) fn supported_auxiliary_file_paths(
         .collect()
 }
 
+pub(super) fn auxiliary_file_paths_for_export(
+    chart_spec: &ChartSpec,
+    chart_path: &str,
+    allows_current_auxiliary_replay: bool,
+) -> BTreeSet<String> {
+    let Some(aux) = chart_auxiliary_data(chart_spec) else {
+        return BTreeSet::new();
+    };
+    let supported = supported_auxiliary_file_paths(&aux, chart_path);
+    if allows_current_auxiliary_replay {
+        return supported;
+    }
+    if chart_spec.is_chart_ex {
+        return BTreeSet::new();
+    }
+
+    let generated_color_style = generated_chart_color_style_data(chart_spec, chart_path).is_some();
+    supported
+        .into_iter()
+        .filter(|path| match auxiliary_kind(path) {
+            Some(AuxiliaryKind::Style) => true,
+            Some(AuxiliaryKind::ColorStyle) => !generated_color_style,
+            Some(AuxiliaryKind::UserShapes) | None => false,
+        })
+        .collect()
+}
+
 fn auxiliary_file_is_replay_safe(aux: &ChartAuxiliaryDataRef<'_>, path: &str) -> bool {
     if !matches!(auxiliary_kind(path), Some(AuxiliaryKind::ColorStyle)) {
         return true;

--- a/file-io/xlsx/parser/src/write/from_parse_output/export_report.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/export_report.rs
@@ -200,23 +200,30 @@ fn append_standard_chart_export_diagnostics(
 
     append_standard_chart_source_cache_diagnostics(chart, chart_path, diagnostics);
     if let Some(aux) = super::chart_auxiliary::chart_auxiliary_data(chart) {
-        if !super::chart_replay::chart_allows_current_auxiliary_replay(chart, &aux.original_path) {
+        let allows_current_auxiliary_replay =
+            super::chart_replay::chart_allows_current_auxiliary_replay(chart, chart_path);
+        let exported_paths = super::chart_auxiliary::auxiliary_file_paths_for_export(
+            chart,
+            chart_path,
+            allows_current_auxiliary_replay,
+        );
+        let supported_paths =
+            super::chart_auxiliary::supported_auxiliary_file_paths(&aux, chart_path);
+        if !allows_current_auxiliary_replay && exported_paths != supported_paths {
             push_chart_diagnostic(
                 diagnostics,
                 ExportDiagnosticCode::ChartAuxiliaryReplaySuppressed,
                 "chartAuxiliary",
-                Some(&aux.original_path),
+                Some(chart_path),
                 ExportSemanticImpact::PackagePreservationDropped,
-                "Imported chart auxiliary package replay was suppressed because authority is not current."
+                "Opaque imported chart auxiliary replay was suppressed because authority is not current; safe style/color companions remain eligible for export."
                     .to_string(),
             );
         }
 
-        let supported_paths =
-            super::chart_auxiliary::supported_auxiliary_file_paths(&aux, &aux.original_path);
         for (path, _) in aux.auxiliary_files {
             let normalized = path.trim_start_matches('/');
-            if !supported_paths.contains(normalized) {
+            if !exported_paths.contains(normalized) {
                 push_chart_diagnostic(
                     diagnostics,
                     ExportDiagnosticCode::ChartAuxiliaryPartDropped,

--- a/file-io/xlsx/parser/src/write/from_parse_output/mod.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/mod.rs
@@ -302,7 +302,18 @@ pub fn write_xlsx_from_parse_output(output: &ParseOutput) -> Result<Vec<u8>, Wri
     // Global VML drawing counter for archive paths (xl/drawings/vmlDrawing{N}.vml).
     // Excel numbers VML drawings sequentially across all sheets (1, 2, 3...),
     // NOT by sheet index. This counter mirrors the pattern used by global_table_idx.
-    let mut global_vml_idx: usize = 0;
+    let mut global_vml_idx = sheet_extras
+        .iter()
+        .flat_map(|extras| {
+            extras
+                .original_vml_path
+                .as_deref()
+                .into_iter()
+                .chain(extras.hf_vml.as_ref().map(|hf| hf.vml_path.as_str()))
+        })
+        .filter_map(extract_vml_drawing_number)
+        .max()
+        .unwrap_or(0);
 
     // Global drawing counter for archive paths (xl/drawings/drawing{N}.xml).
     // Excel numbers drawings sequentially across sheets that have drawings (1, 2, 3...),
@@ -312,10 +323,20 @@ pub fn write_xlsx_from_parse_output(output: &ParseOutput) -> Result<Vec<u8>, Wri
     // Global comment counter for archive paths (xl/comments{N}.xml).
     // Excel numbers comment files sequentially across sheets that have comments (1, 2, 3...),
     // NOT by sheet index. Same pattern as VML drawings and tables.
-    let mut global_comment_idx: usize = 0;
+    let mut global_comment_idx = sheet_extras
+        .iter()
+        .filter_map(|extras| extras.original_comment_path.as_deref())
+        .filter_map(extract_comment_number)
+        .max()
+        .unwrap_or(0);
 
     // Global threaded comment counter (xl/threadedComments/threadedComment{N}.xml).
-    let mut global_tc_idx: usize = 0;
+    let mut global_tc_idx = sheet_extras
+        .iter()
+        .filter_map(|extras| extras.original_threaded_comments_path.as_deref())
+        .filter_map(extract_threaded_comment_number)
+        .max()
+        .unwrap_or(0);
 
     // Global ctrlProp counter for archive paths (xl/ctrlProps/ctrlProp{N}.xml).
     let mut global_ctrl_prop_idx: usize = 0;
@@ -467,15 +488,13 @@ pub fn write_xlsx_from_parse_output(output: &ParseOutput) -> Result<Vec<u8>, Wri
 
         // Comment rels
         if has_comments {
-            global_vml_idx += 1;
-            global_comment_idx += 1;
             let comments_path = sheet_extras[sheet_idx]
                 .original_comment_path
                 .clone()
-                .unwrap_or_else(|| format!("xl/comments{}.xml", global_comment_idx));
-            if let Some(n) = extract_comment_number(&comments_path) {
-                global_comment_idx = global_comment_idx.max(n);
-            }
+                .unwrap_or_else(|| {
+                    global_comment_idx += 1;
+                    format!("xl/comments{}.xml", global_comment_idx)
+                });
             let comments_target = worksheet_relative_target(&comments_path);
             let generated_comments_r_id = rels.add(REL_COMMENTS, &comments_target);
             let comments_relationship_id_hint = sheet_extras[sheet_idx]
@@ -485,10 +504,10 @@ pub fn write_xlsx_from_parse_output(output: &ParseOutput) -> Result<Vec<u8>, Wri
             let vml_path = sheet_extras[sheet_idx]
                 .original_vml_path
                 .clone()
-                .unwrap_or_else(|| format!("xl/drawings/vmlDrawing{}.vml", global_vml_idx));
-            if let Some(n) = extract_vml_drawing_number(&vml_path) {
-                global_vml_idx = global_vml_idx.max(n);
-            }
+                .unwrap_or_else(|| {
+                    global_vml_idx += 1;
+                    format!("xl/drawings/vmlDrawing{}.vml", global_vml_idx)
+                });
             let vml_target = worksheet_relative_target(&vml_path);
             let generated_vml_r_id = rels.add(REL_VML_DRAWING, &vml_target);
             let vml_relationship_id_hint = sheet_extras[sheet_idx]
@@ -559,14 +578,13 @@ pub fn write_xlsx_from_parse_output(output: &ParseOutput) -> Result<Vec<u8>, Wri
 
             // Add VML drawing relationship for form controls (separate from comment VML)
             if !has_comments {
-                global_vml_idx += 1;
                 let path = sheet_extras[sheet_idx]
                     .original_vml_path
                     .clone()
-                    .unwrap_or_else(|| format!("xl/drawings/vmlDrawing{}.vml", global_vml_idx));
-                if let Some(n) = extract_vml_drawing_number(&path) {
-                    global_vml_idx = global_vml_idx.max(n);
-                }
+                    .unwrap_or_else(|| {
+                        global_vml_idx += 1;
+                        format!("xl/drawings/vmlDrawing{}.vml", global_vml_idx)
+                    });
                 let target = worksheet_relative_target(&path);
                 let relationship_id_hint = Some(rels.add(REL_VML_DRAWING, &target));
                 worksheet_form_control_vml_relationships.push(WorksheetFormControlVmlGraphEntry {
@@ -597,14 +615,13 @@ pub fn write_xlsx_from_parse_output(output: &ParseOutput) -> Result<Vec<u8>, Wri
             }
 
             if !has_comments && !has_form_controls {
-                global_vml_idx += 1;
                 let path = sheet_extras[sheet_idx]
                     .original_vml_path
                     .clone()
-                    .unwrap_or_else(|| format!("xl/drawings/vmlDrawing{}.vml", global_vml_idx));
-                if let Some(n) = extract_vml_drawing_number(&path) {
-                    global_vml_idx = global_vml_idx.max(n);
-                }
+                    .unwrap_or_else(|| {
+                        global_vml_idx += 1;
+                        format!("xl/drawings/vmlDrawing{}.vml", global_vml_idx)
+                    });
                 let target = worksheet_relative_target(&path);
                 let relationship_id_hint = Some(rels.add(REL_VML_DRAWING, &target));
                 worksheet_ole_vml_relationships.push(WorksheetOleVmlGraphEntry {
@@ -618,13 +635,11 @@ pub fn write_xlsx_from_parse_output(output: &ParseOutput) -> Result<Vec<u8>, Wri
 
         // Threaded comment rels (must come after legacy comment rels)
         if has_threaded_comments {
-            global_tc_idx += 1;
-            if let Some(path) = sheet_extras[sheet_idx]
+            if sheet_extras[sheet_idx]
                 .original_threaded_comments_path
-                .as_deref()
-                && let Some(n) = extract_threaded_comment_number(path)
+                .is_none()
             {
-                global_tc_idx = global_tc_idx.max(n);
+                global_tc_idx += 1;
             }
             worksheet_threaded_comments_relationships.push(
                 threaded_comments::add_relationship_for_export(
@@ -1430,11 +1445,14 @@ pub fn write_xlsx_from_parse_output(output: &ParseOutput) -> Result<Vec<u8>, Wri
                 chart_spec,
                 &chart_path,
             )?;
-            if chart_replay::chart_allows_current_auxiliary_replay(chart_spec, &chart_path)
-                && let Some(aux) = chart_auxiliary::chart_auxiliary_data(chart_spec)
-            {
-                let auxiliary_paths =
-                    chart_auxiliary::supported_auxiliary_file_paths(&aux, &chart_path);
+            if let Some(aux) = chart_auxiliary::chart_auxiliary_data(chart_spec) {
+                let allows_current_auxiliary_replay =
+                    chart_replay::chart_allows_current_auxiliary_replay(chart_spec, &chart_path);
+                let auxiliary_paths = chart_auxiliary::auxiliary_file_paths_for_export(
+                    chart_spec,
+                    &chart_path,
+                    allows_current_auxiliary_replay,
+                );
                 for (path, _) in aux.auxiliary_files {
                     if !auxiliary_paths.contains(path.trim_start_matches('/')) {
                         continue;
@@ -1495,11 +1513,14 @@ pub fn write_xlsx_from_parse_output(output: &ParseOutput) -> Result<Vec<u8>, Wri
                 chart_spec,
                 &chart_path,
             )?;
-            if chart_replay::chart_allows_current_auxiliary_replay(chart_spec, &chart_path)
-                && let Some(aux) = chart_auxiliary::chart_auxiliary_data(chart_spec)
-            {
-                let auxiliary_paths =
-                    chart_auxiliary::supported_auxiliary_file_paths(&aux, &chart_path);
+            if let Some(aux) = chart_auxiliary::chart_auxiliary_data(chart_spec) {
+                let allows_current_auxiliary_replay =
+                    chart_replay::chart_allows_current_auxiliary_replay(chart_spec, &chart_path);
+                let auxiliary_paths = chart_auxiliary::auxiliary_file_paths_for_export(
+                    chart_spec,
+                    &chart_path,
+                    allows_current_auxiliary_replay,
+                );
                 for (path, _) in aux.auxiliary_files {
                     if !auxiliary_paths.contains(path.trim_start_matches('/')) {
                         continue;

--- a/file-io/xlsx/parser/src/write/from_parse_output/zip_assembly.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/zip_assembly.rs
@@ -607,13 +607,14 @@ pub(super) fn write_zip_package(
                     )?;
                 }
 
-                // Write chart auxiliary files (style XML, colors XML) only
-                // when the current chart still carries imported chart identity.
-                if allows_current_auxiliary_replay
-                    && let Some(aux) = chart_auxiliary::chart_auxiliary_data(chart_spec)
-                {
-                    let auxiliary_paths =
-                        chart_auxiliary::supported_auxiliary_file_paths(&aux, &chart_path);
+                // Imported style/color parts remain valid when a standard chart is
+                // reconstructed. Opaque user-shape replay still requires current authority.
+                if let Some(aux) = chart_auxiliary::chart_auxiliary_data(chart_spec) {
+                    let auxiliary_paths = chart_auxiliary::auxiliary_file_paths_for_export(
+                        chart_spec,
+                        &chart_path,
+                        allows_current_auxiliary_replay,
+                    );
                     // Write auxiliary files (style, colors XML) preserving their original paths.
                     for (path, data) in aux.auxiliary_files {
                         if !auxiliary_paths.contains(path.trim_start_matches('/')) {
@@ -695,11 +696,12 @@ pub(super) fn write_zip_package(
                         color_style.data,
                     )?;
                 }
-                if allows_current_auxiliary_replay
-                    && let Some(aux) = chart_auxiliary::chart_auxiliary_data(chart_spec)
-                {
-                    let auxiliary_paths =
-                        chart_auxiliary::supported_auxiliary_file_paths(&aux, &chart_path);
+                if let Some(aux) = chart_auxiliary::chart_auxiliary_data(chart_spec) {
+                    let auxiliary_paths = chart_auxiliary::auxiliary_file_paths_for_export(
+                        chart_spec,
+                        &chart_path,
+                        allows_current_auxiliary_replay,
+                    );
                     for (path, data) in aux.auxiliary_files {
                         if !auxiliary_paths.contains(path.trim_start_matches('/')) {
                             continue;


### PR DESCRIPTION
## What this fixes

This fixes the three deterministic OOXML repair classes isolated from the v3 stage-gate artifacts:

- Preserve explicit false data-label flags during standard-chart reconstruction at both chart-group and series level.
- Preserve safe imported chart style/color companion parts, relationships, and content-type declarations when an edit forces chart reconstruction.
- Reserve every imported comment, threaded-comment, and VML path before allocating generated parts, using max(existing) + 1 for sparse packages.

No customer workbook is committed; regressions use synthetic package metadata.

## Regression coverage

- Group-level explicit-false chart labels
- Series-level explicit-false chart labels
- Reconstructed chart companion package closure
- Sparse imported comments1/comments3 and VML1/VML3 with a generated sheet first, requiring allocation at 4

## Verification

Run on a temporary GCP high-memory worker at `1319f68f7`:

- `cargo test -p xlsx-parser explicit_false_data_label_flags_survive_reconstruction --locked --lib`: 2 passed
- `cargo test -p xlsx-parser data_label_fidelity --locked --lib`: 9 passed
- `cargo test -p compute-core l2_xlsx_export_reserves_all_imported_comment_paths_before_allocating_new_ones --locked --lib`: 1 passed
- `cargo test -p compute-core test_xlsx_export_comments --locked --lib`: 2 passed
- `cargo test -p compute-core reconstructed_standard_chart_retains_imported_style_and_color_companions --locked --lib`: 1 passed
- `cargo test -p compute-core test_xlsx_export_charts --locked --lib`: 7 passed
- `cargo fmt --all -- --check`

The full release fleet remains a post-merge gate before publishing 0.10.8.