### PR TITLE
fix(xlsx): preserve explicit default column widths

### DIFF
--- a/compute/core/src/storage/engine/services/export/dimensions.rs
+++ b/compute/core/src/storage/engine/services/export/dimensions.rs
@@ -397,40 +397,33 @@ pub(in crate::storage::engine) fn export_dimensions_for_sheet(
         let is_best_fit = best_fit_cols.contains(&col);
         let is_phonetic = phonetic_cols.contains(&col);
 
-        // Only emit a <col> entry if there's an explicit stored width, or the
-        // column is hidden/bestFit. Columns with no stored width inherit the
-        // sheet's defaultColWidth and need no explicit entry.
+        // A stored width represents an authored width and must be emitted even
+        // when it equals defaultColWidth. Dropping it can leave a width-less
+        // <col> created by column style metadata, which Excel renders as a
+        // collapsed column span.
         match explicit_width {
             Some(width) => {
                 let is_custom_width = custom_width_cols.contains(&col);
                 let width_differs = (width.0 - default_col_width.0).abs() > 0.01;
                 let custom = is_custom_width || width_differs;
                 let is_collapsed = collapsed_cols.contains(&col);
-                if custom
-                    || width_differs
-                    || is_hidden
-                    || is_best_fit
-                    || is_collapsed
-                    || is_phonetic
-                {
-                    col_widths.push(ColDimension {
-                        col,
-                        width: width.0,
-                        width_str: None,
-                        width_present: Some(true),
-                        custom_width: custom,
-                        custom_width_attr: custom.then_some(true),
-                        hidden: is_hidden,
-                        hidden_attr: is_hidden.then_some(true),
-                        best_fit: is_best_fit,
-                        best_fit_attr: is_best_fit.then_some(true),
-                        outline_level: None,
-                        collapsed: is_collapsed,
-                        collapsed_attr: is_collapsed.then_some(true),
-                        phonetic: is_phonetic,
-                        phonetic_attr: is_phonetic.then_some(true),
-                    });
-                }
+                col_widths.push(ColDimension {
+                    col,
+                    width: width.0,
+                    width_str: None,
+                    width_present: Some(true),
+                    custom_width: custom,
+                    custom_width_attr: custom.then_some(true),
+                    hidden: is_hidden,
+                    hidden_attr: is_hidden.then_some(true),
+                    best_fit: is_best_fit,
+                    best_fit_attr: is_best_fit.then_some(true),
+                    outline_level: None,
+                    collapsed: is_collapsed,
+                    collapsed_attr: is_collapsed.then_some(true),
+                    phonetic: is_phonetic,
+                    phonetic_attr: is_phonetic.then_some(true),
+                });
             }
             None => {
                 // No explicit width stored — only emit if hidden, bestFit, or collapsed

--- a/compute/core/src/storage/engine/tests/test_xlsx_export.rs
+++ b/compute/core/src/storage/engine/tests/test_xlsx_export.rs
@@ -7,7 +7,8 @@ use crate::snapshot::{
 };
 use cell_types::{ColId, PayloadEncoding, RangeAnchor, RangeId, RangeKind, RowId};
 use domain_types::{
-    AutoFilter, ParseOutput, SheetData, SheetDimensions, SortCondition, SortConditionBy, SortState,
+    AutoFilter, ColDimension, ColStyleRange, DocumentFormat, ParseOutput, SheetData,
+    SheetDimensions, SortCondition, SortConditionBy, SortState,
     domain::comment::{Comment, CommentType, PersonInfo},
     domain::external_link::{ExternalLink, ImportedExternalLinkIdentity},
     domain::workbook::{WorkbookView, WorkbookViewVisibility, WorkbookWebPublishing},
@@ -72,6 +73,60 @@ fn archive_entry_names(bytes: &[u8]) -> Vec<String> {
         .iter()
         .map(|entry| entry.name.clone())
         .collect()
+}
+
+#[test]
+fn imported_explicit_default_width_survives_l2_export_with_column_style() {
+    let explicit_default_width = 8.83203125;
+    let input = ParseOutput {
+        style_palette: vec![DocumentFormat {
+            number_format: Some("0.00".to_string()),
+            ..Default::default()
+        }],
+        sheets: vec![SheetData {
+            name: "ValGraph".to_string(),
+            rows: 1,
+            cols: 8,
+            col_style_ranges: vec![ColStyleRange {
+                start_col: 1,
+                end_col: 7,
+                style_id: 0,
+            }],
+            dimensions: SheetDimensions {
+                default_col_width: Some(explicit_default_width),
+                col_widths: (1..=7)
+                    .map(|col| ColDimension {
+                        col,
+                        width: explicit_default_width,
+                        width_str: Some("8.83203125".to_string()),
+                        width_present: Some(true),
+                        custom_width: false,
+                        custom_width_attr: None,
+                        ..Default::default()
+                    })
+                    .collect(),
+                ..Default::default()
+            },
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let engine = engine_from_parse_output_normal(&input);
+    let exported = engine
+        .export_to_parse_output()
+        .expect("export parse output")
+        .parse_output;
+    let widths = &exported.sheets[0].dimensions.col_widths;
+    assert_eq!(widths.len(), 7, "authored widths must survive hydration");
+    assert!(widths.iter().all(|width| width.width_present == Some(true)));
+
+    let bytes = engine.export_to_xlsx_bytes().expect("export xlsx bytes");
+    let sheet_xml = archive_text(&bytes, "xl/worksheets/sheet1.xml").expect("sheet XML");
+    assert!(
+        sheet_xml.contains(r#"<col min="2" max="8" width="8.83203125""#),
+        "explicit default-width span must not become a widthless <col>: {sheet_xml}"
+    );
 }
 
 fn assert_substrings_in_order(haystack: &str, needles: &[&str]) {

--- a/compute/core/src/storage/infra/hydration/features.rs
+++ b/compute/core/src/storage/infra/hydration/features.rs
@@ -265,10 +265,13 @@ pub(super) fn hydrate_row_heights(
     }
 }
 
-/// Hydrate column widths into the Yrs colWidths map.
+/// Hydrate authored column widths into the Yrs colWidths map.
 ///
-/// Column widths are keyed by ColId (stable identity). We allocate ColIds
-/// for each column that has a custom width via the IdAllocator.
+/// Column widths are keyed by ColId (stable identity). An explicit OOXML
+/// `width` remains authored even when it equals the sheet's default width and
+/// `customWidth` is absent. Retaining those widths is necessary when the same
+/// `<col>` also owns style metadata: otherwise export can leave a width-less
+/// style span that Excel renders as collapsed.
 ///
 /// Values are stored in **character-width units** (canonical OOXML units).
 /// The LayoutIndex converts to pixels on construction.
@@ -277,10 +280,9 @@ pub(super) fn hydrate_col_widths(
     col_widths_map: &MapRef,
     col_id_hexes: &[SmallHex],
     col_widths: &[ColDimension],
-    default_col_width_cw: f64,
 ) {
     for cw in col_widths {
-        if (cw.custom_width || (cw.width - default_col_width_cw).abs() > 0.01)
+        if cw.width_present.unwrap_or(true)
             && let Some(col_id) = col_id_hexes.get(cw.col as usize)
         {
             col_widths_map.insert(txn, col_id.as_str(), Any::Number(cw.width));

--- a/compute/core/src/storage/infra/hydration/sheet/dimensions.rs
+++ b/compute/core/src/storage/infra/hydration/sheet/dimensions.rs
@@ -40,7 +40,6 @@ pub(crate) fn hydrate_dimensions(
         maps.col_widths_map,
         col_id_hexes,
         &sheet.dimensions.col_widths,
-        default_col_width_cw,
     );
 
     if (sheet_default_row_height_pt - 15.0).abs() > 0.01 {

--- a/file-io/xlsx/parser/src/write/from_parse_output/sheet_columns.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/sheet_columns.rs
@@ -150,7 +150,13 @@ pub(super) fn apply_columns(
             continue;
         };
         for col in range.start_col..=range.end_col {
-            if emitted_cols.contains(&col) {
+            let one_based = col.saturating_add(1);
+            let owned_by_trailing_dimension = sheet_data
+                .dimensions
+                .trailing_col_ranges
+                .iter()
+                .any(|trailing| one_based >= trailing.min && one_based <= trailing.max);
+            if emitted_cols.contains(&col) || owned_by_trailing_dimension {
                 continue;
             }
             let outline_level = col_outline_levels.get(&col).copied();

--- a/file-io/xlsx/parser/tests/roundtrip_parse_output/layout.rs
+++ b/file-io/xlsx/parser/tests/roundtrip_parse_output/layout.rs
@@ -7,11 +7,11 @@ use super::helpers::{
 };
 use domain_types::{
     AlignmentFormat, BorderFormat, BorderSide, CFCellRange, CFRule, CFStyle, CellData,
-    ColDimension, Comment, CommentType, ConditionalFormat, DocumentFormat, DocumentProperties,
-    ErrorStyle, FillFormat, FontFormat, FrozenPane, HeaderFooter, MergeRegion, NamedRange,
-    OutlineGroup, PageBreakEntry, PageBreaks, PageMargins, ParseOutput, PrintSettings,
+    ColDimension, ColStyleRange, Comment, CommentType, ConditionalFormat, DocumentFormat,
+    DocumentProperties, ErrorStyle, FillFormat, FontFormat, FrozenPane, HeaderFooter, MergeRegion,
+    NamedRange, OutlineGroup, PageBreakEntry, PageBreaks, PageMargins, ParseOutput, PrintSettings,
     RowDimension, RowStyleEntry, SheetData, SheetDimensions, TableColumnSpec, TableSpec,
-    ValidationOperator, ValidationRule, ValidationSpec,
+    TrailingColRange, ValidationOperator, ValidationRule, ValidationSpec,
 };
 use value_types::{CellError, CellValue, FiniteF64};
 use xlsx_parser::infra::package_integrity::validate_archive_package_integrity;
@@ -278,6 +278,47 @@ fn roundtrip_row_and_col_dimensions() {
         let diff = (orig_w - rt_w).abs();
         assert!(diff < 0.01, "Col {col} width mismatch: {orig_w} vs {rt_w}");
     }
+}
+
+#[test]
+fn trailing_explicit_width_replaces_overlapping_widthless_style_span() {
+    let mut output = make_single_sheet(
+        "Trailing widths",
+        vec![cell(0, 19, CellValue::Text(Arc::from("anchor")))],
+    );
+    output.style_palette = vec![DocumentFormat {
+        number_format: Some("0.00".to_string()),
+        ..Default::default()
+    }];
+    output.sheets[0].col_style_ranges = vec![ColStyleRange {
+        start_col: 20,
+        end_col: 16_383,
+        style_id: 0,
+    }];
+    output.sheets[0].dimensions.trailing_col_ranges = vec![TrailingColRange {
+        min: 21,
+        max: 16_384,
+        width: 8.83203125,
+        width_str: Some("8.83203125".to_string()),
+        width_present: Some(true),
+        style_id: Some(0),
+        ..Default::default()
+    }];
+
+    let bytes = write_xlsx_from_parse_output(&output).expect("export should succeed");
+    let archive = XlsxArchive::new(&bytes).expect("exported XLSX should be readable");
+    let sheet_xml =
+        String::from_utf8(archive.read_file("xl/worksheets/sheet1.xml").unwrap()).unwrap();
+
+    assert_eq!(
+        sheet_xml.matches(r#"min="21" max="16384""#).count(),
+        1,
+        "trailing dimension metadata must not overlap a widthless style span: {sheet_xml}"
+    );
+    assert!(
+        sheet_xml.contains(r#"<col min="21" max="16384" width="8.83203125""#),
+        "the authored trailing width must own the emitted span: {sheet_xml}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

A no-op XLSX roundtrip can drop an authored column width when it equals the sheet default. If the same columns carry style metadata, export then emits widthless `<col>` spans. Excel can render those columns collapsed, moving cell-anchored charts and their labels.

This reproduces in the `ValGraph` sheet of `v25-2_private_co_valuation`: the imported `B:H` span has `width="8.83203125"`, while the affected export retains the style but loses the width.

## Fix

- retain authored widths even when they equal `defaultColWidth`
- emit those widths during L2 export
- prevent a trailing widthless style span from overlapping an authored trailing dimension

## Regression coverage

- compute-core: an imported default-width styled span survives hydration and XLSX export
- xlsx-parser: a sparse trailing explicit-width span owns its emitted range without overlap

`cargo fmt --all -- --check` and `git diff --check` pass locally. Focused Rust tests will be run on remote CI/build infrastructure.