### PR TITLE
fix(xlsx): preserve imported chart series tints

### DIFF
--- a/file-io/xlsx/parser/src/domain/charts/read/extraction/legacy.rs
+++ b/file-io/xlsx/parser/src/domain/charts/read/extraction/legacy.rs
@@ -3,7 +3,7 @@ use super::data_refs::{
     extract_cat_ref_formula, extract_num_ref_formula, reconstruct_data_range,
     reconstruct_data_range_from_chart_groups,
 };
-use super::formatting::extract_fill_color;
+use super::formatting::{extract_chart_format, extract_fill_color};
 use super::labels::{extract_data_label_data, extract_data_label_data_from_chart_type_config};
 use super::markers::extract_marker_config;
 use super::series::extract_single_series;
@@ -183,7 +183,7 @@ pub(in crate::domain::charts::read) fn extract_chart_series(
                 y_error_bars,
                 idx: Some(s.idx),
                 order: Some(s.order),
-                format: None,
+                format: extract_chart_format(s.sp_pr.as_ref(), None),
                 bar_shape: None,
                 invert_color: None,
                 marker_background_color: marker_config.background_color,
@@ -206,6 +206,47 @@ pub(in crate::domain::charts::read) fn extract_chart_series(
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_chart_series;
+    use domain_types::chart::{ChartColorData, ChartFillData};
+
+    #[test]
+    fn flat_series_preserves_theme_tint_in_mutable_chart_format() {
+        let chart = crate::domain::charts::Chart {
+            series: vec![ooxml_types::charts::ChartSeries {
+                idx: 0,
+                order: 0,
+                sp_pr: Some(crate::domain::charts::parse_shape_properties(
+                    br#"<c:spPr xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+                               xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                        <a:solidFill>
+                            <a:schemeClr val="accent1"><a:tint val="86000"/></a:schemeClr>
+                        </a:solidFill>
+                    </c:spPr>"#,
+                )),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let series = extract_chart_series(&chart);
+        let tint_shade = series[0]
+            .format
+            .as_ref()
+            .and_then(|format| format.fill.as_ref())
+            .and_then(|fill| match fill {
+                ChartFillData::Solid {
+                    color: ChartColorData::Theme { tint_shade, .. },
+                    ..
+                } => *tint_shade,
+                _ => None,
+            });
+
+        assert_eq!(tint_shade, Some(0.86));
+    }
 }
 
 fn extract_error_bars_typed(

--- a/kernel/src/domain/charts/__tests__/chart-type-converters.test.ts
+++ b/kernel/src/domain/charts/__tests__/chart-type-converters.test.ts
@@ -13,6 +13,7 @@ import {
   wireToSeriesConfig,
   wireToSizeRepresents,
 } from '../chart-type-converters';
+import type { ChartColorData } from '../../../bridges/compute/compute-types.gen';
 
 describe('chart-type-converters', () => {
   it('narrows canonical and aliased chart type strings at the wire boundary', () => {
@@ -156,6 +157,12 @@ describe('chart-type-converters', () => {
   });
 
   it('converts nested chart format colors between wire tint_shade and contract tintShade', () => {
+    const runtimeColor = {
+      theme: 'accent1',
+      tintShade: 0.86,
+    } as ChartColorData & { tintShade: number };
+    expect(wireToChartColor(runtimeColor)).toEqual({ theme: 'accent1', tintShade: 0.86 });
+
     expect(
       wireToChartFormat({
         fill: { type: 'solid', color: { theme: 'accent1', tint_shade: 0.25 } },

--- a/kernel/src/domain/charts/chart-format-converters.ts
+++ b/kernel/src/domain/charts/chart-format-converters.ts
@@ -54,9 +54,11 @@ export function directHexPaletteToWire(colors: string[] | undefined): string[] |
 export function wireToChartColor(color: ChartColorData | undefined): ChartColor | undefined {
   if (typeof color === 'string') return wireToDirectHexColor(color);
   if (!color || typeof color !== 'object') return undefined;
+  const tintShade =
+    color.tint_shade ?? (color as ChartColorData & { tintShade?: number }).tintShade;
   return {
     theme: color.theme,
-    ...(color.tint_shade !== undefined ? { tintShade: color.tint_shade } : {}),
+    ...(tintShade !== undefined ? { tintShade } : {}),
   };
 }
 


### PR DESCRIPTION
## Problem

Editing an imported chart series forced typed OOXML reconstruction, but flat chart series dropped their imported `spPr` formatting. Theme colors therefore lost their tint/shade transforms and distinct stacked-bar segments collapsed to the same base theme color.

The runtime bridge also returns imported theme transforms as `tintShade`, while the generated wire type uses `tint_shade`; the public conversion boundary discarded the runtime form.

## Fix

- Project flat-series shape properties through the existing chart-format extractor.
- Accept both bridge/runtime `tintShade` and generated-wire `tint_shade` when reading chart colors.
- Add regressions for the parser projection and runtime conversion boundary.

## Verification

- `cargo test -p xlsx-parser flat_series_preserves_theme_tint_in_mutable_chart_format --lib --locked`
- `pnpm --filter @mog-sdk/kernel test -- chart-type-converters.test.ts`
- `pnpm --filter @mog-sdk/kernel typecheck`
- `cargo fmt --all -- --check`
- Prettier check on touched TypeScript files
- Public SDK repro: import an XLSX, call `setSeriesValues`, and save. The exported chart retains the two distinct theme tints (`86000` and `57999`, from `0.86` and `0.58`).

The full parser test binary was also attempted on the remote builder. Default parallelism was SIGKILLed after thousands of tests; a two-thread retry reached the end of the suite but hung in two unrelated existing sheet-cell tests, so no full-suite result is claimed here.
