### PR TITLE
fix(xlsx): preserve imported chart axis and label state

### DIFF
--- a/compute/core/src/storage/engine/tests/test_xlsx_export_charts.rs
+++ b/compute/core/src/storage/engine/tests/test_xlsx_export_charts.rs
@@ -10,9 +10,232 @@ use domain_types::chart::{
 };
 use domain_types::domain::floating_object::ChartDrawingFrameOoxmlProps;
 use domain_types::{CellData, ChartSpec, ParseOutput, SheetData};
+use ooxml_types::charts::{
+    AxisCrosses, AxisType, Chart, ChartAxis, ChartAxisPosition, ChartGroup, ChartSpace,
+    ChartType as OoxmlChartType, ChartTypeConfig, DataLabelOptions, PlotArea, Scaling, TickMark,
+};
 use value_types::{CellValue, FiniteF64};
 
 const STANDARD_CHART_PROJECTION_SCHEMA_VERSION: u32 = 6;
+
+#[test]
+fn imported_axis_visibility_and_formatting_survive_yrs_and_xlsx_export() {
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(assert_imported_axis_visibility_and_formatting_survive_yrs_and_xlsx_export)
+        .expect("spawn chart roundtrip test")
+        .join()
+        .expect("chart roundtrip test");
+}
+
+fn assert_imported_axis_visibility_and_formatting_survive_yrs_and_xlsx_export() {
+    let mut chart = bounded_source_range_chart();
+    chart.axes = Some(domain_types::chart::AxisData {
+        category_axis: Some(domain_types::chart::SingleAxisData {
+            visible: true,
+            visible_explicit: true,
+            ..Default::default()
+        }),
+        value_axis: Some(domain_types::chart::SingleAxisData {
+            visible: true,
+            visible_explicit: true,
+            ..Default::default()
+        }),
+        secondary_category_axis: None,
+        secondary_value_axis: None,
+        series_axis: None,
+    });
+
+    let mut category_axis = imported_axis(AxisType::Category, 10, 20);
+    category_axis.sp_pr = Some(xlsx_parser::domain::charts::parse_shape_properties(
+        br#"<c:spPr xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+                         xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <a:noFill/><a:ln><a:solidFill><a:srgbClr val="123456"/></a:solidFill></a:ln>
+            </c:spPr>"#,
+    ));
+    category_axis.tx_pr = Some(xlsx_parser::domain::charts::parse_text_body(
+        br#"<c:txPr xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+                         xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <a:bodyPr rot="-60000000"/><a:lstStyle/><a:p><a:endParaRPr lang="en-US"/></a:p>
+            </c:txPr>"#,
+    ));
+    chart.definition = Some(domain_types::ChartDefinition::Chart(ChartSpace {
+        chart: Chart {
+            plot_area: PlotArea {
+                axes: vec![category_axis, imported_axis(AxisType::Value, 20, 10)],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    }));
+
+    let input = ParseOutput {
+        sheets: vec![SheetData {
+            name: "Data".to_string(),
+            rows: 16,
+            cols: 10,
+            charts: vec![chart],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let engine = engine_from_parse_output_normal(&input);
+    let exported_bytes = engine.export_to_xlsx_bytes().expect("export xlsx bytes");
+    let chart_xml = archive_text(&exported_bytes, "xl/charts/chart1.xml").expect("chart XML");
+    let category_axis_xml = chart_xml
+        .split_once("<c:catAx>")
+        .and_then(|(_, rest)| rest.split_once("</c:catAx>"))
+        .map(|(axis, _)| axis)
+        .expect("category axis XML");
+
+    assert!(category_axis_xml.contains(r#"<c:delete val="0"/>"#));
+    assert!(category_axis_xml.contains(r#"<a:srgbClr val="123456"/>"#));
+    assert!(category_axis_xml.contains(r#"<a:bodyPr rot="-60000000"/>"#));
+    assert!(category_axis_xml.contains(r#"<a:endParaRPr lang="en-US"/>"#));
+}
+
+#[test]
+fn imported_group_and_series_false_data_label_flags_survive_yrs_and_xlsx_export() {
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(assert_imported_group_and_series_false_data_label_flags_survive_yrs_and_xlsx_export)
+        .expect("spawn chart roundtrip test")
+        .join()
+        .expect("chart roundtrip test");
+}
+
+fn assert_imported_group_and_series_false_data_label_flags_survive_yrs_and_xlsx_export() {
+    let mut chart = bounded_source_range_chart();
+    chart.series[0].idx = Some(0);
+    let false_labels = imported_explicit_false_data_labels();
+    chart.definition = Some(domain_types::ChartDefinition::Chart(ChartSpace {
+        chart: Chart {
+            plot_area: PlotArea {
+                chart_groups: vec![ChartGroup {
+                    chart_type: OoxmlChartType::Bar,
+                    config: ChartTypeConfig::Bar(Default::default()),
+                    series: vec![ooxml_types::charts::ChartSeries {
+                        idx: 0,
+                        order: 0,
+                        d_lbls: Some(false_labels.clone()),
+                        ..Default::default()
+                    }],
+                    d_lbls: Some(false_labels),
+                    ax_id: vec![10, 20],
+                    raw_chart_type_attr: None,
+                    raw_chart_element_name: None,
+                    raw_chart_group_xml: None,
+                }],
+                axes: vec![
+                    imported_axis(AxisType::Category, 10, 20),
+                    imported_axis(AxisType::Value, 20, 10),
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    }));
+
+    let input = ParseOutput {
+        sheets: vec![SheetData {
+            name: "Data".to_string(),
+            rows: 16,
+            cols: 10,
+            charts: vec![chart],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let engine = engine_from_parse_output_normal(&input);
+    let hydrated_sheet_id =
+        SheetId::from_uuid_str(&engine.get_all_sheet_ids()[0]).expect("valid hydrated sheet id");
+    let stored_chart = engine
+        .get_all_floating_objects_typed(&hydrated_sheet_id)
+        .into_iter()
+        .next()
+        .expect("stored chart");
+    let domain_types::domain::floating_object::FloatingObjectData::Chart(stored_chart) =
+        stored_chart.data
+    else {
+        panic!("expected stored chart");
+    };
+    let stored_definition = stored_chart
+        .ooxml
+        .and_then(|ooxml| ooxml.definition)
+        .expect("stored imported definition");
+    let domain_types::ChartDefinition::Chart(stored_definition) = stored_definition else {
+        panic!("expected standard chart definition");
+    };
+    let stored_group = &stored_definition.chart.plot_area.chart_groups[0];
+    assert!(
+        stored_group
+            .d_lbls
+            .as_ref()
+            .is_some_and(|labels| labels.show_value_present)
+    );
+    assert!(
+        stored_group.series[0]
+            .d_lbls
+            .as_ref()
+            .is_some_and(|labels| labels.show_value_present)
+    );
+    let exported_bytes = engine.export_to_xlsx_bytes().expect("export xlsx bytes");
+    let chart_xml = archive_text(&exported_bytes, "xl/charts/chart1.xml").expect("chart XML");
+
+    for flag in [
+        "showVal",
+        "showCatName",
+        "showSerName",
+        "showPercent",
+        "showLegendKey",
+        "showBubbleSize",
+    ] {
+        assert_eq!(
+            chart_xml
+                .matches(&format!(r#"<c:{flag} val="0"/>"#))
+                .count(),
+            2,
+            "expected explicit false {flag} at group and series level: {chart_xml}"
+        );
+    }
+}
+
+fn imported_axis(axis_type: AxisType, ax_id: u32, cross_ax: u32) -> ChartAxis {
+    ChartAxis {
+        axis_type,
+        ax_id,
+        scaling: Scaling::default(),
+        delete: false,
+        delete_explicit: true,
+        ax_pos: if axis_type == AxisType::Category {
+            ChartAxisPosition::Left
+        } else {
+            ChartAxisPosition::Bottom
+        },
+        major_tick_mark: TickMark::None,
+        major_tick_mark_explicit: true,
+        minor_tick_mark: TickMark::None,
+        minor_tick_mark_explicit: true,
+        cross_ax,
+        crosses: AxisCrosses::AutoZero,
+        crosses_explicit: true,
+        ..Default::default()
+    }
+}
+
+fn imported_explicit_false_data_labels() -> DataLabelOptions {
+    DataLabelOptions {
+        show_value_present: true,
+        show_category_present: true,
+        show_series_name_present: true,
+        show_percent_present: true,
+        show_legend_key_present: true,
+        show_bubble_size_present: true,
+        ..Default::default()
+    }
+}
 
 #[test]
 fn sdk_authored_chart_palette_exports_chart_color_style_part() {

--- a/file-io/ooxml/types/src/charts/properties.rs
+++ b/file-io/ooxml/types/src/charts/properties.rs
@@ -100,22 +100,22 @@ pub struct DataLabelOptions {
     /// Show bubble size (bubble charts)
     pub show_bubble_size: bool,
     /// Round-trip metadata: whether `showVal` was present in source XML.
-    #[serde(default, skip)]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub show_value_present: bool,
     /// Round-trip metadata: whether `showCatName` was present in source XML.
-    #[serde(default, skip)]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub show_category_present: bool,
     /// Round-trip metadata: whether `showSerName` was present in source XML.
-    #[serde(default, skip)]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub show_series_name_present: bool,
     /// Round-trip metadata: whether `showPercent` was present in source XML.
-    #[serde(default, skip)]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub show_percent_present: bool,
     /// Round-trip metadata: whether `showLegendKey` was present in source XML.
-    #[serde(default, skip)]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub show_legend_key_present: bool,
     /// Round-trip metadata: whether `showBubbleSize` was present in source XML.
-    #[serde(default, skip)]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub show_bubble_size_present: bool,
     /// Label position
     pub position: DataLabelPosition,

--- a/file-io/xlsx/parser/src/domain/charts/reconstruct/axes.rs
+++ b/file-io/xlsx/parser/src/domain/charts/reconstruct/axes.rs
@@ -335,6 +335,11 @@ fn apply_imported_axis_fidelity(
     if let (Some(title), Some(imported_title)) = (rebuilt.title.as_mut(), original.title.as_ref()) {
         preserve_imported_title_text_properties(title, Some(imported_title));
     }
+    // Modeled formatting takes precedence; imported OOXML fills properties
+    // that the public axis model does not represent.
+    if rebuilt.sp_pr.is_none() {
+        rebuilt.sp_pr = original.sp_pr.clone();
+    }
     preserve_imported_text_body_properties(&mut rebuilt.tx_pr, original.tx_pr.as_ref());
     rebuilt.raw_axis_type_attr = original.raw_axis_type_attr.clone();
 }

--- a/infra/rust-bridge/bridge-ts/generated/ooxml-types.ts
+++ b/infra/rust-bridge/bridge-ts/generated/ooxml-types.ts
@@ -822,6 +822,12 @@ export interface DataLabelOptions {
   show_percent: boolean;
   show_legend_key: boolean;
   show_bubble_size: boolean;
+  show_value_present?: boolean;
+  show_category_present?: boolean;
+  show_series_name_present?: boolean;
+  show_percent_present?: boolean;
+  show_legend_key_present?: boolean;
+  show_bubble_size_present?: boolean;
   position: DataLabelPosition;
   separator: string | null;
   num_fmt: string | null;


### PR DESCRIPTION
## Summary

Fixes two no-edit XLSX chart round-trip regressions planned for v0.10.8:

- preserves imported axis shape properties when the modeled axis rebuild has no replacement, while keeping modeled edits authoritative
- persists the presence metadata that distinguishes an omitted data-label flag from an explicit `false`, at both chart-group and series level

Without the second change, an imported `<c:show* val="0"/>` is serialized through runtime storage as a plain `false` and then omitted on export, allowing Excel to display default labels and creating dense overlaps.

## Verification

- Compute Core import -> Yrs -> XLSX regressions cover axis visibility/shape/text state and all six explicit-false group/series label flags
- focused chart reconstruction regressions pass
- generated TypeScript OOXML types refreshed
- two real no-edit workbook proofs pass ZIP integrity, XML parsing, and package-relationship validation with zero failures/blocks
- real axis proof retains `delete=0`, axis `spPr`, and axis `txPr`
- real label proof retains source counts for explicit-false flags (`showVal=43`, `showCatName=49`, `showSerName=49`)

## Commands

```sh
cargo fmt --all -- --check
CARGO_BUILD_JOBS=2 cargo test -p compute-core --lib survive_yrs_and_xlsx_export --locked
cargo test -p xlsx-parser --lib imported_explicit_visible_axis_serializes_delete_false_from_domain --locked
cargo test -p xlsx-parser --lib imported_axis_text_properties_preserve_unmodeled_run_properties --locked
cargo test -p xlsx-parser --lib imported_group_explicit_false_data_label_flags_survive_reconstruction --locked
cargo test -p xlsx-parser --lib imported_series_explicit_false_data_label_flags_survive_reconstruction --locked
cargo test -p bridge-ts --test generate_ooxml_types -- generate_combined --nocapture
```