### PR TITLE
Office.js alignment checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,26 +47,35 @@ cargo run -p mog -- --eval 'await Excel.run(async (context) => {
 
 ## Scripting surface
 
-The engine exposes the Office.js Excel application-specific API:
+The engine implements a growing portion of the Office.js Excel
+application-specific API:
 
 - `Excel.run` with a `RequestContext`
 - Proxy objects that queue work until `await context.sync()`
-- `load(...)` before reading proxy properties
-- `context.workbook.worksheets.getItem` / `add`
+- `load(...)` with string, array, and nested property projections
+- `context.workbook.worksheets.getItem` / `add` / `getActiveWorksheet`
 - `worksheet.getRange`
 - `Range.values` (2-D get/set)
 - `Range.formulas` writes, with computed values readable after `load` + `sync`
+- Range addresses, dimensions, and row/column indices
+- Range formatting through `format`, `font`, `fill`, and `protection`
+- Worksheet table creation, name/ID lookup, scalar properties, and table ranges
 
-Unloaded proxy properties throw; they are not live values.
+Fresh proxy properties require `load` and `sync` before reading. Assigning a
+writable property also caches that value on the same proxy; use a fresh proxy
+with `load` and `sync` to read the engine's resulting state. A `null` cell in
+a values write preserves the existing cell, while an empty string clears it.
 
 Callers and scripts have full access to the workbook they receive. Applications
 embedding Mog are responsible for authorizing workbook access; the compute
 engine does not enforce caller-specific workbook, sheet, or cell permissions.
 Excel sheet protection remains a separate document feature.
 
-This is not a Microsoft Office compatibility layer beyond the Excel JS mechanics
-above. Charts, pivots, tables, Word, PowerPoint, and Office dialogs are out of
-scope.
+The target contract is Microsoft's Excel JavaScript API. Implementation and
+behavioral coverage are incomplete; the listed features do not establish
+support for an entire Excel API requirement set. Charts, pivots, and many other
+Excel members remain unimplemented. Word, PowerPoint, and Office dialogs are
+outside this spreadsheet engine's scope.
 
 ## Tests
 

--- a/compute/api/src/sheet.rs
+++ b/compute/api/src/sheet.rs
@@ -8,9 +8,12 @@ use crate::dispatch::Dispatch;
 use crate::error::ComputeApiError;
 use cell_types::SheetId;
 use compute_core::ZOrderEntry;
-use domain_types::Comment;
+use domain_types::{Comment, CopyType};
 use snapshot_types::MutationResult;
 use value_types::CellValue;
+
+use crate::mutation::CellInput;
+use crate::types::{BridgeAutoFillRequest, BridgeFlashFillRequest};
 
 // Domain sub-APIs
 pub mod bindings;
@@ -113,6 +116,202 @@ impl Sheet {
             .call_engine(move |e| e.set_cell_values_parsed(&sid, updates))
             .and_then(|r| {
                 r.map(|(_vp, mutation)| mutation)
+                    .map_err(ComputeApiError::from)
+            })
+    }
+
+    /// Set a rectangular range with already-typed cell input intents.
+    ///
+    /// The input grid must have exactly the same row and column dimensions as
+    /// the target range. `None` preserves the corresponding cell. Shape is
+    /// validated before dispatch, so an invalid grid cannot write beyond the
+    /// requested range or partially mutate it.
+    ///
+    /// This is the boundary used by dynamically typed hosts such as Office.js:
+    /// numbers and booleans can use [`CellInput::Value`], strings can use
+    /// [`CellInput::Literal`], and formulas can use [`CellInput::formula`]
+    /// without reducing every input to parser text.
+    pub fn set_range_typed(
+        &self,
+        range: impl Into<CellRange>,
+        values: &[Vec<Option<CellInput>>],
+    ) -> Result<MutationResult, ComputeApiError> {
+        let range = range.into();
+        let (start_row, start_col, end_row, end_col) = range.resolve()?;
+        let expected_rows = end_row
+            .checked_sub(start_row)
+            .and_then(|span| span.checked_add(1))
+            .ok_or_else(|| ComputeApiError::InvalidRange {
+                range: format!("({start_row}, {start_col})..({end_row}, {end_col})"),
+                reason: "range end precedes range start".to_string(),
+            })? as usize;
+        let expected_cols = end_col
+            .checked_sub(start_col)
+            .and_then(|span| span.checked_add(1))
+            .ok_or_else(|| ComputeApiError::InvalidRange {
+                range: format!("({start_row}, {start_col})..({end_row}, {end_col})"),
+                reason: "range end precedes range start".to_string(),
+            })? as usize;
+
+        if values.len() != expected_rows {
+            return Err(ComputeApiError::InvalidRange {
+                range: format!("({start_row}, {start_col})..({end_row}, {end_col})"),
+                reason: format!(
+                    "input grid has {} rows; target range requires {expected_rows}",
+                    values.len()
+                ),
+            });
+        }
+        if let Some((row_index, actual_cols)) = values
+            .iter()
+            .enumerate()
+            .find_map(|(index, row)| (row.len() != expected_cols).then_some((index, row.len())))
+        {
+            return Err(ComputeApiError::InvalidRange {
+                range: format!("({start_row}, {start_col})..({end_row}, {end_col})"),
+                reason: format!(
+                    "input grid row {row_index} has {actual_cols} columns; target range requires {expected_cols}"
+                ),
+            });
+        }
+
+        let sid = self.sheet_id;
+        let updates = values
+            .iter()
+            .enumerate()
+            .flat_map(|(row_offset, row)| {
+                row.iter()
+                    .enumerate()
+                    .filter_map(move |(col_offset, input)| {
+                        input.clone().map(|input| {
+                            (
+                                sid,
+                                start_row + row_offset as u32,
+                                start_col + col_offset as u32,
+                                input,
+                            )
+                        })
+                    })
+            })
+            .collect();
+
+        self.dispatch
+            .call_engine(move |engine| engine.batch_set_cells_by_position(updates, false))
+            .and_then(|result| {
+                result
+                    .map(|(_patches, mutation)| mutation)
+                    .map_err(ComputeApiError::from)
+            })
+    }
+
+    /// Copy a rectangular range using the engine's formula, value, and format
+    /// semantics. The source may belong to another sheet in the same
+    /// workbook. `copy_type`, `skip_blanks`, and `transpose` map directly to
+    /// the production copy operation.
+    #[allow(clippy::too_many_arguments)]
+    pub fn copy_range(
+        &self,
+        source_sheet_id: &SheetId,
+        src_start_row: u32,
+        src_start_col: u32,
+        src_end_row: u32,
+        src_end_col: u32,
+        target_row: u32,
+        target_col: u32,
+        copy_type: CopyType,
+        skip_blanks: bool,
+        transpose: bool,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let source_sid = *source_sheet_id;
+        let target_sid = self.sheet_id;
+        self.dispatch
+            .call_engine(move |engine| {
+                engine.copy_range(
+                    &source_sid,
+                    src_start_row,
+                    src_start_col,
+                    src_end_row,
+                    src_end_col,
+                    &target_sid,
+                    target_row,
+                    target_col,
+                    copy_type,
+                    skip_blanks,
+                    transpose,
+                )
+            })
+            .and_then(|result| {
+                result
+                    .map(|(_patches, mutation)| mutation)
+                    .map_err(ComputeApiError::from)
+            })
+    }
+
+    /// Move a rectangular range while preserving engine cell identity and
+    /// formula references. This deliberately routes through the Yrs
+    /// relocation pipeline rather than the legacy value-only structure API.
+    #[allow(clippy::too_many_arguments)]
+    pub fn relocate_cells_yrs(
+        &self,
+        source_sheet_id: &SheetId,
+        src_start_row: u32,
+        src_start_col: u32,
+        src_end_row: u32,
+        src_end_col: u32,
+        target_row: u32,
+        target_col: u32,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let source_sid = *source_sheet_id;
+        let target_sid = self.sheet_id;
+        self.dispatch
+            .call_engine(move |engine| {
+                engine.relocate_cells_yrs(
+                    &source_sid,
+                    src_start_row,
+                    src_start_col,
+                    src_end_row,
+                    src_end_col,
+                    &target_sid,
+                    target_row,
+                    target_col,
+                )
+            })
+            .and_then(|result| {
+                result
+                    .map(|(_patches, mutation)| mutation)
+                    .map_err(ComputeApiError::from)
+            })
+    }
+
+    /// Fill a target range from a source range using the production
+    /// compute-fill engine. The request carries the exact source/target
+    /// bounds, direction, mode, and include flags expected by the bridge.
+    pub fn auto_fill(
+        &self,
+        request: BridgeAutoFillRequest,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let sid = self.sheet_id;
+        self.dispatch
+            .call_engine(move |engine| engine.auto_fill(&sid, request))
+            .and_then(|result| {
+                result
+                    .map(|(_patches, mutation)| mutation)
+                    .map_err(ComputeApiError::from)
+            })
+    }
+
+    /// Apply Flash Fill to a source/example column pair using the production
+    /// compute-fill engine.
+    pub fn flash_fill(
+        &self,
+        request: BridgeFlashFillRequest,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let sid = self.sheet_id;
+        self.dispatch
+            .call_engine(move |engine| engine.flash_fill(&sid, request))
+            .and_then(|result| {
+                result
+                    .map(|(_patches, mutation)| mutation)
                     .map_err(ComputeApiError::from)
             })
     }

--- a/compute/api/src/sheet/comments.rs
+++ b/compute/api/src/sheet/comments.rs
@@ -3,8 +3,8 @@
 use crate::dispatch::Dispatch;
 use crate::error::ComputeApiError;
 use cell_types::SheetId;
-use domain_types::Comment;
 use domain_types::domain::comment::{CommentMention, CommentType};
+use domain_types::Comment;
 use snapshot_types::MutationResult;
 
 /// Sub-API for comment operations on a single sheet.

--- a/compute/api/src/sheet/hyperlinks.rs
+++ b/compute/api/src/sheet/hyperlinks.rs
@@ -1,21 +1,19 @@
-//! SheetHyperlinks — Hyperlink operations (stub).
+//! Hyperlink operations for a single worksheet.
 //!
-//! The engine does not have standalone hyperlink methods — hyperlinks are
-//! stored as cell properties and managed through the cell format system.
-//! This module is a placeholder for future dedicated hyperlink operations.
+//! Hyperlinks are persisted as cell metadata by the compute engine. This
+//! facade keeps the public API typed while leaving address validation and
+//! Office.js wire translation to their respective boundaries.
 
+use crate::address::{CellAddress, CellRange};
 use crate::dispatch::Dispatch;
+use crate::error::ComputeApiError;
 use cell_types::SheetId;
+use domain_types::domain::hyperlink::Hyperlink;
+use snapshot_types::MutationResult;
 
-/// Hyperlink operations for a single sheet (stub).
-///
-/// Hyperlinks are currently managed as cell properties through the format
-/// system. Dedicated hyperlink CRUD methods may be added to the engine
-/// in the future.
+/// Hyperlink operations for a single sheet.
 pub struct SheetHyperlinks {
-    #[allow(dead_code)]
     dispatch: Dispatch,
-    #[allow(dead_code)]
     sheet_id: SheetId,
 }
 
@@ -24,9 +22,116 @@ impl SheetHyperlinks {
         Self { dispatch, sheet_id }
     }
 
-    // TODO: Add hyperlink-specific methods when engine support lands:
-    // - set_hyperlink(addr, url, display_text) -> Result<MutationResult, ComputeApiError>
-    // - get_hyperlink(addr) -> Result<Option<Hyperlink>, ComputeApiError>
-    // - remove_hyperlink(addr) -> Result<MutationResult, ComputeApiError>
-    // - get_all_hyperlinks() -> Result<Vec<Hyperlink>, ComputeApiError>
+    /// Set an external hyperlink on a cell.
+    ///
+    /// `display_text`, when supplied, is written as literal cell text and
+    /// retained as the hyperlink's display metadata. Omitting it preserves the
+    /// current cell value and derives the display text from that value.
+    pub fn set_hyperlink(
+        &self,
+        addr: impl Into<CellAddress>,
+        url: impl Into<String>,
+        display_text: Option<String>,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let (row, col) = addr.into().resolve()?;
+        let url = url.into();
+        self.set_hyperlink_with_metadata(row, col, Some(&url), None, display_text.as_deref(), None)
+    }
+
+    /// Set a hyperlink with the full Office.js `RangeHyperlink` field set.
+    ///
+    /// This is the typed primitive used by the Office.js host. The target is
+    /// either `address`, `document_reference`, or both; `text_to_display`
+    /// updates the target cell's literal text when present.
+    pub fn set_hyperlink_with_metadata(
+        &self,
+        row: u32,
+        col: u32,
+        address: Option<&str>,
+        document_reference: Option<&str>,
+        text_to_display: Option<&str>,
+        screen_tip: Option<&str>,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let sid = self.sheet_id;
+        let address = address.map(str::to_owned);
+        let document_reference = document_reference.map(str::to_owned);
+        let text_to_display = text_to_display.map(str::to_owned);
+        let screen_tip = screen_tip.map(str::to_owned);
+        self.dispatch
+            .call_engine(move |e| {
+                e.set_hyperlink_with_metadata(
+                    &sid,
+                    row,
+                    col,
+                    address,
+                    document_reference,
+                    text_to_display,
+                    screen_tip,
+                )
+            })
+            .and_then(|r| {
+                r.map(|(_patches, result)| result)
+                    .map_err(ComputeApiError::from)
+            })
+    }
+
+    /// Get the complete hyperlink metadata for a cell or a containing range
+    /// hyperlink.
+    pub fn get_hyperlink(
+        &self,
+        addr: impl Into<CellAddress>,
+    ) -> Result<Option<Hyperlink>, ComputeApiError> {
+        let (row, col) = addr.into().resolve()?;
+        Ok(self
+            .get_all_hyperlinks()?
+            .into_iter()
+            .find(|link| hyperlink_contains(link, row, col)))
+    }
+
+    /// Remove a hyperlink from a cell.
+    pub fn remove_hyperlink(
+        &self,
+        addr: impl Into<CellAddress>,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let (row, col) = addr.into().resolve()?;
+        let sid = self.sheet_id;
+        self.dispatch
+            .call_engine(move |e| e.remove_hyperlink(&sid, row, col))
+            .and_then(|r| {
+                r.map(|(_patches, result)| result)
+                    .map_err(ComputeApiError::from)
+            })
+    }
+
+    /// Get all persisted hyperlink metadata on this sheet.
+    pub fn get_all_hyperlinks(&self) -> Result<Vec<Hyperlink>, ComputeApiError> {
+        let sid = self.sheet_id;
+        self.dispatch.query_engine(move |e| e.get_hyperlinks(&sid))
+    }
+
+    /// Remove hyperlinks from every cell in a rectangular range.
+    pub fn clear_hyperlinks(
+        &self,
+        range: impl Into<CellRange>,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let (start_row, start_col, end_row, end_col) = range.into().resolve()?;
+        let sid = self.sheet_id;
+        self.dispatch
+            .call_engine(move |e| {
+                e.clear_hyperlinks_in_range(&sid, start_row, start_col, end_row, end_col)
+            })
+            .and_then(|r| {
+                r.map(|(_patches, result)| result)
+                    .map_err(ComputeApiError::from)
+            })
+    }
+}
+
+fn hyperlink_contains(link: &Hyperlink, row: u32, col: u32) -> bool {
+    CellRange::from(link.cell_ref.as_str())
+        .resolve()
+        .map(|(start_row, start_col, end_row, end_col)| {
+            row >= start_row && row <= end_row && col >= start_col && col <= end_col
+        })
+        .unwrap_or(false)
 }

--- a/compute/api/src/sheet/layout.rs
+++ b/compute/api/src/sheet/layout.rs
@@ -75,6 +75,18 @@ impl SheetLayout {
             .query_engine(move |e| e.get_col_width_query(&sid, col))
     }
 
+    /// Get the canonical OOXML character width of a column.
+    ///
+    /// This is intentionally separate from [`Self::get_col_width`], whose
+    /// result is in rendering pixels.  Office.js dimension adapters can use
+    /// this query when they need the workbook's persisted character-width
+    /// value instead of an MDW-dependent pixel projection.
+    pub fn get_col_width_chars(&self, col: u32) -> Result<f64, ComputeApiError> {
+        let sid = self.sheet_id;
+        self.dispatch
+            .query_engine(move |e| e.get_col_width_chars_query(&sid, col))
+    }
+
     /// Get the default row height for this sheet.
     pub fn get_default_row_height(&self) -> Result<f64, ComputeApiError> {
         let sid = self.sheet_id;
@@ -87,6 +99,36 @@ impl SheetLayout {
         let sid = self.sheet_id;
         self.dispatch
             .query_engine(move |e| e.get_default_col_width(&sid))
+    }
+
+    /// Get the canonical OOXML character width used by default columns.
+    ///
+    /// The existing [`Self::get_default_col_width`] method returns the
+    /// rendering-pixel projection for UI callers; this method preserves the
+    /// sheet's persisted character-width value.
+    pub fn get_default_col_width_chars(&self) -> Result<f64, ComputeApiError> {
+        let sid = self.sheet_id;
+        self.dispatch
+            .query_engine(move |e| e.get_default_col_width_chars(&sid))
+    }
+
+    /// Compute and set best-fit heights for the selected rows.
+    pub fn auto_fit_rows_and_set(&self, rows: Vec<u32>) -> Result<MutationResult, ComputeApiError> {
+        let sid = self.sheet_id;
+        self.dispatch
+            .call_engine(move |e| e.auto_fit_rows_and_set(&sid, rows).map(|(_, r)| r))
+            .and_then(|r| r.map_err(ComputeApiError::from))
+    }
+
+    /// Compute and set best-fit widths for the selected columns.
+    pub fn auto_fit_columns_and_set(
+        &self,
+        cols: Vec<u32>,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let sid = self.sheet_id;
+        self.dispatch
+            .call_engine(move |e| e.auto_fit_columns_and_set(&sid, cols).map(|(_, r)| r))
+            .and_then(|r| r.map_err(ComputeApiError::from))
     }
 
     // -----------------------------------------------------------------

--- a/compute/api/src/sheet/objects.rs
+++ b/compute/api/src/sheet/objects.rs
@@ -3,10 +3,10 @@
 use crate::dispatch::Dispatch;
 use crate::error::ComputeApiError;
 use cell_types::SheetId;
-use compute_core::SerializedFloatingObjectGroup;
 use compute_core::engine_types::floating_objects::{
     CreateShapeConfig, FlipAxis, MoveTarget, ResizeConfig, ShapeStyleUpdate,
 };
+use compute_core::SerializedFloatingObjectGroup;
 use domain_types::FloatingObject;
 use snapshot_types::MutationResult;
 

--- a/compute/api/src/sheet/pivots.rs
+++ b/compute/api/src/sheet/pivots.rs
@@ -1,21 +1,19 @@
-//! SheetPivots — Pivot table operations (stub).
+//! Sheet-scoped PivotTable operations.
 //!
-//! Pivot tables are managed through the stateless pure API (`compute_api::pure`),
-//! not through sheet-level state. This module is a placeholder for any future
-//! sheet-scoped pivot operations.
+//! The Office.js host uses this facade for persisted PivotTable lifecycle
+//! operations.  Computation and rendering stay in `YrsComputeEngine`: the
+//! facade does not keep a second pivot map or calculate a synthetic result.
 
 use crate::dispatch::Dispatch;
+use crate::error::ComputeApiError;
+use crate::pure::pivot::{PivotExpansionState, PivotTableConfig, PivotTableResult};
 use cell_types::SheetId;
+use serde_json::Value;
+use snapshot_types::MutationResult;
 
-/// Pivot table operations for a single sheet (stub).
-///
-/// Pivot table computation and configuration are handled through the
-/// stateless pure API. Sheet-level pivot CRUD may be added in the future
-/// if pivots gain per-sheet storage in the engine.
+/// Pivot table operations for a single output sheet.
 pub struct SheetPivots {
-    #[allow(dead_code)]
     dispatch: Dispatch,
-    #[allow(dead_code)]
     sheet_id: SheetId,
 }
 
@@ -24,9 +22,105 @@ impl SheetPivots {
         Self { dispatch, sheet_id }
     }
 
-    // TODO: Add sheet-level pivot methods if engine storage is added:
-    // - create_pivot_table(config) -> Result<MutationResult, ComputeApiError>
-    // - refresh_pivot_table(pivot_id) -> Result<MutationResult, ComputeApiError>
-    // - delete_pivot_table(pivot_id) -> Result<MutationResult, ComputeApiError>
-    // - get_pivot_tables() -> Result<Vec<PivotTable>, ComputeApiError>
+    /// Get one persisted PivotTable by its stable ID.
+    pub fn get(&self, pivot_id: &str) -> Result<Option<PivotTableConfig>, ComputeApiError> {
+        let sid = self.sheet_id;
+        let id = pivot_id.to_string();
+        self.dispatch
+            .query_engine(move |engine| engine.pivot_get(&sid, &id))
+    }
+
+    /// Get every persisted PivotTable whose containing/output sheet is this
+    /// sheet.  The engine remains the source of truth for ordering and data.
+    pub fn get_all(&self) -> Result<Vec<PivotTableConfig>, ComputeApiError> {
+        let sid = self.sheet_id;
+        self.dispatch
+            .query_engine(move |engine| engine.pivot_get_all(&sid))
+    }
+
+    /// Create a PivotTable from the engine's canonical JSON configuration.
+    ///
+    /// `config` is validated by the engine before any state is changed.  The
+    /// returned mutation carries the newly allocated stable PivotTable ID in
+    /// its `data` field as a serialized [`PivotTableConfig`].
+    pub fn create(&self, config: &Value) -> Result<MutationResult, ComputeApiError> {
+        let config = config.clone();
+        self.dispatch
+            .call_engine(move |engine| engine.pivot_create(config).map(|(_, result)| result))
+            .and_then(|result| result.map_err(ComputeApiError::from))
+    }
+
+    /// Create a PivotTable and return its canonical persisted configuration.
+    ///
+    /// This convenience is useful to object-model adapters that need the
+    /// generated ID to bind the newly-created proxy in the same batch.
+    pub fn create_config(&self, config: &Value) -> Result<PivotTableConfig, ComputeApiError> {
+        let mutation = self.create(config)?;
+        mutation.extract_data::<PivotTableConfig>().ok_or_else(|| {
+            ComputeApiError::InvalidOperation(
+                "pivot_create returned no PivotTableConfig".to_string(),
+            )
+        })
+    }
+
+    /// Replace a persisted PivotTable configuration.
+    pub fn update(
+        &self,
+        pivot_id: &str,
+        config: PivotTableConfig,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let sid = self.sheet_id;
+        let id = pivot_id.to_string();
+        self.dispatch
+            .call_engine(move |engine| {
+                engine
+                    .pivot_update(&sid, &id, config)
+                    .map(|(_, result)| result)
+            })
+            .and_then(|result| result.map_err(ComputeApiError::from))
+    }
+
+    /// Delete a persisted PivotTable and clear its production materialization.
+    pub fn delete(&self, pivot_id: &str) -> Result<MutationResult, ComputeApiError> {
+        let sid = self.sheet_id;
+        let id = pivot_id.to_string();
+        self.dispatch
+            .call_engine(move |engine| engine.pivot_delete(&sid, &id).map(|(_, result)| result))
+            .and_then(|result| result.map_err(ComputeApiError::from))
+    }
+
+    /// Compute and materialize one PivotTable using its current source range.
+    ///
+    /// This is the operation used by `PivotTable.refresh()`; it writes through
+    /// the engine mirror and updates the persisted rendered bounds.
+    pub fn materialize(
+        &self,
+        pivot_id: &str,
+        expansion_state: Option<PivotExpansionState>,
+    ) -> Result<PivotTableResult, ComputeApiError> {
+        let sid = self.sheet_id;
+        let id = pivot_id.to_string();
+        self.dispatch
+            .call_engine(move |engine| engine.pivot_materialize(&sid, &id, expansion_state))
+            .and_then(|result| result.map_err(ComputeApiError::from))
+    }
+
+    /// Refresh and return the ordinary mutation envelope used by host
+    /// dispatchers.  The embedded result is still produced by the same real
+    /// materializer; this method only adds viewport patches to the envelope.
+    pub fn refresh(
+        &self,
+        pivot_id: &str,
+        expansion_state: Option<PivotExpansionState>,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let sid = self.sheet_id;
+        let id = pivot_id.to_string();
+        self.dispatch
+            .call_engine(move |engine| {
+                engine
+                    .pivot_materialize_mutation(&sid, &id, expansion_state)
+                    .map(|(_, result)| result)
+            })
+            .and_then(|result| result.map_err(ComputeApiError::from))
+    }
 }

--- a/compute/api/src/sheet/protection.rs
+++ b/compute/api/src/sheet/protection.rs
@@ -4,6 +4,7 @@ use crate::dispatch::Dispatch;
 use crate::error::ComputeApiError;
 use cell_types::SheetId;
 use compute_core::engine_types::queries::SheetProtectionConfig;
+use domain_types::domain::sheet::SheetProtectionOptions;
 use snapshot_types::MutationResult;
 
 /// Sheet-level protection operations.
@@ -28,6 +29,41 @@ impl SheetProtection {
         let sid = self.sheet_id;
         self.dispatch
             .call_engine(move |e| e.protect_sheet(&sid, password_hash).map(|(_, r)| r))
+            .and_then(|r| r.map_err(ComputeApiError::from))
+    }
+
+    /// Protect the sheet with an optional password hash and a complete
+    /// replacement protection option set.
+    ///
+    /// The option object is passed directly to the engine's structured sheet
+    /// protection writer so the password, protection flag, and permissions
+    /// are committed atomically.
+    pub fn protect_with_options(
+        &self,
+        password_hash: Option<String>,
+        options: SheetProtectionOptions,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let sid = self.sheet_id;
+        self.dispatch
+            .call_engine(move |e| {
+                e.protect_sheet_with_options(&sid, password_hash, options)
+                    .map(|(_, r)| r)
+            })
+            .and_then(|r| r.map_err(ComputeApiError::from))
+    }
+
+    /// Replace the sheet's complete protection option set while preserving
+    /// the current protection flag and password hash.
+    pub fn set_options(
+        &self,
+        options: SheetProtectionOptions,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let sid = self.sheet_id;
+        self.dispatch
+            .call_engine(move |e| {
+                e.set_sheet_protection_options(&sid, options)
+                    .map(|(_, r)| r)
+            })
             .and_then(|r| r.map_err(ComputeApiError::from))
     }
 

--- a/compute/api/src/sheet/tables.rs
+++ b/compute/api/src/sheet/tables.rs
@@ -182,6 +182,24 @@ impl SheetTables {
             .and_then(|r| r.map(|(_vp, m)| m).map_err(ComputeApiError::from))
     }
 
+    /// Set a persisted table boolean option to an explicit value.
+    ///
+    /// The option names are the canonical engine names: `bandedRows`,
+    /// `bandedColumns`, `emphasizeFirstColumn`, `emphasizeLastColumn`, and
+    /// `showFilterButtons`.
+    pub fn set_bool_option(
+        &self,
+        table_name: &str,
+        option: &str,
+        value: bool,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let name = table_name.to_string();
+        let option = option.to_string();
+        self.dispatch
+            .call_engine(move |e| e.set_table_bool_option(&name, &option, value))
+            .and_then(|r| r.map(|(_vp, m)| m).map_err(ComputeApiError::from))
+    }
+
     // -----------------------------------------------------------------
     // Column operations
     // -----------------------------------------------------------------

--- a/compute/api/src/types.rs
+++ b/compute/api/src/types.rs
@@ -6,8 +6,34 @@
 // Cell identity and grid addressing
 pub use cell_types::{CellId, CellPos, RangePos, SheetId, SheetPos};
 
+// Range copy operation semantics
+pub use domain_types::CopyType;
+
+// Range fill operation requests. These are the bridge types consumed directly
+// by the production compute-fill engine and exposed here so API adapters do
+// not depend on compute-core's internal module path.
+pub use compute_core::bridge_types::{
+    BridgeAutoFillRequest, BridgeFillRangeSpec, BridgeFlashFillRequest,
+};
+
 // Cell values
 pub use value_types::{CellError, CellValue, ComputeError};
 
 // Snapshot and mutation types
-pub use snapshot_types::{MutationResult, RecalcResult, SheetSnapshot, WorkbookSnapshot};
+pub use snapshot_types::{
+    MutationResult, RecalcResult, SheetSnapshot, WorkbookProtectionOptions, WorkbookSnapshot,
+};
+
+// Sheet protection options are shared with the structured engine protection
+// record; adapters should consume this one public type rather than defining a
+// parallel options hierarchy.
+pub use domain_types::domain::sheet::SheetProtectionOptions;
+
+// Defined-name bridge types. These are the typed inputs consumed by
+// `WorkbookNames` and re-exported so higher-level adapters do not depend on
+// compute-core's internal module path.
+pub use compute_core::bridge_types::named_ranges::{DefinedNameInput, NamedRangeUpdate};
+
+// Persisted workbook cell styles.  Higher-level adapters should consume the
+// same domain record rather than introducing a parallel style representation.
+pub use domain_types::domain::cell_style::CellStyleDef;

--- a/compute/api/src/workbook.rs
+++ b/compute/api/src/workbook.rs
@@ -4,7 +4,7 @@
 //! for sheet discovery, cell access via [`Sheet`] handles, and domain sub-APIs.
 
 use cell_types::SheetId;
-use snapshot_types::{RecalcResult, WorkbookSnapshot};
+use snapshot_types::{RecalcOptions, RecalcResult, WorkbookSnapshot};
 
 use crate::Sheet;
 use crate::dispatch::Dispatch;
@@ -154,6 +154,55 @@ impl Workbook {
     /// Return the number of sheets in the workbook.
     pub fn sheet_count(&self) -> Result<usize, ComputeApiError> {
         self.dispatch.query_engine(|e| e.get_sheet_order().len())
+    }
+
+    // -----------------------------------------------------------------
+    // Calculation
+    // -----------------------------------------------------------------
+
+    /// Recalculate the workbook using the requested Office.js calculation
+    /// type.
+    ///
+    /// `Recalculate` uses the engine's dirty-cell aware path. `Full` forces a
+    /// full pass through the existing dependency graph while preserving the
+    /// workbook's iterative settings. `FullRebuild` rebuilds the compute core
+    /// from persisted workbook state before evaluating it.
+    pub fn calculate(&self, calculation_type: &str) -> Result<RecalcResult, ComputeApiError> {
+        match calculation_type {
+            "Recalculate" => self
+                .dispatch
+                .call_engine(|engine| engine.recalculate())
+                .and_then(|result| result.map_err(ComputeApiError::from)),
+            "Full" => {
+                let settings = self.settings().get_workbook_settings()?;
+                let calculation = settings.calculation_settings.unwrap_or_default();
+                // `recalculate_with_options` treats explicit options as a
+                // force-full request. Carry the current values through so
+                // the request changes recalc scope, not calculation policy.
+                let options = RecalcOptions {
+                    iterative: Some(calculation.enable_iterative_calculation),
+                    max_iterations: Some(calculation.max_iterations),
+                    max_change: Some(calculation.max_change),
+                };
+                self.dispatch
+                    .call_engine(move |engine| engine.recalculate_with_options(&options))
+                    .and_then(|result| result.map_err(ComputeApiError::from))
+            }
+            "FullRebuild" => self
+                .dispatch
+                .call_engine(|engine| engine.rebuild_compute_core())
+                .and_then(|result| result.map_err(ComputeApiError::from)),
+            other => Err(ComputeApiError::InvalidOperation(format!(
+                "unsupported calculation type: {other}"
+            ))),
+        }
+    }
+
+    /// Return the current engine calculation state using the Office.js
+    /// `Done`, `Calculating`, and `Pending` vocabulary.
+    pub fn calculation_state(&self) -> Result<String, ComputeApiError> {
+        self.dispatch
+            .query_engine(|engine| engine.calculation_state().to_string())
     }
 
     // -----------------------------------------------------------------

--- a/compute/api/src/workbook/names.rs
+++ b/compute/api/src/workbook/names.rs
@@ -2,9 +2,11 @@
 
 use crate::dispatch::Dispatch;
 use crate::error::ComputeApiError;
+use cell_types::SheetId;
 use compute_core::bridge_types::named_ranges::{DefinedNameInput, NamedRangeUpdate};
 use formula_types::NamedRangeDef;
 use snapshot_types::MutationResult;
+use value_types::CellValue;
 
 /// Named range management for the workbook.
 pub struct WorkbookNames {
@@ -14,6 +16,77 @@ pub struct WorkbookNames {
 impl WorkbookNames {
     pub(crate) fn new(dispatch: Dispatch) -> Self {
         Self { dispatch }
+    }
+
+    /// Evaluate an Excel expression in the context of a worksheet.
+    ///
+    /// This delegates to the compute engine's production parser/evaluator so
+    /// callers such as Office.js named items get the same cell, name, and
+    /// function semantics as worksheet formulas. The expression may include
+    /// or omit its leading `=`.
+    pub fn evaluate_expression(
+        &self,
+        sheet_id: &SheetId,
+        expression: &str,
+    ) -> Result<CellValue, ComputeApiError> {
+        let sid = *sheet_id;
+        let expression = expression.to_owned();
+        self.dispatch
+            .query_engine(move |engine| engine.evaluate_expression(&sid, &expression))
+            .and_then(|result| result.map_err(ComputeApiError::from))
+    }
+
+    /// Return the user-facing formula for a defined name.
+    ///
+    /// Defined names persisted by the engine use an identity formula JSON
+    /// payload. Convert that payload through the engine's production A1
+    /// formatter instead of exposing storage JSON to callers.
+    pub fn get_named_range_formula_by_id(
+        &self,
+        id: &str,
+    ) -> Result<Option<String>, ComputeApiError> {
+        let owned_id = id.to_owned();
+        self.dispatch.query_engine(move |engine| {
+            let record = engine.get_named_range_by_id(&owned_id)?;
+            if let Some(raw) = record.raw_refers_to {
+                return Some(raw);
+            }
+            let identity =
+                serde_json::from_str::<formula_types::IdentityFormula>(&record.refers_to).ok()?;
+            Some(engine.to_a1_display_qualified(&SheetId::from_raw(0), &identity))
+        })
+    }
+
+    /// Get a named range by its stable ID.
+    pub fn get_named_range_by_id(
+        &self,
+        id: &str,
+    ) -> Result<Option<domain_types::domain::named_range::DefinedName>, ComputeApiError> {
+        let owned_id = id.to_owned();
+        self.dispatch
+            .query_engine(move |e| e.get_named_range_by_id(&owned_id))
+    }
+
+    /// Get a named range by name and exact scope.
+    ///
+    /// Pass `None` for workbook scope or `Some(sheet_id)` for worksheet scope.
+    pub fn get_named_range_by_name(
+        &self,
+        name: &str,
+        scope: Option<String>,
+    ) -> Result<Option<domain_types::domain::named_range::DefinedName>, ComputeApiError> {
+        let owned_name = name.to_owned();
+        self.dispatch
+            .query_engine(move |e| e.get_named_range_by_name(&owned_name, scope))
+    }
+
+    /// Get all named ranges in an exact workbook or worksheet scope.
+    pub fn get_named_ranges_by_scope(
+        &self,
+        scope: Option<String>,
+    ) -> Result<Vec<domain_types::domain::named_range::DefinedName>, ComputeApiError> {
+        self.dispatch
+            .query_engine(move |e| e.get_named_ranges_by_scope(scope))
     }
 
     /// Create a new named range (defined name).

--- a/compute/api/src/workbook/protection.rs
+++ b/compute/api/src/workbook/protection.rs
@@ -1,18 +1,16 @@
-//! WorkbookProtection — Workbook-level protection (stub).
+//! WorkbookProtection — Workbook-level protection operations.
 //!
-//! TODO: Workbook-level protection is not fully implemented in the engine yet.
-//! Sheet-level protection is available via `SheetProtection`.
-//! This module is a placeholder for future workbook protection operations
-//! (e.g., protect structure, protect windows).
+//! These methods are thin typed façades over the engine's structured
+//! workbook-protection record.  In particular, callers must use these
+//! operations instead of writing a flat workbook setting: sheet lifecycle
+//! enforcement reads the structured `protection` map.
 
 use crate::dispatch::Dispatch;
+use crate::error::ComputeApiError;
+use snapshot_types::{MutationResult, WorkbookProtectionOptions};
 
-/// Workbook-level protection operations (stub).
-///
-/// Workbook protection (protect structure/windows) is not yet implemented
-/// in the engine. Use `Sheet::protection()` for sheet-level protection.
+/// Workbook-level protection operations.
 pub struct WorkbookProtection {
-    #[allow(dead_code)]
     dispatch: Dispatch,
 }
 
@@ -21,8 +19,67 @@ impl WorkbookProtection {
         Self { dispatch }
     }
 
-    // TODO: Add workbook-level protection methods when engine support lands:
-    // - protect_workbook(password: Option<&str>) -> Result<MutationResult, ComputeApiError>
-    // - unprotect_workbook() -> Result<MutationResult, ComputeApiError>
-    // - is_workbook_protected() -> Result<bool, ComputeApiError>
+    /// Protect workbook structure with an optional already-hashed password.
+    ///
+    /// Password hashing belongs at the host boundary.  The compute engine
+    /// stores only the resulting hash and keeps structural enforcement tied to
+    /// its structured protection map.
+    pub fn protect_workbook(
+        &self,
+        password_hash: Option<String>,
+    ) -> Result<MutationResult, ComputeApiError> {
+        self.protect_workbook_with_options(password_hash, None)
+    }
+
+    /// Protect workbook structure with an optional password hash and options.
+    pub fn protect_workbook_with_options(
+        &self,
+        password_hash: Option<String>,
+        options: Option<WorkbookProtectionOptions>,
+    ) -> Result<MutationResult, ComputeApiError> {
+        self.dispatch
+            .call_engine(move |e| {
+                e.protect_workbook(password_hash, options)
+                    .map(|(_, result)| result)
+            })
+            .and_then(|result| result.map_err(ComputeApiError::from))
+    }
+
+    /// Unprotect the workbook, validating an optional already-hashed password.
+    ///
+    /// The engine returns `MutationResult.data == false` when a supplied
+    /// password does not match.  The Office.js adapter normalizes that result
+    /// to its public error contract; this typed façade intentionally preserves
+    /// the engine result so callers can inspect the outcome without a second
+    /// state flag.
+    pub fn unprotect_workbook(
+        &self,
+        password_hash: Option<String>,
+    ) -> Result<MutationResult, ComputeApiError> {
+        self.dispatch
+            .call_engine(move |e| {
+                e.unprotect_workbook(password_hash)
+                    .map(|(_, result)| result)
+            })
+            .and_then(|result| result.map_err(ComputeApiError::from))
+    }
+
+    /// Return whether workbook structure protection is currently enabled.
+    pub fn is_workbook_protected(&self) -> Result<bool, ComputeApiError> {
+        self.dispatch.query_engine(|e| e.is_workbook_protected())
+    }
+
+    /// Return the persisted workbook protection options.
+    pub fn get_workbook_protection_options(
+        &self,
+    ) -> Result<WorkbookProtectionOptions, ComputeApiError> {
+        self.dispatch
+            .query_engine(|e| e.get_workbook_protection_options())
+    }
+
+    /// Return whether the workbook protection record contains a password hash.
+    pub fn has_workbook_protection_password(&self) -> Result<bool, ComputeApiError> {
+        self.dispatch
+            .query_engine(|e| e.has_workbook_protection_password())
+    }
 }

--- a/compute/api/src/workbook/settings.rs
+++ b/compute/api/src/workbook/settings.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use crate::dispatch::Dispatch;
 use crate::error::ComputeApiError;
+use serde_json::Value;
 use snapshot_types::MutationResult;
 
 /// Workbook-level settings and configuration.
@@ -43,6 +44,47 @@ impl WorkbookSettings {
             .and_then(|r| r.map_err(ComputeApiError::from))
     }
 
+    /// Read the active tab from the first persisted workbook view, if one is
+    /// present. Workbook views are retained as a raw engine setting because
+    /// they are OOXML round-trip metadata rather than workbook settings.
+    pub fn get_workbook_view_active_tab(&self) -> Result<Option<u32>, ComputeApiError> {
+        let raw = self
+            .dispatch
+            .query_engine(|e| e.get_workbook_setting("workbookViews"))?;
+        let views = decode_workbook_views(raw)?;
+        Ok(views.first().map(|view| view.active_tab))
+    }
+
+    /// Persist the active tab in the first workbook view while preserving all
+    /// other view metadata. A missing view is created with the domain default
+    /// values so export can round-trip the explicit active tab.
+    pub fn set_workbook_view_active_tab(
+        &self,
+        active_tab: u32,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let raw = self
+            .dispatch
+            .query_engine(|e| e.get_workbook_setting("workbookViews"))?;
+        let mut views = decode_workbook_views(raw)?;
+        if let Some(view) = views.first_mut() {
+            view.active_tab = active_tab;
+        } else {
+            views.push(domain_types::domain::workbook::WorkbookView {
+                active_tab,
+                ..Default::default()
+            });
+        }
+        let serialized = serde_json::to_string(&views).map_err(|error| {
+            ComputeApiError::InvalidOperation(format!("failed to encode workbook views: {error}"))
+        })?;
+        let result = self.dispatch.call_engine(move |e| {
+            e.set_workbook_setting("workbookViews", Value::String(serialized))
+        })?;
+        result
+            .map(|(_, mutation)| mutation)
+            .map_err(ComputeApiError::from)
+    }
+
     /// Get the theme color palette (slot name -> hex color).
     ///
     /// Returns a cloned `HashMap` since `CultureInfo` is not `Send`.
@@ -80,4 +122,19 @@ impl WorkbookSettings {
             .call_engine(move |e| e.set_iterative_calculation(enabled).map(|(_, r)| r))
             .and_then(|r| r.map_err(ComputeApiError::from))
     }
+}
+
+fn decode_workbook_views(
+    raw: Option<Value>,
+) -> Result<Vec<domain_types::domain::workbook::WorkbookView>, ComputeApiError> {
+    let Some(raw) = raw else {
+        return Ok(Vec::new());
+    };
+    match raw {
+        Value::String(serialized) => serde_json::from_str(&serialized),
+        value => serde_json::from_value(value),
+    }
+    .map_err(|error| {
+        ComputeApiError::InvalidOperation(format!("invalid persisted workbook views: {error}"))
+    })
 }

--- a/compute/api/src/workbook/sheets.rs
+++ b/compute/api/src/workbook/sheets.rs
@@ -100,6 +100,37 @@ impl WorkbookSheets {
             .and_then(|r| r.map_err(ComputeApiError::from))
     }
 
+    /// Set the Office-compatible visibility state of a sheet.
+    ///
+    /// The accepted engine states are `visible`, `hidden`, and `veryHidden`.
+    /// Office.js adapters translate their public enum tokens at the boundary.
+    pub fn set_sheet_visibility(
+        &self,
+        sheet_id: &SheetId,
+        state: &str,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let sid = *sheet_id;
+        let owned_state = state.to_owned();
+        self.dispatch
+            .call_engine(move |e| e.set_sheet_visibility(&sid, &owned_state).map(|(_, r)| r))
+            .and_then(|r| r.map_err(ComputeApiError::from))
+    }
+
+    /// Get the persisted visibility state of a sheet.
+    pub fn get_sheet_visibility(&self, sheet_id: &SheetId) -> Result<String, ComputeApiError> {
+        let sid = *sheet_id;
+        self.dispatch
+            .query_engine(move |e| e.get_sheet_visibility(&sid))
+            .and_then(|result| result.map_err(ComputeApiError::from))
+    }
+
+    /// Get the first persisted worksheet ID, if the workbook has a sheet.
+    /// This is the engine's genuine default-sheet query, rather than an
+    /// Office host fallback over an arbitrary collection proxy.
+    pub fn get_first_sheet_id(&self) -> Result<Option<String>, ComputeApiError> {
+        self.dispatch.query_engine(|e| e.get_first_sheet_id())
+    }
+
     /// Set or clear the tab color for a sheet.
     pub fn set_tab_color(
         &self,

--- a/compute/api/src/workbook/styles.rs
+++ b/compute/api/src/workbook/styles.rs
@@ -1,17 +1,17 @@
-//! WorkbookStyles — Table style management (stub).
+//! WorkbookStyles — persisted custom cell-style management.
 //!
-//! Built-in table styles are exposed via `compute_core::table_get_built_in_styles()`
-//! which is a pure function, not an engine method. Custom table style management
-//! is not yet implemented.
+//! This facade deliberately delegates every operation to the production
+//! compute engine.  Office.js and other adapters can therefore share the
+//! engine's Yrs-backed style registry instead of keeping an in-memory style
+//! catalog of their own.
 
 use crate::dispatch::Dispatch;
+use crate::error::ComputeApiError;
+use domain_types::domain::cell_style::CellStyleDef;
+use snapshot_types::MutationResult;
 
-/// Custom table style management (stub).
-///
-/// Built-in styles are available via `compute_api::pure` (stateless).
-/// Custom style CRUD will be added here when engine support lands.
+/// Workbook-level custom cell-style management.
 pub struct WorkbookStyles {
-    #[allow(dead_code)]
     dispatch: Dispatch,
 }
 
@@ -20,8 +20,52 @@ impl WorkbookStyles {
         Self { dispatch }
     }
 
-    // TODO: Add custom table style methods when engine support lands:
-    // - get_custom_styles() -> Result<Vec<TableStyle>, ComputeApiError>
-    // - add_custom_style(style: TableStyle) -> Result<MutationResult, ComputeApiError>
-    // - remove_custom_style(name: &str) -> Result<MutationResult, ComputeApiError>
+    /// Return all persisted custom cell styles in the engine's canonical
+    /// name-sorted order.
+    pub fn get_all_custom_cell_styles(&self) -> Result<Vec<CellStyleDef>, ComputeApiError> {
+        self.dispatch
+            .query_engine(|engine| engine.get_all_custom_cell_styles())
+    }
+
+    /// Create a persisted custom cell style.
+    pub fn create_custom_cell_style(
+        &self,
+        style: CellStyleDef,
+    ) -> Result<MutationResult, ComputeApiError> {
+        self.dispatch
+            .call_engine(move |engine| {
+                engine
+                    .create_custom_cell_style(style)
+                    .map(|(_, result)| result)
+            })
+            .and_then(|result| result.map_err(ComputeApiError::from))
+    }
+
+    /// Replace a persisted custom cell style by its stable ID.
+    pub fn update_custom_cell_style(
+        &self,
+        id: &str,
+        style: CellStyleDef,
+    ) -> Result<MutationResult, ComputeApiError> {
+        let id = id.to_owned();
+        self.dispatch
+            .call_engine(move |engine| {
+                engine
+                    .update_custom_cell_style(id, style)
+                    .map(|(_, result)| result)
+            })
+            .and_then(|result| result.map_err(ComputeApiError::from))
+    }
+
+    /// Delete a persisted custom cell style by its stable ID.
+    pub fn delete_custom_cell_style(&self, id: &str) -> Result<MutationResult, ComputeApiError> {
+        let id = id.to_owned();
+        self.dispatch
+            .call_engine(move |engine| {
+                engine
+                    .delete_custom_cell_style(id)
+                    .map(|(_, result)| result)
+            })
+            .and_then(|result| result.map_err(ComputeApiError::from))
+    }
 }

--- a/compute/core/crates/compute-schema/src/constraints.rs
+++ b/compute/core/crates/compute-schema/src/constraints.rs
@@ -4,6 +4,7 @@
 //! pattern matching, enum membership). Used by the validator module.
 
 use regex::Regex;
+use value_types::CellValue;
 
 use super::types::{SchemaConstraints, ValidationError, ValidationErrorCode, ValidationSeverity};
 
@@ -142,6 +143,19 @@ pub(crate) fn check_numeric_constraints(
     errors
 }
 
+/// Resolve formula-backed numeric bounds and then apply the normal numeric
+/// constraint checks. Formula bounds are evaluated for each validation call,
+/// preserving dynamic references instead of snapshotting their current value.
+pub(crate) fn check_numeric_constraints_with_formula_evaluator(
+    value: f64,
+    constraints: &SchemaConstraints,
+    evaluate_formula: &mut dyn FnMut(&str) -> Option<CellValue>,
+) -> Vec<ValidationError> {
+    let (resolved, mut errors) = resolve_formula_bounds(constraints, evaluate_formula, false);
+    errors.extend(check_numeric_constraints(value, &resolved));
+    errors
+}
+
 // ---------------------------------------------------------------------------
 // String constraint checking
 // ---------------------------------------------------------------------------
@@ -202,6 +216,116 @@ pub(crate) fn check_string_constraints(
     errors
 }
 
+/// Resolve formula-backed text-length bounds and then apply the normal string
+/// constraint checks. Formula bounds are evaluated for each validation call.
+pub(crate) fn check_string_constraints_with_formula_evaluator(
+    value: &str,
+    constraints: &SchemaConstraints,
+    evaluate_formula: &mut dyn FnMut(&str) -> Option<CellValue>,
+) -> Vec<ValidationError> {
+    let (resolved, mut errors) = resolve_formula_bounds(constraints, evaluate_formula, true);
+    errors.extend(check_string_constraints(value, &resolved));
+    errors
+}
+
+fn resolve_formula_bounds(
+    constraints: &SchemaConstraints,
+    evaluate_formula: &mut dyn FnMut(&str) -> Option<CellValue>,
+    length_bounds: bool,
+) -> (SchemaConstraints, Vec<ValidationError>) {
+    let mut resolved = constraints.clone();
+    let mut errors = Vec::new();
+    let Some(bounds) = constraints.formula_bounds.clone() else {
+        return (resolved, errors);
+    };
+
+    for (key, formula) in bounds {
+        let Some(value) = evaluate_formula(&formula) else {
+            errors.push(formula_bound_error(
+                &key,
+                &formula,
+                "could not be evaluated",
+            ));
+            continue;
+        };
+        let Some(number) = formula_value_number(&value) else {
+            errors.push(formula_bound_error(
+                &key,
+                &formula,
+                "did not return a number",
+            ));
+            continue;
+        };
+        if length_bounds {
+            if number < 0.0 || number.fract() != 0.0 || number > usize::MAX as f64 {
+                errors.push(formula_bound_error(
+                    &key,
+                    &formula,
+                    "must evaluate to a non-negative integer",
+                ));
+                continue;
+            }
+            match key.as_str() {
+                "minLength" => resolved.min_length = Some(number as usize),
+                "maxLength" => resolved.max_length = Some(number as usize),
+                _ => errors.push(formula_bound_error(
+                    &key,
+                    &formula,
+                    "is not a text-length bound",
+                )),
+            }
+        } else {
+            match key.as_str() {
+                "min" => resolved.min = Some(number),
+                "max" => resolved.max = Some(number),
+                "exclusiveMin" => resolved.exclusive_min = Some(number),
+                "exclusiveMax" => resolved.exclusive_max = Some(number),
+                "equal" => resolved.equal = Some(number),
+                "notEqual" => resolved.not_equal = Some(number),
+                "notBetweenMin" => resolved.not_between_min = Some(number),
+                "notBetweenMax" => resolved.not_between_max = Some(number),
+                _ => errors.push(formula_bound_error(
+                    &key,
+                    &formula,
+                    "is not a numeric bound",
+                )),
+            }
+        }
+    }
+
+    (resolved, errors)
+}
+
+fn formula_value_number(value: &CellValue) -> Option<f64> {
+    match value {
+        CellValue::Number(number) => Some(number.get()),
+        CellValue::Boolean(value) => Some(if *value { 1.0 } else { 0.0 }),
+        CellValue::Text(value) => value
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .filter(|number| number.is_finite()),
+        // The production expression query scalarizes an empty result to
+        // numeric zero, which is also Excel's comparison behavior for a
+        // blank numeric operand.
+        CellValue::Null => Some(0.0),
+        CellValue::Control(control) => Some(if control.value { 1.0 } else { 0.0 }),
+        // A Range operand evaluates to an array. Office's scalar validation
+        // operand uses its implicit intersection/top-left value, matching the
+        // production expression facade's scalarization behavior.
+        CellValue::Array(values) => values.get(0, 0).and_then(formula_value_number),
+        _ => None,
+    }
+}
+
+fn formula_bound_error(key: &str, formula: &str, reason: &str) -> ValidationError {
+    ValidationError {
+        code: ValidationErrorCode::Formula,
+        message: format!("Formula bound {key} ({formula}) {reason}"),
+        severity: ValidationSeverity::Warning,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Enum constraint checking
 // ---------------------------------------------------------------------------
@@ -240,10 +364,10 @@ pub(crate) fn check_enum_constraint(
 /// Returns `None` if there is no formula constraint or if the formula passes.
 pub(crate) fn check_formula_constraint<F>(
     constraints: &SchemaConstraints,
-    evaluate_formula: F,
+    mut evaluate_formula: F,
 ) -> Option<ValidationError>
 where
-    F: FnOnce(&str) -> Option<value_types::CellValue>,
+    F: FnMut(&str) -> Option<value_types::CellValue>,
 {
     let formula = match &constraints.formula {
         Some(f) if !f.is_empty() => f,

--- a/compute/core/crates/compute-schema/src/validator.rs
+++ b/compute/core/crates/compute-schema/src/validator.rs
@@ -42,7 +42,7 @@ pub fn validate_with_formula_evaluator<F>(
     evaluate_formula: F,
 ) -> ValidationResult
 where
-    F: FnOnce(&str) -> Option<CellValue>,
+    F: FnMut(&str) -> Option<CellValue>,
 {
     scalar::validate_with_formula_evaluator(value, schema, evaluate_formula)
 }

--- a/compute/core/crates/compute-schema/src/validator/constraint_dispatch.rs
+++ b/compute/core/crates/compute-schema/src/validator/constraint_dispatch.rs
@@ -2,7 +2,8 @@ use value_types::CellValue;
 
 use crate::constraints;
 use crate::types::{
-    ColumnSchema, ValidationError, ValidationErrorCode, ValidationResult, ValidationSeverity,
+    ColumnSchema, SchemaType, ValidationError, ValidationErrorCode, ValidationResult,
+    ValidationSeverity,
 };
 
 use super::numeric;
@@ -72,12 +73,96 @@ pub(super) fn validate_constraints(
     errors
 }
 
+/// Validate constraints while resolving formula-backed bounds through the
+/// production evaluator supplied by the caller.
+pub(super) fn validate_constraints_with_formula_evaluator(
+    value: &CellValue,
+    schema: &ColumnSchema,
+    evaluate_formula: &mut dyn FnMut(&str) -> Option<CellValue>,
+) -> Vec<ValidationError> {
+    let c = match &schema.constraints {
+        Some(c) => c,
+        None => return Vec::new(),
+    };
+    let mut errors = Vec::new();
+
+    if numeric::is_numeric_type(schema.schema_type)
+        && let Some(num) = numeric::extract_number(value, schema.schema_type)
+    {
+        errors.extend(
+            constraints::check_numeric_constraints_with_formula_evaluator(num, c, evaluate_formula),
+        );
+    }
+
+    // Numeric/date/time schemas may accept text input after coercion, but
+    // their formula bounds are numeric. Apply text-length bounds only to the
+    // string family so a date formula such as `=DATE(...)` is not evaluated a
+    // second time as a length constraint.
+    if matches!(
+        schema.schema_type,
+        SchemaType::String
+            | SchemaType::Email
+            | SchemaType::Url
+            | SchemaType::Phone
+            | SchemaType::Company
+            | SchemaType::Person
+            | SchemaType::Stock
+            | SchemaType::Location
+    ) && let CellValue::Text(text) = value
+    {
+        errors.extend(
+            constraints::check_string_constraints_with_formula_evaluator(text, c, evaluate_formula),
+        );
+    }
+
+    // Enum membership is independent of formula-backed scalar bounds.
+    if let Some(ref enum_values) = c.enum_values {
+        match value {
+            CellValue::Text(text) => {
+                if let Some(err) = constraints::check_enum_constraint(text, c) {
+                    errors.push(err);
+                }
+            }
+            CellValue::Number(n) => {
+                if !constraints::is_number_in_enum(n.get(), enum_values) {
+                    errors.push(ValidationError {
+                        code: ValidationErrorCode::Enum,
+                        message: format!(
+                            "Value '{}' is not in allowed values: [{}]",
+                            n.get(),
+                            enum_values.join(", ")
+                        ),
+                        severity: ValidationSeverity::Error,
+                    });
+                }
+            }
+            CellValue::Boolean(b) => {
+                let s = b.to_string();
+                if !constraints::is_in_enum(&s, enum_values) {
+                    errors.push(ValidationError {
+                        code: ValidationErrorCode::Enum,
+                        message: format!(
+                            "Value '{}' is not in allowed values: [{}]",
+                            s,
+                            enum_values.join(", ")
+                        ),
+                        severity: ValidationSeverity::Error,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    errors
+}
+
 pub(super) fn append_formula_error<F>(
     result: &mut ValidationResult,
     schema: &ColumnSchema,
-    evaluate_formula: F,
+    evaluate_formula: &mut F,
 ) where
-    F: FnOnce(&str) -> Option<CellValue>,
+    F: FnMut(&str) -> Option<CellValue>,
 {
     if let Some(ref c) = schema.constraints
         && c.formula.is_some()

--- a/compute/core/crates/compute-schema/src/validator/scalar.rs
+++ b/compute/core/crates/compute-schema/src/validator/scalar.rs
@@ -10,6 +10,14 @@ use super::constraint_dispatch;
 use super::type_check;
 
 pub(super) fn validate(value: &CellValue, schema: &ColumnSchema) -> ValidationResult {
+    validate_internal(value, schema, None)
+}
+
+fn validate_internal(
+    value: &CellValue,
+    schema: &ColumnSchema,
+    mut evaluate_formula: Option<&mut dyn FnMut(&str) -> Option<CellValue>>,
+) -> ValidationResult {
     let mut errors = Vec::new();
     let inferred_type = inference::infer_type(value);
 
@@ -39,7 +47,17 @@ pub(super) fn validate(value: &CellValue, schema: &ColumnSchema) -> ValidationRe
 
     // Step 3: Constraint validation (only if type matches)
     if !has_type_errors && schema.constraints.is_some() {
-        errors.extend(constraint_dispatch::validate_constraints(value, schema));
+        if let Some(evaluate_formula) = evaluate_formula.as_deref_mut() {
+            errors.extend(
+                constraint_dispatch::validate_constraints_with_formula_evaluator(
+                    value,
+                    schema,
+                    evaluate_formula,
+                ),
+            );
+        } else {
+            errors.extend(constraint_dispatch::validate_constraints(value, schema));
+        }
     }
 
     // Step 4: Coercion fallback
@@ -57,10 +75,20 @@ pub(super) fn validate(value: &CellValue, schema: &ColumnSchema) -> ValidationRe
                 && schema.constraints.is_some()
                 && let Some(constraint_value) = constraint_value
             {
-                errors.extend(constraint_dispatch::validate_constraints(
-                    &constraint_value,
-                    schema,
-                ));
+                if let Some(evaluate_formula) = evaluate_formula.as_deref_mut() {
+                    errors.extend(
+                        constraint_dispatch::validate_constraints_with_formula_evaluator(
+                            &constraint_value,
+                            schema,
+                            evaluate_formula,
+                        ),
+                    );
+                } else {
+                    errors.extend(constraint_dispatch::validate_constraints(
+                        &constraint_value,
+                        schema,
+                    ));
+                }
             }
         }
     }
@@ -94,16 +122,16 @@ fn cell_value_result_to_cell_value(value: &crate::types::CellValueResult) -> Opt
 pub(super) fn validate_with_formula_evaluator<F>(
     value: &CellValue,
     schema: &ColumnSchema,
-    evaluate_formula: F,
+    mut evaluate_formula: F,
 ) -> ValidationResult
 where
-    F: FnOnce(&str) -> Option<CellValue>,
+    F: FnMut(&str) -> Option<CellValue>,
 {
-    // Run the standard 4-step validation first
-    let mut result = validate(value, schema);
+    // Run the standard 4-step validation plus formula-backed scalar bounds.
+    let mut result = validate_internal(value, schema, Some(&mut evaluate_formula));
 
     // Step 5: Formula constraint (only if we have constraints with a formula)
-    constraint_dispatch::append_formula_error(&mut result, schema, evaluate_formula);
+    constraint_dispatch::append_formula_error(&mut result, schema, &mut evaluate_formula);
 
     result
 }

--- a/compute/core/src/scheduler/mod.rs
+++ b/compute/core/src/scheduler/mod.rs
@@ -331,6 +331,13 @@ impl ComputeCore {
         self.dirty_since_last_recalc
     }
 
+    /// Whether a manual-calculation edit is waiting for an explicit full
+    /// recalculation. Settings changes also mark the scheduler dirty, but do
+    /// not by themselves create a pending manual edit.
+    pub(crate) fn has_pending_manual_calculation(&self) -> bool {
+        !self.pending_manual_dirty_cells.is_empty()
+    }
+
     fn rebuild_ordered_sheets_cache(&mut self) {
         let mut pairs: Vec<(SheetId, usize)> = self
             .sheet_order

--- a/compute/core/src/storage/cells/data_ops.rs
+++ b/compute/core/src/storage/cells/data_ops.rs
@@ -245,94 +245,93 @@ pub fn split_all_values(
 // Grid index mutation helpers (write txn)
 // ===========================================================================
 
-/// Copy all cell data from one row to another within a column range.
+/// Compact non-duplicate rows while retaining the source cells' identities.
 ///
-/// Used by remove_duplicates during compaction. If the source cell exists,
-/// its value is copied to the target. If the source is empty and the target
-/// exists, the target is deleted. Cell identities are managed through the
-/// supplied `GridIndex` — the SOLE authority for (row, col) ↔ CellId.
+/// Cell payloads are keyed by `CellId`, rather than by position. A row
+/// compaction therefore only needs to rebind each surviving source CellId to
+/// its new position. Copying just `KEY_VALUE` into the destination would leave
+/// the destination CellId in place and silently discard the source formula,
+/// format, and identity metadata. Removing all old bindings first also makes
+/// moves into an occupied destination deterministic.
 #[allow(clippy::too_many_arguments)]
-fn copy_row_cells(
+fn compact_rows_preserving_cells(
     txn: &mut yrs::TransactionMut<'_>,
+    sheets: &MapRef,
+    sheet_hex: &str,
     grid: &mut GridIndex,
     cells_map: &MapRef,
     props_map: Option<&MapRef>,
     start_col: u32,
     end_col: u32,
-    from_row: u32,
-    to_row: u32,
+    first_data_row: u32,
+    end_row: u32,
+    duplicate_rows: &std::collections::HashSet<u32>,
 ) {
-    for col in start_col..=end_col {
-        let from_cell = grid.cell_id_at(from_row, col);
-        let to_cell = grid.cell_id_at(to_row, col);
+    // Snapshot every source identity before changing the GridIndex. The
+    // destination can already contain a duplicate-row identity, so rebinding
+    // while iterating would otherwise overwrite information needed later in
+    // the pass.
+    let mut moves = Vec::new();
+    let mut duplicate_ids = Vec::new();
+    let mut affected_ids = Vec::new();
+    let mut write_row = first_data_row;
 
-        if let Some(src_id) = from_cell {
-            // Source cell exists — read its value and write to target
-            let src_hex = id_to_hex(src_id.as_u128());
-            let src_value = match cells_map.get(txn, src_hex.as_str()) {
-                Some(Out::YMap(m)) => match m.get(txn, KEY_VALUE) {
-                    Some(Out::Any(a)) => a.clone(),
-                    _ => Any::Null,
-                },
-                _ => Any::Null,
-            };
-
-            if let Some(tgt_id) = to_cell {
-                // Target cell exists — update KEY_VALUE in-place within the
-                // existing YMap. Inserting a MapPrelim at an existing YMap key
-                // does not replace the nested map in Yrs; only in-place update works.
-                let tgt_hex = id_to_hex(tgt_id.as_u128());
-                match cells_map.get(txn, tgt_hex.as_str()) {
-                    Some(Out::YMap(cell_map)) => {
-                        cell_map.insert(txn, KEY_VALUE, src_value);
-                    }
-                    _ => {
-                        let cell_prelim = MapPrelim::from([(KEY_VALUE, src_value)]);
-                        cells_map.insert(txn, tgt_hex.as_str(), cell_prelim);
-                    }
+    for read_row in first_data_row..=end_row {
+        if duplicate_rows.contains(&read_row) {
+            for col in start_col..=end_col {
+                if let Some(cell_id) = grid.cell_id_at(read_row, col) {
+                    duplicate_ids.push(cell_id);
+                    affected_ids.push(cell_id);
                 }
-            } else {
-                // No target cell — allocate a new CellId via the GridIndex
-                // (the sole identity authority) and persist the value.
-                let new_id = grid.ensure_cell_id(to_row, col);
-                let new_hex = id_to_hex(new_id.as_u128());
-                let cell_prelim = MapPrelim::from([(KEY_VALUE, src_value)]);
-                cells_map.insert(txn, new_hex.as_str(), cell_prelim);
             }
-        } else if let Some(tgt_id) = to_cell {
-            // Source is empty but target exists — delete target
-            let tgt_hex = id_to_hex(tgt_id.as_u128());
-            cells_map.remove(txn, tgt_hex.as_str());
-            if let Some(pm) = props_map {
-                pm.remove(txn, tgt_hex.as_str());
+        } else {
+            for col in start_col..=end_col {
+                if let Some(cell_id) = grid.cell_id_at(read_row, col) {
+                    moves.push((cell_id, write_row, col));
+                    affected_ids.push(cell_id);
+                }
             }
-            grid.remove_cell(&tgt_id);
+            write_row += 1;
         }
     }
-}
 
-/// Delete all cells in a row within a column range.
-fn delete_row_cells(
-    txn: &mut yrs::TransactionMut<'_>,
-    grid: &mut GridIndex,
-    cells_map: &MapRef,
-    props_map: Option<&MapRef>,
-    start_col: u32,
-    end_col: u32,
-    row: u32,
-) {
-    // Snapshot the CellIds first to avoid iterator invalidation as we
-    // deregister entries from the GridIndex.
-    let to_remove: Vec<(CellId, u32)> = (start_col..=end_col)
-        .filter_map(|col| grid.cell_id_at(row, col).map(|id| (id, col)))
-        .collect();
-    for (cell_id, _col) in to_remove {
-        let hex = id_to_hex(cell_id.as_u128());
-        cells_map.remove(txn, hex.as_str());
+    // Clear all old position bindings before registering destinations. This
+    // removes stale `posToId` entries as well as `idToPos` entries, including
+    // the bindings for duplicate cells that are about to be deleted.
+    for cell_id in &affected_ids {
+        let cell_hex = id_to_hex(cell_id.as_u128());
+        crate::storage::cells::values::remove_cell_position_from_yrs(
+            txn, sheets, sheet_hex, &cell_hex,
+        );
+        grid.remove_cell(cell_id);
+    }
+
+    // Duplicate rows are gone. Their payload and cell-owned properties must
+    // be removed by identity; surviving rows keep their original Yrs maps so
+    // formulas, formatting, and all other cell metadata move with the ID.
+    for cell_id in duplicate_ids {
+        let cell_hex = id_to_hex(cell_id.as_u128());
+        cells_map.remove(txn, cell_hex.as_str());
         if let Some(pm) = props_map {
-            pm.remove(txn, hex.as_str());
+            pm.remove(txn, cell_hex.as_str());
         }
-        grid.remove_cell(&cell_id);
+    }
+
+    // Rebind each surviving source CellId to its compacted position and
+    // mirror that authoritative mapping into Yrs for undo/redo and reload.
+    for (cell_id, to_row, col) in moves {
+        grid.register_cell(cell_id, to_row, col);
+        let cell_hex = id_to_hex(cell_id.as_u128());
+        if let (Some(row_hex), Some(col_hex)) = (grid.row_id_hex(to_row), grid.col_id_hex(col)) {
+            crate::storage::cells::values::write_cell_position_to_yrs(
+                txn,
+                sheets,
+                sheet_hex,
+                &cell_hex,
+                row_hex.as_str(),
+                col_hex.as_str(),
+            );
+        }
     }
 }
 
@@ -468,38 +467,19 @@ pub fn remove_duplicates(
         };
         let props_map = get_properties_map(&txn, sheets, &sheet_hex);
 
-        let mut write_row = first_data_row;
-
-        for read_row in first_data_row..=end_row {
-            if !dup_set.contains(&read_row) {
-                if write_row != read_row {
-                    copy_row_cells(
-                        &mut txn,
-                        grid,
-                        &cells_map,
-                        props_map.as_ref(),
-                        start_col,
-                        end_col,
-                        read_row,
-                        write_row,
-                    );
-                }
-                write_row += 1;
-            }
-        }
-
-        // Clear remaining rows (the ones freed by compaction)
-        for row in write_row..=end_row {
-            delete_row_cells(
-                &mut txn,
-                grid,
-                &cells_map,
-                props_map.as_ref(),
-                start_col,
-                end_col,
-                row,
-            );
-        }
+        compact_rows_preserving_cells(
+            &mut txn,
+            sheets,
+            &sheet_hex,
+            grid,
+            &cells_map,
+            props_map.as_ref(),
+            start_col,
+            end_col,
+            first_data_row,
+            end_row,
+            &dup_set,
+        );
     }
 
     let total_data = end_row - start_row + 1 - if options.has_headers { 1 } else { 0 };

--- a/compute/core/src/storage/engine/objects/hyperlinks.rs
+++ b/compute/core/src/storage/engine/objects/hyperlinks.rs
@@ -1,5 +1,5 @@
 use super::shared;
-use crate::snapshot::MutationResult;
+use crate::snapshot::{MutationResult, RecalcResult};
 use crate::storage::engine::YrsComputeEngine;
 use crate::storage::engine::services;
 use crate::storage::sheet::hyperlinks;
@@ -33,6 +33,75 @@ impl YrsComputeEngine {
             url,
         )
         .map(shared::with_empty_patches)
+    }
+
+    /// Set a hyperlink using the typed worksheet fields.
+    ///
+    /// `text_to_display` is also written as literal cell text. This follows
+    /// Excel's RangeHyperlink contract: the text is displayed in the top-left
+    /// cell of the range while the hyperlink metadata remains attached to the
+    /// cell. Existing formatting is retained by the literal-text edit path.
+    #[bridge::write]
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_hyperlink_with_metadata(
+        &mut self,
+        sheet_id: &SheetId,
+        row: u32,
+        col: u32,
+        address: Option<String>,
+        document_reference: Option<String>,
+        text_to_display: Option<String>,
+        screen_tip: Option<String>,
+    ) -> Result<(Vec<u8>, MutationResult), ComputeError> {
+        if address.as_deref().is_none_or(str::is_empty)
+            && document_reference.as_deref().is_none_or(str::is_empty)
+        {
+            return Err(ComputeError::InvalidInput {
+                message: "hyperlink requires a non-empty address or document reference".to_string(),
+            });
+        }
+
+        let has_display_text = text_to_display.is_some();
+        let mut recalc = self.with_undo_group_if(has_display_text, |engine| {
+            let recalc = match text_to_display.as_deref() {
+                Some(display) => services::cell_editing::set_cell_value_as_text(
+                    &mut engine.stores,
+                    &mut engine.mirror,
+                    &mut engine.mutation,
+                    sheet_id,
+                    row,
+                    col,
+                    display,
+                )?,
+                None => RecalcResult::empty(),
+            };
+
+            {
+                let _guard = engine.mutation.suppress_guard();
+                services::objects::set_hyperlink_with_metadata(
+                    &mut engine.stores,
+                    &mut engine.mirror,
+                    sheet_id,
+                    row,
+                    col,
+                    address.as_deref(),
+                    document_reference.as_deref(),
+                    text_to_display.as_deref(),
+                    screen_tip.as_deref(),
+                )?;
+            }
+            Ok(recalc)
+        })?;
+
+        if has_display_text {
+            self.prepare_recalc_for_flush(&mut recalc);
+            Ok((
+                self.flush_viewport_patches(),
+                MutationResult::from_recalc(recalc),
+            ))
+        } else {
+            Ok((shared::empty_patches(), MutationResult::empty()))
+        }
     }
 
     /// Remove the hyperlink from a cell at the given position.

--- a/compute/core/src/storage/engine/recalc.rs
+++ b/compute/core/src/storage/engine/recalc.rs
@@ -5,6 +5,22 @@ use crate::scheduler::ComputeCore;
 use super::{YrsComputeEngine, construction};
 
 impl YrsComputeEngine {
+    /// Return the synchronous calculation state exposed by the Office.js
+    /// host. A clean engine is complete; a dirty manual workbook has pending
+    /// work; and a dirty automatic workbook is waiting for its next recalc
+    /// boundary. Recalculation itself is synchronous on this engine, so the
+    /// transient in-progress state is never observed by a query.
+    pub fn calculation_state(&self) -> &'static str {
+        if !self.stores.compute.is_dirty() {
+            return "Done";
+        }
+        if self.stores.compute.calc_mode() == crate::snapshot::CalcMode::Manual {
+            "Pending"
+        } else {
+            "Calculating"
+        }
+    }
+
     /// Perform a full recalculation of all formula cells using the existing
     /// dependency graph and AST caches. Does NOT rebuild the ComputeCore.
     ///

--- a/compute/core/src/storage/engine/services/objects/hyperlinks.rs
+++ b/compute/core/src/storage/engine/services/objects/hyperlinks.rs
@@ -49,6 +49,51 @@ pub(in crate::storage::engine) fn set_hyperlink(
     Ok(MutationResult::empty())
 }
 
+pub(in crate::storage::engine) fn set_hyperlink_with_metadata(
+    stores: &mut EngineStores,
+    mirror: &mut CellMirror,
+    sheet_id: &SheetId,
+    row: u32,
+    col: u32,
+    address: Option<&str>,
+    document_reference: Option<&str>,
+    display: Option<&str>,
+    tooltip: Option<&str>,
+) -> Result<MutationResult, ComputeError> {
+    let pre_existing_id = stores
+        .grid_indexes
+        .get(sheet_id)
+        .and_then(|g| g.cell_id_at(row, col));
+
+    let Some(grid) = stores.grid_indexes.get_mut(sheet_id) else {
+        return Ok(MutationResult::empty());
+    };
+    hyperlinks::set_hyperlink_with_metadata(
+        stores.storage.doc(),
+        stores.storage.sheets(),
+        sheet_id,
+        grid,
+        row,
+        col,
+        address,
+        document_reference,
+        display,
+        tooltip,
+    );
+
+    if pre_existing_id.is_none()
+        && let Some(cell_id) = stores
+            .grid_indexes
+            .get(sheet_id)
+            .and_then(|g| g.cell_id_at(row, col))
+    {
+        let pos = cell_types::SheetPos::new(row, col);
+        mirror.apply_edit(sheet_id, cell_id, pos, value_types::CellValue::Null, None);
+    }
+
+    Ok(MutationResult::empty())
+}
+
 pub(in crate::storage::engine) fn remove_hyperlink(
     stores: &mut EngineStores,
     mirror: &mut CellMirror,

--- a/compute/core/src/storage/sheet/hyperlinks/mod.rs
+++ b/compute/core/src/storage/sheet/hyperlinks/mod.rs
@@ -15,7 +15,7 @@ mod mutation_metadata_tests;
 #[cfg(test)]
 mod tests;
 
-pub use mutations::{remove_hyperlink, set_hyperlink};
+pub use mutations::{remove_hyperlink, set_hyperlink, set_hyperlink_with_metadata};
 #[cfg(test)]
 pub use queries::get_hyperlink_full;
 pub use queries::{get_all_hyperlinks, get_hyperlink};

--- a/compute/core/src/storage/sheet/hyperlinks/mutations.rs
+++ b/compute/core/src/storage/sheet/hyperlinks/mutations.rs
@@ -68,6 +68,139 @@ pub fn set_hyperlink(
     }
 }
 
+/// Set a hyperlink with the typed worksheet metadata fields.
+///
+/// `address` is the external target, `document_reference` is the workbook
+/// location, and both may be supplied for an external target with a
+/// sub-address. Display and tooltip are stored independently from the cell
+/// value so callers can preserve metadata when no display text is supplied.
+pub fn set_hyperlink_with_metadata(
+    doc: &Doc,
+    sheets: &MapRef,
+    sheet_id: &SheetId,
+    grid: &mut GridIndex,
+    row: u32,
+    col: u32,
+    address: Option<&str>,
+    document_reference: Option<&str>,
+    display: Option<&str>,
+    tooltip: Option<&str>,
+) {
+    let sheet_hex = id_to_hex(sheet_id.as_u128());
+    let mut txn = doc.transact_mut_with(Origin::from(ORIGIN_USER_EDIT));
+
+    let cells_map = match get_cells_map(&txn, sheets, &sheet_hex) {
+        Some(m) => m,
+        None => return,
+    };
+
+    let cell_map = if let Some(cell_id) = grid.cell_id_at(row, col) {
+        let cell_hex = id_to_hex(cell_id.as_u128());
+        match cells_map.get(&txn, &cell_hex) {
+            Some(Out::YMap(cell_map)) => cell_map,
+            _ => return,
+        }
+    } else {
+        let cell_id = grid.ensure_cell_id(row, col);
+        let cell_hex = id_to_hex(cell_id.as_u128());
+        let row_hex = grid.row_id_hex(row);
+        let col_hex = grid.col_id_hex(col);
+        let cell_prelim = MapPrelim::from([(KEY_VALUE, Any::Null)]);
+        cells_map.insert(&mut txn, &*cell_hex, cell_prelim);
+        if let (Some(rh), Some(ch)) = (row_hex.as_ref(), col_hex.as_ref()) {
+            crate::storage::cells::values::write_cell_position_to_yrs(
+                &mut txn,
+                sheets,
+                &sheet_hex,
+                &cell_hex,
+                rh.as_str(),
+                ch.as_str(),
+            );
+        }
+        match cells_map.get(&txn, &cell_hex) {
+            Some(Out::YMap(cell_map)) => cell_map,
+            _ => return,
+        }
+    };
+
+    let target = address.filter(|value| !value.is_empty());
+    let location = document_reference.filter(|value| !value.is_empty());
+
+    if let Some(target) = target {
+        cell_map.insert(&mut txn, KEY_HYPERLINK, Any::String(Arc::from(target)));
+        cell_map.insert(
+            &mut txn,
+            KEY_HYPERLINK_TARGET_KIND,
+            Any::String(Arc::from(TARGET_KIND_RELATIONSHIP)),
+        );
+        cell_map.insert(
+            &mut txn,
+            KEY_HYPERLINK_TARGET_MODE,
+            Any::String(Arc::from("External")),
+        );
+    } else if let Some(location) = location {
+        cell_map.insert(&mut txn, KEY_HYPERLINK, Any::String(Arc::from(location)));
+        cell_map.insert(
+            &mut txn,
+            KEY_HYPERLINK_LOCATION,
+            Any::String(Arc::from(location)),
+        );
+        cell_map.insert(
+            &mut txn,
+            KEY_HYPERLINK_TARGET_KIND,
+            Any::String(Arc::from(TARGET_KIND_INLINE_LOCATION)),
+        );
+        cell_map.remove(&mut txn, KEY_HYPERLINK_TARGET_MODE);
+    } else {
+        cell_map.remove(&mut txn, KEY_HYPERLINK);
+        cell_map.remove(&mut txn, KEY_HYPERLINK_LOCATION);
+        cell_map.remove(&mut txn, KEY_HYPERLINK_TARGET_KIND);
+        cell_map.remove(&mut txn, KEY_HYPERLINK_TARGET_MODE);
+    }
+
+    if target.is_some() {
+        if let Some(location) = location {
+            cell_map.insert(
+                &mut txn,
+                KEY_HYPERLINK_LOCATION,
+                Any::String(Arc::from(location)),
+            );
+        } else {
+            cell_map.remove(&mut txn, KEY_HYPERLINK_LOCATION);
+        }
+    }
+
+    cell_map.remove(&mut txn, KEY_HYPERLINK_UID);
+    cell_map.remove(&mut txn, KEY_HYPERLINK_RANGE_REF);
+    cell_map.remove(&mut txn, KEY_HYPERLINK_ORDER);
+
+    if let Some(display) = display {
+        cell_map.insert(
+            &mut txn,
+            KEY_HYPERLINK_DISPLAY,
+            Any::String(Arc::from(display)),
+        );
+    } else if let Some(display) = current_cell_display(&txn, &cell_map) {
+        cell_map.insert(
+            &mut txn,
+            KEY_HYPERLINK_DISPLAY,
+            Any::String(Arc::from(display.as_str())),
+        );
+    } else {
+        cell_map.remove(&mut txn, KEY_HYPERLINK_DISPLAY);
+    }
+
+    if let Some(tooltip) = tooltip {
+        cell_map.insert(
+            &mut txn,
+            KEY_HYPERLINK_TOOLTIP,
+            Any::String(Arc::from(tooltip)),
+        );
+    } else {
+        cell_map.remove(&mut txn, KEY_HYPERLINK_TOOLTIP);
+    }
+}
+
 fn write_hyperlink_fields(cell_map: &MapRef, txn: &mut yrs::TransactionMut<'_>, url: &str) {
     let display = current_cell_display(txn, cell_map);
     let target_kind = hyperlink_target_kind_for_target(url);

--- a/compute/core/src/storage/sheet/schemas/validator.rs
+++ b/compute/core/src/storage/sheet/schemas/validator.rs
@@ -33,12 +33,16 @@ pub(in crate::storage::sheet) fn str_to_cell_value(s: &str) -> value_types::Cell
 }
 
 fn schema_has_formula_constraint(schema: &ColumnSchema) -> bool {
-    schema
-        .constraints
-        .as_ref()
-        .and_then(|c| c.formula.as_ref())
-        .map(|f| !f.is_empty())
-        .unwrap_or(false)
+    schema.constraints.as_ref().is_some_and(|constraints| {
+        constraints
+            .formula
+            .as_ref()
+            .is_some_and(|formula| !formula.is_empty())
+            || constraints
+                .formula_bounds
+                .as_ref()
+                .is_some_and(|bounds| !bounds.is_empty())
+    })
 }
 
 fn validate_with_optional_formula(

--- a/compute/officejs/Cargo.toml
+++ b/compute/officejs/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 compute-api = { path = "../api" }
+domain-types = { path = "../../domain-types" }
 value-types = { path = "../core/crates/types/value-types" }
 rquickjs = { version = "0.12.2", features = ["futures"] }
 tokio = { version = "1", features = ["rt"] }

--- a/compute/officejs/src/application.js
+++ b/compute/officejs/src/application.js
@@ -1,0 +1,402 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs;
+
+  function error(code, message) {
+    return new OfficeExtension.Error({ code: code, message: message });
+  }
+
+  function propertyNotLoaded(name) {
+    return error(
+      "PropertyNotLoaded",
+      "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context."
+    );
+  }
+
+  function requirePropertyObject(source, typeName) {
+    if (source == null || typeof source !== "object") {
+      throw error("InvalidArgument", typeName + ".set requires a property object");
+    }
+  }
+
+  function assertSameContext(source, target) {
+    if (source.context !== target.context) {
+      throw error(
+        "InvalidRequestContext",
+        "The object belongs to a different request context."
+      );
+    }
+  }
+
+  function loadedValue(object, name) {
+    if (!object._loaded[name]) throw propertyNotLoaded(name);
+    return object["_" + name];
+  }
+
+  function isClientObject(value) {
+    return value instanceof ClientObject;
+  }
+
+  function queueSet(object, property, value, ensureBinding) {
+    if (ensureBinding) ensureBinding.call(object);
+    object["_" + property] = value;
+    object._loaded[property] = true;
+    object.context._queue.push({
+      op: "set",
+      id: object._id,
+      property: property,
+      value: value,
+    });
+  }
+
+  function enumValue(value, property, allowed) {
+    if (allowed.indexOf(value) < 0) {
+      throw error(
+        "InvalidArgument",
+        property + " must be one of: " + allowed.join(", ")
+      );
+    }
+    return value;
+  }
+
+  function readOnlyProperties(typeName) {
+    return function (name, properties, throwOnReadOnly) {
+      if (properties[name] === undefined) return true;
+      if (throwOnReadOnly) {
+        throw error("InvalidArgument", typeName + "." + name + " is read-only");
+      }
+      return true;
+    };
+  }
+
+  function sourceObject(target, source, typeName) {
+    requirePropertyObject(source, typeName);
+    if (!isClientObject(source)) {
+      return { properties: source };
+    }
+    assertSameContext(source, target);
+    if (Object.getPrototypeOf(source) !== Object.getPrototypeOf(target)) {
+      throw error(
+        "InvalidArgument",
+        "The object passed to " + typeName + ".set must have the same type."
+      );
+    }
+    return { properties: source.toJSON() };
+  }
+
+  function setProperties(target, source, typeName, writable, readOnly, options) {
+    var normalized = sourceObject(target, source, typeName);
+    var properties = normalized.properties;
+    var throwOnReadOnly = !(options && options.throwOnReadOnly === false);
+
+    Object.keys(properties).forEach(function (name) {
+      if (writable.indexOf(name) >= 0) return;
+      if (readOnly.indexOf(name) >= 0) {
+        readOnlyProperties(typeName)(
+          name,
+          properties,
+          throwOnReadOnly
+        );
+        return;
+      }
+      throw error("InvalidArgument", "Unknown " + typeName + " property: " + name);
+    });
+
+    writable.forEach(function (name) {
+      if (Object.prototype.hasOwnProperty.call(properties, name)) {
+        if (properties[name] !== undefined) target[name] = properties[name];
+      }
+    });
+    return properties;
+  }
+
+  function Application(context, workbook) {
+    ClientObject.call(this, context);
+    this._workbook = workbook || null;
+    // These are the scalar members that this headless host can answer from
+    // the compute engine. Unsupported desktop/locale members remain explicit
+    // descriptors below and are never silently fabricated by load().
+    this._scalarProperties = ["calculationMode", "calculationState"];
+    this._navigationProperties = ["iterativeCalculation"];
+    this._bindingQueued = false;
+  }
+  Application.prototype = Object.create(ClientObject.prototype);
+  Application.prototype.constructor = Application;
+
+  Application.prototype._ensureBinding = function () {
+    if (this._bindingQueued) return;
+    this.context._queue.push({ op: "applicationBind", id: this._id });
+    this._bindingQueued = true;
+  };
+
+  Application.prototype.load = function (props) {
+    this._ensureBinding();
+    return ClientObject.prototype.load.call(this, props);
+  };
+
+  function applicationScalar(name, setter) {
+    Object.defineProperty(Application.prototype, name, {
+      configurable: true,
+      get: function () {
+        return loadedValue(this, name);
+      },
+      set: setter,
+    });
+  }
+
+  applicationScalar("calculationMode", function (value) {
+    value = enumValue(value, "Application.calculationMode", [
+      "Automatic",
+      "AutomaticExceptTables",
+      "Manual",
+    ]);
+    queueSet(this, "calculationMode", value, this._ensureBinding);
+  });
+  applicationScalar("calculationState");
+
+  // These members exist in the pinned declarations, but require host
+  // capabilities that this compute-backed runtime does not provide. Keeping
+  // a normal unloaded getter makes an explicit load fail at sync and avoids a
+  // misleading local value.
+  [
+    "calculationEngineVersion",
+    "decimalSeparator",
+    "thousandsSeparator",
+    "useSystemSeparators",
+  ].forEach(function (name) {
+    applicationScalar(name);
+  });
+
+  function IterativeCalculation(context, application) {
+    ClientObject.call(this, context);
+    this._application = application;
+    this._scalarProperties = ["enabled", "maxChange", "maxIteration"];
+    this._bindingQueued = false;
+  }
+  IterativeCalculation.prototype = Object.create(ClientObject.prototype);
+  IterativeCalculation.prototype.constructor = IterativeCalculation;
+
+  IterativeCalculation.prototype._ensureBinding = function () {
+    if (this._bindingQueued) return;
+    this._application._ensureBinding();
+    this.context._queue.push({
+      op: "iterativeCalculationBind",
+      id: this._id,
+      applicationId: this._application._id,
+    });
+    this._bindingQueued = true;
+  };
+
+  IterativeCalculation.prototype.load = function (props) {
+    this._ensureBinding();
+    return ClientObject.prototype.load.call(this, props);
+  };
+
+  ["enabled", "maxChange", "maxIteration"].forEach(function (name) {
+    Object.defineProperty(IterativeCalculation.prototype, name, {
+      configurable: true,
+      get: function () {
+        return loadedValue(this, name);
+      },
+      set: function (value) {
+        if (name === "enabled" && typeof value !== "boolean") {
+          throw error("InvalidArgument", "IterativeCalculation.enabled must be a boolean");
+        }
+        if (
+          name === "maxChange" &&
+          (typeof value !== "number" || !isFinite(value) || value < 0)
+        ) {
+          throw error(
+            "InvalidArgument",
+            "IterativeCalculation.maxChange must be a finite non-negative number"
+          );
+        }
+        if (
+          name === "maxIteration" &&
+          (typeof value !== "number" ||
+            !isFinite(value) ||
+            Math.floor(value) !== value ||
+            value < 0)
+        ) {
+          throw error(
+            "InvalidArgument",
+            "IterativeCalculation.maxIteration must be a non-negative integer"
+          );
+        }
+        queueSet(this, name, value, this._ensureBinding);
+      },
+    });
+  });
+
+  IterativeCalculation.prototype.set = function (source) {
+    setProperties(
+      this,
+      source,
+      "IterativeCalculation",
+      ["enabled", "maxChange", "maxIteration"],
+      [],
+      undefined
+    );
+  };
+
+  IterativeCalculation.prototype.toJSON = function () {
+    var data = {};
+    this._scalarProperties.forEach(function (name) {
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }, this);
+    return data;
+  };
+
+  Object.defineProperty(Application.prototype, "iterativeCalculation", {
+    configurable: true,
+    get: function () {
+      this._ensureBinding();
+      if (!this._iterativeCalculation) {
+        this._iterativeCalculation = new IterativeCalculation(this.context, this);
+      }
+      return this._iterativeCalculation;
+    },
+  });
+
+  Application.prototype.set = function (source, options) {
+    var normalized = sourceObject(this, source, "Application");
+    var properties = normalized.properties;
+    var throwOnReadOnly = !(options && options.throwOnReadOnly === false);
+    Object.keys(properties).forEach(function (name) {
+      if (name === "calculationMode" || name === "iterativeCalculation") return;
+      if (
+        [
+          "activeWindow",
+          "cultureInfo",
+          "calculationEngineVersion",
+          "calculationState",
+          "decimalSeparator",
+          "thousandsSeparator",
+          "useSystemSeparators",
+          "windows",
+        ].indexOf(name) >= 0
+      ) {
+        readOnlyProperties("Application")(name, properties, throwOnReadOnly);
+        return;
+      }
+      throw error("InvalidArgument", "Unknown Application property: " + name);
+    });
+    if (
+      Object.prototype.hasOwnProperty.call(properties, "calculationMode") &&
+      properties.calculationMode !== undefined
+    ) {
+      this.calculationMode = properties.calculationMode;
+    }
+    if (Object.prototype.hasOwnProperty.call(properties, "iterativeCalculation")) {
+      var child = this.iterativeCalculation;
+      if (properties.iterativeCalculation && typeof properties.iterativeCalculation === "object") {
+        child.set(properties.iterativeCalculation);
+      }
+    }
+  };
+
+  Application.prototype.calculate = function (calculationType) {
+    calculationType = enumValue(calculationType, "Application.calculate calculationType", [
+      "Recalculate",
+      "Full",
+      "FullRebuild",
+    ]);
+    this._ensureBinding();
+    this.context._queue.push({
+      op: "applicationCalculate",
+      id: this._id,
+      calculationType: calculationType,
+    });
+  };
+
+  Application.prototype.toJSON = function () {
+    var data = {};
+    this._scalarProperties.forEach(function (name) {
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }, this);
+    if (this._iterativeCalculation) {
+      data.iterativeCalculation = this._iterativeCalculation.toJSON();
+    }
+    return data;
+  };
+
+  function ensureWorkbookBinding() {
+    if (this._workbookBindingQueued) return;
+    this.context._queue.push({ op: "workbookBind", id: this._id });
+    this._workbookBindingQueued = true;
+  }
+
+  // Workbook is created by bootstrap. The extension adds the one scalar
+  // member owned by this family and a binding operation for generic load/set.
+  officeJs.addScalarProperties(Excel.Workbook.prototype, [
+    "usePrecisionAsDisplayed",
+  ]);
+  officeJs.addNavigationProperties(Excel.Workbook.prototype, ["application"]);
+
+  Object.defineProperty(Excel.Workbook.prototype, "application", {
+    configurable: true,
+    get: function () {
+      if (!this._application) this._application = new Application(this.context, this);
+      return this._application;
+    },
+  });
+
+  var workbookLoad = Excel.Workbook.prototype.load;
+  Excel.Workbook.prototype.load = function (props) {
+    ensureWorkbookBinding.call(this);
+    return workbookLoad.call(this, props);
+  };
+
+  Object.defineProperty(Excel.Workbook.prototype, "usePrecisionAsDisplayed", {
+    configurable: true,
+    get: function () {
+      return loadedValue(this, "usePrecisionAsDisplayed");
+    },
+    set: function (value) {
+      if (typeof value !== "boolean") {
+        throw error(
+          "InvalidArgument",
+          "Workbook.usePrecisionAsDisplayed must be a boolean"
+        );
+      }
+      queueSet(this, "usePrecisionAsDisplayed", value, ensureWorkbookBinding);
+    },
+  });
+
+  Excel.Workbook.prototype.set = function (source, options) {
+    setProperties(
+      this,
+      source,
+      "Workbook",
+      ["usePrecisionAsDisplayed"],
+      [],
+      options
+    );
+  };
+
+  Excel.Workbook.prototype.toJSON = function () {
+    var data = {};
+    if (this._loaded.usePrecisionAsDisplayed) {
+      data.usePrecisionAsDisplayed = this._usePrecisionAsDisplayed;
+    }
+    return data;
+  };
+
+  // RequestContext owns the same Workbook proxy, so both navigation paths
+  // produce one canonical Application object per context.
+  Object.defineProperty(Excel.RequestContext.prototype, "application", {
+    configurable: true,
+    get: function () {
+      return this.workbook.application;
+    },
+  });
+
+  Excel.Application = Application;
+  Excel.IterativeCalculation = IterativeCalculation;
+})(globalThis);

--- a/compute/officejs/src/application.rs
+++ b/compute/officejs/src/application.rs
@@ -1,0 +1,418 @@
+//! Office.js application and workbook calculation translation.
+//!
+//! The JavaScript adapter owns request-context proxy identity.  This module
+//! owns the corresponding workbook-backed references and translates the
+//! calculation operations into compute-api calls.  In particular, calculation
+//! is never implemented by a proxy-side flag: `Application.calculate` must
+//! reach the engine's recalculate/rebuild paths.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use compute_api::{ComputeApiError, Workbook};
+use serde_json::{Map, Value};
+use value_types::FiniteF64;
+
+use crate::dispatch::{ExtensionHandler, ExtensionObject, HostDispatchContext};
+use crate::host::BatchError;
+
+/// Handler for the application/workbook calculation wire operations emitted
+/// by `application.js`.
+///
+/// The operation names intentionally stay outside the core `Op` enum so the
+/// family can be integrated by registering this handler without changing the
+/// central host decoder:
+///
+/// * `applicationBind { id }`
+/// * `workbookBind { id }`
+/// * `iterativeCalculationBind { id, applicationId }`
+/// * `applicationCalculate { id, calculationType }`
+pub(crate) struct ApplicationHandler;
+
+impl ExtensionHandler for ApplicationHandler {
+    fn can_handle(&self, operation: &str) -> bool {
+        matches!(
+            operation,
+            "applicationBind"
+                | "workbookBind"
+                | "iterativeCalculationBind"
+                | "applicationCalculate"
+        )
+    }
+
+    fn handle(
+        &self,
+        operation: &Value,
+        context: &mut HostDispatchContext<'_>,
+    ) -> Result<bool, BatchError> {
+        let name = operation
+            .get("op")
+            .and_then(Value::as_str)
+            .ok_or_else(|| invalid("application operation is missing its op name"))?;
+
+        match name {
+            "applicationBind" => {
+                let id = required_string(operation, "id")?;
+                context.bind_object(&id, Arc::new(ApplicationRef::new(context.workbook())));
+                Ok(true)
+            }
+            "workbookBind" => {
+                let id = required_string(operation, "id")?;
+                context.bind_object(&id, Arc::new(WorkbookRef::new(context.workbook())));
+                Ok(true)
+            }
+            "iterativeCalculationBind" => {
+                let id = required_string(operation, "id")?;
+                let application_id = required_string(operation, "applicationId")?;
+                let application = context.extension_object::<ApplicationRef>(&application_id)?;
+                context.bind_object(&id, Arc::new(application.iterative_calculation()));
+                Ok(true)
+            }
+            "applicationCalculate" => {
+                let id = required_string(operation, "id")?;
+                let calculation_type = required_string(operation, "calculationType")?;
+                let application = context.extension_object::<ApplicationRef>(&id)?;
+                application.calculate(calculation_type)?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+/// A workbook-backed `Excel.Application` reference.
+#[derive(Clone)]
+pub(crate) struct ApplicationRef {
+    workbook: Workbook,
+}
+
+/// A workbook-backed `Excel.Workbook` reference for calculation settings.
+#[derive(Clone)]
+pub(crate) struct WorkbookRef {
+    workbook: Workbook,
+}
+
+/// A workbook-backed `Excel.IterativeCalculation` reference.
+#[derive(Clone)]
+pub(crate) struct IterativeCalculationRef {
+    workbook: Workbook,
+}
+
+impl ApplicationRef {
+    pub(crate) fn new(workbook: Workbook) -> Self {
+        Self { workbook }
+    }
+
+    fn iterative_calculation(&self) -> IterativeCalculationRef {
+        IterativeCalculationRef {
+            workbook: self.workbook.clone(),
+        }
+    }
+
+    fn calculation_settings(&self) -> Result<Map<String, Value>, BatchError> {
+        let settings = self
+            .workbook
+            .settings()
+            .get_workbook_settings()
+            .map_err(compute_error)?;
+        let value = serde_json::to_value(settings).map_err(encoding_error)?;
+        Ok(value
+            .get("calculationSettings")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    fn calculation_mode(&self) -> Result<&'static str, BatchError> {
+        let calculation = self.calculation_settings()?;
+        Ok(match calculation.get("calcMode").and_then(Value::as_str) {
+            Some("manual") => "Manual",
+            Some("autoNoTable") => "AutomaticExceptTables",
+            Some("auto") | None => "Automatic",
+            Some(other) => {
+                return Err(engine_error(format!(
+                    "The engine returned an unknown calculation mode '{other}'"
+                )));
+            }
+        })
+    }
+
+    fn calculation_state(&self) -> Result<String, BatchError> {
+        self.workbook.calculation_state().map_err(compute_error)
+    }
+
+    fn calculate(&self, calculation_type: &str) -> Result<(), BatchError> {
+        if !matches!(calculation_type, "Recalculate" | "Full" | "FullRebuild") {
+            return Err(invalid(format!(
+                "Application.calculate calculationType '{calculation_type}' is invalid"
+            )));
+        }
+        self.workbook
+            .calculate(calculation_type)
+            .map(|_| ())
+            .map_err(compute_error)
+    }
+}
+
+impl ExtensionObject for ApplicationRef {
+    fn object_type(&self) -> &'static str {
+        "Application"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                "calculationMode" => Value::String(self.calculation_mode()?.to_string()),
+                "calculationState" => Value::String(self.calculation_state()?),
+                "isNullObject" => Value::Bool(false),
+                // Navigation is bound and loaded as its own ClientObject by
+                // the JavaScript adapter. It must not be hydrated as a scalar.
+                "iterativeCalculation" => continue,
+                "activeWindow" | "cultureInfo" | "windows" => {
+                    return Err(unsupported(format!(
+                        "Application.{property} is not supported by this host"
+                    )));
+                }
+                "calculationEngineVersion"
+                | "decimalSeparator"
+                | "thousandsSeparator"
+                | "useSystemSeparators" => {
+                    return Err(unsupported(format!(
+                        "Application.{property} is not supported by this host"
+                    )));
+                }
+                other => {
+                    return Err(unsupported(format!(
+                        "Application.{other} is not supported by this host"
+                    )));
+                }
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        match property {
+            "calculationMode" => {
+                let mode = value.as_str().ok_or_else(|| {
+                    invalid("Application.calculationMode must be a string".to_string())
+                })?;
+                let mode = match mode {
+                    "Automatic" => "auto",
+                    "AutomaticExceptTables" => "autoNoTable",
+                    "Manual" => "manual",
+                    other => {
+                        return Err(invalid(format!(
+                            "Application.calculationMode '{other}' is invalid"
+                        )));
+                    }
+                };
+                self.workbook
+                    .settings()
+                    .set_calculation_mode(mode)
+                    .map(|_| ())
+                    .map_err(compute_error)
+            }
+            other => Err(unsupported(format!(
+                "Application.{other} is read-only or unsupported"
+            ))),
+        }
+    }
+}
+
+impl ExtensionObject for WorkbookRef {
+    fn object_type(&self) -> &'static str {
+        "Workbook"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        let settings = self
+            .workbook
+            .settings()
+            .get_workbook_settings()
+            .map_err(compute_error)?;
+        let calculation = settings.calculation_settings.unwrap_or_default();
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                "usePrecisionAsDisplayed" => Value::Bool(!calculation.full_precision),
+                "isNullObject" => Value::Bool(false),
+                // The pinned Office.js Workbook declaration has no date1904
+                // or date-system property. The engine still retains date1904
+                // in WorkbookSettings for formula/date semantics and OOXML
+                // round trips; it is deliberately not invented here.
+                "date1904" | "dateSystem" | "calculationEngineVersion" => {
+                    return Err(unsupported(format!(
+                        "Workbook.{property} is not supported by this host"
+                    )));
+                }
+                other => {
+                    return Err(unsupported(format!(
+                        "Workbook.{other} is not supported by this host"
+                    )));
+                }
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        match property {
+            "usePrecisionAsDisplayed" => {
+                let enabled = value.as_bool().ok_or_else(|| {
+                    invalid("Workbook.usePrecisionAsDisplayed must be a boolean".to_string())
+                })?;
+                let mut settings = self
+                    .workbook
+                    .settings()
+                    .get_workbook_settings()
+                    .map_err(compute_error)?;
+                let mut calculation = settings.calculation_settings.unwrap_or_default();
+                calculation.full_precision = !enabled;
+                settings.calculation_settings = Some(calculation);
+                self.workbook
+                    .settings()
+                    .set_workbook_settings(settings)
+                    .map(|_| ())
+                    .map_err(compute_error)
+            }
+            other => Err(unsupported(format!(
+                "Workbook.{other} is read-only or unsupported"
+            ))),
+        }
+    }
+}
+
+impl ExtensionObject for IterativeCalculationRef {
+    fn object_type(&self) -> &'static str {
+        "IterativeCalculation"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        let settings = self
+            .workbook
+            .settings()
+            .get_workbook_settings()
+            .map_err(compute_error)?;
+        let calculation = settings.calculation_settings.unwrap_or_default();
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                "enabled" => Value::Bool(calculation.enable_iterative_calculation),
+                "maxChange" => {
+                    serde_json::to_value(calculation.max_change).map_err(encoding_error)?
+                }
+                "maxIteration" => Value::Number(calculation.max_iterations.into()),
+                "isNullObject" => Value::Bool(false),
+                other => {
+                    return Err(unsupported(format!(
+                        "IterativeCalculation.{other} is not supported by this host"
+                    )));
+                }
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        match property {
+            "enabled" => self
+                .workbook
+                .settings()
+                .set_iterative_calculation(value.as_bool().ok_or_else(|| {
+                    invalid("IterativeCalculation.enabled must be a boolean".to_string())
+                })?)
+                .map(|_| ())
+                .map_err(compute_error),
+            "maxIteration" => {
+                let raw = value.as_u64().ok_or_else(|| {
+                    invalid(
+                        "IterativeCalculation.maxIteration must be a non-negative integer"
+                            .to_string(),
+                    )
+                })?;
+                let value = u32::try_from(raw).map_err(|_| {
+                    invalid("IterativeCalculation.maxIteration is out of range".to_string())
+                })?;
+                self.workbook
+                    .settings()
+                    .set_max_iterations(value)
+                    .map(|_| ())
+                    .map_err(compute_error)
+            }
+            "maxChange" => {
+                let value = value.as_f64().ok_or_else(|| {
+                    invalid(
+                        "IterativeCalculation.maxChange must be a finite non-negative number"
+                            .to_string(),
+                    )
+                })?;
+                let value = FiniteF64::new(value)
+                    .filter(|value| value.get() >= 0.0)
+                    .ok_or_else(|| {
+                        invalid(
+                            "IterativeCalculation.maxChange must be a finite non-negative number"
+                                .to_string(),
+                        )
+                    })?;
+                let mut settings = self
+                    .workbook
+                    .settings()
+                    .get_workbook_settings()
+                    .map_err(compute_error)?;
+                let mut calculation = settings.calculation_settings.unwrap_or_default();
+                calculation.max_change = value;
+                settings.calculation_settings = Some(calculation);
+                self.workbook
+                    .settings()
+                    .set_workbook_settings(settings)
+                    .map(|_| ())
+                    .map_err(compute_error)
+            }
+            other => Err(unsupported(format!(
+                "IterativeCalculation.{other} is read-only or unsupported"
+            ))),
+        }
+    }
+}
+
+fn required_string<'a>(operation: &'a Value, field: &str) -> Result<&'a str, BatchError> {
+    operation.get(field).and_then(Value::as_str).ok_or_else(|| {
+        invalid(format!(
+            "application operation field '{field}' must be a string"
+        ))
+    })
+}
+
+fn invalid(message: String) -> BatchError {
+    BatchError {
+        code: "InvalidArgument",
+        message,
+    }
+}
+
+fn unsupported(message: String) -> BatchError {
+    BatchError {
+        code: "ApiNotFound",
+        message,
+    }
+}
+
+fn engine_error(message: impl Into<String>) -> BatchError {
+    BatchError {
+        code: "GeneralException",
+        message: message.into(),
+    }
+}
+
+fn compute_error(error: ComputeApiError) -> BatchError {
+    engine_error(error.to_string())
+}
+
+fn encoding_error(error: serde_json::Error) -> BatchError {
+    engine_error(format!("failed to encode workbook settings: {error}"))
+}

--- a/compute/officejs/src/bootstrap.js
+++ b/compute/officejs/src/bootstrap.js
@@ -1,20 +1,34 @@
 (function (global) {
   "use strict";
 
+  function RichApiError(info) {
+    info = typeof info === "string" ? { message: info } : (info || {});
+    this.name = "RichApi.Error";
+    this.message = info.message || "Office.js error";
+    this.code = info.code || "GeneralException";
+    this.debugInfo = Object.assign({ code: this.code, message: this.message }, info.debugInfo || {});
+    this.traceMessages = info.traceMessages || [];
+    this.innerError = info.innerError;
+    this.stack = new Error(this.message).stack;
+  }
+  RichApiError.prototype = Object.create(Error.prototype);
+  RichApiError.prototype.constructor = RichApiError;
+
   function propertyNotLoaded(name) {
-    var err = new Error(
+    var err = new RichApiError(
       "The property '" +
         name +
         "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context."
     );
     err.name = "RichApi.Error";
     err.code = "PropertyNotLoaded";
+    err.debugInfo.code = err.code;
     return err;
   }
 
-  function normalizeLoad(props) {
+  function normalizeLoad(props, defaults) {
     if (props == null || props === undefined) {
-      return ["values", "formulas"];
+      return defaults.slice();
     }
     if (typeof props === "string") {
       return props
@@ -25,14 +39,137 @@
         .filter(Boolean);
     }
     if (Array.isArray(props)) {
-      return props.slice();
+      return props.reduce(function (result, entry) {
+        return result.concat(normalizeLoad(entry, defaults));
+      }, []);
     }
     if (typeof props === "object") {
-      return Object.keys(props).filter(function (k) {
-        return props[k];
+      var result = props.$all === true ? defaults.slice() : [];
+      if (props.select != null) result = result.concat(normalizeLoad(props.select, []));
+      if (props.expand != null) result = result.concat(normalizeLoad(props.expand, []));
+      Object.keys(props).forEach(function (key) {
+        if (key === "$all" || key === "select" || key === "expand" || key === "top" || key === "skip") return;
+        var value = props[key];
+        if (value === true) result.push(key);
+        else if (value && typeof value === "object") {
+          if (value.$all === true) result.push(key);
+          normalizeLoad(value, []).forEach(function (path) { result.push(key + "/" + path); });
+        }
       });
+      return result;
     }
     return [String(props)];
+  }
+
+  function invalidContextArgument(message, location) {
+    return new RichApiError({
+      code: "InvalidArgument",
+      message: message,
+      debugInfo: { errorLocation: location || "ClientRequestContext" },
+    });
+  }
+
+  function parseSelectExpand(value, argumentName) {
+    var propertyNames = Array.isArray(value)
+      ? value
+      : typeof value === "string"
+        ? value.split(",")
+        : [];
+    if (!Array.isArray(value) && typeof value !== "string") {
+      throw invalidContextArgument(
+        "The " + argumentName + " load option must be a string or an array of strings.",
+        "ClientRequestContext.loadRecursive"
+      );
+    }
+    return propertyNames.map(function (propertyName) {
+      if (typeof propertyName !== "string") {
+        throw invalidContextArgument(
+          "The " + argumentName + " load option must contain only strings.",
+          "ClientRequestContext.loadRecursive"
+        );
+      }
+      propertyName = propertyName.trim();
+      var lower = propertyName.toLowerCase();
+      if (lower === "items" || lower === "items/") return "*";
+      if (lower.indexOf("items/") === 0 || lower.indexOf("items.") === 0) {
+        propertyName = propertyName.slice(6);
+      }
+      return propertyName.replace(/[/.]items[/.]/gi, "/");
+    }).filter(function (propertyName) {
+      return propertyName.length > 0;
+    });
+  }
+
+  function isLoadOption(value) {
+    if (!isPlainObject(value)) return false;
+    if (value.select !== undefined &&
+        (typeof value.select === "string" || Array.isArray(value.select))) return true;
+    if (value.expand !== undefined &&
+        (typeof value.expand === "string" || Array.isArray(value.expand))) return true;
+    if (value.top !== undefined && typeof value.top === "number") return true;
+    if (value.skip !== undefined && typeof value.skip === "number") return true;
+    return Object.keys(value).length === 0;
+  }
+
+  function parseStrictLoadOption(value, path, argumentName) {
+    var query = { Select: [] };
+    Object.keys(value).forEach(function (key) {
+      var child = value[key];
+      var childArgument = argumentName + "." + key;
+      if (key === "$all") {
+        if (typeof child !== "boolean") {
+          throw invalidContextArgument(
+            "The " + childArgument + " load option must be a boolean.",
+            "ClientRequestContext.loadRecursive"
+          );
+        }
+        if (child) query.Select.push(path + "*");
+      } else if (key === "$top" || key === "$skip") {
+        if (typeof child !== "number" || path.length > 0) {
+          throw invalidContextArgument(
+            "The " + childArgument + " load option must be a number at the root.",
+            "ClientRequestContext.loadRecursive"
+          );
+        }
+        query[key === "$top" ? "Top" : "Skip"] = child;
+      } else if (typeof child === "boolean") {
+        if (child) query.Select.push(path + key);
+      } else if (isPlainObject(child)) {
+        var nested = parseStrictLoadOption(child, path + key + "/", childArgument);
+        nested.Select.forEach(function (name) { query.Select.push(name); });
+        if (nested.Top !== undefined) query.Top = nested.Top;
+        if (nested.Skip !== undefined) query.Skip = nested.Skip;
+      } else {
+        throw invalidContextArgument(
+          "The " + childArgument + " load option is invalid.",
+          "ClientRequestContext.loadRecursive"
+        );
+      }
+    });
+    return query;
+  }
+
+  function parseQueryOption(value, argumentName) {
+    argumentName = argumentName || "option";
+    if (value === null || value === undefined) return {};
+    if (typeof value === "string" || Array.isArray(value)) {
+      return { Select: parseSelectExpand(value, argumentName) };
+    }
+    if (!isPlainObject(value)) {
+      throw invalidContextArgument(
+        "The " + argumentName + " load option is invalid.",
+        "ClientRequestContext.loadRecursive"
+      );
+    }
+    if (isLoadOption(value)) {
+      var query = {};
+      if (value.select !== undefined) query.Select = parseSelectExpand(value.select, argumentName + ".select");
+      if (value.expand !== undefined) query.Expand = parseSelectExpand(value.expand, argumentName + ".expand");
+      if (value.top !== undefined) query.Top = value.top;
+      if (value.skip !== undefined) query.Skip = value.skip;
+      return query;
+    }
+    return parseStrictLoadOption(value, "", argumentName);
   }
 
   var nextId = 1;
@@ -44,33 +181,297 @@
     this.context = context;
     this._id = newId();
     this._loaded = Object.create(null);
+    this._createdAtSync = context._syncCount;
+    this._bindingPending = false;
+    this._bindingFailed = false;
     context._objects[this._id] = this;
   }
 
-  ClientObject.prototype.load = function (props) {
-    this.context._queue.push({
-      op: "load",
-      id: this._id,
-      properties: normalizeLoad(props),
+  function trackedObjectsArgumentError(message) {
+    return new RichApiError({
+      code: "InvalidArgument",
+      message: message,
+      debugInfo: { errorLocation: "ClientRequestContext.trackedObjects" },
     });
+  }
+
+  function trackedObjectsContextError() {
+    return new RichApiError({
+      code: "InvalidRequestContext",
+      message: "The object belongs to a different request context.",
+      debugInfo: { errorLocation: "ClientRequestContext.trackedObjects" },
+    });
+  }
+
+  function normalizeTrackedObjects(objects) {
+    return Array.isArray(objects) ? objects.slice() : [objects];
+  }
+
+  function validateTrackedObjects(objects, context) {
+    objects.forEach(function (object) {
+      if (!(object instanceof ClientObject)) {
+        throw trackedObjectsArgumentError(
+          "Tracked objects must be OfficeExtension.ClientObject instances."
+        );
+      }
+      if (object.context !== context) {
+        throw trackedObjectsContextError();
+      }
+    });
+  }
+
+  function TrackedObjects(context) {
+    this._context = context;
+  }
+
+  function unsupportedTrackingError() {
+    return new RichApiError({
+      code: "ApiNotFound",
+      message:
+        "Tracked Range objects are unavailable because this runtime does not provide Office.js reference IDs and restorable object paths.",
+      debugInfo: { errorLocation: "ClientRequestContext.trackedObjects" },
+    });
+  }
+
+  function requiresReferenceTracking(object) {
+    return object._requiresReferenceTracking === true;
+  }
+
+  TrackedObjects.prototype.add = function (objects) {
+    objects = normalizeTrackedObjects(objects);
+    validateTrackedObjects(objects, this._context);
+    if (objects.some(requiresReferenceTracking)) throw unsupportedTrackingError();
+  };
+
+  TrackedObjects.prototype.remove = function (objects) {
+    objects = normalizeTrackedObjects(objects);
+    validateTrackedObjects(objects, this._context);
+    if (objects.some(requiresReferenceTracking)) throw unsupportedTrackingError();
+  };
+
+  function trackClientObject(object) {
+    object.context.trackedObjects.add(object);
+    return object;
+  }
+
+  function untrackClientObject(object) {
+    object.context.trackedObjects.remove(object);
+    return object;
+  }
+
+  var objectPathParents = ["_worksheet", "_table", "_range", "_collection", "_autoFilter", "_dataValidation", "_sort"];
+
+  function hasFailedObjectPathParent(object, seen) {
+    seen = seen || Object.create(null);
+    if (!object || !(object instanceof ClientObject) || seen[object._id]) return false;
+    seen[object._id] = true;
+    if (object._bindingPending || object._bindingFailed) return true;
+    if (object._loaded.isNullObject && object._isNullObject) return true;
+    for (var i = 0; i < objectPathParents.length; i++) {
+      var parent = object[objectPathParents[i]];
+      if (parent instanceof ClientObject && hasFailedObjectPathParent(parent, seen)) return true;
+    }
+    return false;
+  }
+
+  Object.defineProperty(ClientObject.prototype, "isNullObject", {
+    get: function () {
+      if (!this._loaded.isNullObject) {
+        // Workbook and a few collection proxies are materialized locally and
+        // have no host binding operation.  Once a successful sync has passed,
+        // those ordinary (non-OrNullObject) proxies are known to be present.
+        // A proxy involved in a failed/pending object path remains unloaded.
+        if (
+          this.context._syncCount > this._createdAtSync &&
+          !hasFailedObjectPathParent(this)
+        ) {
+          return false;
+        }
+        throw propertyNotLoaded("isNullObject");
+      }
+      return this._isNullObject;
+    },
+    configurable: true,
+  });
+
+  function combinedProperties(object, primary, additional) {
+    var result = (object[primary] || []).slice();
+    (object[additional] || []).forEach(function (name) {
+      if (result.indexOf(name) < 0) result.push(name);
+    });
+    return result;
+  }
+
+  ClientObject.prototype.load = function (props) {
+    var object = this;
+    var scalar = [];
+    var scalarProperties = combinedProperties(
+      this,
+      "_scalarProperties",
+      "_additionalScalarProperties"
+    );
+    var navigationProperties = combinedProperties(
+      this,
+      "_navigationProperties",
+      "_additionalNavigationProperties"
+    );
+    normalizeLoad(props, scalarProperties).forEach(function (path) {
+      var slash = path.indexOf("/");
+      var name = slash < 0 ? path : path.slice(0, slash);
+      if (name === "items" && typeof object._hydrateItems === "function") {
+        scalar.push(path);
+      } else if (slash >= 0 || navigationProperties.indexOf(name) >= 0) {
+        var child = object[name];
+        if (!(child instanceof ClientObject)) {
+          throw new RichApiError({ code: "InvalidArgument", message: "Unknown navigation property: " + name });
+        }
+        child.load(slash < 0 ? undefined : path.slice(slash + 1));
+      } else scalar.push(path);
+    });
+    if (scalar.length) this.context._queue.push({ op: "load", id: this._id, properties: scalar });
     return this;
   };
 
-  function RequestContext() {
+  function ClientRequestContext() {
     this._queue = [];
     this._objects = Object.create(null);
-    this.workbook = new Workbook(this);
+    this._results = Object.create(null);
+    this._syncCount = 0;
+    this.trackedObjects = new TrackedObjects(this);
   }
 
-  RequestContext.prototype.sync = async function () {
+  function RequestContext() {
+    ClientRequestContext.call(this);
+    this.workbook = new Workbook(this);
+  }
+  RequestContext.prototype = Object.create(ClientRequestContext.prototype);
+  RequestContext.prototype.constructor = RequestContext;
+
+  ClientRequestContext.prototype.load = function (object, props) {
+    if (!(object instanceof ClientObject) || object.context !== this) {
+      throw new RichApiError({ code: "InvalidRequestContext", message: "Object belongs to a different request context." });
+    }
+    object.load(props);
+  };
+
+  ClientRequestContext.prototype.loadRecursive = function (object, options, maxDepth) {
+    // Office.js validates the recursive query map before creating its action.
+    // Keep the same order so malformed options fail synchronously and do not
+    // leave a partially queued request behind.
+    if (!isPlainObject(options)) {
+      throw invalidContextArgument(
+        "The options argument to loadRecursive must be a plain object.",
+        "ClientRequestContext.loadRecursive"
+      );
+    }
+    var queries = {};
+    Object.keys(options).forEach(function (typeName) {
+      queries[typeName] = parseQueryOption(
+        options[typeName],
+        "options." + typeName
+      );
+    });
+    if (!(object instanceof ClientObject) || object.context !== this) {
+      throw new RichApiError({
+        code: "InvalidRequestContext",
+        message: "The object belongs to a different request context.",
+        debugInfo: { errorLocation: "ClientRequestContext.loadRecursive" },
+      });
+    }
+    var operation = {
+      op: "loadRecursive",
+      id: object._id,
+      queries: queries,
+    };
+    // The embedded host keeps proxy IDs separate from its object paths.  Give
+    // the host the already-materialized navigation proxies it can hydrate;
+    // this is a bounded hint, not a client-side recursive walk.  The host
+    // still owns graph discovery and maxDepth for paths that are not cached.
+    var targets = {};
+    function addTarget(target) {
+      if (!(target instanceof ClientObject)) return;
+      var typeName = target._officeType ||
+        (target.constructor && target.constructor.name);
+      if (!typeName) return;
+      if (!targets[typeName]) targets[typeName] = [];
+      if (!targets[typeName].some(function (entry) { return entry.id === target._id; })) {
+        targets[typeName].push({ id: target._id, depth: target === object ? 0 : 1 });
+      }
+    }
+    addTarget(object);
+    Object.keys(object).forEach(function (key) {
+      if (key.charAt(0) !== "_") return;
+      addTarget(object[key]);
+    });
+    if (Object.keys(targets).length) operation.targets = targets;
+    // `queries` mirrors the source action's RecursiveQueryInfo.Queries using
+    // normalized Select/Expand/Top/Skip keys.  The host must apply this
+    // action against the object graph and enforce maxDepth; the client must
+    // not eagerly walk navigation properties and accidentally recurse forever.
+    // An omitted maxDepth is distinct from a supplied value.
+    if (maxDepth !== undefined) operation.maxDepth = maxDepth;
+    this._queue.push(operation);
+  };
+
+  ClientRequestContext.prototype.trace = function (message) {
+    // Trace is an ordered request action.  The host must process this entry
+    // in sequence and return only messages before a failed later action as
+    // result.error.traceMessages; logging here would lose that timing.
+    this._queue.push({ op: "trace", message: message });
+  };
+
+  function debugStatement(operation) {
+    if (!operation || !operation.op) return "";
+    switch (operation.op) {
+      case "trace":
+        return "context.trace();";
+      case "loadRecursive":
+        return "object.loadRecursive(...);";
+      case "load":
+        return "object.load(...);";
+      case "set":
+        return "object." + String(operation.property || "property") + " = ...;";
+      default:
+        return "context." + String(operation.op) + "(...);";
+    }
+  }
+
+  Object.defineProperty(ClientRequestContext.prototype, "debugInfo", {
+    get: function () {
+      return {
+        pendingStatements: this._queue.map(debugStatement).filter(Boolean),
+      };
+    },
+    enumerable: true,
+    configurable: true,
+  });
+
+  ClientRequestContext.prototype.sync = async function (passThroughValue) {
     var ops = this._queue.splice(0, this._queue.length);
+    ops.forEach(function (op) {
+      if (!op || !op.id) return;
+      var object = this._objects[op.id];
+      if (object && !object._loaded.isNullObject) object._bindingPending = true;
+    }, this);
     var raw = __mogApply(JSON.stringify(ops));
     var result = JSON.parse(raw);
     if (result.error) {
-      var err = new Error(result.error.message || "Office.js error");
-      err.name = "RichApi.Error";
-      err.code = result.error.code || "GeneralException";
-      throw err;
+      ops.forEach(function (op) {
+        if (!op || !op.id) return;
+        var object = this._objects[op.id];
+        if (object && object._bindingPending) object._bindingFailed = true;
+      }, this);
+      var error = Object.assign({}, result.error);
+      // The extension host may return response diagnostics at the batch
+      // level, while the Office.js error surface exposes them on Error.
+      // Preserve either wire shape without synthesizing trace timing locally.
+      if (error.traceMessages === undefined && result.traceMessages !== undefined) {
+        error.traceMessages = result.traceMessages;
+      }
+      if (error.debugInfo === undefined && result.debugInfo !== undefined) {
+        error.debugInfo = result.debugInfo;
+      }
+      throw new RichApiError(error);
     }
     var loaded = result.loaded || {};
     var id;
@@ -78,15 +479,118 @@
       if (!Object.prototype.hasOwnProperty.call(loaded, id)) continue;
       var obj = this._objects[id];
       if (!obj) continue;
+      obj._bindingPending = false;
+      obj._bindingFailed = false;
       var props = loaded[id];
       var key;
       for (key in props) {
         if (!Object.prototype.hasOwnProperty.call(props, key)) continue;
-        obj._loaded[key] = true;
-        obj["_" + key] = props[key];
+        hydrateProperty(obj, key, props[key]);
       }
     }
+    var results = result.results || {};
+    for (id in results) {
+      if (!Object.prototype.hasOwnProperty.call(results, id)) continue;
+      var clientResult = this._results[id];
+      if (clientResult) clientResult._handleResult(results[id]);
+    }
+    this._syncCount += 1;
+    return passThroughValue;
   };
+
+  function ClientResult(context) {
+    this.context = context;
+    this._isLoaded = false;
+    if (context) {
+      this._id = newId();
+      context._results[this._id] = this;
+    }
+  }
+
+  Object.defineProperty(ClientResult.prototype, "value", {
+    get: function () {
+      if (!this._isLoaded) {
+        throw new RichApiError({
+          code: "ValueNotLoaded",
+          message:
+            "The value of the result object has not been loaded yet. Before reading the value property, call \"context.sync()\" on the associated request context.",
+          debugInfo: { errorLocation: "clientResult.value" },
+        });
+      }
+      return this._value;
+    },
+    configurable: true,
+  });
+
+  ClientResult.prototype._handleResult = function (value) {
+    this._isLoaded = true;
+    this._value = value;
+  };
+
+  function hydrateProperty(object, name, value) {
+    if (name === "items" && typeof object._hydrateItems === "function") {
+      value = object._hydrateItems(value);
+    }
+    object._loaded[name] = true;
+    object[name === "id" ? "_idValue" : "_" + name] = value;
+  }
+
+  function addProperties(prototype, field, names) {
+    var current = Object.prototype.hasOwnProperty.call(prototype, field)
+      ? prototype[field].slice()
+      : [];
+    names.forEach(function (name) {
+      if (current.indexOf(name) < 0) current.push(name);
+    });
+    prototype[field] = current;
+  }
+
+  function configureCollection(collection, itemFactory) {
+    if (!(collection instanceof ClientObject) || typeof itemFactory !== "function") {
+      throw new TypeError("configureCollection requires a client object and item factory");
+    }
+    if ((collection._scalarProperties || []).indexOf("items") < 0) {
+      collection._scalarProperties = (collection._scalarProperties || []).concat(["items"]);
+    }
+    collection._hydrateItems = function (descriptors) {
+      if (!Array.isArray(descriptors)) {
+        throw new RichApiError({
+          code: "GeneralException",
+          message: "The host returned an invalid collection result.",
+        });
+      }
+      return descriptors.map(function (descriptor) {
+        if (!descriptor || typeof descriptor !== "object" || !("key" in descriptor)) {
+          throw new RichApiError({
+            code: "GeneralException",
+            message: "The host returned an invalid collection item descriptor.",
+          });
+        }
+        var item = itemFactory.call(collection, descriptor.key, descriptor);
+        if (!(item instanceof ClientObject) || item.context !== collection.context) {
+          throw new RichApiError({
+            code: "InvalidRequestContext",
+            message: "A collection item factory returned an object from a different request context.",
+          });
+        }
+        var properties = descriptor.properties || {};
+        Object.keys(properties).forEach(function (name) {
+          hydrateProperty(item, name, properties[name]);
+        });
+        return item;
+      });
+    };
+    if (!("items" in collection)) {
+      Object.defineProperty(collection, "items", {
+        get: function () {
+          if (!this._loaded.items) throw propertyNotLoaded("items");
+          return this._items;
+        },
+        configurable: true,
+      });
+    }
+    return collection;
+  }
 
   function Workbook(context) {
     ClientObject.call(this, context);
@@ -111,6 +615,12 @@
     return ws;
   };
 
+  WorksheetCollection.prototype.getActiveWorksheet = function () {
+    var ws = new Worksheet(this.context, null);
+    this.context._queue.push({ op: "getActiveWorksheet", id: ws._id });
+    return ws;
+  };
+
   WorksheetCollection.prototype.add = function (name) {
     var ws = new Worksheet(this.context, name == null ? null : String(name));
     this.context._queue.push({
@@ -124,6 +634,7 @@
   function Worksheet(context, name) {
     ClientObject.call(this, context);
     this._nameHint = name;
+    this._scalarProperties = ["name", "id"];
   }
   Worksheet.prototype = Object.create(ClientObject.prototype);
   Worksheet.prototype.constructor = Worksheet;
@@ -135,15 +646,23 @@
       }
       return this._name;
     },
+    configurable: true,
+  });
+
+  Object.defineProperty(Worksheet.prototype, "id", {
+    get: function () {
+      if (!this._loaded.id) throw propertyNotLoaded("id");
+      return this._idValue;
+    },
   });
 
   Worksheet.prototype.getRange = function (address) {
-    var range = new Range(this.context, this, String(address));
+    var range = new Range(this.context, this, address === undefined ? null : String(address));
     this.context._queue.push({
       op: "getRange",
       id: range._id,
       worksheetId: this._id,
-      address: String(address),
+      address: address === undefined ? null : String(address),
     });
     return range;
   };
@@ -152,9 +671,33 @@
     ClientObject.call(this, context);
     this._worksheet = worksheet;
     this._address = address;
+    this._requiresReferenceTracking = true;
+    this._scalarProperties = ["values", "formulas", "address", "rowIndex", "columnIndex", "rowCount", "columnCount", "cellCount"];
+    this._navigationProperties = ["format"];
   }
   Range.prototype = Object.create(ClientObject.prototype);
   Range.prototype.constructor = Range;
+
+  // The pinned Excel declarations expose these shorthands on Range (and
+  // range-area types), while the OfficeExtension.ClientObject declaration
+  // does not.  The method shape is present, but this runtime rejects it until
+  // reference IDs and restorable object paths are implemented.
+  Range.prototype.track = function () {
+    return trackClientObject(this);
+  };
+
+  Range.prototype.untrack = function () {
+    return untrackClientObject(this);
+  };
+
+  ["address", "rowIndex", "columnIndex", "rowCount", "columnCount", "cellCount"].forEach(function (name) {
+    Object.defineProperty(Range.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+    });
+  });
 
   Object.defineProperty(Range.prototype, "values", {
     get: function () {
@@ -164,6 +707,8 @@
       return this._values;
     },
     set: function (value) {
+      this._values = value;
+      this._loaded.values = true;
       this.context._queue.push({
         op: "set",
         id: this._id,
@@ -181,6 +726,8 @@
       return this._formulas;
     },
     set: function (value) {
+      this._formulas = value;
+      this._loaded.formulas = true;
       this.context._queue.push({
         op: "set",
         id: this._id,
@@ -190,27 +737,129 @@
     },
   });
 
-  var pendingRuns = [];
-
-  function run(arg) {
-    var callback = typeof arg === "function" ? arg : arg && arg.batch;
-    if (typeof callback !== "function") {
-      return Promise.reject(new TypeError("Excel.run requires a function"));
-    }
-    var promise = (async function () {
-      var context = new RequestContext();
-      var result = await callback(context);
-      await context.sync();
-      return result;
-    })();
-    pendingRuns.push(promise);
-    return promise;
+  function isPlainObject(value) {
+    if (!value || typeof value !== "object") return false;
+    var prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
   }
 
-  global.__mogPendingRuns = pendingRuns;
-  global.Excel = { run: run };
+  function runArgumentError(code, message) {
+    return new RichApiError({
+      code: code,
+      message: message,
+      debugInfo: { errorLocation: "Excel.run" },
+    });
+  }
+
+  function contextFromPrevious(previous) {
+    if (previous instanceof ClientRequestContext) return previous;
+    if (previous instanceof ClientObject) return previous.context;
+    if (!Array.isArray(previous) || previous.length === 0) {
+      throw runArgumentError(
+        "InvalidArgument",
+        "The argument passed to Excel.run is missing or isn't in the right format."
+      );
+    }
+
+    var context;
+    previous.forEach(function (object, index) {
+      if (!(object instanceof ClientObject)) {
+        throw runArgumentError(
+          "InvalidArgument",
+          "The objects passed to Excel.run must be OfficeExtension.ClientObject instances."
+        );
+      }
+      if (index === 0) context = object.context;
+      else if (object.context !== context) {
+        throw runArgumentError(
+          "InvalidRequestContext",
+          "Cannot use objects from different request contexts in the same Excel.run batch."
+        );
+      }
+    });
+    return context;
+  }
+
+  function parseRunArguments(args) {
+    if (args.length === 1 && typeof args[0] === "function") {
+      return { context: new RequestContext(), callback: args[0] };
+    }
+    if (args.length !== 2 || typeof args[1] !== "function") {
+      throw runArgumentError(
+        "InvalidArgument",
+        "The arguments passed to Excel.run are missing or aren't in the right format."
+      );
+    }
+
+    var previousOrOptions = args[0];
+    if (
+      previousOrOptions instanceof ClientRequestContext ||
+      previousOrOptions instanceof ClientObject ||
+      Array.isArray(previousOrOptions)
+    ) {
+      return {
+        context: contextFromPrevious(previousOrOptions),
+        callback: args[1],
+      };
+    }
+    if (!isPlainObject(previousOrOptions)) {
+      throw runArgumentError(
+        "InvalidArgument",
+        "The first argument passed to Excel.run isn't a context, client object, object array, or options object."
+      );
+    }
+    if (previousOrOptions.session != null) {
+      throw runArgumentError(
+        "ApiNotFound",
+        "Remote workbook sessions aren't supported by this host."
+      );
+    }
+    return {
+      context:
+        previousOrOptions.previousObjects == null
+          ? new RequestContext()
+          : contextFromPrevious(previousOrOptions.previousObjects),
+      callback: args[1],
+    };
+  }
+
+  function run() {
+    var args = Array.prototype.slice.call(arguments);
+    return (async function () {
+      var parsed = parseRunArguments(args);
+      var callbackResult = parsed.callback(parsed.context);
+      if (!callbackResult || typeof callbackResult.then !== "function") {
+        throw runArgumentError(
+          "RunMustReturnPromise",
+          "The batch function passed to the \".run\" method didn't return a promise."
+        );
+      }
+      var result = await callbackResult;
+      await parsed.context.sync();
+      return result;
+    })();
+  }
+
+  global.Excel = { run: run, RequestContext: RequestContext, Workbook: Workbook,
+    WorksheetCollection: WorksheetCollection, Worksheet: Worksheet, Range: Range };
   global.OfficeExtension = {
     ClientObject: ClientObject,
-    RequestContext: RequestContext,
+    ClientRequestContext: ClientRequestContext,
+    ClientResult: ClientResult,
+    TrackedObjects: TrackedObjects,
+    Error: RichApiError,
+  };
+  global.__mogOfficeJs = {
+    addScalarProperties: function (prototype, names) {
+      addProperties(prototype, "_additionalScalarProperties", names);
+    },
+    addNavigationProperties: function (prototype, names) {
+      addProperties(prototype, "_additionalNavigationProperties", names);
+    },
+    configureCollection: configureCollection,
+    createClientResult: function (context) {
+      return new ClientResult(context);
+    },
+    hydrateProperty: hydrateProperty,
   };
 })(globalThis);

--- a/compute/officejs/src/borders.js
+++ b/compute/officejs/src/borders.js
@@ -1,0 +1,412 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var ClientObject = global.OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs || {};
+
+  // Excel exposes the collection in this order.  The order is observable via
+  // items and getItemAt, so keep it as one shared contract instead of deriving
+  // it from the sparse CellBorders object.
+  var BORDER_KEYS = [
+    "EdgeTop",
+    "EdgeBottom",
+    "EdgeLeft",
+    "EdgeRight",
+    "InsideVertical",
+    "InsideHorizontal",
+    "DiagonalDown",
+    "DiagonalUp",
+  ];
+  var BORDER_PROPERTIES = [
+    "color",
+    "sideIndex",
+    "style",
+    "tintAndShade",
+    "weight",
+  ];
+  var COLLECTION_PROPERTIES = ["count", "tintAndShade", "items"];
+  var ITEM_PROPERTIES = ["color", "sideIndex", "style", "tintAndShade", "weight"];
+
+  function propertyNotLoaded(name) {
+    var error = new global.OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function invalidArgument(message) {
+    return new global.OfficeExtension.Error({
+      code: "InvalidArgument",
+      message: message,
+    });
+  }
+
+  function requirePropertyObject(source) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+  }
+
+  function appendUnique(output, value) {
+    if (output.indexOf(value) < 0) output.push(value);
+  }
+
+  function normalizeNames(value, defaults) {
+    if (value == null || value === undefined) return defaults.slice();
+    if (typeof value === "string") {
+      return value
+        .split(",")
+        .map(function (name) {
+          return name.trim();
+        })
+        .filter(Boolean);
+    }
+    if (Array.isArray(value)) {
+      var names = [];
+      value.forEach(function (entry) {
+        normalizeNames(entry, defaults).forEach(function (name) {
+          appendUnique(names, name);
+        });
+      });
+      return names;
+    }
+    if (typeof value !== "object") return [String(value)];
+
+    var names = value.$all === true ? defaults.slice() : [];
+    if (value.select != null) {
+      normalizeNames(value.select, []).forEach(function (name) {
+        appendUnique(names, name);
+      });
+    }
+    if (value.expand != null) {
+      normalizeNames(value.expand, []).forEach(function (name) {
+        appendUnique(names, name);
+      });
+    }
+    Object.keys(value).forEach(function (key) {
+      if (key === "$all" || key === "select" || key === "expand" || key === "top" || key === "skip") return;
+      var child = value[key];
+      if (child === true) appendUnique(names, key);
+      else if (child && typeof child === "object") {
+        if (child.$all === true) appendUnique(names, key);
+        normalizeNames(child, []).forEach(function (name) {
+          appendUnique(names, key + "/" + name);
+        });
+      }
+    });
+    return names;
+  }
+
+  function normalizeCollectionNames(value) {
+    // Collection load options use the collection's scalar names directly and
+    // use items/<property> for fields requested on every child.  This is the
+    // shape consumed by the shared host collection hydration protocol.
+    var names = [];
+    var defaults = COLLECTION_PROPERTIES.slice();
+    if (value == null || value === undefined) {
+      names.push("count", "tintAndShade", "items/$all");
+      return names;
+    }
+
+    function add(name) {
+      appendUnique(names, name);
+    }
+
+    function addItemNames(itemValue) {
+      if (itemValue == null || itemValue === undefined || itemValue === true) {
+        add("items");
+        return;
+      }
+      if (typeof itemValue === "string" || Array.isArray(itemValue)) {
+        normalizeNames(itemValue, []).forEach(function (name) {
+          add("items/" + name);
+        });
+        return;
+      }
+      if (typeof itemValue !== "object") {
+        add("items/" + String(itemValue));
+        return;
+      }
+      if (itemValue.$all === true) add("items/$all");
+      if (itemValue.select != null) {
+        normalizeNames(itemValue.select, []).forEach(function (name) {
+          add("items/" + name);
+        });
+      }
+      if (itemValue.expand != null) {
+        normalizeNames(itemValue.expand, []).forEach(function (name) {
+          add("items/" + name);
+        });
+      }
+      Object.keys(itemValue).forEach(function (key) {
+        if (key === "$all" || key === "select" || key === "expand" || key === "top" || key === "skip") return;
+        if (itemValue[key] === true) add("items/" + key);
+        else if (itemValue[key] && typeof itemValue[key] === "object") {
+          // Nested item navigation is unsupported by RangeBorder. Preserve
+          // the path so the host reports a precise unsupported-property error.
+          add("items/" + key + "/" + normalizeNames(itemValue[key], []).join("/"));
+        }
+      });
+      if (itemValue.$all !== true && Object.keys(itemValue).length === 0) add("items");
+    }
+
+    function visit(input) {
+      if (input == null || input === undefined) {
+        defaults.forEach(add);
+        add("items/$all");
+        return;
+      }
+      if (typeof input === "string") {
+        input
+          .split(",")
+          .map(function (name) { return name.trim(); })
+          .filter(Boolean)
+          .forEach(function (name) {
+            if (name === "items") add("items");
+            else if (ITEM_PROPERTIES.indexOf(name) >= 0) add("items/" + name);
+            else add(name);
+          });
+        return;
+      }
+      if (Array.isArray(input)) {
+        input.forEach(visit);
+        return;
+      }
+      if (typeof input !== "object") {
+        add(String(input));
+        return;
+      }
+      if (input.$all === true) {
+        add("count");
+        add("tintAndShade");
+        add("items/$all");
+      }
+      if (input.select != null) visit(input.select);
+      if (input.expand != null) visit(input.expand);
+      Object.keys(input).forEach(function (key) {
+        if (key === "$all" || key === "select" || key === "expand" || key === "top" || key === "skip") return;
+        var child = input[key];
+        if (key === "items") addItemNames(child);
+        else if (child === true) {
+          if (ITEM_PROPERTIES.indexOf(key) >= 0) add("items/" + key);
+          else add(key);
+        } else if (child && typeof child === "object") {
+          add(key + "/" + normalizeNames(child, []).join("/"));
+        }
+      });
+    }
+
+    visit(value);
+    return names;
+  }
+
+  function defineScalar(proto, name, writable) {
+    if (Object.getOwnPropertyDescriptor(proto, name)) return;
+    Object.defineProperty(proto, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: writable
+        ? function (value) {
+            this["_" + name] = value;
+            this._loaded[name] = true;
+            this.context._queue.push({
+              op: "set",
+              id: this._id,
+              property: name,
+              value: value,
+            });
+          }
+        : undefined,
+    });
+  }
+
+  function borderSet(source, options) {
+    requirePropertyObject(source);
+    var isClientObject = source instanceof ClientObject;
+    if (isClientObject) {
+      if (Object.getPrototypeOf(this) !== Object.getPrototypeOf(source)) {
+        throw invalidArgument("The object passed to set must have the same type.");
+      }
+    }
+
+    // `sideIndex` is metadata on the live object, rather than a member of
+    // RangeBorderUpdateData. Match Office's UpdateOptions behavior for a
+    // plain object that attempts to include the read-only field. A source
+    // RangeBorder may contain sideIndex in toJSON, but copying it is skipped.
+    if (!isClientObject && Object.prototype.hasOwnProperty.call(source, "sideIndex") &&
+        (!options || options.throwOnReadOnly !== false)) {
+      throw invalidArgument("The property 'sideIndex' is read-only.");
+    }
+
+    ["color", "style", "tintAndShade", "weight"].forEach(function (name) {
+      if (isClientObject) {
+        if (source._loaded[name]) this[name] = source[name];
+      } else if (Object.prototype.hasOwnProperty.call(source, name)) {
+        this[name] = source[name];
+      }
+    }, this);
+  }
+
+  function borderToJSON() {
+    var data = {};
+    BORDER_PROPERTIES.forEach(function (name) {
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }, this);
+    return data;
+  }
+
+  function collectionToJSON() {
+    var data = {};
+    if (this._loaded.items) {
+      data.items = (this._items || []).map(function (item) {
+        return item && typeof item.toJSON === "function" ? item.toJSON() : item;
+      });
+    }
+    // `count` and collection tint are scalar properties on the live object,
+    // but RangeBorderCollectionData intentionally contains only items.  Keep
+    // toJSON aligned with Microsoft's shallow data contract.
+    return data;
+  }
+
+  function RangeBorderCollection(context, range) {
+    ClientObject.call(this, context);
+    this._range = range;
+    this._rangeId = range._id;
+    this._items = [];
+    this._itemsByKey = Object.create(null);
+    this._scalarProperties = COLLECTION_PROPERTIES.slice();
+    this.context._queue.push({
+      op: "getRangeBorderCollection",
+      id: this._id,
+      rangeId: range._id,
+    });
+    if (typeof officeJs.configureCollection === "function") {
+      var collection = this;
+      officeJs.configureCollection(this, function (key) {
+        return collection.getItem(key);
+      });
+    }
+  }
+  RangeBorderCollection.prototype = Object.create(ClientObject.prototype);
+  RangeBorderCollection.prototype.constructor = RangeBorderCollection;
+
+  defineScalar(RangeBorderCollection.prototype, "count", false);
+  defineScalar(RangeBorderCollection.prototype, "tintAndShade", true);
+
+  Object.defineProperty(RangeBorderCollection.prototype, "items", {
+    get: function () {
+      if (!this._loaded.items) throw propertyNotLoaded("items");
+      return this._items || [];
+    },
+  });
+
+  RangeBorderCollection.prototype.getItem = function (index) {
+    if (typeof index !== "string") {
+      throw invalidArgument("RangeBorderCollection.getItem requires a BorderIndex string");
+    }
+    if (BORDER_KEYS.indexOf(index) < 0) {
+      throw invalidArgument("Unsupported BorderIndex value '" + index + "'");
+    }
+    if (this._itemsByKey[index]) return this._itemsByKey[index];
+    var border = new RangeBorder(this.context, this, index);
+    this._itemsByKey[index] = border;
+    return border;
+  };
+
+  RangeBorderCollection.prototype.getItemAt = function (index) {
+    if (typeof index !== "number" || !isFinite(index) || Math.floor(index) !== index) {
+      throw invalidArgument("RangeBorderCollection.getItemAt requires an integer index");
+    }
+    if (index < 0 || index >= BORDER_KEYS.length) {
+      throw invalidArgument("RangeBorderCollection index is out of range");
+    }
+    return this.getItem(BORDER_KEYS[index]);
+  };
+
+  RangeBorderCollection.prototype.load = function (options) {
+    var properties = normalizeCollectionNames(options);
+    if (properties.length) {
+      this.context._queue.push({
+        op: "load",
+        id: this._id,
+        properties: properties,
+      });
+    }
+    return this;
+  };
+
+  RangeBorderCollection.prototype.toJSON = collectionToJSON;
+
+  function RangeBorder(context, collection, key) {
+    ClientObject.call(this, context);
+    this._collection = collection;
+    this._collectionId = collection._id;
+    this._range = collection._range;
+    this._rangeId = collection._rangeId;
+    this._selectorKey = key;
+    this._scalarProperties = BORDER_PROPERTIES.slice();
+    this.context._queue.push({
+      op: "getRangeBorder",
+      id: this._id,
+      collectionId: collection._id,
+      index: key,
+    });
+  }
+  RangeBorder.prototype = Object.create(ClientObject.prototype);
+  RangeBorder.prototype.constructor = RangeBorder;
+
+  ["color", "style", "tintAndShade", "weight"].forEach(function (name) {
+    defineScalar(RangeBorder.prototype, name, true);
+  });
+  defineScalar(RangeBorder.prototype, "sideIndex", false);
+  RangeBorder.prototype.set = borderSet;
+  RangeBorder.prototype.toJSON = borderToJSON;
+
+  // RangeFormat is created by format.js, which intentionally owns the other
+  // format children.  Extend its prototype after that module has installed
+  // the constructor; no constructor wrapping is needed.
+  Object.defineProperty(Excel.RangeFormat.prototype, "borders", {
+    get: function () {
+      if (!this._borders) this._borders = new RangeBorderCollection(this.context, this._range);
+      return this._borders;
+    },
+  });
+  if (typeof officeJs.addNavigationProperties === "function") {
+    officeJs.addNavigationProperties(Excel.RangeFormat.prototype, ["borders"]);
+  } else {
+    // Keep the extension usable in a bootstrap-only harness that predates the
+    // shared metadata helper. Production uses addNavigationProperties above.
+    var navigation = Excel.RangeFormat.prototype._navigationProperties || [];
+    if (navigation.indexOf("borders") < 0) navigation.push("borders");
+    Excel.RangeFormat.prototype._navigationProperties = navigation;
+  }
+  if (typeof officeJs.addScalarProperties === "function") {
+    officeJs.addScalarProperties(RangeBorder.prototype, BORDER_PROPERTIES);
+    officeJs.addScalarProperties(RangeBorderCollection.prototype, COLLECTION_PROPERTIES);
+  }
+
+  // format.js predates collection navigation and only serializes its scalar
+  // fields. Add the shallow borders member while preserving its behavior for
+  // all existing format fields.
+  var originalFormatToJSON = Excel.RangeFormat.prototype.toJSON;
+  Excel.RangeFormat.prototype.toJSON = function () {
+    var data = originalFormatToJSON ? originalFormatToJSON.call(this) : {};
+    if (this._borders && this._borders._loaded.items) {
+      data.borders = this._borders.toJSON().items;
+    }
+    return data;
+  };
+
+  Excel.RangeBorder = RangeBorder;
+  Excel.RangeBorderCollection = RangeBorderCollection;
+  Excel.__mogBorderKeys = BORDER_KEYS.slice();
+})(globalThis);

--- a/compute/officejs/src/borders.rs
+++ b/compute/officejs/src/borders.rs
@@ -1,0 +1,859 @@
+//! Office.js `RangeBorder` and `RangeBorderCollection` projection.
+//!
+//! The compute engine stores borders as `CellBorders`, while Office.js
+//! exposes a stable eight-item collection whose members describe the outer,
+//! inner, and diagonal lines of a range.  This module owns that projection and
+//! emits the JSON form of the production `BorderPatchOperation` primitive for
+//! the host router to deserialize and apply.
+//!
+//! The JavaScript extension uses these host operations:
+//!
+//! * `getRangeBorderCollection { id, rangeId }` binds a range collection.
+//! * `getRangeBorder { id, collectionId, index }` binds one exact selector.
+//! * Generic `load { id, properties }` routes to [`BorderCollectionRef::load`]
+//!   or [`BorderRef::load`]. Collection responses contain
+//!   `items: [{ key, properties }]` descriptors; the shared runtime invokes
+//!   the normal `getItem` factory for each descriptor.
+//! * Generic `set { id, property, value }` routes to [`BorderRef::apply_set`]
+//!   or [`BorderCollectionRef::set`], which build and apply production border
+//!   patches.
+
+use std::collections::HashMap;
+
+use compute_api::{CellRange, Sheet};
+use serde_json::{Map, Value, json};
+
+/// Error returned while projecting or validating Office.js border objects.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BorderError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl BorderError {
+    fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            code: "InvalidArgument",
+            message: message.into(),
+        }
+    }
+
+    fn unsupported(message: impl Into<String>) -> Self {
+        Self {
+            code: "InvalidArgument",
+            message: message.into(),
+        }
+    }
+
+    fn engine(error: impl std::fmt::Display) -> Self {
+        Self {
+            code: "GeneralException",
+            message: error.to_string(),
+        }
+    }
+}
+
+/// The eight `Excel.BorderIndex` values and their observable collection order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum BorderIndex {
+    EdgeTop,
+    EdgeBottom,
+    EdgeLeft,
+    EdgeRight,
+    InsideVertical,
+    InsideHorizontal,
+    DiagonalDown,
+    DiagonalUp,
+}
+
+impl BorderIndex {
+    pub(crate) const ALL: [Self; 8] = [
+        Self::EdgeTop,
+        Self::EdgeBottom,
+        Self::EdgeLeft,
+        Self::EdgeRight,
+        Self::InsideVertical,
+        Self::InsideHorizontal,
+        Self::DiagonalDown,
+        Self::DiagonalUp,
+    ];
+
+    pub(crate) fn parse(value: &str) -> Result<Self, BorderError> {
+        match value {
+            "EdgeTop" => Ok(Self::EdgeTop),
+            "EdgeBottom" => Ok(Self::EdgeBottom),
+            "EdgeLeft" => Ok(Self::EdgeLeft),
+            "EdgeRight" => Ok(Self::EdgeRight),
+            "InsideVertical" => Ok(Self::InsideVertical),
+            "InsideHorizontal" => Ok(Self::InsideHorizontal),
+            "DiagonalDown" => Ok(Self::DiagonalDown),
+            "DiagonalUp" => Ok(Self::DiagonalUp),
+            other => Err(BorderError::invalid(format!(
+                "Unsupported BorderIndex value '{other}'"
+            ))),
+        }
+    }
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::EdgeTop => "EdgeTop",
+            Self::EdgeBottom => "EdgeBottom",
+            Self::EdgeLeft => "EdgeLeft",
+            Self::EdgeRight => "EdgeRight",
+            Self::InsideVertical => "InsideVertical",
+            Self::InsideHorizontal => "InsideHorizontal",
+            Self::DiagonalDown => "DiagonalDown",
+            Self::DiagonalUp => "DiagonalUp",
+        }
+    }
+
+    /// The `CellBorders` member used by this Office.js side.
+    const fn field(self) -> &'static str {
+        match self {
+            Self::EdgeTop => "top",
+            Self::EdgeBottom => "bottom",
+            Self::EdgeLeft => "left",
+            Self::EdgeRight => "right",
+            Self::InsideVertical => "vertical",
+            Self::InsideHorizontal => "horizontal",
+            Self::DiagonalDown | Self::DiagonalUp => "diagonal",
+        }
+    }
+
+    const fn diagonal_flag(self) -> Option<&'static str> {
+        match self {
+            Self::DiagonalDown => Some("diagonalDown"),
+            Self::DiagonalUp => Some("diagonalUp"),
+            _ => None,
+        }
+    }
+}
+
+/// A range-level border collection host proxy.
+#[derive(Clone)]
+pub(crate) struct BorderCollectionRef {
+    sheet: Sheet,
+    address: String,
+}
+
+/// A single border host proxy anchored to a collection and side selector.
+#[derive(Clone)]
+pub(crate) struct BorderRef {
+    collection: BorderCollectionRef,
+    index: BorderIndex,
+}
+
+impl BorderCollectionRef {
+    pub(crate) fn new(sheet: Sheet, address: String) -> Result<Self, BorderError> {
+        validate_address(&address)?;
+        Ok(Self { sheet, address })
+    }
+
+    pub(crate) fn get_item(&self, index: &str) -> Result<BorderRef, BorderError> {
+        Ok(BorderRef {
+            collection: self.clone(),
+            index: BorderIndex::parse(index)?,
+        })
+    }
+
+    /// Read collection scalar fields and item descriptors.
+    ///
+    /// The returned `items` value follows the shared Office.js collection
+    /// contract: each descriptor has a stable selector key and a properties
+    /// object containing only fields requested by the caller.
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, BorderError> {
+        let mut result = HashMap::new();
+        let mut item_properties = Vec::new();
+        let mut load_items = false;
+        let mut load_all_items = false;
+
+        for property in properties {
+            match property.as_str() {
+                "count" => {
+                    result.insert("count".to_string(), json!(BorderIndex::ALL.len()));
+                }
+                "tintAndShade" => {
+                    let mut values = Vec::with_capacity(BorderIndex::ALL.len());
+                    for index in BorderIndex::ALL {
+                        let border = self.get_item(index.as_str())?;
+                        let loaded = border.load(&["tintAndShade".to_string()])?;
+                        values.push(loaded.get("tintAndShade").cloned().unwrap_or(Value::Null));
+                    }
+                    result.insert("tintAndShade".to_string(), aggregate_values(values));
+                }
+                // Office's default collection item projection is the child
+                // object's declared scalar surface.  `items` therefore has
+                // the same child fields as `items/$all`; an explicit
+                // `items/<property>` remains a narrow projection.
+                "items" => {
+                    load_items = true;
+                    load_all_items = true;
+                }
+                "items/$all" | "$all" => {
+                    load_items = true;
+                    load_all_items = true;
+                }
+                name if name.starts_with("items/") => {
+                    load_items = true;
+                    let item_property = &name["items/".len()..];
+                    if item_property == "$all" {
+                        load_all_items = true;
+                    } else if item_property.contains('/') {
+                        return Err(BorderError::unsupported(format!(
+                            "Unsupported RangeBorderCollection item load property '{name}'"
+                        )));
+                    } else {
+                        validate_border_property(item_property)?;
+                        if !item_properties.iter().any(|item| item == item_property) {
+                            item_properties.push(item_property.to_string());
+                        }
+                    }
+                }
+                // Be liberal for host integrations that pass item scalar
+                // names directly instead of the normalized items/<name> path.
+                name if BORDER_PROPERTY_NAMES.contains(&name) => {
+                    load_items = true;
+                    if !item_properties.iter().any(|item| item == name) {
+                        item_properties.push(name.to_string());
+                    }
+                }
+                other => {
+                    return Err(BorderError::unsupported(format!(
+                        "Unsupported RangeBorderCollection load property '{other}'"
+                    )));
+                }
+            }
+        }
+
+        if load_items {
+            if load_all_items {
+                item_properties = BORDER_PROPERTY_NAMES
+                    .iter()
+                    .map(|name| (*name).to_string())
+                    .collect();
+            }
+            let mut items = Vec::with_capacity(BorderIndex::ALL.len());
+            for index in BorderIndex::ALL {
+                let border = self.get_item(index.as_str())?;
+                let properties = border.load(&item_properties)?;
+                items.push(json!({
+                    "key": index.as_str(),
+                    "properties": properties,
+                }));
+            }
+            result.insert("items".to_string(), Value::Array(items));
+        }
+
+        Ok(result)
+    }
+
+    /// Apply a collection tint to each of the eight range-border sides.
+    ///
+    /// `CellBorders` stores tint on a side, rather than on the collection, so
+    /// the Office collection setter expands into one complete side operation
+    /// per selector.  Each operation is built from a fresh projection and
+    /// carries the existing color/style/weight values; the production batch
+    /// then validates and applies all operations atomically.
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), BorderError> {
+        if property != "tintAndShade" {
+            return Err(BorderError::unsupported(format!(
+                "RangeBorderCollection.{property} is read-only or unsupported"
+            )));
+        }
+        validate_tint(value)?;
+
+        let mut operations = Vec::with_capacity(BorderIndex::ALL.len());
+        for index in BorderIndex::ALL {
+            let border = self.get_item(index.as_str())?;
+            operations.push(border.set("tintAndShade", value)?);
+        }
+
+        // Keep production deserialization here, beside the collection-level
+        // expansion.  The expected argument of `patch_borders` supplies the
+        // concrete bridge type without adding a private compute-core import
+        // to the Office.js adapter.
+        let operations = operations
+            .into_iter()
+            .map(|operation| serde_json::from_value(operation).map_err(BorderError::engine))
+            .collect::<Result<Vec<_>, _>>()?;
+        self.sheet
+            .formats()
+            .patch_borders(operations)
+            .map_err(BorderError::engine)?;
+        Ok(())
+    }
+}
+
+impl BorderRef {
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, BorderError> {
+        let projection = self.projection(false)?;
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                "sideIndex" => json!(self.index.as_str()),
+                "color" => projection.color.to_value(),
+                "style" => projection.style.to_value(),
+                "tintAndShade" => projection.tint.to_value(),
+                "weight" => projection.weight.to_value(),
+                other => {
+                    return Err(BorderError::unsupported(format!(
+                        "Unsupported RangeBorder load property '{other}'"
+                    )));
+                }
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    /// Build the JSON form of one production `BorderPatchOperation`.
+    ///
+    /// [`Self::apply_set`] deserializes this value and calls
+    /// `SheetFormats::patch_borders`. Keeping the conversion here means all
+    /// geometry, enum, and mixed-range rules are shared by direct and
+    /// collection-created border proxies.
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<Value, BorderError> {
+        // DiagonalDown and DiagonalUp share one CellBorders.diagonal side but
+        // carry independent direction flags.  A mutation must inspect that
+        // shared side even when the selected direction is currently disabled;
+        // otherwise clearing one direction could erase the style used by the
+        // other direction.
+        let projection = self.projection(true)?;
+        let mut side = Map::new();
+
+        match property {
+            "color" => {
+                let color = value
+                    .as_str()
+                    .filter(|color| !color.is_empty())
+                    .ok_or_else(|| {
+                        BorderError::invalid("RangeBorder.color must be a non-empty string")
+                    })?;
+                ensure_preservable(&projection, property, &["style", "weight", "tintAndShade"])?;
+                if let Some(style) = internal_style_for_projection(&projection)? {
+                    side.insert("style".to_string(), json!(style));
+                }
+                if let Some(color_tint) = projection.tint.value_if_uniform() {
+                    if *color_tint != 0.0 {
+                        side.insert("colorTint".to_string(), json!(color_tint));
+                    }
+                }
+                side.insert("color".to_string(), json!(color));
+            }
+            "style" => {
+                let style = value.as_str().ok_or_else(|| {
+                    BorderError::invalid("RangeBorder.style must be a string enum value")
+                })?;
+                validate_style(style)?;
+                // CellBorders stores style and width in one OOXML token. A
+                // style-only write therefore needs a uniform current width
+                // and complete-side values for the production replacement.
+                let internal = if style == "None" {
+                    "none"
+                } else {
+                    let weight = projection
+                        .weight
+                        .value_if_uniform()
+                        .map(String::as_str)
+                        .ok_or_else(|| {
+                            BorderError::unsupported(
+                                "RangeBorder.style cannot preserve mixed weight values across the range",
+                            )
+                    })?;
+                    internal_style_for_pair(style, weight)?
+                };
+                ensure_preservable(&projection, property, &["color", "tintAndShade"])?;
+                side.insert("style".to_string(), json!(internal));
+                if let Some(color) = projection
+                    .color
+                    .value_if_uniform()
+                    .and_then(|color| color.as_ref())
+                {
+                    side.insert("color".to_string(), json!(color));
+                }
+                if let Some(color_tint) = projection.tint.value_if_uniform() {
+                    if *color_tint != 0.0 {
+                        side.insert("colorTint".to_string(), json!(color_tint));
+                    }
+                }
+            }
+            "tintAndShade" => {
+                let tint = validate_tint(value)?;
+                ensure_preservable(&projection, property, &["style", "weight", "color"])?;
+                if let Some(style) = internal_style_for_projection(&projection)? {
+                    side.insert("style".to_string(), json!(style));
+                }
+                if let Some(color) = projection
+                    .color
+                    .value_if_uniform()
+                    .and_then(|color| color.as_ref())
+                {
+                    side.insert("color".to_string(), json!(color));
+                }
+                side.insert("colorTint".to_string(), json!(tint));
+            }
+            "weight" => {
+                let weight = value.as_str().ok_or_else(|| {
+                    BorderError::invalid("RangeBorder.weight must be a string enum value")
+                })?;
+                validate_weight(weight)?;
+                ensure_preservable(&projection, property, &["style", "color", "tintAndShade"])?;
+                // Width is encoded into the stored style token. A complete
+                // side replacement is required because patch_borders treats
+                // each supplied side as one value.
+                let style = projection
+                    .style
+                    .value_if_uniform()
+                    .map(String::as_str)
+                    .ok_or_else(|| {
+                        BorderError::unsupported(
+                            "RangeBorder.weight cannot preserve mixed style values across the range",
+                        )
+                    })?;
+                if style == "None" {
+                    return Err(BorderError::unsupported(
+                        "RangeBorder.weight cannot create a border when the current style is None",
+                    ));
+                }
+                let internal = internal_style_for_pair(style, weight)?;
+                side.insert("style".to_string(), json!(internal));
+                if let Some(color) = projection
+                    .color
+                    .value_if_uniform()
+                    .and_then(|color| color.as_ref())
+                {
+                    side.insert("color".to_string(), json!(color));
+                }
+                if let Some(color_tint) = projection.tint.value_if_uniform() {
+                    if *color_tint != 0.0 {
+                        side.insert("colorTint".to_string(), json!(color_tint));
+                    }
+                }
+            }
+            other => {
+                return Err(BorderError::unsupported(format!(
+                    "RangeBorder.{other} is read-only or unsupported"
+                )));
+            }
+        }
+
+        // Setting style None on a diagonal side turns off that direction while
+        // retaining the other diagonal direction.  For all other sides the
+        // side value itself is enough to represent the operation.
+        let mut borders = Map::new();
+        if !(self.index.diagonal_flag().is_some()
+            && property == "style"
+            && value.as_str() == Some("None"))
+        {
+            borders.insert(self.index.field().to_string(), Value::Object(side));
+        }
+        if let Some(flag) = self.index.diagonal_flag() {
+            let enable = if property == "style" {
+                value.as_str() != Some("None")
+            } else {
+                true
+            };
+            borders.insert(flag.to_string(), json!(enable));
+        }
+
+        let target = target_for(self.index, self.bounds()?);
+        Ok(json!({
+            "target": target,
+            "borders": borders,
+            "clearFields": [],
+        }))
+    }
+
+    /// Apply one border property through the production border mutation API.
+    ///
+    /// The JSON construction remains in [`Self::set`] so the wire operation is
+    /// inspectable at the host boundary, while this helper owns deserialization
+    /// and dispatch. Type inference obtains the concrete
+    /// `compute_core::bridge_types::BorderPatchOperation` from
+    /// `SheetFormats::patch_borders` without adding a private crate dependency
+    /// to the Office.js adapter.
+    pub(crate) fn apply_set(&self, property: &str, value: &Value) -> Result<(), BorderError> {
+        let operation = self.set(property, value)?;
+        let operation = serde_json::from_value(operation).map_err(BorderError::engine)?;
+        self.collection
+            .sheet
+            .formats()
+            .patch_borders(vec![operation])
+            .map_err(BorderError::engine)?;
+        Ok(())
+    }
+
+    fn bounds(&self) -> Result<(u32, u32, u32, u32), BorderError> {
+        parse_bounds(&self.collection.address)
+    }
+
+    fn projection(&self, include_disabled_diagonal: bool) -> Result<BorderProjection, BorderError> {
+        let bounds = self.bounds()?;
+        let mut projection = BorderProjection::default();
+        for_each_sample(bounds, self.index, |row, col| {
+            let format = self
+                .collection
+                .sheet
+                .formats()
+                .get_cell_format(row, col)
+                .map_err(BorderError::engine)?;
+            let value = serde_json::to_value(format).map_err(BorderError::engine)?;
+            projection.observe(sample_side(&value, self.index, include_disabled_diagonal)?);
+            Ok::<(), BorderError>(())
+        })?;
+        Ok(projection)
+    }
+}
+
+const BORDER_PROPERTY_NAMES: [&str; 5] = ["color", "sideIndex", "style", "tintAndShade", "weight"];
+
+fn validate_border_property(property: &str) -> Result<(), BorderError> {
+    if BORDER_PROPERTY_NAMES.contains(&property) {
+        Ok(())
+    } else {
+        Err(BorderError::unsupported(format!(
+            "Unsupported RangeBorder property '{property}'"
+        )))
+    }
+}
+
+fn validate_address(address: &str) -> Result<(), BorderError> {
+    parse_bounds(address).map(|_| ())
+}
+
+fn parse_bounds(address: &str) -> Result<(u32, u32, u32, u32), BorderError> {
+    CellRange::from(address)
+        .resolve()
+        .map_err(|error| BorderError::invalid(error.to_string()))
+}
+
+/// Run a sample over the cells whose effective border contributes to one
+/// range-level Office.js side.
+fn for_each_sample(
+    bounds: (u32, u32, u32, u32),
+    index: BorderIndex,
+    mut visit: impl FnMut(u32, u32) -> Result<(), BorderError>,
+) -> Result<(), BorderError> {
+    let (start_row, start_col, end_row, end_col) = bounds;
+    match index {
+        BorderIndex::EdgeTop => {
+            for col in start_col..=end_col {
+                visit(start_row, col)?;
+            }
+        }
+        BorderIndex::EdgeBottom => {
+            for col in start_col..=end_col {
+                visit(end_row, col)?;
+            }
+        }
+        BorderIndex::EdgeLeft => {
+            for row in start_row..=end_row {
+                visit(row, start_col)?;
+            }
+        }
+        BorderIndex::EdgeRight => {
+            for row in start_row..=end_row {
+                visit(row, end_col)?;
+            }
+        }
+        BorderIndex::InsideVertical | BorderIndex::InsideHorizontal => {
+            for row in start_row..=end_row {
+                for col in start_col..=end_col {
+                    visit(row, col)?;
+                }
+            }
+        }
+        BorderIndex::DiagonalDown | BorderIndex::DiagonalUp => {
+            for row in start_row..=end_row {
+                for col in start_col..=end_col {
+                    visit(row, col)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn target_for(index: BorderIndex, bounds: (u32, u32, u32, u32)) -> Value {
+    let (start_row, start_col, end_row, end_col) = bounds;
+    let (start_row, start_col, end_row, end_col) = match index {
+        BorderIndex::EdgeTop => (start_row, start_col, start_row, end_col),
+        BorderIndex::EdgeBottom => (end_row, start_col, end_row, end_col),
+        BorderIndex::EdgeLeft => (start_row, start_col, end_row, start_col),
+        BorderIndex::EdgeRight => (start_row, end_col, end_row, end_col),
+        BorderIndex::InsideVertical
+        | BorderIndex::InsideHorizontal
+        | BorderIndex::DiagonalDown
+        | BorderIndex::DiagonalUp => (start_row, start_col, end_row, end_col),
+    };
+    json!({
+        "kind": "cells",
+        "startRow": start_row,
+        "startCol": start_col,
+        "endRow": end_row,
+        "endCol": end_col,
+    })
+}
+
+#[derive(Debug, Clone, Default)]
+struct BorderProjection {
+    color: Uniform<Option<String>>,
+    style: Uniform<String>,
+    tint: Uniform<f64>,
+    weight: Uniform<String>,
+}
+
+impl BorderProjection {
+    fn observe(&mut self, sample: BorderSample) {
+        self.color.observe(sample.color);
+        self.style.observe(sample.style);
+        self.tint.observe(sample.tint);
+        self.weight.observe(sample.weight);
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BorderSample {
+    color: Option<String>,
+    style: String,
+    tint: f64,
+    weight: String,
+}
+
+#[derive(Debug, Clone)]
+struct Uniform<T> {
+    value: Option<T>,
+    uniform: bool,
+}
+
+impl<T> Default for Uniform<T> {
+    fn default() -> Self {
+        Self {
+            value: None,
+            uniform: true,
+        }
+    }
+}
+
+impl<T: PartialEq + Clone> Uniform<T> {
+    fn observe(&mut self, next: T) {
+        match &self.value {
+            None => self.value = Some(next),
+            Some(previous) if previous == &next => {}
+            Some(_) => self.uniform = false,
+        }
+    }
+
+    fn value_if_uniform(&self) -> Option<&T> {
+        self.uniform.then_some(self.value.as_ref()).flatten()
+    }
+
+    fn to_value(&self) -> Value
+    where
+        T: serde::Serialize,
+    {
+        if self.uniform {
+            self.value
+                .as_ref()
+                .map(|value| serde_json::to_value(value).unwrap_or(Value::Null))
+                .unwrap_or(Value::Null)
+        } else {
+            Value::Null
+        }
+    }
+}
+
+fn sample_side(
+    format: &Value,
+    index: BorderIndex,
+    include_disabled_diagonal: bool,
+) -> Result<BorderSample, BorderError> {
+    let borders = format.get("borders").and_then(Value::as_object);
+    let directional = index.diagonal_flag();
+    let direction_enabled = directional
+        .map(|flag| {
+            include_disabled_diagonal
+                || borders
+                    .and_then(|borders| borders.get(flag))
+                    .and_then(Value::as_bool)
+                    == Some(true)
+        })
+        .unwrap_or(true);
+    let side = if direction_enabled {
+        borders
+            .and_then(|borders| borders.get(index.field()))
+            .and_then(Value::as_object)
+    } else {
+        None
+    };
+    let style_token = side
+        .and_then(|side| side.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("none");
+    let (style, weight) = office_style_weight(style_token)?;
+    let color = side
+        .and_then(|side| side.get("color"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let tint = side
+        .and_then(|side| side.get("colorTint"))
+        .and_then(Value::as_f64)
+        .unwrap_or(0.0);
+    Ok(BorderSample {
+        color,
+        style: style.to_string(),
+        tint,
+        weight: weight.to_string(),
+    })
+}
+
+fn aggregate_values(values: Vec<Value>) -> Value {
+    let Some(first) = values.first() else {
+        return Value::Null;
+    };
+    if values.iter().all(|value| value == first) {
+        first.clone()
+    } else {
+        Value::Null
+    }
+}
+
+fn ensure_preservable(
+    projection: &BorderProjection,
+    changed: &str,
+    fields: &[&str],
+) -> Result<(), BorderError> {
+    for field in fields {
+        let uniform = match *field {
+            "color" => projection.color.uniform,
+            "style" => projection.style.uniform,
+            "tintAndShade" => projection.tint.uniform,
+            "weight" => projection.weight.uniform,
+            _ => true,
+        };
+        if !uniform {
+            return Err(BorderError::unsupported(format!(
+                "RangeBorder.{changed} cannot preserve mixed {field} values across the range"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn internal_style_for_projection(
+    projection: &BorderProjection,
+) -> Result<Option<&'static str>, BorderError> {
+    let Some(style) = projection.style.value_if_uniform() else {
+        return Err(BorderError::unsupported(
+            "RangeBorder mutation cannot preserve a mixed style",
+        ));
+    };
+    let Some(weight) = projection.weight.value_if_uniform() else {
+        return Err(BorderError::unsupported(
+            "RangeBorder mutation cannot preserve a mixed weight",
+        ));
+    };
+    if style == "None" {
+        // A color or tint can exist on a no-style side without making the
+        // border visible; omitting style preserves that sparse representation.
+        Ok(None)
+    } else {
+        internal_style_for_pair(style, weight).map(Some)
+    }
+}
+
+fn validate_style(style: &str) -> Result<(), BorderError> {
+    if OFFICE_STYLES.contains(&style) {
+        Ok(())
+    } else {
+        Err(BorderError::invalid(format!(
+            "Unsupported BorderLineStyle value '{style}'"
+        )))
+    }
+}
+
+fn validate_weight(weight: &str) -> Result<(), BorderError> {
+    if OFFICE_WEIGHTS.contains(&weight) {
+        Ok(())
+    } else {
+        Err(BorderError::invalid(format!(
+            "Unsupported BorderWeight value '{weight}'"
+        )))
+    }
+}
+
+fn validate_tint(value: &Value) -> Result<f64, BorderError> {
+    value
+        .as_f64()
+        .filter(|tint| tint.is_finite() && (-1.0..=1.0).contains(tint))
+        .ok_or_else(|| BorderError::invalid("RangeBorder.tintAndShade must be between -1 and 1"))
+}
+
+const OFFICE_STYLES: [&str; 8] = [
+    "None",
+    "Continuous",
+    "Dash",
+    "DashDot",
+    "DashDotDot",
+    "Dot",
+    "Double",
+    "SlantDashDot",
+];
+
+const OFFICE_WEIGHTS: [&str; 4] = ["Hairline", "Thin", "Medium", "Thick"];
+
+/// Convert the engine's OOXML border style token to Office's independent
+/// style/weight pair.  The pair is intentionally explicit: the engine has no
+/// second storage field for width, so unsupported combinations are rejected at
+/// mutation time instead of silently dropping width.
+fn office_style_weight(token: &str) -> Result<(&'static str, &'static str), BorderError> {
+    match token {
+        "none" => Ok(("None", "Thin")),
+        "thin" => Ok(("Continuous", "Thin")),
+        "medium" => Ok(("Continuous", "Medium")),
+        "thick" => Ok(("Continuous", "Thick")),
+        "hair" => Ok(("Continuous", "Hairline")),
+        "dashed" => Ok(("Dash", "Thin")),
+        "mediumDashed" => Ok(("Dash", "Medium")),
+        "dotted" => Ok(("Dot", "Thin")),
+        "dashDot" => Ok(("DashDot", "Thin")),
+        "mediumDashDot" => Ok(("DashDot", "Medium")),
+        "dashDotDot" => Ok(("DashDotDot", "Thin")),
+        "mediumDashDotDot" => Ok(("DashDotDot", "Medium")),
+        "double" => Ok(("Double", "Thin")),
+        "slantDashDot" => Ok(("SlantDashDot", "Thin")),
+        other => Err(BorderError::engine(format!(
+            "The engine returned unsupported border style token '{other}'"
+        ))),
+    }
+}
+
+fn internal_style_for_pair(style: &str, weight: &str) -> Result<&'static str, BorderError> {
+    validate_style(style)?;
+    validate_weight(weight)?;
+    match (style, weight) {
+        ("None", _) => Ok("none"),
+        ("Continuous", "Hairline") => Ok("hair"),
+        ("Continuous", "Thin") => Ok("thin"),
+        ("Continuous", "Medium") => Ok("medium"),
+        ("Continuous", "Thick") => Ok("thick"),
+        ("Dash", "Thin") => Ok("dashed"),
+        ("Dash", "Medium") => Ok("mediumDashed"),
+        ("DashDot", "Thin") => Ok("dashDot"),
+        ("DashDot", "Medium") => Ok("mediumDashDot"),
+        ("DashDotDot", "Thin") => Ok("dashDotDot"),
+        ("DashDotDot", "Medium") => Ok("mediumDashDotDot"),
+        ("Dot", "Thin") => Ok("dotted"),
+        ("Double", "Thin") => Ok("double"),
+        ("SlantDashDot", "Thin") => Ok("slantDashDot"),
+        _ => Err(BorderError::unsupported(format!(
+            "BorderLineStyle '{style}' with BorderWeight '{weight}' has no lossless engine representation"
+        ))),
+    }
+}

--- a/compute/officejs/src/chart_axes.js
+++ b/compute/officejs/src/chart_axes.js
@@ -1,0 +1,468 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs;
+
+  function propertyNotLoaded(name) {
+    return new OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+  }
+
+  function invalidArgument(message) {
+    return new OfficeExtension.Error({ code: "InvalidArgument", message: message });
+  }
+
+  function invalidRequestContext() {
+    return new OfficeExtension.Error({
+      code: "InvalidRequestContext",
+      message: "The object belongs to a different request context.",
+    });
+  }
+
+  function requirePropertyObject(source) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+  }
+
+  function navigationProperties(object) {
+    var names = (object._navigationProperties || []).slice();
+    (object._additionalNavigationProperties || []).forEach(function (name) {
+      if (names.indexOf(name) < 0) names.push(name);
+    });
+    return names;
+  }
+
+  function chartId(chart) {
+    return chart._chartKey || chart._chartId || chart._idValue || null;
+  }
+
+  function chartNameHint(chart) {
+    if (typeof chart._name === "string" && chart._name.length) return chart._name;
+    var cache = chart._collection && chart._collection._itemCache;
+    if (!cache) return null;
+    var keys = Object.keys(cache);
+    for (var i = 0; i < keys.length; i++) {
+      if (cache[keys[i]] !== chart) continue;
+      var separator = keys[i].indexOf(":");
+      if (separator >= 0 && ["name", "null"].indexOf(keys[i].slice(0, separator)) >= 0) {
+        return keys[i].slice(separator + 1);
+      }
+    }
+    return null;
+  }
+
+  function chartIndexHint(chart) {
+    var cache = chart._collection && chart._collection._itemCache;
+    if (!cache) return null;
+    var keys = Object.keys(cache);
+    for (var i = 0; i < keys.length; i++) {
+      if (cache[keys[i]] !== chart || keys[i].slice(0, 6) !== "index:") continue;
+      var index = Number(keys[i].slice(6));
+      if (isFinite(index)) return index;
+    }
+    return null;
+  }
+
+  function chartWorksheetId(chart) {
+    return chart._worksheet ? chart._worksheet._id : chart._worksheetId || null;
+  }
+
+  function axisOperation(object, op) {
+    var operation = {
+      op: op,
+      id: object._id,
+      chartId: object._chartId,
+      chartName: object._chartName,
+      chartIndex: object._chartIndex,
+      chartProxyId: object._chart ? object._chart._id : null,
+      parentId: object._chart ? object._chart._id : null,
+      worksheetId: object._worksheetId,
+    };
+    if (object._axisType) operation.axisType = object._axisType;
+    if (object._axisGroup) operation.axisGroup = object._axisGroup;
+    return operation;
+  }
+
+  function queueAxisBinding(object) {
+    object.context._queue.push(axisOperation(object, "chartAxisGet"));
+  }
+
+  function queueTitleBinding(object) {
+    object.context._queue.push(axisOperation(object, "chartAxisTitleGet"));
+  }
+
+  function defineLoadedScalar(prototype, name) {
+    Object.defineProperty(prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        this["_" + name] = value;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: value,
+        });
+      },
+      configurable: true,
+    });
+  }
+
+  function ClientSet(source, object, names) {
+    requirePropertyObject(source);
+    if (source instanceof ClientObject) {
+      if (Object.getPrototypeOf(source) !== Object.getPrototypeOf(object)) {
+        throw invalidArgument("The object passed to set must have the same type.");
+      }
+      names.forEach(function (name) {
+        if (source._loaded[name]) object[name] = source[name];
+      });
+      return;
+    }
+    names.forEach(function (name) {
+      if (Object.prototype.hasOwnProperty.call(source, name) && source[name] !== undefined) {
+        object[name] = source[name];
+      }
+    });
+  }
+
+  function ChartAxes(context, chart) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._chartId = chartId(chart);
+    this._chartName = chartNameHint(chart);
+    this._chartIndex = chartIndexHint(chart);
+    this._worksheetId = chartWorksheetId(chart);
+    this._navigationProperties = ["categoryAxis", "seriesAxis", "valueAxis"];
+    this._axisCache = Object.create(null);
+    context._queue.push({
+      op: "chartAxesGet",
+      id: this._id,
+      chartId: this._chartId,
+      chartName: this._chartName,
+      chartIndex: this._chartIndex,
+      chartProxyId: chart._id,
+      parentId: chart._id,
+      worksheetId: this._worksheetId,
+    });
+  }
+  ChartAxes.prototype = Object.create(ClientObject.prototype);
+  ChartAxes.prototype.constructor = ChartAxes;
+
+  function axisCacheKey(type, group) {
+    return String(group || "Primary") + ":" + type;
+  }
+
+  ChartAxes.prototype._getAxis = function (type, group) {
+    var key = axisCacheKey(type, group);
+    var axis = this._axisCache[key];
+    if (!axis) {
+      axis = new ChartAxis(this.context, this, type, group);
+      this._axisCache[key] = axis;
+    }
+    return axis;
+  };
+
+  [
+    ["categoryAxis", "Category"],
+    ["seriesAxis", "Series"],
+    ["valueAxis", "Value"],
+  ].forEach(function (entry) {
+    Object.defineProperty(ChartAxes.prototype, entry[0], {
+      get: function () {
+        return this._getAxis(entry[1], "Primary");
+      },
+      configurable: true,
+    });
+  });
+
+  ChartAxes.prototype.getItem = function (type, group) {
+    type = type == null ? type : String(type);
+    group = group == null ? "Primary" : String(group);
+    if (["Category", "Value", "Series"].indexOf(type) < 0) {
+      throw invalidArgument("ChartAxes.getItem type must be Category, Value, or Series");
+    }
+    if (["Primary", "Secondary"].indexOf(group) < 0) {
+      throw invalidArgument("ChartAxes.getItem group must be Primary or Secondary");
+    }
+    if (type === "Series" && group === "Secondary") {
+      throw invalidArgument("ChartAxes.getItem does not support a secondary series axis");
+    }
+    return this._getAxis(type, group);
+  };
+
+  ChartAxes.prototype.set = function (source) {
+    requirePropertyObject(source);
+    if (source instanceof ClientObject) {
+      if (Object.getPrototypeOf(source) !== Object.getPrototypeOf(this)) {
+        throw invalidArgument("The object passed to set must have the same type.");
+      }
+      source = source.toJSON();
+    }
+    ["categoryAxis", "seriesAxis", "valueAxis"].forEach(function (name) {
+      if (!Object.prototype.hasOwnProperty.call(source, name) || source[name] === undefined) {
+        return;
+      }
+      this[name].set(source[name]);
+    }, this);
+  };
+
+  ChartAxes.prototype.toJSON = function () {
+    var data = {};
+    ["categoryAxis", "seriesAxis", "valueAxis"].forEach(function (name) {
+      var type = name === "categoryAxis" ? "Category" : name === "valueAxis" ? "Value" : "Series";
+      var axis = this._axisCache[axisCacheKey(type, "Primary")];
+      if (axis && typeof axis.toJSON === "function") data[name] = axis.toJSON();
+    }, this);
+    return data;
+  };
+
+  function ChartAxis(context, axes, type, group) {
+    ClientObject.call(this, context);
+    this._axes = axes;
+    this._chart = axes._chart;
+    this._chartId = axes._chartId;
+    this._chartName = axes._chartName;
+    this._chartIndex = axes._chartIndex;
+    this._worksheetId = axes._worksheetId;
+    this._axisType = type;
+    this._axisGroup = group || "Primary";
+    this._navigationProperties = ["title"];
+    this._scalarProperties = [
+      "alignment",
+      "axisGroup",
+      "baseTimeUnit",
+      "categoryType",
+      "customDisplayUnit",
+      "displayUnit",
+      "isBetweenCategories",
+      "linkNumberFormat",
+      "logBase",
+      "majorTickMark",
+      "majorTimeUnitScale",
+      "majorUnit",
+      "maximum",
+      "minimum",
+      "minorTickMark",
+      "minorTimeUnitScale",
+      "minorUnit",
+      "multiLevel",
+      "numberFormat",
+      "offset",
+      "position",
+      "positionAt",
+      "reversePlotOrder",
+      "scaleType",
+      "showDisplayUnitLabel",
+      "textOrientation",
+      "tickLabelPosition",
+      "tickLabelSpacing",
+      "tickMarkSpacing",
+      "type",
+      "visible",
+    ];
+    queueAxisBinding(this);
+  }
+  ChartAxis.prototype = Object.create(ClientObject.prototype);
+  ChartAxis.prototype.constructor = ChartAxis;
+
+  ChartAxis.prototype._queueAxisOperation = function (op) {
+    this.context._queue.push(axisOperation(this, op));
+  };
+
+  Object.defineProperty(ChartAxis.prototype, "title", {
+    get: function () {
+      if (!this._title) {
+        this._title = new ChartAxisTitle(this.context, this);
+      }
+      return this._title;
+    },
+    configurable: true,
+  });
+
+  [
+    "alignment",
+    "baseTimeUnit",
+    "categoryType",
+    "displayUnit",
+    "isBetweenCategories",
+    "linkNumberFormat",
+    "logBase",
+    "majorTickMark",
+    "majorTimeUnitScale",
+    "majorUnit",
+    "maximum",
+    "minimum",
+    "minorTickMark",
+    "minorTimeUnitScale",
+    "minorUnit",
+    "multiLevel",
+    "numberFormat",
+    "offset",
+    "position",
+    "reversePlotOrder",
+    "scaleType",
+    "showDisplayUnitLabel",
+    "textOrientation",
+    "tickLabelPosition",
+    "tickLabelSpacing",
+    "tickMarkSpacing",
+    "visible",
+  ].forEach(function (name) {
+    defineLoadedScalar(ChartAxis.prototype, name);
+  });
+
+  ["axisGroup", "customDisplayUnit", "positionAt", "type"].forEach(function (name) {
+    Object.defineProperty(ChartAxis.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      configurable: true,
+    });
+  });
+
+  ChartAxis.prototype.set = function (source) {
+    requirePropertyObject(source);
+    var names = [
+      "alignment",
+      "baseTimeUnit",
+      "categoryType",
+      "displayUnit",
+      "isBetweenCategories",
+      "linkNumberFormat",
+      "logBase",
+      "majorTickMark",
+      "majorTimeUnitScale",
+      "majorUnit",
+      "maximum",
+      "minimum",
+      "minorTickMark",
+      "minorTimeUnitScale",
+      "minorUnit",
+      "multiLevel",
+      "numberFormat",
+      "offset",
+      "position",
+      "reversePlotOrder",
+      "scaleType",
+      "showDisplayUnitLabel",
+      "textOrientation",
+      "tickLabelPosition",
+      "tickLabelSpacing",
+      "tickMarkSpacing",
+      "visible",
+    ];
+    ClientSet(source, this, names);
+    if (source instanceof ClientObject) {
+      if (source._title) this.title.set(source._title);
+    } else if (Object.prototype.hasOwnProperty.call(source, "title") && source.title !== undefined) {
+      this.title.set(source.title);
+    }
+  };
+
+  ChartAxis.prototype.setCategoryNames = function (sourceData) {
+    if (!(sourceData instanceof Excel.Range)) {
+      throw invalidArgument("ChartAxis.setCategoryNames requires a Range");
+    }
+    if (sourceData.context !== this.context) throw invalidRequestContext();
+    var operation = axisOperation(this, "chartAxisSetCategoryNames");
+    operation.rangeId = sourceData._id;
+    this.context._queue.push(operation);
+  };
+
+  ChartAxis.prototype.setCustomDisplayUnit = function (value) {
+    if (typeof value !== "number" || !isFinite(value)) {
+      throw invalidArgument("ChartAxis.setCustomDisplayUnit value must be a number");
+    }
+    var operation = axisOperation(this, "chartAxisSetCustomDisplayUnit");
+    operation.value = value;
+    this.context._queue.push(operation);
+  };
+
+  ChartAxis.prototype.setPositionAt = function (value) {
+    if (typeof value !== "number" || !isFinite(value)) {
+      throw invalidArgument("ChartAxis.setPositionAt value must be a number");
+    }
+    var operation = axisOperation(this, "chartAxisSetPositionAt");
+    operation.value = value;
+    this.context._queue.push(operation);
+  };
+
+  ChartAxis.prototype.toJSON = function () {
+    var data = {};
+    (this._scalarProperties || []).forEach(function (name) {
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }, this);
+    if (this._title) data.title = this._title.toJSON();
+    return data;
+  };
+
+  function ChartAxisTitle(context, axis) {
+    ClientObject.call(this, context);
+    this._axis = axis;
+    this._chart = axis._chart;
+    this._chartId = axis._chartId;
+    this._chartName = axis._chartName;
+    this._chartIndex = axis._chartIndex;
+    this._worksheetId = axis._worksheetId;
+    this._axisType = axis._axisType;
+    this._axisGroup = axis._axisGroup;
+    this._scalarProperties = ["text", "textOrientation", "visible"];
+    queueTitleBinding(this);
+  }
+  ChartAxisTitle.prototype = Object.create(ClientObject.prototype);
+  ChartAxisTitle.prototype.constructor = ChartAxisTitle;
+
+  ["text", "textOrientation", "visible"].forEach(function (name) {
+    defineLoadedScalar(ChartAxisTitle.prototype, name);
+  });
+
+  ChartAxisTitle.prototype.set = function (source) {
+    ClientSet(source, this, ["text", "textOrientation", "visible"]);
+  };
+
+  ChartAxisTitle.prototype.setFormula = function () {
+    throw new OfficeExtension.Error({
+      code: "ApiNotFound",
+      message: "ChartAxisTitle.setFormula is not supported by this host.",
+    });
+  };
+
+  ChartAxisTitle.prototype.toJSON = function () {
+    var data = {};
+    this._scalarProperties.forEach(function (name) {
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }, this);
+    return data;
+  };
+
+  if (Excel.Chart && Object.prototype.hasOwnProperty.call(Excel.Chart.prototype, "axes") === false) {
+    Object.defineProperty(Excel.Chart.prototype, "axes", {
+      get: function () {
+        if (!this._axes) this._axes = new ChartAxes(this.context, this);
+        return this._axes;
+      },
+      configurable: true,
+    });
+    if (officeJs && typeof officeJs.addNavigationProperties === "function") {
+      officeJs.addNavigationProperties(Excel.Chart.prototype, ["axes"]);
+    }
+  }
+
+  Excel.ChartAxes = ChartAxes;
+  Excel.ChartAxis = ChartAxis;
+  Excel.ChartAxisTitle = ChartAxisTitle;
+})(globalThis);

--- a/compute/officejs/src/chart_axes.rs
+++ b/compute/officejs/src/chart_axes.rs
@@ -1,0 +1,1267 @@
+//! Office.js chart axes and axis-title bindings.
+//!
+//! Axis state is persisted as the chart's `AxisData` object.  The adapter
+//! reads that object for every request and writes a patched copy back through
+//! `ChartRef::update_fields`; this keeps a proxy read-after-write coherent and
+//! avoids a second in-memory axis store.  The JavaScript adapter sends a
+//! stable chart ID and worksheet proxy ID with each family operation.  The
+//! chart host integrator registers [`ChartAxesHandler`] with the common
+//! extension dispatcher.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde_json::{Map, Value, json};
+
+use crate::chart_core::{ChartCollectionRef, ChartRef};
+use crate::dispatch::{ExtensionHandler, ExtensionObject, HostDispatchContext};
+use crate::host::BatchError;
+
+/// Axis kind understood by the Office.js `ChartAxisType` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChartAxisKind {
+    Category,
+    Value,
+    Series,
+}
+
+impl ChartAxisKind {
+    fn parse(value: &str) -> Result<Self, ChartError> {
+        match value {
+            "Category" | "category" => Ok(Self::Category),
+            "Value" | "value" => Ok(Self::Value),
+            "Series" | "series" => Ok(Self::Series),
+            "Invalid" | "invalid" => {
+                Err(invalid("ChartAxisType.Invalid does not identify an axis"))
+            }
+            other => Err(invalid(format!(
+                "ChartAxes.getItem type must be Category, Value, or Series; got '{other}'"
+            ))),
+        }
+    }
+
+    fn wire_name(self) -> &'static str {
+        match self {
+            Self::Category => "Category",
+            Self::Value => "Value",
+            Self::Series => "Series",
+        }
+    }
+
+    fn persisted_key(self, group: ChartAxisGroup) -> &'static str {
+        match (self, group) {
+            (Self::Category, ChartAxisGroup::Primary) => "categoryAxis",
+            (Self::Category, ChartAxisGroup::Secondary) => "secondaryCategoryAxis",
+            (Self::Value, ChartAxisGroup::Primary) => "valueAxis",
+            (Self::Value, ChartAxisGroup::Secondary) => "secondaryValueAxis",
+            (Self::Series, _) => "seriesAxis",
+        }
+    }
+
+    fn ooxml_type(self) -> &'static str {
+        match self {
+            Self::Category => "catAx",
+            Self::Value => "valAx",
+            Self::Series => "serAx",
+        }
+    }
+}
+
+/// Primary or secondary chart axis group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChartAxisGroup {
+    Primary,
+    Secondary,
+}
+
+impl ChartAxisGroup {
+    fn parse(value: Option<&str>) -> Result<Self, ChartError> {
+        match value.unwrap_or("Primary") {
+            "Primary" | "primary" => Ok(Self::Primary),
+            "Secondary" | "secondary" => Ok(Self::Secondary),
+            other => Err(invalid(format!(
+                "ChartAxisGroup must be Primary or Secondary; got '{other}'"
+            ))),
+        }
+    }
+
+    fn wire_name(self) -> &'static str {
+        match self {
+            Self::Primary => "Primary",
+            Self::Secondary => "Secondary",
+        }
+    }
+}
+
+/// Errors produced by chart-axis translation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChartError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+/// Collection reference behind `Chart.axes`.
+#[derive(Clone)]
+pub(crate) struct ChartAxesRef {
+    chart: ChartRef,
+}
+
+impl ChartAxesRef {
+    pub(crate) fn new(chart: ChartRef) -> Self {
+        Self { chart }
+    }
+
+    pub(crate) fn chart(&self) -> ChartRef {
+        self.chart.clone()
+    }
+
+    pub(crate) fn axis(
+        &self,
+        kind: ChartAxisKind,
+        group: ChartAxisGroup,
+    ) -> Result<ChartAxisRef, ChartError> {
+        let axis = ChartAxisRef {
+            chart: self.chart.clone(),
+            kind,
+            group,
+        };
+        axis.ensure_available()?;
+        Ok(axis)
+    }
+
+    pub(crate) fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, ChartError> {
+        let mut result = HashMap::new();
+        for property in properties {
+            if property != "isNullObject" {
+                return Err(unsupported_load_property("ChartAxes", property));
+            }
+            result.insert(property.clone(), Value::Bool(false));
+        }
+        Ok(result)
+    }
+}
+
+/// A chart axis bound to a persisted chart ID and axis slot.
+#[derive(Clone)]
+pub(crate) struct ChartAxisRef {
+    chart: ChartRef,
+    kind: ChartAxisKind,
+    group: ChartAxisGroup,
+}
+
+impl ChartAxisRef {
+    pub(crate) fn new(
+        chart: ChartRef,
+        kind: ChartAxisKind,
+        group: ChartAxisGroup,
+    ) -> Result<Self, ChartError> {
+        let axis = Self { chart, kind, group };
+        axis.ensure_available()?;
+        Ok(axis)
+    }
+
+    pub(crate) fn title(&self) -> ChartAxisTitleRef {
+        ChartAxisTitleRef { axis: self.clone() }
+    }
+
+    pub(crate) fn kind(&self) -> ChartAxisKind {
+        self.kind
+    }
+
+    pub(crate) fn group(&self) -> ChartAxisGroup {
+        self.group
+    }
+
+    fn ensure_available(&self) -> Result<(), ChartError> {
+        let snapshot = self.chart.snapshot().map_err(chart_error)?;
+        ensure_axis_available(&snapshot, self.kind, self.group)
+    }
+
+    pub(crate) fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, ChartError> {
+        let snapshot = self.chart.snapshot().map_err(chart_error)?;
+        ensure_axis_available(&snapshot, self.kind, self.group)?;
+        let axis = persisted_axis(&snapshot, self.kind, self.group);
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = load_axis_property(property, axis, self.kind, self.group)?;
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), ChartError> {
+        let mut snapshot = self.chart.snapshot().map_err(chart_error)?;
+        ensure_axis_available(&snapshot, self.kind, self.group)?;
+        let axis = ensure_axis_map(&mut snapshot, self.kind, self.group)?;
+        set_axis_property(axis, property, value)?;
+        self.persist_axis(&snapshot)
+    }
+
+    pub(crate) fn set_custom_display_unit(&self, value: &Value) -> Result<(), ChartError> {
+        let value = finite_number(value, "ChartAxis.setCustomDisplayUnit value")?;
+        if value <= 0.0 {
+            return Err(invalid(
+                "ChartAxis.setCustomDisplayUnit value must be greater than zero",
+            ));
+        }
+        let mut snapshot = self.chart.snapshot().map_err(chart_error)?;
+        ensure_axis_available(&snapshot, self.kind, self.group)?;
+        let axis = ensure_axis_map(&mut snapshot, self.kind, self.group)?;
+        insert_number(axis, "customDisplayUnit", value);
+        axis.insert(
+            "displayUnit".to_string(),
+            Value::String("custom".to_string()),
+        );
+        self.persist_axis(&snapshot)
+    }
+
+    pub(crate) fn set_position_at(&self, value: &Value) -> Result<(), ChartError> {
+        let value = finite_number(value, "ChartAxis.setPositionAt value")?;
+        let mut snapshot = self.chart.snapshot().map_err(chart_error)?;
+        ensure_axis_available(&snapshot, self.kind, self.group)?;
+        let axis = ensure_axis_map(&mut snapshot, self.kind, self.group)?;
+        axis.insert("crossesAt".to_string(), Value::String("custom".to_string()));
+        insert_number(axis, "crossesAtValue", value);
+        self.persist_axis(&snapshot)
+    }
+
+    fn persist_axis(&self, snapshot: &Value) -> Result<(), ChartError> {
+        let axis = snapshot
+            .get("axis")
+            .cloned()
+            .unwrap_or_else(|| Value::Object(Map::new()));
+        self.chart
+            .update_fields(&json!({ "axis": axis }))
+            .map_err(chart_error)
+    }
+}
+
+/// Axis title reference.  Title values are kept inside the owning axis so a
+/// title mutation cannot affect another axis or the chart's main title.
+#[derive(Clone)]
+pub(crate) struct ChartAxisTitleRef {
+    axis: ChartAxisRef,
+}
+
+impl ChartAxisTitleRef {
+    pub(crate) fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, ChartError> {
+        let snapshot = self.axis.chart.snapshot().map_err(chart_error)?;
+        ensure_axis_available(&snapshot, self.axis.kind, self.axis.group)?;
+        let axis = persisted_axis(&snapshot, self.axis.kind, self.axis.group);
+        let text = string_value(axis, "title").unwrap_or_default();
+        let title_visible = axis
+            .and_then(|axis| axis.get("titleVisible"))
+            .and_then(Value::as_bool)
+            .unwrap_or(!text.is_empty());
+        let orientation = number_value(axis, "textOrientation").unwrap_or(0.0);
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                "text" => Value::String(text.clone()),
+                "visible" => Value::Bool(title_visible),
+                "textOrientation" => number_json(orientation),
+                "isNullObject" => Value::Bool(false),
+                other => return Err(unsupported_load_property("ChartAxisTitle", other)),
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), ChartError> {
+        let mut snapshot = self.axis.chart.snapshot().map_err(chart_error)?;
+        ensure_axis_available(&snapshot, self.axis.kind, self.axis.group)?;
+        let axis = ensure_axis_map(&mut snapshot, self.axis.kind, self.axis.group)?;
+        match property {
+            "text" => {
+                let text = value
+                    .as_str()
+                    .ok_or_else(|| invalid("ChartAxisTitle.text must be a string".to_string()))?;
+                if text.is_empty() {
+                    axis.remove("title");
+                    axis.insert("titleVisible".to_string(), Value::Bool(false));
+                } else {
+                    axis.insert("title".to_string(), Value::String(text.to_string()));
+                    // A newly-authored title is visible by default.  Preserve
+                    // an explicit titleVisible=false set by the caller.
+                    if !axis.contains_key("titleVisible") {
+                        axis.insert("titleVisible".to_string(), Value::Bool(true));
+                    }
+                }
+            }
+            "visible" => {
+                let visible = value.as_bool().ok_or_else(|| {
+                    invalid("ChartAxisTitle.visible must be a boolean".to_string())
+                })?;
+                axis.insert("titleVisible".to_string(), Value::Bool(visible));
+            }
+            "textOrientation" => {
+                let orientation = text_orientation(value, "ChartAxisTitle.textOrientation")?;
+                insert_number(axis, "textOrientation", orientation);
+            }
+            "format" => {
+                return Err(unsupported_set_property(
+                    "ChartAxisTitle.format is not supported by this host",
+                ));
+            }
+            other => return Err(unsupported_set_property(format!("ChartAxisTitle.{other}"))),
+        }
+        self.axis.persist_axis(&snapshot)
+    }
+}
+
+impl ExtensionObject for ChartAxesRef {
+    fn object_type(&self) -> &'static str {
+        "ChartAxes"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        ChartAxesRef::load(self, properties).map_err(batch_error)
+    }
+
+    fn set(&self, property: &str, _value: &Value) -> Result<(), BatchError> {
+        Err(batch_error(unsupported_set_property(format!(
+            "ChartAxes.{property} is read-only or unsupported"
+        ))))
+    }
+}
+
+impl ExtensionObject for ChartAxisRef {
+    fn object_type(&self) -> &'static str {
+        "ChartAxis"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        ChartAxisRef::load(self, properties).map_err(batch_error)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        ChartAxisRef::set(self, property, value).map_err(batch_error)
+    }
+}
+
+impl ExtensionObject for ChartAxisTitleRef {
+    fn object_type(&self) -> &'static str {
+        "ChartAxisTitle"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        ChartAxisTitleRef::load(self, properties).map_err(batch_error)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        ChartAxisTitleRef::set(self, property, value).map_err(batch_error)
+    }
+}
+
+/// Host extension handler for all chart-axis operations emitted by
+/// `chart_axes.js`.
+///
+/// The chart core handler should bind `ChartRef` using the stable chart ID
+/// before this handler is reached.  Axis operations also carry `chartId` so
+/// they remain valid when a chart proxy is recreated in a later request
+/// context.  `worksheetId` is deliberately resolved through the host's
+/// worksheet map rather than by worksheet name.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct ChartAxesHandler;
+
+impl ExtensionHandler for ChartAxesHandler {
+    fn can_handle(&self, operation: &str) -> bool {
+        matches!(
+            operation,
+            "chartAxesGet"
+                | "chartAxisGet"
+                | "chartAxisTitleGet"
+                | "chartAxisSetCategoryNames"
+                | "chartAxisSetCustomDisplayUnit"
+                | "chartAxisSetPositionAt"
+        )
+    }
+
+    fn handle(
+        &self,
+        operation: &Value,
+        context: &mut HostDispatchContext<'_>,
+    ) -> Result<bool, BatchError> {
+        let op = operation
+            .get("op")
+            .and_then(Value::as_str)
+            .ok_or_else(|| batch_error(invalid("Chart axis operation has no op")))?;
+        match op {
+            "chartAxesGet" => {
+                let id = required_operation_string(operation, "id")?;
+                let chart = chart_from_operation(operation, context)?;
+                context.bind_object(&id, Arc::new(ChartAxesRef::new(chart)));
+            }
+            "chartAxisGet" => {
+                let id = required_operation_string(operation, "id")?;
+                let chart = chart_from_operation(operation, context)?;
+                let kind = ChartAxisKind::parse(required_operation_string(operation, "axisType")?)
+                    .map_err(batch_error)?;
+                let group =
+                    ChartAxisGroup::parse(operation.get("axisGroup").and_then(Value::as_str))
+                        .map_err(batch_error)?;
+                let axis = ChartAxisRef::new(chart, kind, group).map_err(batch_error)?;
+                context.bind_object(&id, Arc::new(axis));
+            }
+            "chartAxisTitleGet" => {
+                let id = required_operation_string(operation, "id")?;
+                let chart = chart_from_operation(operation, context)?;
+                let kind = ChartAxisKind::parse(required_operation_string(operation, "axisType")?)
+                    .map_err(batch_error)?;
+                let group =
+                    ChartAxisGroup::parse(operation.get("axisGroup").and_then(Value::as_str))
+                        .map_err(batch_error)?;
+                let axis = ChartAxisRef::new(chart, kind, group).map_err(batch_error)?;
+                context.bind_object(&id, Arc::new(axis.title()));
+            }
+            "chartAxisSetCustomDisplayUnit" => {
+                let chart = chart_from_operation(operation, context)?;
+                let kind = ChartAxisKind::parse(required_operation_string(operation, "axisType")?)
+                    .map_err(batch_error)?;
+                let group =
+                    ChartAxisGroup::parse(operation.get("axisGroup").and_then(Value::as_str))
+                        .map_err(batch_error)?;
+                ChartAxisRef::new(chart, kind, group)
+                    .map_err(batch_error)?
+                    .set_custom_display_unit(operation.get("value").ok_or_else(|| {
+                        batch_error(invalid(
+                            "ChartAxis.setCustomDisplayUnit has no value".to_string(),
+                        ))
+                    })?)
+                    .map_err(batch_error)?;
+            }
+            "chartAxisSetPositionAt" => {
+                let chart = chart_from_operation(operation, context)?;
+                let kind = ChartAxisKind::parse(required_operation_string(operation, "axisType")?)
+                    .map_err(batch_error)?;
+                let group =
+                    ChartAxisGroup::parse(operation.get("axisGroup").and_then(Value::as_str))
+                        .map_err(batch_error)?;
+                ChartAxisRef::new(chart, kind, group)
+                    .map_err(batch_error)?
+                    .set_position_at(operation.get("value").ok_or_else(|| {
+                        batch_error(invalid("ChartAxis.setPositionAt has no value".to_string()))
+                    })?)
+                    .map_err(batch_error)?;
+            }
+            "chartAxisSetCategoryNames" => {
+                let chart = chart_from_operation(operation, context)?;
+                let range_id = required_operation_string(operation, "rangeId")?;
+                let range = context.range(&range_id)?;
+                if range.is_null_object() {
+                    return Err(BatchError {
+                        code: "InvalidObjectPath",
+                        message: "ChartAxis.setCategoryNames cannot use a null Range.".to_string(),
+                    });
+                }
+                let address = range.address().ok_or_else(|| BatchError {
+                    code: "InvalidArgument",
+                    message: "ChartAxis.setCategoryNames requires a bounded Range.".to_string(),
+                })?;
+                let chart_sheet = chart.sheet();
+                if chart_sheet.id() != range.sheet().id() {
+                    return Err(BatchError {
+                        code: "InvalidArgument",
+                        message:
+                            "ChartAxis.setCategoryNames Range must belong to the chart worksheet."
+                                .to_string(),
+                    });
+                }
+                let kind = ChartAxisKind::parse(required_operation_string(operation, "axisType")?)
+                    .map_err(batch_error)?;
+                let group =
+                    ChartAxisGroup::parse(operation.get("axisGroup").and_then(Value::as_str))
+                        .map_err(batch_error)?;
+                let axis = ChartAxisRef::new(chart, kind, group).map_err(batch_error)?;
+                axis.chart
+                    .update_fields(&json!({ "categoryRange": address }))
+                    .map_err(chart_error)
+                    .map_err(batch_error)?;
+            }
+            _ => unreachable!("can_handle and handle operation names differ"),
+        }
+        Ok(true)
+    }
+}
+
+fn chart_from_operation(
+    operation: &Value,
+    context: &HostDispatchContext<'_>,
+) -> Result<ChartRef, BatchError> {
+    for field in ["parentId", "chartObjectId", "chartProxyId"] {
+        if let Some(id) = operation.get(field).and_then(Value::as_str)
+            && let Ok(chart) = context.extension_object::<ChartRef>(id)
+        {
+            return Ok((*chart).clone());
+        }
+    }
+    let worksheet_id = required_operation_string(operation, "worksheetId")?;
+    let worksheet = context.worksheet(&worksheet_id)?;
+    let chart_id = operation
+        .get("chartId")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty());
+    if let Some(chart_id) = chart_id {
+        return Ok(ChartRef::new(worksheet.sheet(), chart_id));
+    }
+    if let Some(index) = operation.get("chartIndex").and_then(Value::as_i64) {
+        return ChartCollectionRef::new(worksheet.sheet())
+            .get_item_at(index)
+            .map_err(chart_error)
+            .map_err(batch_error);
+    }
+    let chart_name = operation
+        .get("chartName")
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| BatchError {
+            code: "InvalidObjectPath",
+            message: "Chart axis operation requires a chart ID or name.".to_string(),
+        })?;
+    ChartCollectionRef::new(worksheet.sheet())
+        .get_item(chart_name)
+        .map_err(chart_error)
+        .map_err(batch_error)
+}
+
+fn required_operation_string<'a>(operation: &'a Value, field: &str) -> Result<&'a str, BatchError> {
+    operation
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| BatchError {
+            code: "InvalidArgument",
+            message: format!("Chart axis operation requires a non-empty {field}"),
+        })
+}
+
+fn persisted_axis<'a>(
+    snapshot: &'a Value,
+    kind: ChartAxisKind,
+    group: ChartAxisGroup,
+) -> Option<&'a Map<String, Value>> {
+    snapshot
+        .get("axis")
+        .and_then(Value::as_object)
+        .and_then(|axes| axes.get(kind.persisted_key(group)))
+        .and_then(Value::as_object)
+}
+
+fn ensure_axis_map<'a>(
+    snapshot: &'a mut Value,
+    kind: ChartAxisKind,
+    group: ChartAxisGroup,
+) -> Result<&'a mut Map<String, Value>, ChartError> {
+    let root = snapshot
+        .as_object_mut()
+        .ok_or_else(|| encoding("Persisted chart is not an object"))?;
+    let axis = root
+        .entry("axis".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let axes = axis
+        .as_object_mut()
+        .ok_or_else(|| encoding("Persisted chart axis data is not an object"))?;
+    let key = kind.persisted_key(group).to_string();
+    let target = axes.entry(key).or_insert_with(|| {
+        json!({
+            "axisType": kind.ooxml_type(),
+            "visible": true,
+        })
+    });
+    if !target.is_object() {
+        *target = json!({
+            "axisType": kind.ooxml_type(),
+            "visible": true,
+        });
+    }
+    target
+        .as_object_mut()
+        .ok_or_else(|| encoding("Persisted chart axis entry is not an object"))
+}
+
+fn ensure_axis_available(
+    snapshot: &Value,
+    kind: ChartAxisKind,
+    group: ChartAxisGroup,
+) -> Result<(), ChartError> {
+    // A series axis is a primary-only Office.js object even if malformed or
+    // imported data happens to carry a second `seriesAxis` entry.
+    if kind == ChartAxisKind::Series && group == ChartAxisGroup::Secondary {
+        return Err(item_not_found(format!(
+            "{} {} axis",
+            group.wire_name(),
+            kind.wire_name()
+        )));
+    }
+    let explicit = persisted_axis(snapshot, kind, group).is_some();
+    let chart_type = chart_type_name(snapshot);
+    let requires_axes = chart_type_requires_axes(&chart_type);
+    let modeled_secondary = chart_has_secondary_series(snapshot);
+    let available = if explicit {
+        true
+    } else if !requires_axes {
+        false
+    } else if chart_type_is_scatter_like(&chart_type) {
+        kind == ChartAxisKind::Value
+            && matches!(group, ChartAxisGroup::Primary | ChartAxisGroup::Secondary)
+    } else {
+        match (kind, group) {
+            (ChartAxisKind::Category | ChartAxisKind::Value, ChartAxisGroup::Primary) => true,
+            (ChartAxisKind::Series, ChartAxisGroup::Primary) => {
+                chart_type_supports_series_axis(&chart_type)
+            }
+            (ChartAxisKind::Category | ChartAxisKind::Value, ChartAxisGroup::Secondary) => {
+                modeled_secondary
+            }
+            (ChartAxisKind::Series, ChartAxisGroup::Secondary) => false,
+        }
+    };
+    if available {
+        Ok(())
+    } else {
+        Err(item_not_found(format!(
+            "{} {} axis",
+            group.wire_name(),
+            kind.wire_name()
+        )))
+    }
+}
+
+fn chart_type_name(snapshot: &Value) -> String {
+    snapshot
+        .get("chartType")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+}
+
+fn chart_type_is_scatter_like(chart_type: &str) -> bool {
+    chart_type.contains("scatter") || chart_type.contains("bubble")
+}
+
+fn chart_type_requires_axes(chart_type: &str) -> bool {
+    !(chart_type.contains("pie") || chart_type.contains("doughnut") || chart_type.contains("ofpie"))
+}
+
+fn chart_type_supports_series_axis(chart_type: &str) -> bool {
+    chart_type.contains("3d")
+        && (chart_type.contains("bar")
+            || chart_type.contains("column")
+            || chart_type.contains("line")
+            || chart_type.contains("area"))
+        || chart_type.contains("surface")
+}
+
+fn chart_has_secondary_series(snapshot: &Value) -> bool {
+    snapshot
+        .get("series")
+        .and_then(Value::as_array)
+        .is_some_and(|series| {
+            series.iter().any(|item| {
+                item.get("yAxisIndex")
+                    .and_then(Value::as_u64)
+                    .is_some_and(|index| index == 1)
+            })
+        })
+}
+
+fn load_axis_property(
+    property: &str,
+    axis: Option<&Map<String, Value>>,
+    kind: ChartAxisKind,
+    group: ChartAxisGroup,
+) -> Result<Value, ChartError> {
+    let get_bool = |key: &str, default| bool_value(axis, key).unwrap_or(default);
+    let get_number = |key: &str, default| number_value(axis, key).unwrap_or(default);
+    let value = match property {
+        "isNullObject" => Value::Bool(false),
+        "alignment" => token_value(
+            axis,
+            "alignment",
+            "Center",
+            &[
+                ("ctr", "Center"),
+                ("center", "Center"),
+                ("l", "Left"),
+                ("left", "Left"),
+                ("r", "Right"),
+                ("right", "Right"),
+            ],
+        ),
+        "axisGroup" => Value::String(group.wire_name().to_string()),
+        "baseTimeUnit" => token_value(
+            axis,
+            "baseTimeUnit",
+            "Days",
+            &[("days", "Days"), ("months", "Months"), ("years", "Years")],
+        ),
+        "categoryType" => token_value(
+            axis,
+            "categoryType",
+            "Automatic",
+            &[
+                ("automatic", "Automatic"),
+                ("text", "TextAxis"),
+                ("textAxis", "TextAxis"),
+                ("date", "DateAxis"),
+                ("dateAxis", "DateAxis"),
+            ],
+        ),
+        "customDisplayUnit" => number_json(get_number("customDisplayUnit", 0.0)),
+        "displayUnit" => {
+            if number_value(axis, "customDisplayUnit").is_some() {
+                Value::String("Custom".to_string())
+            } else {
+                token_value(axis, "displayUnit", "None", display_unit_tokens())
+            }
+        }
+        "isBetweenCategories" => Value::Bool(
+            bool_value(axis, "isBetweenCategories")
+                .or_else(|| string_value(axis, "crossBetween").map(|value| value == "between"))
+                .unwrap_or(false),
+        ),
+        "linkNumberFormat" => Value::Bool(get_bool("linkNumberFormat", false)),
+        "logBase" => number_json(get_number("logBase", 10.0)),
+        "majorTickMark" => token_value(axis, "tickMarks", "Cross", tick_mark_tokens()),
+        "majorTimeUnitScale" => token_value(axis, "majorTimeUnit", "Days", time_unit_tokens()),
+        "majorUnit" => number_json(get_number("majorUnit", 0.0)),
+        "maximum" => number_json(get_number("max", 0.0)),
+        "minimum" => number_json(get_number("min", 0.0)),
+        "minorTickMark" => token_value(axis, "minorTickMarks", "Cross", tick_mark_tokens()),
+        "minorTimeUnitScale" => token_value(axis, "minorTimeUnit", "Days", time_unit_tokens()),
+        "minorUnit" => number_json(get_number("minorUnit", 0.0)),
+        "multiLevel" => Value::Bool(
+            bool_value(axis, "noMultiLevelLabels")
+                .map(|value| !value)
+                .unwrap_or(false),
+        ),
+        "numberFormat" => Value::String(
+            string_value(axis, "numberFormat").unwrap_or_else(|| "General".to_string()),
+        ),
+        "offset" => json!(number_value(axis, "labelOffset").unwrap_or(0.0) as u32),
+        "position" => token_value(axis, "crossesAt", "Automatic", position_tokens()),
+        "positionAt" => number_json(number_value(axis, "crossesAtValue").unwrap_or(0.0)),
+        "reversePlotOrder" => Value::Bool(get_bool("reverse", false)),
+        "scaleType" => {
+            let logarithmic = string_value(axis, "scaleType")
+                .map(|value| value.eq_ignore_ascii_case("logarithmic"))
+                .unwrap_or_else(|| number_value(axis, "logBase").is_some());
+            Value::String(if logarithmic { "Logarithmic" } else { "Linear" }.to_string())
+        }
+        "showDisplayUnitLabel" => Value::Bool(
+            string_value(axis, "displayUnitLabel").is_some()
+                || bool_value(axis, "showDisplayUnitLabel").unwrap_or(false),
+        ),
+        "textOrientation" => number_json(get_number("textOrientation", 0.0)),
+        "tickLabelPosition" => token_value(
+            axis,
+            "tickLabelPosition",
+            "NextToAxis",
+            tick_label_position_tokens(),
+        ),
+        "tickLabelSpacing" => json!(number_value(axis, "tickLabelSpacing").unwrap_or(1.0) as u32),
+        "tickMarkSpacing" => json!(number_value(axis, "tickMarkSpacing").unwrap_or(1.0) as u32),
+        "type" => Value::String(kind.wire_name().to_string()),
+        "visible" => Value::Bool(effective_visible(axis)),
+        // Geometry is not represented by the persisted chart model.  Keep
+        // those declarations explicit instead of returning fabricated sizes.
+        "height" | "left" | "top" | "width" => {
+            return Err(unsupported_load_property("ChartAxis", property));
+        }
+        other => return Err(unsupported_load_property("ChartAxis", other)),
+    };
+    Ok(value)
+}
+
+fn set_axis_property(
+    axis: &mut Map<String, Value>,
+    property: &str,
+    value: &Value,
+) -> Result<(), ChartError> {
+    match property {
+        "alignment" => {
+            let value = enum_string(value, "ChartAxis.alignment")?;
+            let normalized = normalize_token(
+                value,
+                "ChartAxis.alignment",
+                &[("Center", "ctr"), ("Left", "l"), ("Right", "r")],
+            )?;
+            axis.insert(
+                "alignment".to_string(),
+                Value::String(normalized.to_string()),
+            );
+        }
+        "baseTimeUnit" => {
+            let value = enum_string(value, "ChartAxis.baseTimeUnit")?;
+            insert_enum(
+                axis,
+                "baseTimeUnit",
+                value,
+                time_unit_tokens(),
+                "ChartAxis.baseTimeUnit",
+            )?;
+        }
+        "categoryType" => {
+            let value = enum_string(value, "ChartAxis.categoryType")?;
+            let normalized = normalize_token(
+                value,
+                "ChartAxis.categoryType",
+                &[
+                    ("Automatic", "automatic"),
+                    ("TextAxis", "text"),
+                    ("DateAxis", "date"),
+                ],
+            )?;
+            axis.insert(
+                "categoryType".to_string(),
+                Value::String(normalized.to_string()),
+            );
+        }
+        "displayUnit" => {
+            let value = enum_string(value, "ChartAxis.displayUnit")?;
+            insert_enum(
+                axis,
+                "displayUnit",
+                value,
+                display_unit_tokens(),
+                "ChartAxis.displayUnit",
+            )?;
+            if !value.eq_ignore_ascii_case("Custom") {
+                axis.remove("customDisplayUnit");
+            }
+        }
+        "isBetweenCategories" => {
+            let value = value.as_bool().ok_or_else(|| {
+                invalid("ChartAxis.isBetweenCategories must be a boolean".to_string())
+            })?;
+            axis.insert("isBetweenCategories".to_string(), Value::Bool(value));
+            axis.insert(
+                "crossBetween".to_string(),
+                Value::String(if value { "between" } else { "midCat" }.to_string()),
+            );
+        }
+        "linkNumberFormat" => {
+            let value = value.as_bool().ok_or_else(|| {
+                invalid("ChartAxis.linkNumberFormat must be a boolean".to_string())
+            })?;
+            axis.insert("linkNumberFormat".to_string(), Value::Bool(value));
+        }
+        "logBase" => {
+            let value = finite_number(value, "ChartAxis.logBase")?;
+            if value <= 1.0 {
+                return Err(invalid(
+                    "ChartAxis.logBase must be greater than 1".to_string(),
+                ));
+            }
+            insert_number(axis, "logBase", value);
+            axis.insert(
+                "scaleType".to_string(),
+                Value::String("logarithmic".to_string()),
+            );
+        }
+        "majorTickMark" => {
+            let value = enum_string(value, "ChartAxis.majorTickMark")?;
+            insert_enum(
+                axis,
+                "tickMarks",
+                value,
+                tick_mark_tokens(),
+                "ChartAxis.majorTickMark",
+            )?;
+        }
+        "majorTimeUnitScale" => {
+            let value = enum_string(value, "ChartAxis.majorTimeUnitScale")?;
+            insert_enum(
+                axis,
+                "majorTimeUnit",
+                value,
+                time_unit_tokens(),
+                "ChartAxis.majorTimeUnitScale",
+            )?;
+        }
+        "majorUnit" => set_number_or_auto(axis, "majorUnit", value, "ChartAxis.majorUnit", true)?,
+        "maximum" => set_number_or_auto(axis, "max", value, "ChartAxis.maximum", false)?,
+        "minimum" => set_number_or_auto(axis, "min", value, "ChartAxis.minimum", false)?,
+        "minorTickMark" => {
+            let value = enum_string(value, "ChartAxis.minorTickMark")?;
+            insert_enum(
+                axis,
+                "minorTickMarks",
+                value,
+                tick_mark_tokens(),
+                "ChartAxis.minorTickMark",
+            )?;
+        }
+        "minorTimeUnitScale" => {
+            let value = enum_string(value, "ChartAxis.minorTimeUnitScale")?;
+            insert_enum(
+                axis,
+                "minorTimeUnit",
+                value,
+                time_unit_tokens(),
+                "ChartAxis.minorTimeUnitScale",
+            )?;
+        }
+        "minorUnit" => set_number_or_auto(axis, "minorUnit", value, "ChartAxis.minorUnit", true)?,
+        "multiLevel" => {
+            let value = value
+                .as_bool()
+                .ok_or_else(|| invalid("ChartAxis.multiLevel must be a boolean".to_string()))?;
+            axis.insert("noMultiLevelLabels".to_string(), Value::Bool(!value));
+        }
+        "numberFormat" => {
+            let value = value
+                .as_str()
+                .ok_or_else(|| invalid("ChartAxis.numberFormat must be a string".to_string()))?;
+            axis.insert("numberFormat".to_string(), Value::String(value.to_string()));
+        }
+        "offset" => {
+            let value = bounded_integer(value, "ChartAxis.offset", 0, 1000)?;
+            axis.insert("labelOffset".to_string(), json!(value));
+        }
+        "position" => {
+            let value = enum_string(value, "ChartAxis.position")?;
+            insert_enum(
+                axis,
+                "crossesAt",
+                value,
+                position_tokens(),
+                "ChartAxis.position",
+            )?;
+            if !value.eq_ignore_ascii_case("Custom") {
+                axis.remove("crossesAtValue");
+            }
+        }
+        "reversePlotOrder" => {
+            let value = value.as_bool().ok_or_else(|| {
+                invalid("ChartAxis.reversePlotOrder must be a boolean".to_string())
+            })?;
+            axis.insert("reverse".to_string(), Value::Bool(value));
+        }
+        "scaleType" => {
+            let value = enum_string(value, "ChartAxis.scaleType")?;
+            match value {
+                "Linear" => {
+                    axis.insert("scaleType".to_string(), Value::String("linear".to_string()));
+                    axis.remove("logBase");
+                }
+                "Logarithmic" => {
+                    axis.insert(
+                        "scaleType".to_string(),
+                        Value::String("logarithmic".to_string()),
+                    );
+                    if !axis.contains_key("logBase") {
+                        insert_number(axis, "logBase", 10.0);
+                    }
+                }
+                other => {
+                    return Err(invalid(format!(
+                        "ChartAxis.scaleType must be Linear or Logarithmic; got '{other}'"
+                    )));
+                }
+            }
+        }
+        "showDisplayUnitLabel" => {
+            let value = value.as_bool().ok_or_else(|| {
+                invalid("ChartAxis.showDisplayUnitLabel must be a boolean".to_string())
+            })?;
+            if value {
+                axis.entry("displayUnitLabel".to_string())
+                    .or_insert_with(|| Value::String("Display Unit".to_string()));
+            } else {
+                axis.remove("displayUnitLabel");
+            }
+            axis.insert("showDisplayUnitLabel".to_string(), Value::Bool(value));
+        }
+        "textOrientation" => {
+            let value = text_orientation(value, "ChartAxis.textOrientation")?;
+            insert_number(axis, "textOrientation", value);
+        }
+        "tickLabelPosition" => {
+            let value = enum_string(value, "ChartAxis.tickLabelPosition")?;
+            insert_enum(
+                axis,
+                "tickLabelPosition",
+                value,
+                tick_label_position_tokens(),
+                "ChartAxis.tickLabelPosition",
+            )?;
+        }
+        "tickLabelSpacing" => {
+            if value.as_str() == Some("") {
+                axis.remove("tickLabelSpacing");
+            } else {
+                let value = bounded_integer(value, "ChartAxis.tickLabelSpacing", 1, 31999)?;
+                axis.insert("tickLabelSpacing".to_string(), json!(value));
+            }
+        }
+        "tickMarkSpacing" => {
+            let value = bounded_integer(value, "ChartAxis.tickMarkSpacing", 1, u32::MAX)?;
+            axis.insert("tickMarkSpacing".to_string(), json!(value));
+        }
+        "visible" => {
+            let value = value
+                .as_bool()
+                .ok_or_else(|| invalid("ChartAxis.visible must be a boolean".to_string()))?;
+            axis.insert("visible".to_string(), Value::Bool(value));
+            axis.insert("visibleExplicit".to_string(), Value::Bool(true));
+        }
+        "axisGroup" | "customDisplayUnit" | "height" | "left" | "positionAt" | "top" | "type"
+        | "width" => {
+            return Err(unsupported_set_property(format!(
+                "ChartAxis.{property} is read-only"
+            )));
+        }
+        "format" | "majorGridlines" | "minorGridlines" | "title" => {
+            return Err(unsupported_set_property(format!(
+                "ChartAxis.{property} is handled by its child object"
+            )));
+        }
+        other => return Err(unsupported_set_property(format!("ChartAxis.{other}"))),
+    }
+    Ok(())
+}
+
+fn effective_visible(axis: Option<&Map<String, Value>>) -> bool {
+    let visible = bool_value(axis, "visible").unwrap_or(true);
+    visible || !bool_value(axis, "visibleExplicit").unwrap_or(false)
+}
+
+fn set_number_or_auto(
+    axis: &mut Map<String, Value>,
+    key: &str,
+    value: &Value,
+    property: &str,
+    positive: bool,
+) -> Result<(), ChartError> {
+    if value.as_str() == Some("") {
+        axis.remove(key);
+        return Ok(());
+    }
+    let value = finite_number(value, property)?;
+    if positive && value <= 0.0 {
+        return Err(invalid(format!("{property} must be greater than zero")));
+    }
+    insert_number(axis, key, value);
+    Ok(())
+}
+
+fn bounded_integer(
+    value: &Value,
+    property: &str,
+    minimum: u32,
+    maximum: u32,
+) -> Result<u32, ChartError> {
+    let value = value
+        .as_u64()
+        .and_then(|value| u32::try_from(value).ok())
+        .or_else(|| {
+            value.as_f64().and_then(|value| {
+                (value.is_finite() && value.fract() == 0.0 && value >= 0.0)
+                    .then_some(value as u64)
+                    .and_then(|value| u32::try_from(value).ok())
+            })
+        })
+        .ok_or_else(|| invalid(format!("{property} must be an integer")))?;
+    if value < minimum || value > maximum {
+        return Err(invalid(format!(
+            "{property} must be between {minimum} and {maximum}"
+        )));
+    }
+    Ok(value)
+}
+
+fn text_orientation(value: &Value, property: &str) -> Result<f64, ChartError> {
+    let value = finite_number(value, property)?;
+    if value.fract() != 0.0 || (value < -90.0 || value > 90.0) && value != 180.0 {
+        return Err(invalid(format!(
+            "{property} must be an integer from -90 to 90 or 180"
+        )));
+    }
+    Ok(value)
+}
+
+fn enum_string<'a>(value: &'a Value, property: &str) -> Result<&'a str, ChartError> {
+    value
+        .as_str()
+        .ok_or_else(|| invalid(format!("{property} must be a string")))
+}
+
+fn insert_enum(
+    axis: &mut Map<String, Value>,
+    key: &str,
+    value: &str,
+    choices: &[(&str, &str)],
+    property: &str,
+) -> Result<(), ChartError> {
+    let normalized = choices
+        .iter()
+        .find(|(wire, output)| {
+            wire.eq_ignore_ascii_case(value) || output.eq_ignore_ascii_case(value)
+        })
+        .map(|(wire, _)| *wire)
+        .ok_or_else(|| invalid(format!("{property} has an invalid value '{value}'")))?;
+    axis.insert(key.to_string(), Value::String(normalized.to_string()));
+    Ok(())
+}
+
+fn normalize_token<'a>(
+    value: &str,
+    property: &str,
+    choices: &'a [(&'a str, &'a str)],
+) -> Result<&'a str, ChartError> {
+    choices
+        .iter()
+        .find(|(wire, _)| wire.eq_ignore_ascii_case(value))
+        .map(|(_, normalized)| *normalized)
+        .ok_or_else(|| invalid(format!("{property} has an invalid value '{value}'")))
+}
+
+fn token_value(
+    axis: Option<&Map<String, Value>>,
+    key: &str,
+    default: &str,
+    choices: &[(&str, &str)],
+) -> Value {
+    let raw = string_value(axis, key).unwrap_or_else(|| default.to_string());
+    let mapped = choices
+        .iter()
+        .find(|(wire, output)| wire.eq_ignore_ascii_case(&raw) || output.eq_ignore_ascii_case(&raw))
+        .map(|(_, output)| *output)
+        .unwrap_or(default);
+    Value::String(mapped.to_string())
+}
+
+fn tick_mark_tokens() -> &'static [(&'static str, &'static str)] {
+    &[
+        ("none", "None"),
+        ("cross", "Cross"),
+        ("in", "Inside"),
+        ("out", "Outside"),
+    ]
+}
+
+fn tick_label_position_tokens() -> &'static [(&'static str, &'static str)] {
+    &[
+        ("nextTo", "NextToAxis"),
+        ("high", "High"),
+        ("low", "Low"),
+        ("none", "None"),
+    ]
+}
+
+fn time_unit_tokens() -> &'static [(&'static str, &'static str)] {
+    &[("days", "Days"), ("months", "Months"), ("years", "Years")]
+}
+
+fn display_unit_tokens() -> &'static [(&'static str, &'static str)] {
+    &[
+        ("none", "None"),
+        ("hundreds", "Hundreds"),
+        ("thousands", "Thousands"),
+        ("tenThousands", "TenThousands"),
+        ("hundredThousands", "HundredThousands"),
+        ("millions", "Millions"),
+        ("tenMillions", "TenMillions"),
+        ("hundredMillions", "HundredMillions"),
+        ("billions", "Billions"),
+        ("trillions", "Trillions"),
+        ("custom", "Custom"),
+    ]
+}
+
+fn position_tokens() -> &'static [(&'static str, &'static str)] {
+    &[
+        ("automatic", "Automatic"),
+        ("max", "Maximum"),
+        ("min", "Minimum"),
+        ("custom", "Custom"),
+    ]
+}
+
+fn bool_value(axis: Option<&Map<String, Value>>, key: &str) -> Option<bool> {
+    axis.and_then(|axis| axis.get(key)).and_then(Value::as_bool)
+}
+
+fn number_value(axis: Option<&Map<String, Value>>, key: &str) -> Option<f64> {
+    axis.and_then(|axis| axis.get(key)).and_then(Value::as_f64)
+}
+
+fn string_value(axis: Option<&Map<String, Value>>, key: &str) -> Option<String> {
+    axis.and_then(|axis| axis.get(key))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn finite_number(value: &Value, property: &str) -> Result<f64, ChartError> {
+    let value = value
+        .as_f64()
+        .ok_or_else(|| invalid(format!("{property} must be a number")))?;
+    if !value.is_finite() {
+        return Err(invalid(format!("{property} must be finite")));
+    }
+    Ok(value)
+}
+
+fn insert_number(axis: &mut Map<String, Value>, key: &str, value: f64) {
+    axis.insert(key.to_string(), number_json(value));
+}
+
+fn number_json(value: f64) -> Value {
+    serde_json::Number::from_f64(value)
+        .map(Value::Number)
+        .unwrap_or(Value::Null)
+}
+
+fn batch_error(error: ChartError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn chart_error(error: crate::chart_core::ChartError) -> ChartError {
+    ChartError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn encoding(message: impl Into<String>) -> ChartError {
+    ChartError {
+        code: "GeneralException",
+        message: message.into(),
+    }
+}
+
+fn invalid(message: impl Into<String>) -> ChartError {
+    ChartError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn item_not_found(message: impl Into<String>) -> ChartError {
+    ChartError {
+        code: "ItemNotFound",
+        message: format!(
+            "The requested chart axis does not exist: {}",
+            message.into()
+        ),
+    }
+}
+
+fn unsupported_load_property(object: &str, property: &str) -> ChartError {
+    ChartError {
+        code: "InvalidArgument",
+        message: format!("{object}.{property} is not supported by this Office.js host"),
+    }
+}
+
+fn unsupported_set_property(message: impl Into<String>) -> ChartError {
+    ChartError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}

--- a/compute/officejs/src/chart_core.js
+++ b/compute/officejs/src/chart_core.js
@@ -1,0 +1,388 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs;
+
+  function propertyNotLoaded(name) {
+    var error = new OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function invalidArgument(message) {
+    var error = new OfficeExtension.Error({
+      code: "InvalidArgument",
+      message: message,
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidArgument";
+    return error;
+  }
+
+  function invalidRequestContext() {
+    var error = new OfficeExtension.Error({
+      code: "InvalidRequestContext",
+      message: "The object belongs to a different request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidRequestContext";
+    return error;
+  }
+
+  function apiNotFound(message) {
+    var error = new OfficeExtension.Error({
+      code: "ApiNotFound",
+      message: message,
+    });
+    error.name = "RichApi.Error";
+    error.code = "ApiNotFound";
+    return error;
+  }
+
+  function integerArgument(value, property) {
+    if (typeof value !== "number" || !isFinite(value) || Math.floor(value) !== value) {
+      throw invalidArgument(property + " must be an integer");
+    }
+    return value;
+  }
+
+  function stringArgument(value, property) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw invalidArgument(property + " must be a non-empty string");
+    }
+    return value;
+  }
+
+  function enumArgument(value, property) {
+    if (value !== undefined && value !== "Auto" && value !== "Rows" && value !== "Columns") {
+      throw invalidArgument(property + " must be Auto, Rows, or Columns");
+    }
+    return value;
+  }
+
+  function newClientResult(context) {
+    return officeJs.createClientResult(context);
+  }
+
+  function collectionItemsToJSON(collection) {
+    return (collection._items || []).map(function (item) {
+      return item && typeof item.toJSON === "function" ? item.toJSON() : item;
+    });
+  }
+
+  function navigationProperties(object) {
+    var names = (object._navigationProperties || []).slice();
+    (object._additionalNavigationProperties || []).forEach(function (name) {
+      if (names.indexOf(name) < 0) names.push(name);
+    });
+    return names;
+  }
+
+  function requirePropertyObject(source) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+  }
+
+  function rangeArgument(value, context, property, optional) {
+    if (value === undefined || value === null) {
+      if (optional) return null;
+      throw invalidArgument(property + " requires a Range or range address");
+    }
+    if (value instanceof Excel.Range) {
+      if (value.context !== context) throw invalidRequestContext();
+      return { rangeId: value._id };
+    }
+    if (typeof value === "string" && value.trim().length > 0) {
+      return { address: value };
+    }
+    throw invalidArgument(property + " requires a Range or range address");
+  }
+
+  function ChartCollection(context, worksheet) {
+    ClientObject.call(this, context);
+    this._worksheet = worksheet || null;
+    this._scalarProperties = ["items", "count"];
+    this._navigationProperties = ["items"];
+    this._itemCache = Object.create(null);
+
+    context._queue.push({
+      op: "getChartCollection",
+      id: this._id,
+      worksheetId: this._worksheet ? this._worksheet._id : null,
+    });
+
+    officeJs.configureCollection(this, function (key) {
+      return this.getItem(String(key));
+    });
+  }
+  ChartCollection.prototype = Object.create(ClientObject.prototype);
+  ChartCollection.prototype.constructor = ChartCollection;
+
+  Object.defineProperty(ChartCollection.prototype, "items", {
+    get: function () {
+      if (!this._loaded.items) throw propertyNotLoaded("items");
+      return this._items || [];
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(ChartCollection.prototype, "count", {
+    get: function () {
+      if (!this._loaded.count) throw propertyNotLoaded("count");
+      return this._count;
+    },
+    configurable: true,
+  });
+
+  ChartCollection.prototype.add = function (type, sourceData, seriesBy) {
+    type = stringArgument(type, "ChartCollection.add type");
+    if (!(sourceData instanceof Excel.Range)) {
+      throw invalidArgument("ChartCollection.add sourceData must be a Range");
+    }
+    if (sourceData.context !== this.context) throw invalidRequestContext();
+    enumArgument(seriesBy, "ChartCollection.add seriesBy");
+
+    var chart = new Chart(this.context, this._worksheet, this);
+    this.context._queue.push({
+      op: "chartAdd",
+      id: chart._id,
+      collectionId: this._id,
+      worksheetId: this._worksheet ? this._worksheet._id : null,
+      type: type,
+      rangeId: sourceData._id,
+      seriesBy: seriesBy === undefined ? null : seriesBy,
+    });
+    return chart;
+  };
+
+  ChartCollection.prototype.getItem = function (name) {
+    name = stringArgument(name, "ChartCollection.getItem name");
+    var cacheKey = "name:" + name.toLowerCase();
+    var chart = this._itemCache[cacheKey];
+    if (!chart) {
+      chart = new Chart(this.context, this._worksheet, this);
+      this._itemCache[cacheKey] = chart;
+      this.context._queue.push({
+        op: "chartGetItem",
+        id: chart._id,
+        collectionId: this._id,
+        worksheetId: this._worksheet ? this._worksheet._id : null,
+        name: name,
+        orNullObject: false,
+      });
+    }
+    return chart;
+  };
+
+  ChartCollection.prototype.getItemAt = function (index) {
+    index = integerArgument(index, "ChartCollection.getItemAt index");
+    var cacheKey = "index:" + index;
+    var chart = this._itemCache[cacheKey];
+    if (!chart) {
+      chart = new Chart(this.context, this._worksheet, this);
+      this._itemCache[cacheKey] = chart;
+      this.context._queue.push({
+        op: "chartGetItemAt",
+        id: chart._id,
+        collectionId: this._id,
+        worksheetId: this._worksheet ? this._worksheet._id : null,
+        index: index,
+      });
+    }
+    return chart;
+  };
+
+  ChartCollection.prototype.getItemOrNullObject = function (name) {
+    name = stringArgument(name, "ChartCollection.getItemOrNullObject name");
+    var cacheKey = "null:" + name.toLowerCase();
+    var chart = this._itemCache[cacheKey];
+    if (!chart) {
+      chart = new Chart(this.context, this._worksheet, this);
+      this._itemCache[cacheKey] = chart;
+      this.context._queue.push({
+        op: "chartGetItem",
+        id: chart._id,
+        collectionId: this._id,
+        worksheetId: this._worksheet ? this._worksheet._id : null,
+        name: name,
+        orNullObject: true,
+      });
+    }
+    return chart;
+  };
+
+  ChartCollection.prototype.getCount = function () {
+    var result = newClientResult(this.context);
+    this.context._queue.push({
+      op: "chartCollectionGetCount",
+      collectionId: this._id,
+      worksheetId: this._worksheet ? this._worksheet._id : null,
+      resultId: result._id,
+    });
+    return result;
+  };
+
+  ChartCollection.prototype.toJSON = function () {
+    if (!this._loaded.items) return {};
+    return { items: collectionItemsToJSON(this) };
+  };
+
+  function Chart(context, worksheet, collection) {
+    ClientObject.call(this, context);
+    this._worksheet = worksheet || null;
+    this._collection = collection || null;
+    this._scalarProperties = ["id", "name", "chartType", "height", "left", "top", "width"];
+    this._navigationProperties = [];
+  }
+  Chart.prototype = Object.create(ClientObject.prototype);
+  Chart.prototype.constructor = Chart;
+
+  // Child chart adapters use this internal value when constructing their
+  // operation payloads.  Before the first sync the proxy ID is the only
+  // available identity; after an id load, the persisted engine ID is used.
+  // Keeping the proxy fallback lets child navigation be requested in the
+  // same batch as chart creation without conflating the two IDs in the host.
+  Object.defineProperty(Chart.prototype, "_chartId", {
+    get: function () {
+      return this._idValue || this._id;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(Chart.prototype, "id", {
+    get: function () {
+      if (!this._loaded.id) throw propertyNotLoaded("id");
+      return this._idValue;
+    },
+    configurable: true,
+  });
+
+  ["name", "chartType", "height", "left", "top", "width"].forEach(function (name) {
+    Object.defineProperty(Chart.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        this["_" + name] = value;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: value,
+        });
+      },
+      configurable: true,
+    });
+  });
+
+  Chart.prototype.set = function (source, options) {
+    requirePropertyObject(source);
+    var isClientObject = source instanceof ClientObject;
+    if (isClientObject) {
+      if (Object.getPrototypeOf(this) !== Object.getPrototypeOf(source)) {
+        throw invalidArgument("The object passed to set must have the same type.");
+      }
+      source = source.toJSON();
+    }
+
+    ["name", "chartType", "height", "left", "top", "width"].forEach(function (name) {
+      if (Object.prototype.hasOwnProperty.call(source, name) && source[name] !== undefined) {
+        this[name] = source[name];
+      }
+    }, this);
+
+    var navigation = navigationProperties(this);
+    navigation.forEach(function (name) {
+      if (!Object.prototype.hasOwnProperty.call(source, name) || source[name] === undefined) {
+        return;
+      }
+      var child = isClientObject ? source[name] : source[name];
+      this[name].set(child, options);
+    }, this);
+  };
+
+  Chart.prototype.activate = function () {
+    throw apiNotFound("Chart.activate is not supported by this host.");
+  };
+
+  Chart.prototype.delete = function () {
+    this.context._queue.push({
+      op: "chartDelete",
+      id: this._id,
+      chartId: this._chartId,
+      worksheetId: this._worksheet ? this._worksheet._id : null,
+    });
+  };
+
+  Chart.prototype.setData = function (sourceData, seriesBy) {
+    if (!(sourceData instanceof Excel.Range)) {
+      throw invalidArgument("Chart.setData sourceData must be a Range");
+    }
+    if (sourceData.context !== this.context) throw invalidRequestContext();
+    enumArgument(seriesBy, "Chart.setData seriesBy");
+    this.context._queue.push({
+      op: "chartSetData",
+      id: this._id,
+      chartId: this._chartId,
+      worksheetId: this._worksheet ? this._worksheet._id : null,
+      rangeId: sourceData._id,
+      seriesBy: seriesBy === undefined ? null : seriesBy,
+    });
+  };
+
+  Chart.prototype.setPosition = function (startCell, endCell) {
+    var start = rangeArgument(startCell, this.context, "Chart.setPosition startCell", false);
+    var end = rangeArgument(endCell, this.context, "Chart.setPosition endCell", true);
+    var operation = {
+      op: "chartSetPosition",
+      id: this._id,
+      chartId: this._chartId,
+      worksheetId: this._worksheet ? this._worksheet._id : null,
+    };
+    if (start.rangeId !== undefined) operation.startRangeId = start.rangeId;
+    else operation.startAddress = start.address;
+    if (end) {
+      if (end.rangeId !== undefined) operation.endRangeId = end.rangeId;
+      else operation.endAddress = end.address;
+    }
+    this.context._queue.push(operation);
+  };
+
+  Chart.prototype.toJSON = function () {
+    var data = {};
+    (this._scalarProperties || []).forEach(function (name) {
+      if (!this._loaded[name]) return;
+      data[name] = name === "id" ? this._idValue : this["_" + name];
+    }, this);
+
+    navigationProperties(this).forEach(function (name) {
+      var child = this["_" + name];
+      if (child && typeof child.toJSON === "function") data[name] = child.toJSON();
+    }, this);
+    return data;
+  };
+
+  Object.defineProperty(Excel.Worksheet.prototype, "charts", {
+    get: function () {
+      if (!this._charts) this._charts = new ChartCollection(this.context, this);
+      return this._charts;
+    },
+    configurable: true,
+  });
+
+  Excel.ChartCollection = ChartCollection;
+  Excel.Chart = Chart;
+})(globalThis);

--- a/compute/officejs/src/chart_core.rs
+++ b/compute/officejs/src/chart_core.rs
@@ -1,0 +1,674 @@
+//! Office.js chart collection and chart core bindings.
+//!
+//! The Office.js layer keeps request-context proxy IDs separate from the
+//! persisted floating-object IDs used by the compute engine.  `ChartRef`
+//! therefore stores the engine chart ID and resolves the current chart for
+//! every operation.  This is what keeps a chart proxy valid after a chart is
+//! renamed or its worksheet position changes.
+//!
+//! The JavaScript adapter's host wire contract is intentionally small:
+//! `getChartCollection { id, worksheetId }`, `chartAdd { id, collectionId,
+//! worksheetId, type, rangeId, seriesBy }`, `chartGetItem { id,
+//! collectionId, worksheetId, name, orNullObject }`, `chartGetItemAt { id,
+//! collectionId, worksheetId, index }`, `chartCollectionGetCount {
+//! collectionId, worksheetId, resultId }`, `chartSetData { id, rangeId,
+//! seriesBy }`, `chartSetPosition { id, startRangeId|startAddress,
+//! endRangeId|endAddress }`, and `chartDelete { id }`.  Core scalar writes
+//! use the shared `set { id, property, value }` operation.  Collection and
+//! chart loads use the shared `load { id, properties }` operation.
+
+use std::collections::HashMap;
+
+use compute_api::{CellRange, Sheet};
+use serde::Serialize;
+use serde_json::{json, Value};
+
+/// Errors returned by the chart Office.js adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChartError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+/// A chart item in a `ChartCollection` hydration response.
+///
+/// The JavaScript collection helper uses `key` to enter the normal
+/// `ChartCollection.getItem` path, then hydrates the returned chart proxy with
+/// the listed scalar properties.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ChartCollectionItem {
+    pub(crate) key: String,
+    pub(crate) properties: HashMap<String, Value>,
+}
+
+/// A host-side chart reference anchored by the engine's stable object ID.
+#[derive(Clone)]
+pub(crate) struct ChartRef {
+    sheet: Sheet,
+    stable_id: String,
+}
+
+/// A worksheet-scoped chart collection.
+#[derive(Clone)]
+pub(crate) struct ChartCollectionRef {
+    sheet: Sheet,
+}
+
+const DEFAULT_CHART_PROPERTIES: &[&str] =
+    &["id", "name", "chartType", "height", "left", "top", "width"];
+
+impl ChartCollectionRef {
+    /// Construct a worksheet-scoped chart collection.
+    pub(crate) fn new(sheet: Sheet) -> Self {
+        Self { sheet }
+    }
+
+    /// Return the worksheet backing this collection.
+    pub(crate) fn sheet(&self) -> Sheet {
+        self.sheet.clone()
+    }
+
+    /// Create a chart from an Office.js chart type and source range.
+    ///
+    /// The compute API owns ID allocation, timestamps, and persistence.  The
+    /// Office.js adapter only translates the source range and series
+    /// orientation into the engine's chart configuration.
+    pub(crate) fn add(
+        &self,
+        chart_type: &str,
+        source_data: &str,
+        series_by: Option<&str>,
+    ) -> Result<ChartRef, ChartError> {
+        let chart_type = required_string(chart_type, "ChartCollection.add type")?;
+        validate_range(source_data, "ChartCollection.add sourceData")?;
+        let series_orientation = series_orientation(series_by)?;
+
+        let mut config = json!({
+            "chartType": chart_type,
+            "dataRange": source_data,
+            "width": 400.0,
+            "height": 300.0,
+            "widthPt": 400.0,
+            "heightPt": 300.0,
+            "leftPt": 0.0,
+            "topPt": 0.0,
+        });
+        if let Some(orientation) = series_orientation {
+            config["seriesOrientation"] = Value::String(orientation.to_string());
+        }
+
+        let result = self.sheet.charts().create(&config).map_err(compute_error)?;
+        let stable_id = result
+            .data
+            .as_ref()
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty())
+            .ok_or_else(|| encoding("ChartCollection.add did not return a chart ID"))?;
+        Ok(ChartRef::new(self.sheet.clone(), stable_id))
+    }
+
+    /// Resolve a chart by its name or stable engine ID.
+    pub(crate) fn get_item(&self, key: &str) -> Result<ChartRef, ChartError> {
+        let key = required_string(key, "ChartCollection.getItem name")?;
+        let chart = self
+            .charts()?
+            .into_iter()
+            .find(|chart| {
+                chart_id(chart).eq_ignore_ascii_case(key)
+                    || chart_name(chart).eq_ignore_ascii_case(key)
+            })
+            .ok_or_else(|| item_not_found(key))?;
+        Ok(ChartRef::new(self.sheet.clone(), chart_id(&chart)))
+    }
+
+    /// Resolve a chart by name or ID, returning `None` for a missing item.
+    pub(crate) fn get_item_or_null_object(
+        &self,
+        key: &str,
+    ) -> Result<Option<ChartRef>, ChartError> {
+        let key = required_string(key, "ChartCollection.getItemOrNullObject name")?;
+        Ok(self
+            .charts()?
+            .into_iter()
+            .find(|chart| {
+                chart_id(chart).eq_ignore_ascii_case(key)
+                    || chart_name(chart).eq_ignore_ascii_case(key)
+            })
+            .map(|chart| ChartRef::new(self.sheet.clone(), chart_id(&chart))))
+    }
+
+    /// Resolve a chart by zero-based collection position.
+    pub(crate) fn get_item_at(&self, index: i64) -> Result<ChartRef, ChartError> {
+        let charts = self.charts()?;
+        let index = checked_collection_index(index, charts.len(), "chart")?;
+        Ok(ChartRef::new(self.sheet.clone(), chart_id(&charts[index])))
+    }
+
+    /// Return the number of charts in this worksheet.
+    pub(crate) fn get_count(&self) -> Result<usize, ChartError> {
+        Ok(self.charts()?.len())
+    }
+
+    /// Alias used by host integrations that model collection count as a
+    /// property rather than the Office.js `getCount` method.
+    pub(crate) fn count(&self) -> Result<usize, ChartError> {
+        self.get_count()
+    }
+
+    /// Project the properties requested by a generic Office.js `load` action.
+    ///
+    /// Collection items are returned as descriptors because the JavaScript
+    /// collection hydrator owns the item proxy cache.  A descriptor's key is
+    /// the persisted chart ID, so the following `getItem` action resolves the
+    /// same chart even if its name changes between batches.
+    pub(crate) fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, ChartError> {
+        let mut result = HashMap::new();
+        let mut item_properties = Vec::new();
+        let mut load_items = false;
+
+        for property in properties {
+            match property.as_str() {
+                "count" => {
+                    result.insert(property.clone(), json!(self.get_count()?));
+                }
+                "isNullObject" => {
+                    result.insert(property.clone(), Value::Bool(false));
+                }
+                "items" => load_items = true,
+                item_path if item_path.starts_with("items/") => {
+                    let item_property = item_path.trim_start_matches("items/");
+                    if item_property.is_empty() || item_property.contains('/') {
+                        return Err(invalid(format!(
+                            "Invalid ChartCollection item property '{item_path}'"
+                        )));
+                    }
+                    load_items = true;
+                    item_properties.push(item_property.to_string());
+                }
+                other => return Err(unsupported_load_property("ChartCollection", other)),
+            }
+        }
+
+        if load_items {
+            let items = self.collection_items(&item_properties)?;
+            result.insert(
+                "items".to_string(),
+                serde_json::to_value(items).map_err(encoding)?,
+            );
+        }
+        Ok(result)
+    }
+
+    /// Return descriptors for collection hydration.
+    pub(crate) fn collection_items(
+        &self,
+        properties: &[String],
+    ) -> Result<Vec<ChartCollectionItem>, ChartError> {
+        let properties = if properties.is_empty() {
+            DEFAULT_CHART_PROPERTIES
+                .iter()
+                .map(|property| (*property).to_string())
+                .collect::<Vec<_>>()
+        } else {
+            properties.to_vec()
+        };
+
+        self.charts()?
+            .into_iter()
+            .map(|chart| {
+                let key = chart_id(&chart);
+                let reference = ChartRef::new(self.sheet.clone(), key.clone());
+                Ok(ChartCollectionItem {
+                    key,
+                    properties: reference.load(&properties)?,
+                })
+            })
+            .collect()
+    }
+
+    fn charts(&self) -> Result<Vec<Value>, ChartError> {
+        self.sheet
+            .charts()
+            .get_all()
+            .map_err(compute_error)
+            .and_then(|charts| {
+                charts
+                    .into_iter()
+                    .map(|chart| serde_json::to_value(chart).map_err(encoding))
+                    .collect()
+            })
+    }
+}
+
+impl ChartRef {
+    /// Construct a chart reference from a stable engine object ID.
+    pub(crate) fn new(sheet: Sheet, stable_id: impl Into<String>) -> Self {
+        Self {
+            sheet,
+            stable_id: stable_id.into(),
+        }
+    }
+
+    /// Return the stable engine chart ID.
+    pub(crate) fn stable_id(&self) -> &str {
+        &self.stable_id
+    }
+
+    /// Alias for integrations that call the persisted ID simply `id`.
+    pub(crate) fn id(&self) -> &str {
+        self.stable_id()
+    }
+
+    /// Return the worksheet containing this chart.
+    pub(crate) fn sheet(&self) -> Sheet {
+        self.sheet.clone()
+    }
+
+    /// Load the core Chart scalar properties supported by this adapter.
+    pub(crate) fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, ChartError> {
+        let chart = self.snapshot()?;
+        let properties = if properties.is_empty() {
+            DEFAULT_CHART_PROPERTIES
+                .iter()
+                .map(|property| (*property).to_string())
+                .collect::<Vec<_>>()
+        } else {
+            properties.to_vec()
+        };
+
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                "id" => Value::String(chart_id(&chart)),
+                "name" => Value::String(chart_name(&chart)),
+                "chartType" => chart_type(&chart)?,
+                "height" => number_property(&chart, "/height", "Chart.height")?,
+                "width" => number_property(&chart, "/width", "Chart.width")?,
+                "left" => {
+                    chart_position(&self.sheet, &chart, "left", "/anchor/anchorColOffsetEmu")?
+                }
+                "top" => chart_position(&self.sheet, &chart, "top", "/anchor/anchorRowOffsetEmu")?,
+                "isNullObject" => Value::Bool(false),
+                other => return Err(unsupported_load_property(other)),
+            };
+            result.insert(property, value);
+        }
+        Ok(result)
+    }
+
+    /// Return the complete current chart snapshot for child adapters.
+    pub(crate) fn snapshot(&self) -> Result<Value, ChartError> {
+        let chart = self
+            .sheet
+            .charts()
+            .get(&self.stable_id)
+            .map_err(compute_error)?
+            .ok_or_else(|| item_not_found(&self.stable_id))?;
+        serde_json::to_value(chart).map_err(encoding)
+    }
+
+    /// Apply a partial chart update through the persisted compute-api chart
+    /// facade. Child adapters use this helper for chart-owned nested fields.
+    pub(crate) fn update_fields(&self, updates: &Value) -> Result<(), ChartError> {
+        if !updates.is_object() {
+            return Err(invalid("Chart updates must be an object"));
+        }
+        self.ensure_exists()?;
+        self.sheet
+            .charts()
+            .update(&self.stable_id, updates)
+            .map_err(compute_error)?;
+        Ok(())
+    }
+
+    /// Set a writable core Chart property.
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), ChartError> {
+        let updates = match property {
+            "name" => json!({ "name": required_value_string(value, "Chart.name")? }),
+            "chartType" => {
+                json!({ "chartType": required_value_string(value, "Chart.chartType")? })
+            }
+            "height" => {
+                let value = required_finite_number(value, "Chart.height")?;
+                json!({ "height": value, "heightPt": value })
+            }
+            "width" => {
+                let value = required_finite_number(value, "Chart.width")?;
+                json!({ "width": value, "widthPt": value })
+            }
+            "left" => {
+                let value = required_finite_number(value, "Chart.left")?;
+                json!({ "leftPt": value })
+            }
+            "top" => {
+                let value = required_finite_number(value, "Chart.top")?;
+                json!({ "topPt": value })
+            }
+            "id" => {
+                return Err(ChartError {
+                    code: "InvalidArgument",
+                    message: "Chart.id is read-only".to_string(),
+                });
+            }
+            other => {
+                return Err(ChartError {
+                    code: "InvalidArgument",
+                    message: format!("Chart.{other} is read-only or unsupported"),
+                });
+            }
+        };
+        self.update_fields(&updates)
+    }
+
+    /// Reset the source data range and optional series orientation.
+    pub(crate) fn set_data(
+        &self,
+        source_data: &str,
+        series_by: Option<&str>,
+    ) -> Result<(), ChartError> {
+        validate_range(source_data, "Chart.setData sourceData")?;
+        let mut updates = json!({ "dataRange": source_data });
+        if series_by.is_some() {
+            updates["seriesOrientation"] = match series_by {
+                Some("Rows") => Value::String("rows".to_string()),
+                Some("Columns") => Value::String("columns".to_string()),
+                Some("Auto") => Value::Null,
+                Some(other) => {
+                    return Err(invalid(format!(
+                        "Chart seriesBy must be Auto, Rows, or Columns; got '{other}'"
+                    )));
+                }
+                None => unreachable!("series_by.is_some() was checked above"),
+            };
+        }
+        self.update_fields(&updates)
+    }
+
+    /// Position the chart from worksheet cell/range addresses.
+    ///
+    /// The engine stores anchor coordinates as zero-based rows and columns.
+    /// The chart's point position is projected from the worksheet layout.  If
+    /// an end range is supplied, the chart is resized to cover the current
+    /// persisted dimensions of the covered cells and is switched to a
+    /// two-cell anchor.
+    pub(crate) fn set_position(
+        &self,
+        start_cell: &str,
+        end_cell: Option<&str>,
+    ) -> Result<(), ChartError> {
+        let start = resolve_range(start_cell, "Chart.setPosition startCell")?;
+        let (start_row, start_col, _, _) = start;
+        let left = (0..start_col).try_fold(0.0, |total, column| {
+            self.sheet
+                .layout()
+                .get_col_width(column)
+                .map(|width| total + width)
+                .map_err(compute_error)
+        })?;
+        let top = (0..start_row).try_fold(0.0, |total, row| {
+            self.sheet
+                .layout()
+                .get_row_height(row)
+                .map(|height| total + height)
+                .map_err(compute_error)
+        })?;
+        let mut updates = json!({
+            "anchor": {
+                "anchorRow": start_row,
+                "anchorCol": start_col,
+                "anchorMode": "oneCell",
+            },
+            "leftPt": left,
+            "topPt": top,
+        });
+
+        if let Some(end_cell) = end_cell {
+            let end = resolve_range(end_cell, "Chart.setPosition endCell")?;
+            let (_, _, end_row, end_col) = end;
+            if end_row < start_row || end_col < start_col {
+                return Err(invalid(
+                    "Chart.setPosition endCell must be at or below and to the right of startCell"
+                        .to_string(),
+                ));
+            }
+            let width = (start_col..=end_col).try_fold(0.0, |total, column| {
+                self.sheet
+                    .layout()
+                    .get_col_width(column)
+                    .map(|width| total + width)
+                    .map_err(compute_error)
+            })?;
+            let height = (start_row..=end_row).try_fold(0.0, |total, row| {
+                self.sheet
+                    .layout()
+                    .get_row_height(row)
+                    .map(|height| total + height)
+                    .map_err(compute_error)
+            })?;
+            updates["anchor"]["endRow"] = json!(end_row);
+            updates["anchor"]["endCol"] = json!(end_col);
+            updates["anchor"]["anchorMode"] = Value::String("twoCell".to_string());
+            updates["width"] = json!(width);
+            updates["height"] = json!(height);
+            updates["widthPt"] = json!(width);
+            updates["heightPt"] = json!(height);
+        }
+        self.update_fields(&updates)
+    }
+
+    /// Delete the chart from its worksheet.
+    pub(crate) fn delete(&self) -> Result<(), ChartError> {
+        self.ensure_exists()?;
+        self.sheet
+            .charts()
+            .delete(&self.stable_id)
+            .map_err(compute_error)?;
+        Ok(())
+    }
+
+    fn ensure_exists(&self) -> Result<(), ChartError> {
+        self.sheet
+            .charts()
+            .get(&self.stable_id)
+            .map_err(compute_error)?
+            .map(|_| ())
+            .ok_or_else(|| item_not_found(&self.stable_id))
+    }
+}
+
+const EMU_PER_POINT: f64 = 12_700.0;
+
+fn chart_id(chart: &Value) -> String {
+    chart
+        .get("id")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn chart_name(chart: &Value) -> String {
+    chart
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn chart_type(chart: &Value) -> Result<Value, ChartError> {
+    chart
+        .get("chartType")
+        .cloned()
+        .ok_or_else(|| encoding("Persisted chart has no chartType"))
+}
+
+fn number_property(chart: &Value, pointer: &str, property: &str) -> Result<Value, ChartError> {
+    chart
+        .pointer(pointer)
+        .and_then(Value::as_f64)
+        .and_then(serde_json::Number::from_f64)
+        .map(Value::Number)
+        .ok_or_else(|| encoding(format!("Persisted chart has no finite {property}")))
+}
+
+fn chart_position(
+    sheet: &Sheet,
+    chart: &Value,
+    side: &str,
+    anchor_pointer: &str,
+) -> Result<Value, ChartError> {
+    if let Some(value) = chart
+        .get(match side {
+            "left" => "leftPt",
+            "top" => "topPt",
+            _ => unreachable!("chart position side is validated by callers"),
+        })
+        .and_then(Value::as_f64)
+        .and_then(serde_json::Number::from_f64)
+    {
+        return Ok(Value::Number(value));
+    }
+
+    // A chart created from a cell anchor may carry only EMU offsets. Resolve
+    // the cell origin through the persisted worksheet layout, then expose the
+    // result in the Office.js point unit used by `left` and `top`.
+    let anchor = chart.get("anchor");
+    let anchor_index = anchor
+        .and_then(|anchor| {
+            anchor
+                .get(if side == "left" {
+                    "anchorCol"
+                } else {
+                    "anchorRow"
+                })
+                .and_then(Value::as_u64)
+        })
+        .and_then(|index| u32::try_from(index).ok())
+        .unwrap_or(0);
+    let origin = if side == "left" {
+        (0..anchor_index).try_fold(0.0, |total, column| {
+            sheet
+                .layout()
+                .get_col_width(column)
+                .map(|width| total + width)
+                .map_err(compute_error)
+        })?
+    } else {
+        (0..anchor_index).try_fold(0.0, |total, row| {
+            sheet
+                .layout()
+                .get_row_height(row)
+                .map(|height| total + height)
+                .map_err(compute_error)
+        })?
+    };
+    let emu = chart
+        .pointer(anchor_pointer)
+        .and_then(Value::as_f64)
+        .unwrap_or(0.0);
+    serde_json::Number::from_f64(origin + emu / EMU_PER_POINT)
+        .map(Value::Number)
+        .ok_or_else(|| encoding(format!("Persisted chart has no finite Chart.{side}")))
+}
+
+fn resolve_range(address: &str, property: &str) -> Result<(u32, u32, u32, u32), ChartError> {
+    validate_range(address, property)?;
+    CellRange::from(address).resolve().map_err(compute_error)
+}
+
+fn validate_range(address: &str, property: &str) -> Result<(), ChartError> {
+    let (start_row, start_col, end_row, end_col) =
+        CellRange::from(address).resolve().map_err(compute_error)?;
+    if start_row > end_row || start_col > end_col {
+        return Err(invalid(format!("{property} must be a non-empty range")));
+    }
+    Ok(())
+}
+
+fn series_orientation(series_by: Option<&str>) -> Result<Option<&'static str>, ChartError> {
+    match series_by {
+        None | Some("Auto") => Ok(None),
+        Some("Rows") => Ok(Some("rows")),
+        Some("Columns") => Ok(Some("columns")),
+        Some(other) => Err(invalid(format!(
+            "Chart seriesBy must be Auto, Rows, or Columns; got '{other}'"
+        ))),
+    }
+}
+
+fn required_string<'a>(value: &'a str, property: &str) -> Result<&'a str, ChartError> {
+    if value.trim().is_empty() {
+        Err(invalid(format!("{property} must be a non-empty string")))
+    } else {
+        Ok(value)
+    }
+}
+
+fn required_value_string<'a>(value: &'a Value, property: &str) -> Result<&'a str, ChartError> {
+    value
+        .as_str()
+        .ok_or_else(|| invalid(format!("{property} must be a string")))
+        .and_then(|value| required_string(value, property))
+}
+
+fn required_finite_number(value: &Value, property: &str) -> Result<f64, ChartError> {
+    let number = value
+        .as_f64()
+        .ok_or_else(|| invalid(format!("{property} must be a number")))?;
+    if !number.is_finite() {
+        return Err(invalid(format!("{property} must be finite")));
+    }
+    Ok(number)
+}
+
+fn checked_collection_index(index: i64, length: usize, kind: &str) -> Result<usize, ChartError> {
+    let index = usize::try_from(index).map_err(|_| item_not_found(&index.to_string()))?;
+    if index >= length {
+        return Err(ChartError {
+            code: "ItemNotFound",
+            message: format!("The requested {kind} index {index} is outside the collection."),
+        });
+    }
+    Ok(index)
+}
+
+fn compute_error(error: compute_api::ComputeApiError) -> ChartError {
+    let code = match &error {
+        compute_api::ComputeApiError::SheetNotFound { .. } => "ItemNotFound",
+        compute_api::ComputeApiError::InvalidAddress { .. }
+        | compute_api::ComputeApiError::InvalidRange { .. } => "InvalidArgument",
+        compute_api::ComputeApiError::InvalidOperation(_) => "InvalidOperation",
+        _ => "GeneralException",
+    };
+    ChartError {
+        code,
+        message: error.to_string(),
+    }
+}
+
+fn encoding(error: impl std::fmt::Display) -> ChartError {
+    ChartError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn item_not_found(key: &str) -> ChartError {
+    ChartError {
+        code: "ItemNotFound",
+        message: format!("The requested chart doesn't exist. Name or ID: {key}"),
+    }
+}
+
+fn invalid(message: String) -> ChartError {
+    ChartError {
+        code: "InvalidArgument",
+        message,
+    }
+}
+
+fn unsupported_load_property(property: &str) -> ChartError {
+    ChartError {
+        code: "InvalidArgument",
+        message: format!("Chart.{property} is not supported by this Office.js host"),
+    }
+}

--- a/compute/officejs/src/chart_format.js
+++ b/compute/officejs/src/chart_format.js
@@ -1,0 +1,963 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs;
+
+  function error(code, message) {
+    var result = new OfficeExtension.Error({ code: code, message: message });
+    result.name = "RichApi.Error";
+    result.code = code;
+    return result;
+  }
+
+  function propertyNotLoaded(name) {
+    return error(
+      "PropertyNotLoaded",
+      "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context."
+    );
+  }
+
+  function invalidArgument(message) {
+    return error("InvalidArgument", message);
+  }
+
+  function unsupported(message) {
+    return error("ApiNotFound", message);
+  }
+
+  function invalidRequestContext() {
+    return error(
+      "InvalidRequestContext",
+      "The object belongs to a different request context."
+    );
+  }
+
+  function requireObject(source) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+  }
+
+  function bool(value, property) {
+    if (typeof value !== "boolean") {
+      throw invalidArgument(property + " must be a boolean");
+    }
+    return value;
+  }
+
+  function string(value, property) {
+    if (typeof value !== "string") {
+      throw invalidArgument(property + " must be a string");
+    }
+    return value;
+  }
+
+  function nonEmptyString(value, property) {
+    value = string(value, property);
+    if (value.trim().length === 0) {
+      throw invalidArgument(property + " must be a non-empty string");
+    }
+    return value;
+  }
+
+  function finiteNumber(value, property) {
+    if (typeof value !== "number" || !isFinite(value)) {
+      throw invalidArgument(property + " must be a finite number");
+    }
+    return value;
+  }
+
+  function orientation(value, property) {
+    value = finiteNumber(value, property);
+    if (!((-90 <= value && value <= 90) || value === 180)) {
+      throw invalidArgument(property + " must be -90 through 90, or 180");
+    }
+    return value;
+  }
+
+  function enumValue(value, property, values) {
+    if (typeof value !== "string" || values.indexOf(value) < 0) {
+      throw invalidArgument(
+        property + " must be one of: " + values.join(", ")
+      );
+    }
+    return value;
+  }
+
+  function color(value, property) {
+    value = string(value, property);
+    var hex = value.charAt(0) === "#" ? value.slice(1) : value;
+    if (!/^[0-9a-fA-F]{6}$/.test(hex)) {
+      throw invalidArgument(
+        property +
+          " must be an HTML #RRGGBB color; named and theme colors are not persisted by the chart model"
+      );
+    }
+    return "#" + hex.toUpperCase();
+  }
+
+  function navigationProperties(object) {
+    var names = (object._navigationProperties || []).slice();
+    (object._additionalNavigationProperties || []).forEach(function (name) {
+      if (names.indexOf(name) < 0) names.push(name);
+    });
+    return names;
+  }
+
+  function setProperties(source, options) {
+    requireObject(source);
+    var isClientObject = source instanceof ClientObject;
+    var properties = source;
+    if (isClientObject) {
+      if (
+        Object.getPrototypeOf(this) !== Object.getPrototypeOf(source) ||
+        source.context !== this.context
+      ) {
+        throw invalidArgument("The object passed to set must have the same type and request context.");
+      }
+      properties = source.toJSON();
+    }
+
+    var scalar = this._scalarProperties || [];
+    for (var i = 0; i < scalar.length; i++) {
+      var name = scalar[i];
+      if (
+        Object.prototype.hasOwnProperty.call(properties, name) &&
+        properties[name] !== undefined
+      ) {
+        this[name] = properties[name];
+      }
+    }
+
+    var nav = navigationProperties(this);
+    for (i = 0; i < nav.length; i++) {
+      name = nav[i];
+      if (
+        !Object.prototype.hasOwnProperty.call(properties, name) ||
+        properties[name] === undefined
+      ) {
+        continue;
+      }
+      var child = isClientObject ? source[name] : properties[name];
+      this[name].set(child, options);
+    }
+  }
+
+  function toJSON() {
+    var data = {};
+    var scalar = this._scalarProperties || [];
+    for (var i = 0; i < scalar.length; i++) {
+      var name = scalar[i];
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }
+    var nav = navigationProperties(this);
+    for (i = 0; i < nav.length; i++) {
+      var child = this["_" + nav[i]];
+      if (child && typeof child.toJSON === "function") {
+        data[nav[i]] = child.toJSON();
+      }
+    }
+    return data;
+  }
+
+  function defineScalar(ctor, name, writable, validator) {
+    Object.defineProperty(ctor.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        if (!writable) {
+          throw unsupported(ctor._officeType + "." + name + " is read-only");
+        }
+        if (validator) value = validator(value, name);
+        this["_" + name] = value;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: value,
+        });
+      },
+      configurable: true,
+    });
+  }
+
+  function defineScalars(ctor, names, validators, readOnly) {
+    ctor._officeType = ctor._officeType || ctor.name || "ChartObject";
+    names.forEach(function (name) {
+      var writable = !readOnly || readOnly.indexOf(name) < 0;
+      defineScalar(ctor, name, writable, validators && validators[name]);
+    });
+  }
+
+  function commonPrototype(ctor, typeName, scalar, validators, readOnly) {
+    ctor._officeType = typeName;
+    // Keep the function's existing prototype object.  Format navigation
+    // descriptors are installed once below; replacing the prototype from a
+    // constructor would discard those descriptors on the first object.
+    if (!(ctor.prototype instanceof ClientObject)) {
+      Object.setPrototypeOf(ctor.prototype, ClientObject.prototype);
+    }
+    ctor.prototype.constructor = ctor;
+    ctor.prototype.set = setProperties;
+    ctor.prototype.toJSON = toJSON;
+    ctor.prototype._scalarProperties = scalar.slice();
+    defineScalars(ctor, scalar, validators, readOnly || []);
+  }
+
+  function chartFor(object) {
+    return object._chart || object;
+  }
+
+  function queueIdentity(object, operation) {
+    var chart = chartFor(object);
+    operation.parentId = chart._id;
+    if (chart._chartId !== undefined && chart._chartId !== null) {
+      operation.chartId = String(chart._chartId);
+    } else if (chart._idValue !== undefined && chart._idValue !== null) {
+      operation.chartId = String(chart._idValue);
+    }
+    if (chart._worksheet && chart._worksheet._id) {
+      operation.worksheetId = chart._worksheet._id;
+    }
+  }
+
+  function queueObject(object, kind) {
+    var operation = {
+      op: "chartFormatGetObject",
+      id: object._id,
+      kind: kind,
+    };
+    queueIdentity(object, operation);
+    object.context._queue.push(operation);
+  }
+
+  function queueCollection(object) {
+    var operation = {
+      op: "chartFormatGetLegendEntries",
+      id: object._id,
+    };
+    queueIdentity(object, operation);
+    object.context._queue.push(operation);
+  }
+
+  function createResult(context) {
+    return officeJs && officeJs.createClientResult
+      ? officeJs.createClientResult(context)
+      : new OfficeExtension.ClientResult(context);
+  }
+
+  var horizontalAlignmentValues = [
+    "Center",
+    "Left",
+    "Right",
+    "Justify",
+    "Distributed",
+  ];
+  var verticalAlignmentValues = [
+    "Center",
+    "Bottom",
+    "Top",
+    "Justify",
+    "Distributed",
+  ];
+  var titlePositionValues = [
+    "Automatic",
+    "Top",
+    "Bottom",
+    "Left",
+    "Right",
+  ];
+  var legendPositionValues = [
+    "Invalid",
+    "Top",
+    "Bottom",
+    "Left",
+    "Right",
+    "Corner",
+    "Custom",
+  ];
+  var labelPositionValues = [
+    "Invalid",
+    "None",
+    "Center",
+    "InsideEnd",
+    "InsideBase",
+    "OutsideEnd",
+    "Left",
+    "Right",
+    "Top",
+    "Bottom",
+    "BestFit",
+    "Callout",
+  ];
+  var lineStyleValues = [
+    "None",
+    "Continuous",
+    "Dash",
+    "DashDot",
+    "DashDotDot",
+    "Dot",
+    "Grey25",
+    "Grey50",
+    "Grey75",
+    "Automatic",
+    "RoundDot",
+  ];
+  var colorSchemeValues = [
+    "ColorfulPalette1",
+    "ColorfulPalette2",
+    "ColorfulPalette3",
+    "ColorfulPalette4",
+    "MonochromaticPalette1",
+    "MonochromaticPalette2",
+    "MonochromaticPalette3",
+    "MonochromaticPalette4",
+    "MonochromaticPalette5",
+    "MonochromaticPalette6",
+    "MonochromaticPalette7",
+    "MonochromaticPalette8",
+    "MonochromaticPalette9",
+    "MonochromaticPalette10",
+    "MonochromaticPalette11",
+    "MonochromaticPalette12",
+    "MonochromaticPalette13",
+  ];
+
+  function titleHorizontal(value, property) {
+    return enumValue(value, property, horizontalAlignmentValues);
+  }
+
+  function titleVertical(value, property) {
+    return enumValue(value, property, verticalAlignmentValues);
+  }
+
+  function legendPosition(value, property) {
+    return enumValue(value, property, legendPositionValues);
+  }
+
+  function labelPosition(value, property) {
+    return enumValue(value, property, labelPositionValues);
+  }
+
+  function geometricShape(value, property) {
+    value = string(value, property);
+    var values = Excel.GeometricShapeType || {};
+    var found = false;
+    for (var key in values) {
+      if (Object.prototype.hasOwnProperty.call(values, key) && values[key] === value) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      throw invalidArgument(property + " must be an Excel.GeometricShapeType value");
+    }
+    return value;
+  }
+
+  function dataLabelHorizontal(value, property) {
+    return enumValue(value, property, horizontalAlignmentValues);
+  }
+
+  function dataLabelVertical(value, property) {
+    return enumValue(value, property, verticalAlignmentValues);
+  }
+
+  var fontValidators = {
+    bold: bool,
+    color: color,
+    italic: bool,
+    name: function (value, property) {
+      value = nonEmptyString(value, property);
+      if (value.length > 31) {
+        throw invalidArgument(property + " must contain 1 through 31 characters");
+      }
+      return value;
+    },
+    size: function (value, property) {
+      value = finiteNumber(value, property);
+      if (value < 1 || value > 409) {
+        throw invalidArgument(property + " must be between 1 and 409 points");
+      }
+      return value;
+    },
+    underline: function (value, property) {
+      return enumValue(value, property, ["None", "Single"]);
+    },
+  };
+
+  function queueFillMethod(object, property, value) {
+    object.context._queue.push({
+      op: "set",
+      id: object._id,
+      property: property,
+      value: value,
+    });
+  }
+
+  function ChartTitle(context, chart) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._navigationProperties = ["format"];
+    commonPrototype(
+      ChartTitle,
+      "ChartTitle",
+      [
+        "height",
+        "horizontalAlignment",
+        "left",
+        "overlay",
+        "position",
+        "showShadow",
+        "text",
+        "textOrientation",
+        "top",
+        "verticalAlignment",
+        "visible",
+        "width",
+      ],
+      {
+        horizontalAlignment: titleHorizontal,
+        overlay: bool,
+        position: function (value, property) {
+          return enumValue(value, property, titlePositionValues);
+        },
+        showShadow: bool,
+        text: string,
+        textOrientation: orientation,
+        verticalAlignment: titleVertical,
+        visible: bool,
+      },
+      ["height", "left", "top", "width"]
+    );
+    queueObject(this, "title");
+  }
+
+  Object.defineProperty(ChartTitle.prototype, "format", {
+    get: function () {
+      if (!this._format) this._format = new ChartTitleFormat(this.context, this._chart);
+      return this._format;
+    },
+    configurable: true,
+  });
+
+  function ChartLegend(context, chart) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._navigationProperties = ["format", "legendEntries"];
+    commonPrototype(
+      ChartLegend,
+      "ChartLegend",
+      ["height", "left", "overlay", "position", "showShadow", "top", "visible", "width"],
+      {
+        overlay: bool,
+        position: legendPosition,
+        showShadow: bool,
+        visible: bool,
+      },
+      ["height", "left", "top", "width"]
+    );
+    queueObject(this, "legend");
+  }
+
+  Object.defineProperty(ChartLegend.prototype, "format", {
+    get: function () {
+      if (!this._format) this._format = new ChartLegendFormat(this.context, this._chart);
+      return this._format;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(ChartLegend.prototype, "legendEntries", {
+    get: function () {
+      if (!this._legendEntries) {
+        this._legendEntries = new ChartLegendEntryCollection(
+          this.context,
+          this._chart
+        );
+      }
+      return this._legendEntries;
+    },
+    configurable: true,
+  });
+
+  function ChartDataLabels(context, chart) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._navigationProperties = ["format", "leaderLines"];
+    commonPrototype(
+      ChartDataLabels,
+      "ChartDataLabels",
+      [
+        "autoText",
+        "geometricShapeType",
+        "horizontalAlignment",
+        "linkNumberFormat",
+        "numberFormat",
+        "position",
+        "separator",
+        "showAsStickyCallout",
+        "showBubbleSize",
+        "showCategoryName",
+        "showLeaderLines",
+        "showLegendKey",
+        "showPercentage",
+        "showSeriesName",
+        "showValue",
+        "textOrientation",
+        "verticalAlignment",
+      ],
+      {
+        autoText: bool,
+        geometricShapeType: geometricShape,
+        horizontalAlignment: dataLabelHorizontal,
+        linkNumberFormat: bool,
+        numberFormat: string,
+        position: labelPosition,
+        separator: string,
+        showBubbleSize: bool,
+        showCategoryName: bool,
+        showLeaderLines: bool,
+        showLegendKey: bool,
+        showPercentage: bool,
+        showSeriesName: bool,
+        showValue: bool,
+        textOrientation: orientation,
+        verticalAlignment: dataLabelVertical,
+      },
+      ["showAsStickyCallout"]
+    );
+    queueObject(this, "dataLabels");
+  }
+
+  Object.defineProperty(ChartDataLabels.prototype, "format", {
+    get: function () {
+      if (!this._format) {
+        this._format = new ChartDataLabelFormat(this.context, this._chart);
+      }
+      return this._format;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(ChartDataLabels.prototype, "leaderLines", {
+    get: function () {
+      if (!this._leaderLines) {
+        this._leaderLines = new ChartLeaderLines(this.context, this._chart);
+      }
+      return this._leaderLines;
+    },
+    configurable: true,
+  });
+
+  function ChartAreaFormat(context, chart) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._navigationProperties = ["border", "fill", "font"];
+    commonPrototype(
+      ChartAreaFormat,
+      "ChartAreaFormat",
+      ["colorScheme", "roundedCorners"],
+      {
+        colorScheme: function (value, property) {
+          return enumValue(value, property, colorSchemeValues);
+        },
+        roundedCorners: bool,
+      }
+    );
+    queueObject(this, "areaFormat");
+  }
+
+  function ChartTitleFormat(context, chart) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._navigationProperties = ["border", "fill", "font"];
+    commonPrototype(ChartTitleFormat, "ChartTitleFormat", []);
+    queueObject(this, "titleFormat");
+  }
+
+  function ChartLegendFormat(context, chart) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._navigationProperties = ["border", "fill", "font"];
+    commonPrototype(ChartLegendFormat, "ChartLegendFormat", []);
+    queueObject(this, "legendFormat");
+  }
+
+  function ChartDataLabelFormat(context, chart) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._navigationProperties = ["border", "fill", "font"];
+    commonPrototype(ChartDataLabelFormat, "ChartDataLabelFormat", []);
+    queueObject(this, "dataLabelFormat");
+  }
+
+  function ChartFill(context, chart, kind) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._kind = kind;
+    commonPrototype(ChartFill, "ChartFill", []);
+    queueObject(this, kind);
+  }
+
+  ChartFill.prototype.clear = function () {
+    queueFillMethod(this, "clear", null);
+  };
+
+  ChartFill.prototype.getSolidColor = function () {
+    var result = createResult(this.context);
+    var operation = {
+      op: "chartFormatFillGetSolidColor",
+      resultId: result._id,
+      kind: this._kind,
+    };
+    queueIdentity(this, operation);
+    this.context._queue.push(operation);
+    return result;
+  };
+
+  ChartFill.prototype.setSolidColor = function (value) {
+    queueFillMethod(this, "solidColor", color(value, "ChartFill.setSolidColor color"));
+  };
+
+  function ChartBorder(context, chart, kind) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._kind = kind;
+    commonPrototype(
+      ChartBorder,
+      "ChartBorder",
+      ["color", "lineStyle", "weight"],
+      {
+        color: color,
+        lineStyle: function (value, property) {
+          return enumValue(value, property, lineStyleValues);
+        },
+        weight: function (value, property) {
+          value = finiteNumber(value, property);
+          if (value < 0) throw invalidArgument(property + " must be non-negative");
+          return value;
+        },
+      }
+    );
+    queueObject(this, kind);
+  }
+
+  ChartBorder.prototype.clear = function () {
+    queueFillMethod(this, "clear", null);
+  };
+
+  function ChartLineFormat(context, chart, kind) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._kind = kind;
+    commonPrototype(
+      ChartLineFormat,
+      "ChartLineFormat",
+      ["color", "lineStyle", "weight"],
+      {
+        color: color,
+        lineStyle: function (value, property) {
+          return enumValue(value, property, lineStyleValues);
+        },
+        weight: function (value, property) {
+          value = finiteNumber(value, property);
+          if (value < 0) throw invalidArgument(property + " must be non-negative");
+          return value;
+        },
+      }
+    );
+    queueObject(this, kind);
+  }
+
+  ChartLineFormat.prototype.clear = function () {
+    queueFillMethod(this, "clear", null);
+  };
+
+  function ChartFont(context, chart, kind) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._kind = kind;
+    commonPrototype(
+      ChartFont,
+      "ChartFont",
+      ["bold", "color", "italic", "name", "size", "underline"],
+      fontValidators
+    );
+    queueObject(this, kind);
+  }
+
+  function ChartLeaderLines(context, chart) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._navigationProperties = ["format"];
+    commonPrototype(ChartLeaderLines, "ChartLeaderLines", []);
+    queueObject(this, "leaderLines");
+  }
+
+  Object.defineProperty(ChartLeaderLines.prototype, "format", {
+    get: function () {
+      if (!this._format) {
+        this._format = new ChartLeaderLinesFormat(this.context, this._chart);
+      }
+      return this._format;
+    },
+    configurable: true,
+  });
+
+  function ChartLeaderLinesFormat(context, chart) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._navigationProperties = ["line"];
+    commonPrototype(ChartLeaderLinesFormat, "ChartLeaderLinesFormat", []);
+    queueObject(this, "leaderLinesFormat");
+  }
+
+  Object.defineProperty(ChartLeaderLinesFormat.prototype, "line", {
+    get: function () {
+      if (!this._line) {
+        this._line = new ChartLineFormat(
+          this.context,
+          this._chart,
+          "leaderLinesLine"
+        );
+      }
+      return this._line;
+    },
+    configurable: true,
+  });
+
+  function ChartLegendEntry(context, chart, collection, index, queue) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._collection = collection || null;
+    this._entryIndex = index;
+    commonPrototype(
+      ChartLegendEntry,
+      "ChartLegendEntry",
+      ["height", "index", "left", "top", "visible", "width"],
+      {
+        visible: bool,
+      },
+      ["height", "index", "left", "top", "width"]
+    );
+    if (queue) queueLegendEntry(this);
+  }
+
+  function queueLegendEntry(object) {
+    var operation = {
+      op: "chartFormatLegendEntriesGetItemAt",
+      id: object._id,
+      index: object._entryIndex,
+      collectionId: object._collection ? object._collection._id : null,
+    };
+    queueIdentity(object, operation);
+    object.context._queue.push(operation);
+  }
+
+  function ChartLegendEntryCollection(context, chart) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._navigationProperties = ["items"];
+    this._scalarProperties = ["items"];
+    this._itemCache = Object.create(null);
+    this._bindingQueued = true;
+    commonPrototype(ChartLegendEntryCollection, "ChartLegendEntryCollection", ["items"]);
+    if (officeJs && officeJs.configureCollection) {
+      officeJs.configureCollection(this, function (key, descriptor) {
+        var index = Number(key);
+        var entry = new ChartLegendEntry(
+          this.context,
+          this._chart,
+          this,
+          index,
+          true
+        );
+        return entry;
+      });
+    }
+    queueCollection(this);
+  }
+
+  ChartLegendEntryCollection.prototype.getCount = function () {
+    var result = createResult(this.context);
+    this.context._queue.push({
+      op: "chartFormatLegendEntriesGetCount",
+      collectionId: this._id,
+      resultId: result._id,
+    });
+    return result;
+  };
+
+  ChartLegendEntryCollection.prototype.getItemAt = function (index) {
+    index = finiteNumber(index, "ChartLegendEntryCollection.getItemAt index");
+    if (Math.floor(index) !== index || index < 0) {
+      throw invalidArgument(
+        "ChartLegendEntryCollection.getItemAt index must be a non-negative integer"
+      );
+    }
+    var cacheKey = String(index);
+    var entry = this._itemCache[cacheKey];
+    if (!entry) {
+      entry = new ChartLegendEntry(this.context, this._chart, this, index, true);
+      this._itemCache[cacheKey] = entry;
+    }
+    return entry;
+  };
+
+  ChartLegendEntryCollection.prototype.load = function (properties) {
+    return ClientObject.prototype.load.call(this, properties);
+  };
+
+  ChartLegendEntryCollection.prototype.toJSON = function () {
+    if (!this._loaded.items) return {};
+    return {
+      items: (this._items || []).map(function (item) {
+        return item.toJSON();
+      }),
+    };
+  };
+
+  function defineFormatNavigation(ctor, fillKind, fontKind, borderKind) {
+    Object.defineProperty(ctor.prototype, "fill", {
+      get: function () {
+        if (!this._fill) {
+          this._fill = new ChartFill(this.context, this._chart, fillKind);
+        }
+        return this._fill;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(ctor.prototype, "font", {
+      get: function () {
+        if (!this._font) {
+          this._font = new ChartFont(this.context, this._chart, fontKind);
+        }
+        return this._font;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(ctor.prototype, "border", {
+      get: function () {
+        if (!this._border) {
+          this._border = new ChartBorder(this.context, this._chart, borderKind);
+        }
+        return this._border;
+      },
+      configurable: true,
+    });
+  }
+
+  defineFormatNavigation(
+    ChartAreaFormat,
+    "areaFill",
+    "areaFont",
+    "areaBorder"
+  );
+  defineFormatNavigation(
+    ChartTitleFormat,
+    "titleFill",
+    "titleFont",
+    "titleBorder"
+  );
+  defineFormatNavigation(
+    ChartLegendFormat,
+    "legendFill",
+    "legendFont",
+    "legendBorder"
+  );
+  defineFormatNavigation(
+    ChartDataLabelFormat,
+    "dataLabelFill",
+    "dataLabelFont",
+    "dataLabelBorder"
+  );
+
+  function attachChartNavigation() {
+    if (!Excel.Chart) return false;
+    if (officeJs && officeJs.addNavigationProperties) {
+      officeJs.addNavigationProperties(Excel.Chart.prototype, [
+        "title",
+        "legend",
+        "format",
+        "dataLabels",
+      ]);
+    }
+    Object.defineProperty(Excel.Chart.prototype, "title", {
+      get: function () {
+        if (!this._title) this._title = new ChartTitle(this.context, this);
+        return this._title;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(Excel.Chart.prototype, "legend", {
+      get: function () {
+        if (!this._legend) this._legend = new ChartLegend(this.context, this);
+        return this._legend;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(Excel.Chart.prototype, "format", {
+      get: function () {
+        if (!this._format) this._format = new ChartAreaFormat(this.context, this);
+        return this._format;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(Excel.Chart.prototype, "dataLabels", {
+      get: function () {
+        if (!this._dataLabels) {
+          this._dataLabels = new ChartDataLabels(this.context, this);
+        }
+        return this._dataLabels;
+      },
+      configurable: true,
+    });
+    return true;
+  }
+
+  // chart_core.js is loaded before this file in the production runtime. The
+  // exported hook also lets an integrator attach these properties after a
+  // dynamically loaded Chart constructor is installed.
+  attachChartNavigation();
+
+  global.__mogChartFormat = {
+    attachChartNavigation: attachChartNavigation,
+    ChartFormatKind: {
+      title: "title",
+      legend: "legend",
+      dataLabels: "dataLabels",
+      areaFormat: "areaFormat",
+      titleFormat: "titleFormat",
+      legendFormat: "legendFormat",
+      dataLabelFormat: "dataLabelFormat",
+      leaderLines: "leaderLines",
+      leaderLinesFormat: "leaderLinesFormat",
+      leaderLinesLine: "leaderLinesLine",
+    },
+  };
+
+  Excel.ChartTitle = ChartTitle;
+  Excel.ChartLegend = ChartLegend;
+  Excel.ChartDataLabels = ChartDataLabels;
+  Excel.ChartAreaFormat = ChartAreaFormat;
+  Excel.ChartTitleFormat = ChartTitleFormat;
+  Excel.ChartLegendFormat = ChartLegendFormat;
+  Excel.ChartDataLabelFormat = ChartDataLabelFormat;
+  Excel.ChartFill = ChartFill;
+  Excel.ChartBorder = ChartBorder;
+  Excel.ChartLineFormat = ChartLineFormat;
+  Excel.ChartFont = ChartFont;
+  Excel.ChartLeaderLines = ChartLeaderLines;
+  Excel.ChartLeaderLinesFormat = ChartLeaderLinesFormat;
+  Excel.ChartLegendEntry = ChartLegendEntry;
+  Excel.ChartLegendEntryCollection = ChartLegendEntryCollection;
+})(globalThis);

--- a/compute/officejs/src/chart_format.rs
+++ b/compute/officejs/src/chart_format.rs
@@ -1,0 +1,1592 @@
+//! Office.js chart title, legend, data-label, and formatting projections.
+//!
+//! The chart API is backed by the persisted ChartData hierarchy. Every read
+//! resolves the current chart through ChartRef, and every write reads the
+//! current nested value before sending a complete top-level field back
+//! through the compute chart facade. The latter is required because the
+//! floating-object update API merges top-level keys and therefore replaces a
+//! nested object as a unit.
+//!
+//! The JavaScript adapter uses these extension operations. The
+//! chartId/worksheetId pair is preferred; parentId is accepted when a chart
+//! was created and has not loaded its engine ID yet.
+//!
+//! * chartFormatGetObject binds a title, legend, data-label, format, or
+//!   formatting-part object (kind identifies the target).
+//! * chartFormatGetLegendEntries binds a legend-entry collection.
+//! * chartFormatLegendEntriesGetCount completes a collection count result.
+//! * chartFormatLegendEntriesGetItemAt binds one legend entry.
+//! * chartFormatFillGetSolidColor completes a fill color result.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use compute_api::Sheet;
+use domain_types::domain::chart::{
+    ChartColorData, ChartDashStyle, ChartFillData, ChartFontData, ChartFormatData, ChartLineData,
+    ChartUnderlineStyle,
+};
+use domain_types::domain::floating_object::{ChartData, FloatingObject, FloatingObjectData};
+use serde_json::{Map, Value, json};
+
+use crate::chart_core::{ChartError, ChartRef};
+use crate::dispatch::{ExtensionHandler, ExtensionObject, HostDispatchContext};
+use crate::host::BatchError;
+
+/// Errors returned by the chart formatting adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChartFormatError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChartFormatOwner {
+    Chart,
+    Title,
+    Legend,
+    DataLabels,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChartFormatKind {
+    Title,
+    Legend,
+    DataLabels,
+    AreaFormat,
+    TitleFormat,
+    LegendFormat,
+    DataLabelFormat,
+    LeaderLines,
+    LeaderLinesFormat,
+    LeaderLinesLine,
+    Fill(ChartFormatOwner),
+    Font(ChartFormatOwner),
+    Border(ChartFormatOwner),
+    Line(ChartFormatOwner),
+    LegendEntries,
+    LegendEntry(usize),
+}
+
+impl ChartFormatKind {
+    /// Parse the stable wire names emitted by chart_format.js.
+    pub(crate) fn from_wire(kind: &str) -> Result<Self, ChartFormatError> {
+        let kind = match kind {
+            "title" | "chartTitle" => Self::Title,
+            "legend" | "chartLegend" => Self::Legend,
+            "dataLabels" | "chartDataLabels" => Self::DataLabels,
+            "format" | "chartFormat" | "areaFormat" | "chartAreaFormat" => Self::AreaFormat,
+            "titleFormat" | "chartTitleFormat" => Self::TitleFormat,
+            "legendFormat" | "chartLegendFormat" => Self::LegendFormat,
+            "dataLabelFormat" | "chartDataLabelFormat" => Self::DataLabelFormat,
+            "leaderLines" | "chartLeaderLines" => Self::LeaderLines,
+            "leaderLinesFormat" | "chartLeaderLinesFormat" => Self::LeaderLinesFormat,
+            "leaderLinesLine" | "chartLeaderLinesLine" => Self::LeaderLinesLine,
+            "areaFill" | "chartFill" | "chartFormatFill" => Self::Fill(ChartFormatOwner::Chart),
+            "titleFill" | "titleFormatFill" => Self::Fill(ChartFormatOwner::Title),
+            "legendFill" | "legendFormatFill" => Self::Fill(ChartFormatOwner::Legend),
+            "dataLabelFill" | "dataLabelsFill" | "dataLabelFormatFill" => {
+                Self::Fill(ChartFormatOwner::DataLabels)
+            }
+            "areaFont" | "chartFont" | "chartFormatFont" => Self::Font(ChartFormatOwner::Chart),
+            "titleFont" | "titleFormatFont" => Self::Font(ChartFormatOwner::Title),
+            "legendFont" | "legendFormatFont" => Self::Font(ChartFormatOwner::Legend),
+            "dataLabelFont" | "dataLabelsFont" | "dataLabelFormatFont" => {
+                Self::Font(ChartFormatOwner::DataLabels)
+            }
+            "areaBorder" | "chartBorder" | "chartFormatBorder" => {
+                Self::Border(ChartFormatOwner::Chart)
+            }
+            "titleBorder" | "titleFormatBorder" => Self::Border(ChartFormatOwner::Title),
+            "legendBorder" | "legendFormatBorder" => Self::Border(ChartFormatOwner::Legend),
+            "dataLabelBorder" | "dataLabelsBorder" | "dataLabelFormatBorder" => {
+                Self::Border(ChartFormatOwner::DataLabels)
+            }
+            "areaLine" | "chartLine" | "chartFormatLine" => Self::Line(ChartFormatOwner::Chart),
+            "titleLine" | "titleFormatLine" => Self::Line(ChartFormatOwner::Title),
+            "legendLine" | "legendFormatLine" => Self::Line(ChartFormatOwner::Legend),
+            "dataLabelLine" | "dataLabelsLine" | "dataLabelFormatLine" => {
+                Self::Line(ChartFormatOwner::DataLabels)
+            }
+            _ => {
+                return Err(unsupported(format!(
+                    "Unsupported chart formatting kind '{kind}'"
+                )));
+            }
+        };
+        Ok(kind)
+    }
+}
+
+/// A typed chart child reference. It deliberately stores only a stable ChartRef
+/// and a target selector; no mutable formatting state is cached.
+#[derive(Clone)]
+pub(crate) struct ChartFormatRef {
+    chart: ChartRef,
+    kind: ChartFormatKind,
+}
+
+impl ChartFormatRef {
+    pub(crate) fn new(
+        sheet: Sheet,
+        chart_id: impl Into<String>,
+        kind: &str,
+    ) -> Result<Self, ChartFormatError> {
+        Self::from_chart(ChartRef::new(sheet, chart_id), kind)
+    }
+
+    pub(crate) fn from_chart(chart: ChartRef, kind: &str) -> Result<Self, ChartFormatError> {
+        Ok(Self {
+            chart,
+            kind: ChartFormatKind::from_wire(kind)?,
+        })
+    }
+
+    pub(crate) fn from_target(chart: ChartRef, kind: ChartFormatKind) -> Self {
+        Self { chart, kind }
+    }
+
+    pub(crate) fn chart(&self) -> &ChartRef {
+        &self.chart
+    }
+
+    pub(crate) fn kind(&self) -> ChartFormatKind {
+        self.kind
+    }
+
+    pub(crate) fn load_properties(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, ChartFormatError> {
+        let chart = self.chart_data()?;
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match self.kind {
+                ChartFormatKind::Title => load_title_property(&chart, property)?,
+                ChartFormatKind::Legend => load_legend_property(&chart, property)?,
+                ChartFormatKind::DataLabels => load_data_labels_property(&chart, property)?,
+                ChartFormatKind::AreaFormat => load_area_format_property(&chart, property)?,
+                ChartFormatKind::TitleFormat
+                | ChartFormatKind::LegendFormat
+                | ChartFormatKind::DataLabelFormat
+                | ChartFormatKind::LeaderLines
+                | ChartFormatKind::LeaderLinesFormat => {
+                    return Err(unsupported(format!(
+                        "Chart format navigation property '{property}' is not scalar"
+                    )));
+                }
+                ChartFormatKind::Fill(owner) => load_fill_property(&chart, owner, property)?,
+                ChartFormatKind::Font(owner) => load_font_property(&chart, owner, property)?,
+                ChartFormatKind::Border(owner) | ChartFormatKind::Line(owner) => {
+                    load_line_property(&chart, owner, property)?
+                }
+                ChartFormatKind::LeaderLinesLine => load_leader_line_property(&chart, property)?,
+                ChartFormatKind::LegendEntries | ChartFormatKind::LegendEntry(_) => {
+                    return Err(unsupported(format!(
+                        "Chart formatting target cannot load '{property}'"
+                    )));
+                }
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn set_property(
+        &self,
+        property: &str,
+        value: &Value,
+    ) -> Result<(), ChartFormatError> {
+        match self.kind {
+            ChartFormatKind::Title => self.set_title_property(property, value),
+            ChartFormatKind::Legend => self.set_legend_property(property, value),
+            ChartFormatKind::DataLabels => self.set_data_labels_property(property, value),
+            ChartFormatKind::AreaFormat => self.set_area_format_property(property, value),
+            ChartFormatKind::TitleFormat
+            | ChartFormatKind::LegendFormat
+            | ChartFormatKind::DataLabelFormat
+            | ChartFormatKind::LeaderLines
+            | ChartFormatKind::LeaderLinesFormat => Err(unsupported(format!(
+                "Chart format navigation property '{property}' is read-only"
+            ))),
+            ChartFormatKind::Fill(owner) => self.set_fill_property(owner, property, value),
+            ChartFormatKind::Font(owner) => self.set_font_property(owner, property, value),
+            ChartFormatKind::Border(owner) | ChartFormatKind::Line(owner) => {
+                self.set_line_property(owner, property, value)
+            }
+            ChartFormatKind::LeaderLinesLine => self.set_leader_line_property(property, value),
+            ChartFormatKind::LegendEntries => Err(unsupported(format!(
+                "Chart legend entry collection property '{property}' is read-only"
+            ))),
+            ChartFormatKind::LegendEntry(index) => {
+                if property != "visible" {
+                    return Err(unsupported(format!(
+                        "ChartLegendEntry.{property} is read-only or unsupported"
+                    )));
+                }
+                let visible = boolean(value, property)?;
+                self.set_legend_entry(index, visible)
+            }
+        }
+    }
+
+    pub(crate) fn solid_color(&self) -> Result<Value, ChartFormatError> {
+        let ChartFormatKind::Fill(owner) = self.kind else {
+            return Err(unsupported(
+                "getSolidColor is only available on ChartFill".to_string(),
+            ));
+        };
+        let chart = self.chart_data()?;
+        let Some(format) = format_for(&chart, owner) else {
+            return Ok(Value::Null);
+        };
+        let Some(ChartFillData::Solid { color, .. }) = format.fill.as_ref() else {
+            return Ok(Value::Null);
+        };
+        color_value(color)
+    }
+
+    fn chart_data(&self) -> Result<ChartData, ChartFormatError> {
+        let snapshot = self.chart.snapshot().map_err(chart_error)?;
+        let object: FloatingObject = serde_json::from_value(snapshot).map_err(encoding)?;
+        match object.data {
+            FloatingObjectData::Chart(chart) => Ok(chart),
+            _ => Err(invalid("The referenced floating object is not a chart")),
+        }
+    }
+
+    fn update_field(&self, field: &str, value: Value) -> Result<(), ChartFormatError> {
+        self.chart
+            .update_fields(&json!({ field: value }))
+            .map_err(chart_error)
+    }
+
+    fn update_format<F>(&self, owner: ChartFormatOwner, mutate: F) -> Result<(), ChartFormatError>
+    where
+        F: FnOnce(&mut ChartFormatData) -> Result<(), ChartFormatError>,
+    {
+        let chart = self.chart_data()?;
+        let mut format = format_for(&chart, owner)
+            .cloned()
+            .unwrap_or_else(empty_format);
+        mutate(&mut format)?;
+        let serialized = serde_json::to_value(format).map_err(encoding)?;
+        match owner {
+            ChartFormatOwner::Chart => self.update_field("chartFormat", serialized),
+            ChartFormatOwner::Title => self.update_field("titleFormat", serialized),
+            ChartFormatOwner::Legend => {
+                let chart = self.chart_data()?;
+                let mut legend = chart.legend.clone().unwrap_or_else(default_legend);
+                legend.format = Some(serde_json::from_value(serialized).map_err(encoding)?);
+                self.update_field("legend", serde_json::to_value(legend).map_err(encoding)?)
+            }
+            ChartFormatOwner::DataLabels => {
+                let chart = self.chart_data()?;
+                let mut labels = chart
+                    .data_labels
+                    .clone()
+                    .unwrap_or_else(default_data_labels);
+                labels.visual_format = Some(serde_json::from_value(serialized).map_err(encoding)?);
+                self.update_field(
+                    "dataLabels",
+                    serde_json::to_value(labels).map_err(encoding)?,
+                )
+            }
+        }
+    }
+
+    fn update_legend<F>(&self, mutate: F) -> Result<(), ChartFormatError>
+    where
+        F: FnOnce(&mut domain_types::domain::chart::LegendData) -> Result<(), ChartFormatError>,
+    {
+        let chart = self.chart_data()?;
+        let mut legend = chart.legend.clone().unwrap_or_else(default_legend);
+        mutate(&mut legend)?;
+        self.update_field("legend", serde_json::to_value(legend).map_err(encoding)?)
+    }
+
+    fn update_data_labels<F>(&self, mutate: F) -> Result<(), ChartFormatError>
+    where
+        F: FnOnce(&mut domain_types::domain::chart::DataLabelData) -> Result<(), ChartFormatError>,
+    {
+        let chart = self.chart_data()?;
+        let mut labels = chart
+            .data_labels
+            .clone()
+            .unwrap_or_else(default_data_labels);
+        mutate(&mut labels)?;
+        self.update_field(
+            "dataLabels",
+            serde_json::to_value(labels).map_err(encoding)?,
+        )
+    }
+
+    fn set_title_property(&self, property: &str, value: &Value) -> Result<(), ChartFormatError> {
+        match property {
+            "text" => self.update_field("title", string(value, property).map(Value::String)?),
+            "visible" => {
+                let visible = boolean(value, property)?;
+                self.update_field("autoTitleDeleted", Value::Bool(!visible))
+            }
+            "horizontalAlignment" => self.update_field(
+                "titleHAlign",
+                Value::String(title_horizontal_alignment(value, property)?.to_string()),
+            ),
+            "verticalAlignment" => self.update_field(
+                "titleVAlign",
+                Value::String(title_vertical_alignment(value, property)?.to_string()),
+            ),
+            "showShadow" => {
+                self.update_field("titleShowShadow", Value::Bool(boolean(value, property)?))
+            }
+            "textOrientation" => {
+                let orientation = text_orientation(value, property)?;
+                self.update_format(ChartFormatOwner::Title, |format| {
+                    format.text_rotation = Some(orientation);
+                    Ok(())
+                })
+            }
+            "overlay" | "position" => Err(unsupported(format!(
+                "ChartTitle.{property} has no persisted chart-data representation"
+            ))),
+            "height" | "left" | "top" | "width" => Err(read_only(property, "ChartTitle")),
+            other => Err(unsupported(format!("ChartTitle.{other} is unsupported"))),
+        }
+    }
+
+    fn set_legend_property(&self, property: &str, value: &Value) -> Result<(), ChartFormatError> {
+        match property {
+            "visible" => {
+                let visible = boolean(value, property)?;
+                self.update_legend(|legend| {
+                    legend.visible = visible;
+                    legend.show = visible;
+                    Ok(())
+                })
+            }
+            "overlay" => {
+                let overlay = boolean(value, property)?;
+                self.update_legend(|legend| {
+                    legend.overlay = Some(overlay);
+                    Ok(())
+                })
+            }
+            "position" => {
+                let position = legend_position(value, property)?;
+                self.update_legend(|legend| {
+                    legend.position = position.to_string();
+                    Ok(())
+                })
+            }
+            "showShadow" => {
+                let show_shadow = boolean(value, property)?;
+                self.update_legend(|legend| {
+                    legend.show_shadow = Some(show_shadow);
+                    Ok(())
+                })
+            }
+            "height" | "left" | "top" | "width" => Err(read_only(property, "ChartLegend")),
+            "legendEntries" => Err(read_only(property, "ChartLegend")),
+            other => Err(unsupported(format!("ChartLegend.{other} is unsupported"))),
+        }
+    }
+
+    fn set_data_labels_property(
+        &self,
+        property: &str,
+        value: &Value,
+    ) -> Result<(), ChartFormatError> {
+        match property {
+            "autoText" => self.update_data_labels(|labels| {
+                labels.auto_text = Some(boolean(value, property)?);
+                Ok(())
+            }),
+            "geometricShapeType" => self.update_data_labels(|labels| {
+                labels.geometric_shape_type = Some(string(value, property)?);
+                Ok(())
+            }),
+            "horizontalAlignment" => {
+                let alignment = data_label_horizontal_alignment(value, property)?.to_string();
+                self.update_data_labels(|labels| {
+                    labels.horizontal_alignment = Some(alignment);
+                    Ok(())
+                })
+            }
+            "linkNumberFormat" => self.update_data_labels(|labels| {
+                labels.link_number_format = Some(boolean(value, property)?);
+                Ok(())
+            }),
+            "numberFormat" => self.update_data_labels(|labels| {
+                labels.number_format = Some(string(value, property)?);
+                Ok(())
+            }),
+            "position" => {
+                let position = data_label_position(value, property)?.to_string();
+                self.update_data_labels(|labels| {
+                    labels.position = Some(position);
+                    Ok(())
+                })
+            }
+            "separator" => self.update_data_labels(|labels| {
+                labels.separator = Some(string(value, property)?);
+                Ok(())
+            }),
+            "showBubbleSize" => self.update_data_labels(|labels| {
+                let value = boolean(value, property)?;
+                labels.show_bubble_size = Some(value);
+                recompute_label_visibility(labels);
+                Ok(())
+            }),
+            "showCategoryName" => self.update_data_labels(|labels| {
+                let value = boolean(value, property)?;
+                labels.show_category_name = Some(value);
+                recompute_label_visibility(labels);
+                Ok(())
+            }),
+            "showLeaderLines" => self.update_data_labels(|labels| {
+                labels.show_leader_lines = Some(boolean(value, property)?);
+                Ok(())
+            }),
+            "showLegendKey" => self.update_data_labels(|labels| {
+                let value = boolean(value, property)?;
+                labels.show_legend_key = Some(value);
+                recompute_label_visibility(labels);
+                Ok(())
+            }),
+            "showPercentage" => self.update_data_labels(|labels| {
+                let value = boolean(value, property)?;
+                labels.show_percentage = Some(value);
+                recompute_label_visibility(labels);
+                Ok(())
+            }),
+            "showSeriesName" => self.update_data_labels(|labels| {
+                let value = boolean(value, property)?;
+                labels.show_series_name = Some(value);
+                recompute_label_visibility(labels);
+                Ok(())
+            }),
+            "showValue" => self.update_data_labels(|labels| {
+                let value = boolean(value, property)?;
+                labels.show_value = Some(value);
+                recompute_label_visibility(labels);
+                Ok(())
+            }),
+            "textOrientation" => {
+                let orientation = text_orientation(value, property)?;
+                self.update_data_labels(|labels| {
+                    labels.text_orientation = Some(orientation);
+                    let format = labels.visual_format.get_or_insert_with(empty_format);
+                    format.text_rotation = Some(orientation);
+                    Ok(())
+                })
+            }
+            "verticalAlignment" => {
+                let alignment = data_label_vertical_alignment(value, property)?.to_string();
+                self.update_data_labels(|labels| {
+                    labels.vertical_alignment = Some(alignment);
+                    Ok(())
+                })
+            }
+            "showAsStickyCallout" => Err(read_only(property, "ChartDataLabels")),
+            other => Err(unsupported(format!(
+                "ChartDataLabels.{other} is unsupported"
+            ))),
+        }
+    }
+
+    fn set_area_format_property(
+        &self,
+        property: &str,
+        value: &Value,
+    ) -> Result<(), ChartFormatError> {
+        match property {
+            "colorScheme" => {
+                let scheme = color_scheme(value, property)?;
+                self.update_field("colorScheme", json!(scheme))
+            }
+            "roundedCorners" => {
+                self.update_field("roundedCorners", Value::Bool(boolean(value, property)?))
+            }
+            other => Err(unsupported(format!(
+                "ChartAreaFormat.{other} is unsupported"
+            ))),
+        }
+    }
+
+    fn set_fill_property(
+        &self,
+        owner: ChartFormatOwner,
+        property: &str,
+        value: &Value,
+    ) -> Result<(), ChartFormatError> {
+        match property {
+            "solidColor" | "setSolidColor" => {
+                let color = parse_color(value, property)?;
+                self.update_format(owner, |format| {
+                    format.fill = Some(ChartFillData::Solid {
+                        color,
+                        transparency: None,
+                    });
+                    Ok(())
+                })
+            }
+            "clear" => self.update_format(owner, |format| {
+                if !value.is_null() {
+                    return Err(invalid("ChartFill.clear does not accept a value"));
+                }
+                format.fill = Some(ChartFillData::NoFill);
+                Ok(())
+            }),
+            other => Err(unsupported(format!("ChartFill.{other} is unsupported"))),
+        }
+    }
+
+    fn set_font_property(
+        &self,
+        owner: ChartFormatOwner,
+        property: &str,
+        value: &Value,
+    ) -> Result<(), ChartFormatError> {
+        self.update_format(owner, |format| {
+            let font = format.font.get_or_insert_with(empty_font);
+            match property {
+                "bold" => font.bold = Some(boolean(value, property)?),
+                "color" => font.color = Some(parse_color(value, property)?),
+                "italic" => font.italic = Some(boolean(value, property)?),
+                "name" => {
+                    let name = string(value, property)?;
+                    let length = name.chars().count();
+                    if !(1..=31).contains(&length) {
+                        return Err(invalid(
+                            "ChartFont.name must contain 1 through 31 characters",
+                        ));
+                    }
+                    font.name = Some(name);
+                }
+                "size" => {
+                    let size = finite_number(value, property)?;
+                    if !(1.0..=409.0).contains(&size) {
+                        return Err(invalid("ChartFont.size must be between 1 and 409 points"));
+                    }
+                    font.size = Some(size);
+                }
+                "underline" => font.underline = Some(underline(value, property)?),
+                other => return Err(unsupported(format!("ChartFont.{other} is unsupported"))),
+            }
+            Ok(())
+        })
+    }
+
+    fn set_line_property(
+        &self,
+        owner: ChartFormatOwner,
+        property: &str,
+        value: &Value,
+    ) -> Result<(), ChartFormatError> {
+        self.update_format(owner, |format| {
+            let line = format.line.get_or_insert_with(empty_line);
+            match property {
+                "color" => {
+                    line.color = Some(parse_color(value, property)?);
+                    line.no_fill = Some(false);
+                }
+                "lineStyle" => {
+                    let (style, no_fill) = line_style(value, property)?;
+                    line.dash_style = style;
+                    line.no_fill = Some(no_fill);
+                }
+                "weight" => {
+                    let weight = finite_number(value, property)?;
+                    if weight < 0.0 {
+                        return Err(invalid("ChartLineFormat.weight must be non-negative"));
+                    }
+                    line.width = Some(weight);
+                }
+                "clear" => {
+                    if !value.is_null() {
+                        return Err(invalid("ChartLineFormat.clear does not accept a value"));
+                    }
+                    line.color = None;
+                    line.width = None;
+                    line.dash_style = None;
+                    line.transparency = None;
+                    line.no_fill = Some(true);
+                }
+                other => {
+                    return Err(unsupported(format!(
+                        "ChartLineFormat.{other} is unsupported"
+                    )));
+                }
+            }
+            Ok(())
+        })
+    }
+
+    fn set_leader_line_property(
+        &self,
+        property: &str,
+        value: &Value,
+    ) -> Result<(), ChartFormatError> {
+        let chart = self.chart_data()?;
+        let mut labels = chart
+            .data_labels
+            .clone()
+            .unwrap_or_else(default_data_labels);
+        let line = labels.leader_lines_format.get_or_insert_with(empty_line);
+        match property {
+            "color" => {
+                line.color = Some(parse_color(value, property)?);
+                line.no_fill = Some(false);
+            }
+            "lineStyle" => {
+                let (style, no_fill) = line_style(value, property)?;
+                line.dash_style = style;
+                line.no_fill = Some(no_fill);
+            }
+            "weight" => {
+                let weight = finite_number(value, property)?;
+                if weight < 0.0 {
+                    return Err(invalid("ChartLineFormat.weight must be non-negative"));
+                }
+                line.width = Some(weight);
+            }
+            "clear" => {
+                if !value.is_null() {
+                    return Err(invalid("ChartLineFormat.clear does not accept a value"));
+                }
+                line.color = None;
+                line.width = None;
+                line.dash_style = None;
+                line.transparency = None;
+                line.no_fill = Some(true);
+            }
+            other => {
+                return Err(unsupported(format!(
+                    "ChartLineFormat.{other} is unsupported"
+                )));
+            }
+        }
+        self.update_field(
+            "dataLabels",
+            serde_json::to_value(labels).map_err(encoding)?,
+        )
+    }
+
+    fn set_legend_entry(&self, index: usize, visible: bool) -> Result<(), ChartFormatError> {
+        let chart = self.chart_data()?;
+        let mut legend = chart.legend.clone().unwrap_or_else(default_legend);
+        let entries = legend.entries.get_or_insert_with(Vec::new);
+        let Some(entry) = entries.get_mut(index) else {
+            return Err(item_not_found(&index.to_string(), "legend entry"));
+        };
+        entry.visible = Some(visible);
+        entry.delete = Some(!visible);
+        self.update_field("legend", serde_json::to_value(legend).map_err(encoding)?)
+    }
+}
+
+impl ExtensionObject for ChartFormatRef {
+    fn object_type(&self) -> &'static str {
+        "ChartFormat"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        self.load_properties(properties).map_err(batch_error)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        self.set_property(property, value).map_err(batch_error)
+    }
+}
+
+/// Host-side legend-entry collection. Collection items are bound by the JS
+/// item factory, so the engine remains the authority for every entry read and
+/// write while the collection can use the normal Office.js hydration shape.
+#[derive(Clone)]
+pub(crate) struct ChartLegendEntriesRef {
+    chart: ChartRef,
+}
+
+impl ChartLegendEntriesRef {
+    pub(crate) fn new(chart: ChartRef) -> Self {
+        Self { chart }
+    }
+
+    fn entries(
+        &self,
+    ) -> Result<Vec<domain_types::domain::chart::LegendEntryData>, ChartFormatError> {
+        let snapshot = self.chart.snapshot().map_err(chart_error)?;
+        let object: FloatingObject = serde_json::from_value(snapshot).map_err(encoding)?;
+        let FloatingObjectData::Chart(chart) = object.data else {
+            return Err(invalid("The referenced floating object is not a chart"));
+        };
+        Ok(chart
+            .legend
+            .and_then(|legend| legend.entries)
+            .unwrap_or_default())
+    }
+
+    pub(crate) fn count(&self) -> Result<usize, ChartFormatError> {
+        Ok(self.entries()?.len())
+    }
+
+    pub(crate) fn item(&self, index: usize) -> ChartFormatRef {
+        ChartFormatRef::from_target(self.chart.clone(), ChartFormatKind::LegendEntry(index))
+    }
+
+    pub(crate) fn load_collection(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, ChartFormatError> {
+        let mut result = HashMap::new();
+        if properties
+            .iter()
+            .any(|p| p == "items" || p.starts_with("items/"))
+        {
+            let item_properties: Vec<String> = properties
+                .iter()
+                .filter_map(|property| property.strip_prefix("items/"))
+                .filter(|property| !property.is_empty())
+                .map(ToString::to_string)
+                .collect();
+            let item_properties = if item_properties.is_empty() {
+                vec!["index".to_string(), "visible".to_string()]
+            } else {
+                item_properties
+            };
+            let entries = self.entries()?;
+            let mut descriptors = Vec::with_capacity(entries.len());
+            for index in 0..entries.len() {
+                let reference = self.item(index);
+                descriptors.push(json!({
+                    "key": index.to_string(),
+                    "properties": reference.load_properties(&item_properties)?,
+                }));
+            }
+            result.insert("items".to_string(), Value::Array(descriptors));
+        }
+        Ok(result)
+    }
+}
+
+impl ExtensionObject for ChartLegendEntriesRef {
+    fn object_type(&self) -> &'static str {
+        "ChartLegendEntryCollection"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        self.load_collection(properties).map_err(batch_error)
+    }
+
+    fn set(&self, property: &str, _value: &Value) -> Result<(), BatchError> {
+        Err(batch_error(unsupported(format!(
+            "ChartLegendEntryCollection.{property} is read-only"
+        ))))
+    }
+}
+
+/// Extension operation handler used by the host integrator.
+pub(crate) struct ChartFormatExtensionHandler;
+
+impl ExtensionHandler for ChartFormatExtensionHandler {
+    fn can_handle(&self, operation: &str) -> bool {
+        matches!(
+            operation,
+            "chartFormatGetObject"
+                | "chartFormatGetLegendEntries"
+                | "chartFormatLegendEntriesGetCount"
+                | "chartFormatLegendEntriesGetItemAt"
+                | "chartFormatFillGetSolidColor"
+        )
+    }
+
+    fn handle(
+        &self,
+        operation: &Value,
+        context: &mut HostDispatchContext<'_>,
+    ) -> Result<(), BatchError> {
+        let op = operation
+            .get("op")
+            .and_then(Value::as_str)
+            .ok_or_else(|| batch_error(invalid("Chart formatting operation has no op")))?;
+        match op {
+            "chartFormatGetLegendEntries" => {
+                let id = required_field(operation, "id")?;
+                let chart = chart_from_operation(operation, context)?;
+                context.bind_object(&id, Arc::new(ChartLegendEntriesRef::new(chart)));
+            }
+            "chartFormatLegendEntriesGetCount" => {
+                let result_id = required_field(operation, "resultId")?;
+                let parent_id = required_field(operation, "collectionId")?;
+                let collection = context.extension_object::<ChartLegendEntriesRef>(&parent_id)?;
+                let count = collection.count().map_err(batch_error)?;
+                context.set_result(&result_id, json!(count));
+            }
+            "chartFormatLegendEntriesGetItemAt" => {
+                let id = required_field(operation, "id")?;
+                let index = operation
+                    .get("index")
+                    .and_then(Value::as_u64)
+                    .ok_or_else(|| batch_error(invalid("legend entry index must be an integer")))?;
+                let chart = chart_from_operation(operation, context)?;
+                let reference = ChartFormatRef::from_target(
+                    chart,
+                    ChartFormatKind::LegendEntry(index as usize),
+                );
+                context.bind_object(&id, Arc::new(reference));
+            }
+            "chartFormatFillGetSolidColor" => {
+                let result_id = required_field(operation, "resultId")?;
+                let chart = chart_from_operation(operation, context)?;
+                let kind = operation
+                    .get("kind")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| batch_error(invalid("ChartFill operation has no kind")))?;
+                let reference = ChartFormatRef::from_chart(chart, kind).map_err(batch_error)?;
+                context.set_result(&result_id, reference.solid_color().map_err(batch_error)?);
+            }
+            "chartFormatGetObject" => {
+                let id = required_field(operation, "id")?;
+                let kind = operation
+                    .get("kind")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| batch_error(invalid("Chart formatting object has no kind")))?;
+                let chart = chart_from_operation(operation, context)?;
+                let reference = ChartFormatRef::from_chart(chart, kind).map_err(batch_error)?;
+                context.bind_object(&id, Arc::new(reference));
+            }
+            _ => unreachable!("can_handle filters chart formatting operations"),
+        }
+        Ok(())
+    }
+}
+
+fn chart_from_operation(
+    operation: &Value,
+    context: &HostDispatchContext<'_>,
+) -> Result<ChartRef, BatchError> {
+    if let Some(parent_id) = operation.get("parentId").and_then(Value::as_str)
+        && let Ok(chart) = context.extension_object::<ChartRef>(parent_id)
+    {
+        return Ok((*chart).clone());
+    }
+
+    let chart_id = required_field(operation, "chartId")?;
+    let worksheet_id = required_field(operation, "worksheetId")?;
+    let worksheet = context.worksheet(&worksheet_id)?;
+    Ok(ChartRef::new(worksheet.sheet(), chart_id))
+}
+
+fn required_field(operation: &Value, field: &str) -> Result<String, BatchError> {
+    operation
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .ok_or_else(|| {
+            batch_error(invalid(format!(
+                "Chart formatting operation requires {field}"
+            )))
+        })
+}
+
+fn load_title_property(chart: &ChartData, property: &str) -> Result<Value, ChartFormatError> {
+    match property {
+        "text" => Ok(Value::String(chart.title.clone().unwrap_or_default())),
+        "visible" => Ok(Value::Bool(title_visible(chart))),
+        "horizontalAlignment" => Ok(Value::String(
+            read_alignment(
+                chart.title_h_align.as_deref(),
+                "Center",
+                &["left", "center", "right"],
+            )?
+            .to_string(),
+        )),
+        "verticalAlignment" => Ok(Value::String(
+            read_alignment(
+                chart.title_v_align.as_deref(),
+                "Center",
+                &["top", "middle", "bottom"],
+            )?
+            .to_string(),
+        )),
+        "showShadow" => Ok(Value::Bool(chart.title_show_shadow.unwrap_or(false))),
+        "textOrientation" => Ok(json!(
+            chart
+                .title_format
+                .as_ref()
+                .and_then(|format| format.text_rotation)
+                .unwrap_or(0.0)
+        )),
+        "height" | "left" | "top" | "width" => Ok(Value::Null),
+        "overlay" | "position" => Err(unsupported(format!(
+            "ChartTitle.{property} has no persisted chart-data representation"
+        ))),
+        other => Err(unsupported(format!("ChartTitle.{other} is unsupported"))),
+    }
+}
+
+fn load_legend_property(chart: &ChartData, property: &str) -> Result<Value, ChartFormatError> {
+    let legend = chart.legend.as_ref();
+    match property {
+        "visible" => Ok(Value::Bool(legend.is_some_and(|legend| legend.visible))),
+        "overlay" => Ok(Value::Bool(
+            legend.and_then(|legend| legend.overlay).unwrap_or(false),
+        )),
+        "position" => Ok(Value::String(legend_position_read(
+            legend
+                .map(|legend| legend.position.as_str())
+                .unwrap_or("right"),
+        )?)),
+        "showShadow" => Ok(Value::Bool(
+            legend
+                .and_then(|legend| legend.show_shadow)
+                .or_else(|| legend.and_then(|legend| legend.shadow.as_ref()?.visible))
+                .unwrap_or(false),
+        )),
+        "height" | "left" | "top" | "width" => Ok(Value::Null),
+        "legendEntries" => Err(unsupported(
+            "ChartLegend.legendEntries is a navigation property".to_string(),
+        )),
+        other => Err(unsupported(format!("ChartLegend.{other} is unsupported"))),
+    }
+}
+
+fn load_data_labels_property(chart: &ChartData, property: &str) -> Result<Value, ChartFormatError> {
+    let labels = chart.data_labels.as_ref();
+    match property {
+        "autoText" => Ok(Value::Bool(
+            labels.and_then(|labels| labels.auto_text).unwrap_or(true),
+        )),
+        "geometricShapeType" => Ok(labels
+            .and_then(|labels| labels.geometric_shape_type.clone())
+            .map(Value::String)
+            .unwrap_or(Value::Null)),
+        "horizontalAlignment" => Ok(Value::String(read_alignment(
+            labels.and_then(|labels| labels.horizontal_alignment.as_deref()),
+            "Center",
+            &["left", "center", "right"],
+        )?)),
+        "linkNumberFormat" => Ok(Value::Bool(
+            labels
+                .and_then(|labels| labels.link_number_format)
+                .unwrap_or(false),
+        )),
+        "numberFormat" => Ok(Value::String(
+            labels
+                .and_then(|labels| {
+                    labels
+                        .number_format
+                        .clone()
+                        .or_else(|| labels.format.clone())
+                })
+                .unwrap_or_else(|| "General".to_string()),
+        )),
+        "position" => Ok(Value::String(data_label_position_read(
+            labels.and_then(|labels| labels.position.as_deref()),
+        )?)),
+        "separator" => Ok(Value::String(
+            labels
+                .and_then(|labels| labels.separator.clone())
+                .unwrap_or_else(|| ",".to_string()),
+        )),
+        "showAsStickyCallout" => Ok(Value::Bool(labels.is_some_and(|labels| {
+            labels
+                .geometric_shape_type
+                .as_deref()
+                .is_some_and(is_sticky_callout)
+        }))),
+        "showBubbleSize" => Ok(Value::Bool(
+            labels
+                .and_then(|labels| labels.show_bubble_size)
+                .unwrap_or(false),
+        )),
+        "showCategoryName" => Ok(Value::Bool(
+            labels
+                .and_then(|labels| labels.show_category_name)
+                .unwrap_or(false),
+        )),
+        "showLeaderLines" => Ok(Value::Bool(
+            labels
+                .and_then(|labels| labels.show_leader_lines)
+                .unwrap_or(false),
+        )),
+        "showLegendKey" => Ok(Value::Bool(
+            labels
+                .and_then(|labels| labels.show_legend_key)
+                .unwrap_or(false),
+        )),
+        "showPercentage" => Ok(Value::Bool(
+            labels
+                .and_then(|labels| labels.show_percentage)
+                .unwrap_or(false),
+        )),
+        "showSeriesName" => Ok(Value::Bool(
+            labels
+                .and_then(|labels| labels.show_series_name)
+                .unwrap_or(false),
+        )),
+        "showValue" => Ok(Value::Bool(
+            labels.and_then(|labels| labels.show_value).unwrap_or(false),
+        )),
+        "textOrientation" => Ok(json!(
+            labels
+                .and_then(|labels| {
+                    labels.text_orientation.or_else(|| {
+                        labels
+                            .visual_format
+                            .as_ref()
+                            .and_then(|format| format.text_rotation)
+                    })
+                })
+                .unwrap_or(0.0)
+        )),
+        "verticalAlignment" => Ok(Value::String(read_alignment(
+            labels.and_then(|labels| labels.vertical_alignment.as_deref()),
+            "Center",
+            &["top", "middle", "bottom"],
+        )?)),
+        other => Err(unsupported(format!(
+            "ChartDataLabels.{other} is unsupported"
+        ))),
+    }
+}
+
+fn load_area_format_property(chart: &ChartData, property: &str) -> Result<Value, ChartFormatError> {
+    match property {
+        "colorScheme" => Ok(Value::String(color_scheme_read(chart.color_scheme)?)),
+        "roundedCorners" => Ok(Value::Bool(chart.rounded_corners.unwrap_or(false))),
+        other => Err(unsupported(format!(
+            "ChartAreaFormat.{other} is unsupported"
+        ))),
+    }
+}
+
+fn load_fill_property(
+    chart: &ChartData,
+    owner: ChartFormatOwner,
+    property: &str,
+) -> Result<Value, ChartFormatError> {
+    if property != "solidColor" {
+        return Err(unsupported(format!("ChartFill.{property} is unsupported")));
+    }
+    let Some(format) = format_for(chart, owner) else {
+        return Ok(Value::Null);
+    };
+    let Some(ChartFillData::Solid { color, .. }) = format.fill.as_ref() else {
+        return Ok(Value::Null);
+    };
+    color_value(color)
+}
+
+fn load_font_property(
+    chart: &ChartData,
+    owner: ChartFormatOwner,
+    property: &str,
+) -> Result<Value, ChartFormatError> {
+    let font = format_for(chart, owner).and_then(|format| format.font.as_ref());
+    match property {
+        "bold" => Ok(Value::Bool(
+            font.and_then(|font| font.bold).unwrap_or(false),
+        )),
+        "color" => match font.and_then(|font| font.color.as_ref()) {
+            Some(color) => color_value(color),
+            None => Ok(Value::String("#000000".to_string())),
+        },
+        "italic" => Ok(Value::Bool(
+            font.and_then(|font| font.italic).unwrap_or(false),
+        )),
+        "name" => Ok(Value::String(
+            font.and_then(|font| font.name.clone())
+                .unwrap_or_else(|| "Calibri".to_string()),
+        )),
+        "size" => Ok(json!(font.and_then(|font| font.size).unwrap_or(11.0))),
+        "underline" => Ok(Value::String(underline_read(
+            font.and_then(|font| font.underline.as_ref()),
+        )?)),
+        other => Err(unsupported(format!("ChartFont.{other} is unsupported"))),
+    }
+}
+
+fn load_line_property(
+    chart: &ChartData,
+    owner: ChartFormatOwner,
+    property: &str,
+) -> Result<Value, ChartFormatError> {
+    let line = format_for(chart, owner).and_then(|format| format.line.as_ref());
+    match property {
+        "color" => match line.and_then(|line| line.color.as_ref()) {
+            Some(color) => color_value(color),
+            None => Ok(Value::String("#000000".to_string())),
+        },
+        "lineStyle" => Ok(Value::String(line_style_read(line)?)),
+        "weight" => Ok(json!(line.and_then(|line| line.width).unwrap_or(0.0))),
+        other => Err(unsupported(format!(
+            "ChartLineFormat.{other} is unsupported"
+        ))),
+    }
+}
+
+fn load_leader_line_property(chart: &ChartData, property: &str) -> Result<Value, ChartFormatError> {
+    let line = chart
+        .data_labels
+        .as_ref()
+        .and_then(|labels| labels.leader_lines_format.as_ref());
+    match property {
+        "color" => match line.and_then(|line| line.color.as_ref()) {
+            Some(color) => color_value(color),
+            None => Ok(Value::String("#000000".to_string())),
+        },
+        "lineStyle" => Ok(Value::String(line_style_read(line)?)),
+        "weight" => Ok(json!(line.and_then(|line| line.width).unwrap_or(0.0))),
+        other => Err(unsupported(format!(
+            "ChartLineFormat.{other} is unsupported"
+        ))),
+    }
+}
+
+fn format_for<'a>(chart: &'a ChartData, owner: ChartFormatOwner) -> Option<&'a ChartFormatData> {
+    match owner {
+        ChartFormatOwner::Chart => chart.chart_format.as_ref(),
+        ChartFormatOwner::Title => chart.title_format.as_ref(),
+        ChartFormatOwner::Legend => chart.legend.as_ref()?.format.as_ref(),
+        ChartFormatOwner::DataLabels => chart.data_labels.as_ref()?.visual_format.as_ref(),
+    }
+}
+
+fn empty_format() -> ChartFormatData {
+    serde_json::from_value(Value::Object(Map::new())).expect("empty chart format is valid")
+}
+
+fn empty_font() -> ChartFontData {
+    serde_json::from_value(Value::Object(Map::new())).expect("empty chart font is valid")
+}
+
+fn empty_line() -> ChartLineData {
+    serde_json::from_value(Value::Object(Map::new())).expect("empty chart line is valid")
+}
+
+fn default_legend() -> domain_types::domain::chart::LegendData {
+    serde_json::from_value(json!({
+        "show": false,
+        "position": "right",
+        "visible": false,
+    }))
+    .expect("default chart legend is valid")
+}
+
+fn default_data_labels() -> domain_types::domain::chart::DataLabelData {
+    serde_json::from_value(json!({ "show": false })).expect("default data labels are valid")
+}
+
+fn title_visible(chart: &ChartData) -> bool {
+    chart.auto_title_deleted != Some(true)
+        && (chart.title.is_some() || chart.auto_title_deleted == Some(false))
+}
+
+fn recompute_label_visibility(labels: &mut domain_types::domain::chart::DataLabelData) {
+    labels.show = labels.delete != Some(true)
+        && [
+            labels.show_value,
+            labels.show_category_name,
+            labels.show_series_name,
+            labels.show_percentage,
+            labels.show_bubble_size,
+            labels.show_legend_key,
+        ]
+        .into_iter()
+        .flatten()
+        .any(|value| value);
+}
+
+fn color_value(color: &ChartColorData) -> Result<Value, ChartFormatError> {
+    match color {
+        ChartColorData::Hex(value) => Ok(Value::String(if value.starts_with('#') {
+            value.clone()
+        } else {
+            format!("#{value}")
+        })),
+        ChartColorData::Theme { .. } => Err(unsupported(
+            "Theme chart colors cannot be projected to ChartFont/ChartFill HTML colors".to_string(),
+        )),
+    }
+}
+
+fn parse_color(value: &Value, property: &str) -> Result<ChartColorData, ChartFormatError> {
+    let value = string(value, property)?;
+    let hex = value.strip_prefix('#').unwrap_or(&value);
+    if hex.len() != 6 || !hex.chars().all(|character| character.is_ascii_hexdigit()) {
+        return Err(invalid(format!(
+            "{property} must be an HTML #RRGGBB color; named and theme colors are not persisted by the chart model"
+        )));
+    }
+    Ok(ChartColorData::Hex(hex.to_ascii_uppercase()))
+}
+
+fn read_alignment(
+    value: Option<&str>,
+    default: &str,
+    allowed: &[&str],
+) -> Result<&'static str, ChartFormatError> {
+    let value = value.unwrap_or(default);
+    let value = match value {
+        "left" | "Left" => "Left",
+        "center" | "middle" | "Center" => "Center",
+        "right" | "Right" => "Right",
+        "top" | "Top" => "Top",
+        "bottom" | "Bottom" => "Bottom",
+        "justify" | "Justify" => "Justify",
+        "distributed" | "Distributed" => "Distributed",
+        other => {
+            return Err(encoding(format!(
+                "Unknown persisted chart alignment '{other}'"
+            )));
+        }
+    };
+    if allowed.iter().any(|allowed| {
+        (*allowed == "left" && value == "Left")
+            || (*allowed == "center" && value == "Center")
+            || (*allowed == "right" && value == "Right")
+            || (*allowed == "top" && value == "Top")
+            || (*allowed == "middle" && value == "Center")
+            || (*allowed == "bottom" && value == "Bottom")
+    }) {
+        Ok(value)
+    } else {
+        Err(unsupported(format!(
+            "Persisted chart alignment '{value}' is not representable"
+        )))
+    }
+}
+
+fn title_horizontal_alignment(
+    value: &Value,
+    property: &str,
+) -> Result<&'static str, ChartFormatError> {
+    enum_value(
+        value,
+        property,
+        &[("Center", "center"), ("Left", "left"), ("Right", "right")],
+    )
+}
+
+fn title_vertical_alignment(
+    value: &Value,
+    property: &str,
+) -> Result<&'static str, ChartFormatError> {
+    enum_value(
+        value,
+        property,
+        &[("Center", "middle"), ("Top", "top"), ("Bottom", "bottom")],
+    )
+}
+
+fn data_label_horizontal_alignment(
+    value: &Value,
+    property: &str,
+) -> Result<&'static str, ChartFormatError> {
+    enum_value(
+        value,
+        property,
+        &[("Center", "center"), ("Left", "left"), ("Right", "right")],
+    )
+}
+
+fn data_label_vertical_alignment(
+    value: &Value,
+    property: &str,
+) -> Result<&'static str, ChartFormatError> {
+    enum_value(
+        value,
+        property,
+        &[("Center", "middle"), ("Top", "top"), ("Bottom", "bottom")],
+    )
+}
+
+fn legend_position(value: &Value, property: &str) -> Result<&'static str, ChartFormatError> {
+    enum_value(
+        value,
+        property,
+        &[
+            ("Top", "top"),
+            ("Bottom", "bottom"),
+            ("Left", "left"),
+            ("Right", "right"),
+            ("Corner", "topRight"),
+        ],
+    )
+}
+
+fn legend_position_read(value: &str) -> Result<String, ChartFormatError> {
+    match value {
+        "top" | "Top" => Ok("Top".to_string()),
+        "bottom" | "Bottom" => Ok("Bottom".to_string()),
+        "left" | "Left" => Ok("Left".to_string()),
+        "right" | "Right" | "" => Ok("Right".to_string()),
+        "topRight" | "corner" | "Corner" => Ok("Corner".to_string()),
+        "custom" | "Custom" => Ok("Custom".to_string()),
+        other => Err(encoding(format!(
+            "Unknown persisted chart legend position '{other}'"
+        ))),
+    }
+}
+
+fn data_label_position(value: &Value, property: &str) -> Result<&'static str, ChartFormatError> {
+    enum_value(
+        value,
+        property,
+        &[
+            ("Center", "center"),
+            ("InsideEnd", "insideEnd"),
+            ("InsideBase", "insideBase"),
+            ("OutsideEnd", "outsideEnd"),
+            ("Left", "left"),
+            ("Right", "right"),
+            ("Top", "top"),
+            ("Bottom", "bottom"),
+            ("BestFit", "bestFit"),
+        ],
+    )
+}
+
+fn data_label_position_read(value: Option<&str>) -> Result<String, ChartFormatError> {
+    match value.unwrap_or("bestFit") {
+        "center" | "Center" => Ok("Center".to_string()),
+        "insideEnd" | "InsideEnd" => Ok("InsideEnd".to_string()),
+        "insideBase" | "InsideBase" => Ok("InsideBase".to_string()),
+        "outsideEnd" | "OutsideEnd" => Ok("OutsideEnd".to_string()),
+        "left" | "Left" => Ok("Left".to_string()),
+        "right" | "Right" => Ok("Right".to_string()),
+        "top" | "Top" => Ok("Top".to_string()),
+        "bottom" | "Bottom" => Ok("Bottom".to_string()),
+        "bestFit" | "BestFit" => Ok("BestFit".to_string()),
+        "none" | "None" | "invalid" | "Invalid" | "callout" | "Callout" => Err(unsupported(
+            "The persisted chart model does not represent this data-label position".to_string(),
+        )),
+        other => Err(encoding(format!(
+            "Unknown persisted chart data-label position '{other}'"
+        ))),
+    }
+}
+
+fn color_scheme(value: &Value, property: &str) -> Result<u8, ChartFormatError> {
+    let value = value
+        .as_str()
+        .ok_or_else(|| invalid(format!("{property} must be a ChartColorScheme value")))?;
+    let number = match value {
+        "ColorfulPalette1" => 1,
+        "ColorfulPalette2" => 2,
+        "ColorfulPalette3" => 3,
+        "ColorfulPalette4" => 4,
+        "MonochromaticPalette1" => 5,
+        "MonochromaticPalette2" => 6,
+        "MonochromaticPalette3" => 7,
+        "MonochromaticPalette4" => 8,
+        "MonochromaticPalette5" => 9,
+        "MonochromaticPalette6" => 10,
+        "MonochromaticPalette7" => 11,
+        "MonochromaticPalette8" => 12,
+        "MonochromaticPalette9" => 13,
+        "MonochromaticPalette10" => 14,
+        "MonochromaticPalette11" => 15,
+        "MonochromaticPalette12" => 16,
+        "MonochromaticPalette13" => 17,
+        _ => return Err(invalid(format!("Invalid ChartColorScheme value '{value}'"))),
+    };
+    Ok(number)
+}
+
+fn color_scheme_read(value: Option<u8>) -> Result<String, ChartFormatError> {
+    let value = value.unwrap_or(1);
+    let name = match value {
+        1..=4 => format!("ColorfulPalette{value}"),
+        5..=17 => format!("MonochromaticPalette{}", value - 4),
+        _ => {
+            return Err(encoding(format!(
+                "Unknown persisted chart color scheme {value}"
+            )));
+        }
+    };
+    Ok(name)
+}
+
+fn line_style(
+    value: &Value,
+    property: &str,
+) -> Result<(Option<ChartDashStyle>, bool), ChartFormatError> {
+    let value = value
+        .as_str()
+        .ok_or_else(|| invalid(format!("{property} must be a ChartLineStyle value")))?;
+    let style = match value {
+        "None" => return Ok((None, true)),
+        "Continuous" => ChartDashStyle::Solid,
+        "Dash" => ChartDashStyle::Dash,
+        "DashDot" => ChartDashStyle::DashDot,
+        "Dot" => ChartDashStyle::Dot,
+        "DashDotDot" | "Grey25" | "Grey50" | "Grey75" | "Automatic" | "RoundDot" => {
+            return Err(unsupported(format!(
+                "ChartLineStyle.{value} has no lossless ChartLineData representation"
+            )));
+        }
+        _ => return Err(invalid(format!("Invalid ChartLineStyle value '{value}'"))),
+    };
+    Ok((Some(style), false))
+}
+
+fn line_style_read(line: Option<&ChartLineData>) -> Result<String, ChartFormatError> {
+    let Some(line) = line else {
+        return Ok("None".to_string());
+    };
+    if line.no_fill == Some(true) {
+        return Ok("None".to_string());
+    }
+    match line.dash_style.as_ref().unwrap_or(&ChartDashStyle::Solid) {
+        ChartDashStyle::Solid => Ok("Continuous".to_string()),
+        ChartDashStyle::Dash => Ok("Dash".to_string()),
+        ChartDashStyle::DashDot => Ok("DashDot".to_string()),
+        ChartDashStyle::Dot => Ok("Dot".to_string()),
+        ChartDashStyle::LongDash
+        | ChartDashStyle::LongDashDot
+        | ChartDashStyle::LongDashDotDot
+        | ChartDashStyle::SysDash
+        | ChartDashStyle::SysDot
+        | ChartDashStyle::SysDashDot
+        | ChartDashStyle::SysDashDotDot => Err(unsupported(
+            "The persisted chart line style is not representable by ChartLineStyle".to_string(),
+        )),
+    }
+}
+
+fn underline(value: &Value, property: &str) -> Result<ChartUnderlineStyle, ChartFormatError> {
+    match value.as_str() {
+        Some("None") => Ok(ChartUnderlineStyle::None),
+        Some("Single") => Ok(ChartUnderlineStyle::Single),
+        Some(other) => Err(unsupported(format!(
+            "ChartUnderlineStyle.{other} is not representable by the pinned ChartFont API"
+        ))),
+        None => Err(invalid(format!(
+            "{property} must be a ChartUnderlineStyle value"
+        ))),
+    }
+}
+
+fn underline_read(value: Option<&ChartUnderlineStyle>) -> Result<String, ChartFormatError> {
+    match value.unwrap_or(&ChartUnderlineStyle::None) {
+        ChartUnderlineStyle::None => Ok("None".to_string()),
+        ChartUnderlineStyle::Single => Ok("Single".to_string()),
+        _ => Err(unsupported(
+            "The persisted chart underline style is not representable by ChartUnderlineStyle"
+                .to_string(),
+        )),
+    }
+}
+
+fn is_sticky_callout(value: &str) -> bool {
+    matches!(
+        value,
+        "AccentCallout1"
+            | "AccentCallout2"
+            | "BorderCallout1"
+            | "BorderCallout2"
+            | "WedgeRectCallout"
+            | "WedgeRRectCallout"
+            | "WedgeEllipseCallout"
+    )
+}
+
+fn text_orientation(value: &Value, property: &str) -> Result<f64, ChartFormatError> {
+    let value = finite_number(value, property)?;
+    if !((-90.0..=90.0).contains(&value) || value == 180.0) {
+        return Err(invalid(format!(
+            "{property} must be -90 through 90, or 180"
+        )));
+    }
+    Ok(value)
+}
+
+fn enum_value(
+    value: &Value,
+    property: &str,
+    allowed: &[(&'static str, &'static str)],
+) -> Result<&'static str, ChartFormatError> {
+    let value = value
+        .as_str()
+        .ok_or_else(|| invalid(format!("{property} must be an enum value")))?;
+    allowed
+        .iter()
+        .find(|(wire, _)| *wire == value)
+        .map(|(_, persisted)| *persisted)
+        .ok_or_else(|| invalid(format!("Invalid {property} value '{value}'")))
+}
+
+fn string(value: &Value, property: &str) -> Result<String, ChartFormatError> {
+    value
+        .as_str()
+        .map(ToString::to_string)
+        .ok_or_else(|| invalid(format!("{property} must be a string")))
+}
+
+fn boolean(value: &Value, property: &str) -> Result<bool, ChartFormatError> {
+    value
+        .as_bool()
+        .ok_or_else(|| invalid(format!("{property} must be a boolean")))
+}
+
+fn finite_number(value: &Value, property: &str) -> Result<f64, ChartFormatError> {
+    let value = value
+        .as_f64()
+        .ok_or_else(|| invalid(format!("{property} must be a number")))?;
+    if !value.is_finite() {
+        return Err(invalid(format!("{property} must be finite")));
+    }
+    Ok(value)
+}
+
+fn chart_error(error: ChartError) -> ChartFormatError {
+    ChartFormatError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn batch_error(error: ChartFormatError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn invalid(message: impl Into<String>) -> ChartFormatError {
+    ChartFormatError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn unsupported(message: impl Into<String>) -> ChartFormatError {
+    ChartFormatError {
+        code: "ApiNotFound",
+        message: message.into(),
+    }
+}
+
+fn encoding(message: impl Into<String>) -> ChartFormatError {
+    ChartFormatError {
+        code: "GeneralException",
+        message: message.into(),
+    }
+}
+
+fn read_only(property: &str, object: &str) -> ChartFormatError {
+    ChartFormatError {
+        code: "InvalidArgument",
+        message: format!("{object}.{property} is read-only"),
+    }
+}
+
+fn item_not_found(index: &str, object: &str) -> ChartFormatError {
+    ChartFormatError {
+        code: "ItemNotFound",
+        message: format!("The requested {object} index {index} does not exist"),
+    }
+}

--- a/compute/officejs/src/chart_series.js
+++ b/compute/officejs/src/chart_series.js
@@ -1,0 +1,436 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs;
+
+  function propertyNotLoaded(name) {
+    var error = new OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function invalidArgument(message) {
+    return new OfficeExtension.Error({
+      code: "InvalidArgument",
+      message: message,
+    });
+  }
+
+  function invalidRequestContext() {
+    return new OfficeExtension.Error({
+      code: "InvalidRequestContext",
+      message: "The object belongs to a different request context.",
+    });
+  }
+
+  function integerArgument(value, property, allowNull) {
+    if (allowNull && (value === null || value === undefined)) return value;
+    if (typeof value !== "number" || !isFinite(value) || Math.floor(value) !== value) {
+      throw invalidArgument(property + " must be an integer");
+    }
+    return value;
+  }
+
+  function normalizeLoad(props, defaults) {
+    if (props === undefined || props === null) return defaults.slice();
+    if (typeof props === "string") {
+      return props
+        .split(",")
+        .map(function (entry) { return entry.trim(); })
+        .filter(Boolean);
+    }
+    if (Array.isArray(props)) {
+      return props.reduce(function (all, entry) {
+        return all.concat(normalizeLoad(entry, defaults));
+      }, []);
+    }
+    if (typeof props === "object") {
+      var result = props.$all === true ? defaults.slice() : [];
+      if (props.select != null) result = result.concat(normalizeLoad(props.select, []));
+      if (props.expand != null) result = result.concat(normalizeLoad(props.expand, []));
+      Object.keys(props).forEach(function (key) {
+        if (key === "$all" || key === "select" || key === "expand" || key === "top" || key === "skip") return;
+        var value = props[key];
+        if (value === true) result.push(key);
+        else if (value && typeof value === "object") {
+          if (value.$all === true) result.push(key);
+          normalizeLoad(value, []).forEach(function (path) {
+            result.push(key + "/" + path);
+          });
+        }
+      });
+      return result;
+    }
+    return [String(props)];
+  }
+
+  function seedLoaded(object, properties) {
+    if (!properties || typeof properties !== "object") return;
+    Object.keys(properties).forEach(function (name) {
+      object._loaded[name] = true;
+      object[name === "id" ? "_idValue" : "_" + name] = properties[name];
+    });
+  }
+
+  function toJSONScalars(object) {
+    var result = {};
+    (object._scalarProperties || []).forEach(function (name) {
+      if (object._loaded[name]) {
+        result[name] = name === "id" ? object._idValue : object["_" + name];
+      }
+    });
+    return result;
+  }
+
+  function newClientResult(context) {
+    if (officeJs && typeof officeJs.createClientResult === "function") {
+      return officeJs.createClientResult(context);
+    }
+    return new OfficeExtension.ClientResult(context);
+  }
+
+  function queueSeriesBinding(series, collection, index) {
+    series._collection = collection;
+    series._collectionId = collection._id;
+    series._index = index;
+    series.context._queue.push({
+      op: "chartSeriesCollectionGetItem",
+      id: series._id,
+      collectionId: collection._id,
+      chartId: collection._chart._id,
+      index: index,
+    });
+  }
+
+  function requireRange(source, context, property) {
+    if (!(source instanceof Excel.Range)) {
+      throw invalidArgument(property + " requires a Range");
+    }
+    if (source.context !== context) throw invalidRequestContext();
+    return source;
+  }
+
+  function ChartSeriesCollection(context, chart) {
+    ClientObject.call(this, context);
+    this._chart = chart;
+    this._worksheet = chart._worksheet || chart._sheet || null;
+    this._scalarProperties = ["items", "count"];
+    this._navigationProperties = ["items"];
+    this._itemCache = Object.create(null);
+    this._bindingQueued = false;
+
+    context._queue.push({
+      op: "getChartSeriesCollection",
+      id: this._id,
+      chartId: chart._id,
+      worksheetId: this._worksheet ? this._worksheet._id : undefined,
+    });
+
+    var hooks = global.__mogOfficeJs;
+    if (hooks && typeof hooks.configureCollection === "function") {
+      hooks.configureCollection(this, function (key) {
+        return this.getItemAt(Number(key));
+      });
+    } else {
+      this._hydrateItems = function (descriptors) {
+        if (!Array.isArray(descriptors)) {
+          throw new OfficeExtension.Error({
+            code: "GeneralException",
+            message: "The host returned an invalid chart series collection result.",
+          });
+        }
+        return descriptors.map(function (descriptor, index) {
+          var key = descriptor && descriptor.key !== undefined ? descriptor.key : index;
+          var item = this.getItemAt(Number(key));
+          seedLoaded(item, descriptor && descriptor.properties);
+          return item;
+        }, this);
+      };
+    }
+  }
+  ChartSeriesCollection.prototype = Object.create(ClientObject.prototype);
+  ChartSeriesCollection.prototype.constructor = ChartSeriesCollection;
+
+  Object.defineProperty(ChartSeriesCollection.prototype, "items", {
+    get: function () {
+      if (!this._loaded.items) throw propertyNotLoaded("items");
+      return this._items || [];
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(ChartSeriesCollection.prototype, "count", {
+    get: function () {
+      if (!this._loaded.count) throw propertyNotLoaded("count");
+      return this._count;
+    },
+    configurable: true,
+  });
+
+  ChartSeriesCollection.prototype._getItem = function (index) {
+    integerArgument(index, "ChartSeriesCollection.getItemAt index", false);
+    var key = String(index);
+    var item = this._itemCache[key];
+    if (!item) {
+      item = new ChartSeries(this.context, this, index, false);
+      queueSeriesBinding(item, this, index);
+      this._itemCache[key] = item;
+    }
+    return item;
+  };
+
+  ChartSeriesCollection.prototype.getItemAt = function (index) {
+    return this._getItem(index);
+  };
+
+  ChartSeriesCollection.prototype.add = function (name, index) {
+    if (name !== undefined && name !== null && typeof name !== "string") {
+      throw invalidArgument("ChartSeriesCollection.add name must be a string");
+    }
+    integerArgument(index, "ChartSeriesCollection.add index", true);
+    var series = new ChartSeries(this.context, this, index, false);
+    var operation = {
+      op: "chartSeriesCollectionAdd",
+      id: series._id,
+      collectionId: this._id,
+      chartId: this._chart._id,
+    };
+    if (name !== undefined && name !== null) operation.name = name;
+    if (index !== undefined && index !== null) operation.index = index;
+    this.context._queue.push(operation);
+    return series;
+  };
+
+  ChartSeriesCollection.prototype.getCount = function () {
+    var result = newClientResult(this.context);
+    this.context._queue.push({
+      op: "chartSeriesCollectionGetCount",
+      collectionId: this._id,
+      chartId: this._chart._id,
+      resultId: result._id,
+    });
+    return result;
+  };
+
+  ChartSeriesCollection.prototype.load = function (props) {
+    var defaults = ["items", "count"];
+    var itemProperties = [
+      "name", "axisGroup", "chartType", "filtered", "smooth", "plotOrder",
+    ];
+    var paths = normalizeLoad(props, defaults).map(function (path) {
+      if (path === "items" || path === "count" || path.indexOf("items/") === 0) return path;
+      return itemProperties.indexOf(path) >= 0 ? "items/" + path : path;
+    });
+    if (paths.length) {
+      this.context._queue.push({
+        op: "load",
+        id: this._id,
+        properties: paths,
+      });
+    }
+    return this;
+  };
+
+  ChartSeriesCollection.prototype.toJSON = function () {
+    if (!this._loaded.items) return {};
+    return {
+      items: this.items.map(function (item) {
+        return item && typeof item.toJSON === "function" ? item.toJSON() : item;
+      }),
+    };
+  };
+
+  function ChartSeries(context, collection, index, bind) {
+    ClientObject.call(this, context);
+    this._collection = collection;
+    this._collectionId = collection._id;
+    this._chart = collection._chart;
+    this._worksheet = collection._worksheet;
+    this._index = index === undefined || index === null ? null : index;
+    this._scalarProperties = [
+      "axisGroup", "chartType", "filtered", "name", "plotOrder", "smooth",
+    ];
+    if (bind) queueSeriesBinding(this, collection, index);
+  }
+  ChartSeries.prototype = Object.create(ClientObject.prototype);
+  ChartSeries.prototype.constructor = ChartSeries;
+
+  ["axisGroup", "chartType", "filtered", "name", "plotOrder", "smooth"].forEach(function (name) {
+    Object.defineProperty(ChartSeries.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        if (name === "axisGroup" && value !== "Primary" && value !== "Secondary") {
+          throw invalidArgument("ChartSeries.axisGroup must be Primary or Secondary");
+        }
+        if (name === "chartType" && typeof value !== "string") {
+          throw invalidArgument("ChartSeries.chartType must be a string");
+        }
+        if (name === "filtered" || name === "smooth") {
+          if (typeof value !== "boolean") throw invalidArgument("ChartSeries." + name + " must be a boolean");
+        }
+        if (name === "name") {
+          if (typeof value !== "string") throw invalidArgument("ChartSeries.name must be a string");
+          if (value.length > 255) throw invalidArgument("ChartSeries.name cannot exceed 255 characters");
+        }
+        if (name === "plotOrder") integerArgument(value, "ChartSeries.plotOrder", false);
+        this["_" + name] = value;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: value,
+        });
+      },
+      configurable: true,
+    });
+  });
+
+  ChartSeries.prototype.set = function (source, options) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+    var readOnly = ["context", "isNullObject"];
+    var names = ["axisGroup", "chartType", "filtered", "name", "plotOrder", "smooth"];
+    var isClientObject = source instanceof ClientObject;
+    if (isClientObject && Object.getPrototypeOf(source) !== Object.getPrototypeOf(this)) {
+      throw invalidArgument("The object passed to set must have the same type.");
+    }
+    if (!isClientObject && (!options || options.throwOnReadOnly !== false)) {
+      for (var i = 0; i < readOnly.length; i++) {
+        if (Object.prototype.hasOwnProperty.call(source, readOnly[i])) {
+          throw invalidArgument("The property '" + readOnly[i] + "' is read-only.");
+        }
+      }
+    }
+    for (var j = 0; j < names.length; j++) {
+      var name = names[j];
+      if (isClientObject) {
+        if (source._loaded[name]) this[name] = source[name];
+      } else if (Object.prototype.hasOwnProperty.call(source, name)) {
+        this[name] = source[name];
+      }
+    }
+  };
+
+  ChartSeries.prototype.delete = function () {
+    this.context._queue.push({
+      op: "chartSeriesDelete",
+      id: this._id,
+      chartId: this._chart._id,
+    });
+  };
+
+  function queueDimensionResult(series, operation, dimension) {
+    if (typeof dimension !== "string") {
+      throw invalidArgument(operation + " dimension must be a ChartSeriesDimension");
+    }
+    var result = newClientResult(series.context);
+    series.context._queue.push({
+      op: operation,
+      id: series._id,
+      chartId: series._chart._id,
+      dimension: dimension,
+      resultId: result._id,
+    });
+    return result;
+  }
+
+  ChartSeries.prototype.getDimensionDataSourceString = function (dimension) {
+    return queueDimensionResult(this, "chartSeriesGetDimensionDataSourceString", dimension);
+  };
+
+  ChartSeries.prototype.getDimensionDataSourceType = function (dimension) {
+    return queueDimensionResult(this, "chartSeriesGetDimensionDataSourceType", dimension);
+  };
+
+  ChartSeries.prototype.getDimensionValues = function (dimension) {
+    return queueDimensionResult(this, "chartSeriesGetDimensionValues", dimension);
+  };
+
+  function setDimensionSource(series, dimension, sourceData, method) {
+    var range = requireRange(sourceData, series.context, method);
+    series.context._queue.push({
+      op: "chartSeriesSetDimensionSource",
+      id: series._id,
+      chartId: series._chart._id,
+      dimension: dimension,
+      rangeId: range._id,
+    });
+  }
+
+  ChartSeries.prototype.setBubbleSizes = function (sourceData) {
+    setDimensionSource(this, "BubbleSizes", sourceData, "ChartSeries.setBubbleSizes");
+  };
+
+  ChartSeries.prototype.setValues = function (sourceData) {
+    setDimensionSource(this, "Values", sourceData, "ChartSeries.setValues");
+  };
+
+  ChartSeries.prototype.setXAxisValues = function (sourceData) {
+    setDimensionSource(this, "XValues", sourceData, "ChartSeries.setXAxisValues");
+  };
+
+  ChartSeries.prototype.toJSON = function () {
+    return toJSONScalars(this);
+  };
+
+  function chartSeriesForChart(chart) {
+    chart._navigationProperties = chart._navigationProperties || [];
+    if (chart._navigationProperties.indexOf("series") < 0) {
+      chart._navigationProperties.push("series");
+    }
+    if (!chart._series) {
+      chart._series = new ChartSeriesCollection(chart.context, chart);
+    }
+    return chart._series;
+  }
+
+  function installChartSeries() {
+    if (!Excel || !Excel.Chart || !Excel.Chart.prototype) return false;
+    Object.defineProperty(Excel.Chart.prototype, "series", {
+      get: function () {
+        return chartSeriesForChart(this);
+      },
+      configurable: true,
+    });
+    // A caller may load `chart.load("series")` before ever reading the
+    // navigation property.  The core Chart constructor starts with an empty
+    // navigation list, so make the base ClientObject loader see this child in
+    // that order as well as when `chart.series` is read first.
+    var chartLoad = Excel.Chart.prototype.load;
+    if (typeof chartLoad === "function" && !chartLoad._chartSeriesNavigation) {
+      var wrappedLoad = function (props) {
+        this._navigationProperties = this._navigationProperties || [];
+        if (this._navigationProperties.indexOf("series") < 0) {
+          this._navigationProperties.push("series");
+        }
+        return chartLoad.apply(this, arguments);
+      };
+      wrappedLoad._chartSeriesNavigation = true;
+      Excel.Chart.prototype.load = wrappedLoad;
+    }
+    Excel.ChartSeriesCollection = ChartSeriesCollection;
+    Excel.ChartSeries = ChartSeries;
+    return true;
+  }
+
+  // The chart core module is loaded before this module in production. Keep an
+  // install hook as well so a host that evaluates modules in a different order
+  // can attach the navigation after defining Excel.Chart.
+  if (global.__mogOfficeJs) global.__mogOfficeJs.installChartSeries = installChartSeries;
+  installChartSeries();
+})(globalThis);

--- a/compute/officejs/src/chart_series.rs
+++ b/compute/officejs/src/chart_series.rs
@@ -1,0 +1,886 @@
+//! Office.js chart series and series collection bindings.
+//!
+//! A series does not have a persisted identity in the compute engine.  The
+//! adapter therefore keeps only the chart's stable ID and the current ordinal
+//! position.  Every operation reads the chart again before it acts.  This is
+//! deliberate: inserting or deleting a series must immediately be visible to
+//! all existing proxies, and a proxy must never carry a second, stale series
+//! list in the Office.js host.
+
+use crate::chart_core::{ChartError, ChartRef};
+use compute_api::{CellRange, Sheet, Workbook};
+use serde::Serialize;
+use serde_json::{Map, Value, json};
+use std::collections::HashMap;
+
+/// Errors returned by the chart series Office.js adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChartSeriesError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+/// A series item in a `ChartSeriesCollection` hydration response.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ChartSeriesCollectionItem {
+    pub(crate) key: String,
+    pub(crate) properties: HashMap<String, Value>,
+}
+
+/// A worksheet/chart scoped series collection.
+///
+/// `Workbook` is retained for resolving a formula that names another
+/// worksheet.  `ChartRef` remains the owner of chart persistence and lookup;
+/// the collection does not cache a copied series vector.
+#[derive(Clone)]
+pub(crate) struct ChartSeriesCollectionRef {
+    workbook: Workbook,
+    chart: ChartRef,
+}
+
+/// A series proxy anchored by the chart's stable engine ID and current index.
+#[derive(Clone)]
+pub(crate) struct ChartSeriesRef {
+    workbook: Workbook,
+    chart: ChartRef,
+    index: usize,
+}
+
+const DEFAULT_SERIES_PROPERTIES: &[&str] = &["name", "axisGroup", "chartType"];
+
+impl ChartSeriesCollectionRef {
+    /// Construct a series collection owned by `chart`.
+    pub(crate) fn new(workbook: Workbook, chart: ChartRef) -> Self {
+        Self { workbook, chart }
+    }
+
+    /// Construct a collection from a workbook/sheet/stable chart ID tuple.
+    /// This is useful to host dispatchers that store only the chart identity.
+    pub(crate) fn from_parts(
+        workbook: Workbook,
+        sheet: Sheet,
+        chart_id: impl Into<String>,
+    ) -> Self {
+        Self::new(workbook, ChartRef::new(sheet, chart_id))
+    }
+
+    pub(crate) fn chart(&self) -> ChartRef {
+        self.chart.clone()
+    }
+
+    /// Return the current number of series in the persisted chart.
+    pub(crate) fn count(&self) -> Result<usize, ChartSeriesError> {
+        Ok(read_series(&self.chart_snapshot()?).len())
+    }
+
+    /// Alias for hosts that model collection count as `getCount`.
+    pub(crate) fn get_count(&self) -> Result<usize, ChartSeriesError> {
+        self.count()
+    }
+
+    /// Return a series proxy for a zero-based current collection position.
+    pub(crate) fn get_item_at(&self, index: i64) -> Result<ChartSeriesRef, ChartSeriesError> {
+        let series = read_series(&self.chart_snapshot()?);
+        let index = checked_index(index, series.len())?;
+        Ok(self.series_ref(index))
+    }
+
+    /// Add a new series and return its newly inserted proxy.
+    pub(crate) fn add(
+        &self,
+        name: Option<&str>,
+        index: Option<i64>,
+    ) -> Result<ChartSeriesRef, ChartSeriesError> {
+        let snapshot = self.chart_snapshot()?;
+        let mut series = read_series(&snapshot);
+        let insertion_index = match index {
+            Some(index) => checked_insertion_index(index, series.len())?,
+            None => series.len(),
+        };
+
+        let mut new_series = Map::new();
+        if let Some(name) = name {
+            new_series.insert(
+                "name".to_string(),
+                Value::String(validate_series_name(name)?.to_string()),
+            );
+        }
+        series.insert(insertion_index, Value::Object(new_series));
+        self.persist_series(series)?;
+        Ok(self.series_ref(insertion_index))
+    }
+
+    /// Load collection properties, including `items` descriptors.
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, ChartSeriesError> {
+        let requested = if properties.is_empty() {
+            vec!["count".to_string()]
+        } else {
+            properties.to_vec()
+        };
+        let snapshot = self.chart_snapshot()?;
+        let series = read_series(&snapshot);
+        let mut result = HashMap::new();
+        let mut item_properties = Vec::new();
+        let mut load_items = false;
+
+        for property in requested {
+            match property.as_str() {
+                "count" => {
+                    result.insert(property, json!(series.len()));
+                }
+                "isNullObject" => {
+                    result.insert(property, Value::Bool(false));
+                }
+                "items" => {
+                    load_items = true;
+                }
+                item_path if item_path.starts_with("items/") => {
+                    let item_property = item_path.trim_start_matches("items/");
+                    if item_property.is_empty() || item_property.contains('/') {
+                        return Err(invalid(format!(
+                            "Invalid ChartSeriesCollection item property '{item_path}'"
+                        )));
+                    }
+                    load_items = true;
+                    item_properties.push(item_property.to_string());
+                }
+                other => {
+                    return Err(unsupported_collection_property(other));
+                }
+            }
+        }
+
+        if load_items {
+            if item_properties.is_empty() {
+                item_properties = DEFAULT_SERIES_PROPERTIES
+                    .iter()
+                    .map(|property| (*property).to_string())
+                    .collect();
+            }
+            let items = series
+                .iter()
+                .enumerate()
+                .map(|(index, item)| {
+                    Ok(ChartSeriesCollectionItem {
+                        key: index.to_string(),
+                        properties: project_series(
+                            &snapshot,
+                            item,
+                            index,
+                            &item_properties,
+                            &self.workbook,
+                            &self.chart.sheet(),
+                        )?,
+                    })
+                })
+                .collect::<Result<Vec<_>, ChartSeriesError>>()?;
+            result.insert(
+                "items".to_string(),
+                serde_json::to_value(items).map_err(encoding)?,
+            );
+        }
+
+        Ok(result)
+    }
+
+    /// Return item descriptors for collection hydration helpers.
+    pub(crate) fn collection_items(
+        &self,
+        properties: &[String],
+    ) -> Result<Vec<ChartSeriesCollectionItem>, ChartSeriesError> {
+        let snapshot = self.chart_snapshot()?;
+        let series = read_series(&snapshot);
+        let properties = if properties.is_empty() {
+            DEFAULT_SERIES_PROPERTIES
+                .iter()
+                .map(|property| (*property).to_string())
+                .collect::<Vec<_>>()
+        } else {
+            properties.to_vec()
+        };
+        series
+            .iter()
+            .enumerate()
+            .map(|(index, item)| {
+                Ok(ChartSeriesCollectionItem {
+                    key: index.to_string(),
+                    properties: project_series(
+                        &snapshot,
+                        item,
+                        index,
+                        &properties,
+                        &self.workbook,
+                        &self.chart.sheet(),
+                    )?,
+                })
+            })
+            .collect()
+    }
+
+    fn series_ref(&self, index: usize) -> ChartSeriesRef {
+        ChartSeriesRef {
+            workbook: self.workbook.clone(),
+            chart: self.chart.clone(),
+            index,
+        }
+    }
+
+    fn chart_snapshot(&self) -> Result<Value, ChartSeriesError> {
+        self.chart.snapshot().map_err(from_chart_error)
+    }
+
+    fn persist_series(&self, series: Vec<Value>) -> Result<(), ChartSeriesError> {
+        self.chart
+            .update_fields(&json!({ "series": series }))
+            .map_err(from_chart_error)
+    }
+}
+
+impl ChartSeriesRef {
+    pub(crate) fn new(workbook: Workbook, chart: ChartRef, index: usize) -> Self {
+        Self {
+            workbook,
+            chart,
+            index,
+        }
+    }
+
+    pub(crate) fn chart(&self) -> ChartRef {
+        self.chart.clone()
+    }
+
+    pub(crate) fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Load current scalar series properties from the engine-backed chart.
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, ChartSeriesError> {
+        let snapshot = self.chart_snapshot()?;
+        let series = current_series(&snapshot, self.index)?;
+        let properties = if properties.is_empty() {
+            DEFAULT_SERIES_PROPERTIES
+                .iter()
+                .map(|property| (*property).to_string())
+                .collect::<Vec<_>>()
+        } else {
+            properties.to_vec()
+        };
+        project_series(
+            &snapshot,
+            series,
+            self.index,
+            &properties,
+            &self.workbook,
+            &self.chart.sheet(),
+        )
+    }
+
+    /// Set a writable scalar series property and persist the complete series
+    /// vector through the chart owner.
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), ChartSeriesError> {
+        let snapshot = self.chart_snapshot()?;
+        let mut series = read_series(&snapshot);
+        let target = series
+            .get_mut(self.index)
+            .ok_or_else(|| item_not_found(self.index))?;
+        let target = target
+            .as_object_mut()
+            .ok_or_else(|| invalid("Persisted chart series must be an object"))?;
+
+        match property {
+            "name" => {
+                let name = value
+                    .as_str()
+                    .ok_or_else(|| invalid("ChartSeries.name must be a string"))?;
+                target.insert(
+                    "name".to_string(),
+                    Value::String(validate_series_name(name)?.to_string()),
+                );
+            }
+            "axisGroup" => {
+                let axis_group = value
+                    .as_str()
+                    .ok_or_else(|| invalid("ChartSeries.axisGroup must be a string"))?;
+                let axis_index = match axis_group {
+                    "Primary" => 0,
+                    "Secondary" => 1,
+                    other => {
+                        return Err(invalid(format!(
+                            "ChartSeries.axisGroup must be Primary or Secondary; got '{other}'"
+                        )));
+                    }
+                };
+                target.insert("yAxisIndex".to_string(), json!(axis_index));
+            }
+            "chartType" => {
+                let chart_type = value
+                    .as_str()
+                    .ok_or_else(|| invalid("ChartSeries.chartType must be a string"))?;
+                if chart_type.trim().is_empty() {
+                    return Err(invalid("ChartSeries.chartType must be a non-empty string"));
+                }
+                target.insert(
+                    "type".to_string(),
+                    Value::String(internal_chart_type(chart_type)),
+                );
+            }
+            "filtered" | "smooth" => {
+                let value = value
+                    .as_bool()
+                    .ok_or_else(|| invalid(format!("ChartSeries.{property} must be a boolean")))?;
+                target.insert(property.to_string(), Value::Bool(value));
+            }
+            "plotOrder" => {
+                let value = value
+                    .as_i64()
+                    .ok_or_else(|| invalid("ChartSeries.plotOrder must be an integer"))?;
+                if value < 0 {
+                    return Err(invalid("ChartSeries.plotOrder must be non-negative"));
+                }
+                target.insert("plotOrder".to_string(), json!(value));
+            }
+            "isNullObject" => {
+                return Err(invalid("ChartSeries.isNullObject is read-only"));
+            }
+            other => return Err(unsupported_series_property(other)),
+        }
+
+        self.persist_series(series)
+    }
+
+    /// Delete this series from the current chart.
+    pub(crate) fn delete(&self) -> Result<(), ChartSeriesError> {
+        let snapshot = self.chart_snapshot()?;
+        let mut series = read_series(&snapshot);
+        if self.index >= series.len() {
+            return Err(item_not_found(self.index));
+        }
+        series.remove(self.index);
+        self.persist_series(series)
+    }
+
+    /// Get a formula/source string for one of the chart's data dimensions.
+    pub(crate) fn get_dimension_data_source_string(
+        &self,
+        dimension: &str,
+    ) -> Result<String, ChartSeriesError> {
+        let snapshot = self.chart_snapshot()?;
+        let series = current_series(&snapshot, self.index)?;
+        dimension_source(&snapshot, series, dimension).map(|source| source.unwrap_or_default())
+    }
+
+    /// Return the source kind used by one chart data dimension.
+    pub(crate) fn get_dimension_data_source_type(
+        &self,
+        dimension: &str,
+    ) -> Result<String, ChartSeriesError> {
+        let snapshot = self.chart_snapshot()?;
+        let series = current_series(&snapshot, self.index)?;
+        let source = dimension_source(&snapshot, series, dimension)?;
+        Ok(source_type(source.as_deref()))
+    }
+
+    /// Resolve one chart data dimension to display strings from the source
+    /// range.  A cached chart point is used only when no source formula exists.
+    pub(crate) fn get_dimension_values(
+        &self,
+        dimension: &str,
+    ) -> Result<Vec<String>, ChartSeriesError> {
+        let snapshot = self.chart_snapshot()?;
+        let series = current_series(&snapshot, self.index)?;
+        let source = dimension_source(&snapshot, series, dimension)?;
+        if let Some(source) = source {
+            return resolve_source_values(&self.workbook, &self.chart.sheet(), &source);
+        }
+        Ok(cached_dimension_values(series, dimension))
+    }
+
+    /// Bind a chart data dimension to an Office.js Range proxy's source.
+    pub(crate) fn set_dimension_source(
+        &self,
+        dimension: &str,
+        source_sheet: &Sheet,
+        source_address: &str,
+    ) -> Result<(), ChartSeriesError> {
+        let source = source_formula(source_sheet, source_address)?;
+        let snapshot = self.chart_snapshot()?;
+        let mut series = read_series(&snapshot);
+        let target = series
+            .get_mut(self.index)
+            .ok_or_else(|| item_not_found(self.index))?;
+        let target = target
+            .as_object_mut()
+            .ok_or_else(|| invalid("Persisted chart series must be an object"))?;
+
+        match dimension {
+            "Categories" => {
+                target.insert("categories".to_string(), Value::String(source));
+            }
+            "Values" | "YValues" => {
+                target.insert("values".to_string(), Value::String(source));
+            }
+            "XValues" => {
+                target.insert("categories".to_string(), Value::String(source));
+                target.insert(
+                    "xRole".to_string(),
+                    Value::String("quantitative".to_string()),
+                );
+            }
+            "BubbleSizes" => {
+                target.insert("bubbleSize".to_string(), Value::String(source));
+            }
+            other => return Err(unsupported_dimension(other)),
+        }
+        self.persist_series(series)
+    }
+
+    // Concise aliases make the host adapter insensitive to whether it names
+    // these operations after the Office.js method or the persisted dimension.
+    pub(crate) fn dimension_source_string(
+        &self,
+        dimension: &str,
+    ) -> Result<String, ChartSeriesError> {
+        self.get_dimension_data_source_string(dimension)
+    }
+
+    pub(crate) fn dimension_source_type(
+        &self,
+        dimension: &str,
+    ) -> Result<String, ChartSeriesError> {
+        self.get_dimension_data_source_type(dimension)
+    }
+
+    pub(crate) fn dimension_values(
+        &self,
+        dimension: &str,
+    ) -> Result<Vec<String>, ChartSeriesError> {
+        self.get_dimension_values(dimension)
+    }
+
+    fn chart_snapshot(&self) -> Result<Value, ChartSeriesError> {
+        self.chart.snapshot().map_err(from_chart_error)
+    }
+
+    fn persist_series(&self, series: Vec<Value>) -> Result<(), ChartSeriesError> {
+        self.chart
+            .update_fields(&json!({ "series": series }))
+            .map_err(from_chart_error)
+    }
+}
+
+fn read_series(chart: &Value) -> Vec<Value> {
+    chart
+        .get("series")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn current_series(chart: &Value, index: usize) -> Result<&Value, ChartSeriesError> {
+    chart
+        .get("series")
+        .and_then(Value::as_array)
+        .and_then(|series| series.get(index))
+        .ok_or_else(|| item_not_found(index))
+}
+
+fn project_series(
+    chart: &Value,
+    series: &Value,
+    index: usize,
+    properties: &[String],
+    workbook: &Workbook,
+    default_sheet: &Sheet,
+) -> Result<HashMap<String, Value>, ChartSeriesError> {
+    let mut result = HashMap::new();
+    for property in properties {
+        let value = match property.as_str() {
+            "name" => Value::String(series_name(series, index, workbook, default_sheet)),
+            "axisGroup" => Value::String(axis_group(series)),
+            "chartType" => Value::String(series_chart_type(chart, series)),
+            "filtered" => Value::Bool(
+                series
+                    .get("filtered")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            ),
+            "smooth" => Value::Bool(
+                series
+                    .get("smooth")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            ),
+            "plotOrder" => series
+                .get("plotOrder")
+                .cloned()
+                .unwrap_or_else(|| json!(index)),
+            "isNullObject" => Value::Bool(false),
+            other => return Err(unsupported_series_property(other)),
+        };
+        result.insert(property.clone(), value);
+    }
+    Ok(result)
+}
+
+fn series_name(series: &Value, index: usize, workbook: &Workbook, default_sheet: &Sheet) -> String {
+    if let Some(name) = series.get("name").and_then(Value::as_str) {
+        return name.to_string();
+    }
+    if let Some(name_ref) = series.get("nameRef").and_then(Value::as_str)
+        && let Ok(values) = resolve_source_values(workbook, default_sheet, name_ref)
+        && let Some(name) = values.into_iter().find(|value| !value.is_empty())
+    {
+        return name;
+    }
+    format!("Series{}", index + 1)
+}
+
+fn axis_group(series: &Value) -> String {
+    if series
+        .get("yAxisIndex")
+        .and_then(Value::as_i64)
+        .is_some_and(|index| index > 0)
+    {
+        "Secondary".to_string()
+    } else {
+        "Primary".to_string()
+    }
+}
+
+fn series_chart_type(chart: &Value, series: &Value) -> String {
+    let token = series
+        .get("type")
+        .and_then(Value::as_str)
+        .or_else(|| chart.get("chartType").and_then(Value::as_str))
+        .unwrap_or("ColumnClustered");
+    office_chart_type(token)
+}
+
+fn office_chart_type(token: &str) -> String {
+    match token {
+        // Domain chart type tokens.
+        "column" => "ColumnClustered",
+        "column3D" => "3DColumnClustered",
+        "bar" => "BarClustered",
+        "bar3D" => "3DBarClustered",
+        "line" => "Line",
+        "line3D" => "3DLine",
+        "pie" => "Pie",
+        "pie3D" => "3DPie",
+        "doughnut" => "Doughnut",
+        "scatter" => "XYScatter",
+        "area" => "Area",
+        "area3D" => "3DArea",
+        "radar" => "Radar",
+        "bubble" => "Bubble",
+        "stock" => "StockHLC",
+        "surface" => "Surface",
+        "surface3D" => "3DSurface",
+        "ofPie" => "PieOfPie",
+        "waterfall" => "Waterfall",
+        "treemap" => "Treemap",
+        "sunburst" => "Sunburst",
+        "funnel" => "Funnel",
+        "regionMap" => "RegionMap",
+        "histogram" => "Histogram",
+        "pareto" => "Pareto",
+        "boxplot" => "Boxwhisker",
+        _ => token,
+    }
+    .to_string()
+}
+
+fn internal_chart_type(token: &str) -> String {
+    // `ChartType::Unknown` intentionally preserves Office's richer series
+    // subtype tokens (ColumnStacked, XYScatterSmooth, and so on).  Storing
+    // the token verbatim therefore keeps a series subtype round-trippable;
+    // the read path maps only the domain's coarse chart tokens to Office's
+    // public defaults.
+    token.to_string()
+}
+
+fn dimension_source<'a>(
+    chart: &'a Value,
+    series: &'a Value,
+    dimension: &str,
+) -> Result<Option<String>, ChartSeriesError> {
+    let field = match dimension {
+        "Categories" => "categories",
+        "Values" | "YValues" => "values",
+        "XValues" => "categories",
+        "BubbleSizes" => "bubbleSize",
+        other => return Err(unsupported_dimension(other)),
+    };
+    if let Some(source) = series.get(field).and_then(Value::as_str) {
+        return Ok(Some(source.to_string()));
+    }
+    if dimension == "Categories"
+        && let Some(source) = chart.get("categoryRange").and_then(Value::as_str)
+    {
+        return Ok(Some(source.to_string()));
+    }
+    Ok(None)
+}
+
+fn source_type(source: Option<&str>) -> String {
+    let Some(source) = source
+        .map(str::trim)
+        .map(|source| source.trim_start_matches('=').trim())
+        .filter(|source| !source.is_empty())
+    else {
+        return "Unknown".to_string();
+    };
+    if source.contains('[') {
+        "ExternalRange".to_string()
+    } else if source.contains('!') || CellRange::from(source).resolve().is_ok() {
+        "LocalRange".to_string()
+    } else if source.contains(',') {
+        "List".to_string()
+    } else {
+        "Unknown".to_string()
+    }
+}
+
+fn cached_dimension_values(series: &Value, dimension: &str) -> Vec<String> {
+    let field = match dimension {
+        "Categories" => "categoriesValues",
+        "Values" | "YValues" => "valuesValues",
+        "XValues" => "xValuesValues",
+        "BubbleSizes" => "bubbleSizeValues",
+        _ => return Vec::new(),
+    };
+    let legacy_values = series
+        .get(field)
+        .and_then(Value::as_array)
+        .map(|values| values.iter().map(value_to_string).collect::<Vec<_>>());
+    if let Some(values) = legacy_values {
+        return values;
+    }
+
+    let cache_field = match dimension {
+        "Categories" | "XValues" => "categoryCache",
+        "Values" | "YValues" => "valueCache",
+        "BubbleSizes" => "bubbleSizeCache",
+        _ => return Vec::new(),
+    };
+    series
+        .get(cache_field)
+        .and_then(|cache| cache.get("points"))
+        .and_then(Value::as_array)
+        .map(|points| {
+            points
+                .iter()
+                .filter_map(|point| point.get("value"))
+                .map(value_to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn source_formula(sheet: &Sheet, address: &str) -> Result<String, ChartSeriesError> {
+    let address = address.trim();
+    let (start_row, start_col, end_row, end_col) =
+        CellRange::from(address).resolve().map_err(compute_error)?;
+    if start_row > end_row || start_col > end_col {
+        return Err(invalid("ChartSeries source range must be non-empty"));
+    }
+    let sheet_name = sheet.name().map_err(compute_error)?;
+    Ok(format!("{}!{}", quote_sheet_name(&sheet_name), address))
+}
+
+fn resolve_source_values(
+    workbook: &Workbook,
+    default_sheet: &Sheet,
+    source: &str,
+) -> Result<Vec<String>, ChartSeriesError> {
+    let source = source.trim().trim_start_matches('=').trim();
+    if source.contains('[') {
+        return Err(unsupported_source(
+            "External chart series sources are not available",
+        ));
+    }
+    if !source.contains('!') && CellRange::from(source).resolve().is_err() && source.contains(',') {
+        return Ok(source
+            .split(',')
+            .map(str::trim)
+            .map(|value| {
+                if value.len() >= 2 && value.starts_with('"') && value.ends_with('"') {
+                    value[1..value.len() - 1].replace("\"\"", "\"")
+                } else {
+                    value.to_string()
+                }
+            })
+            .collect());
+    }
+    let (sheet, address) = split_source_reference(source, workbook, default_sheet)?;
+    let values = sheet
+        .get_range_values_2d(CellRange::from(address.as_str()))
+        .map_err(compute_error)?;
+    Ok(values
+        .into_iter()
+        .flatten()
+        .map(|value| value.to_string())
+        .collect())
+}
+
+fn split_source_reference(
+    source: &str,
+    workbook: &Workbook,
+    default_sheet: &Sheet,
+) -> Result<(Sheet, String), ChartSeriesError> {
+    let Some(separator) = source.rfind('!') else {
+        validate_bounded_range(source)?;
+        return Ok((default_sheet.clone(), source.to_string()));
+    };
+    let sheet_token = source[..separator].trim();
+    let address = source[separator + 1..].trim();
+    if sheet_token.is_empty() || address.is_empty() {
+        return Err(invalid(format!("Invalid chart series source '{source}'")));
+    }
+    let sheet_name = unquote_sheet_name(sheet_token);
+    let sheet_count = workbook.sheet_count().map_err(compute_error)?;
+    for index in 0..sheet_count {
+        let sheet = workbook.sheet_by_index(index).map_err(compute_error)?;
+        if sheet
+            .name()
+            .map_err(compute_error)?
+            .eq_ignore_ascii_case(&sheet_name)
+        {
+            validate_bounded_range(address)?;
+            return Ok((sheet, address.to_string()));
+        }
+    }
+    Err(ChartSeriesError {
+        code: "ItemNotFound",
+        message: format!("The chart series source worksheet '{sheet_name}' does not exist"),
+    })
+}
+
+fn validate_bounded_range(address: &str) -> Result<(), ChartSeriesError> {
+    let (start_row, start_col, end_row, end_col) =
+        CellRange::from(address).resolve().map_err(compute_error)?;
+    if start_row > end_row || start_col > end_col {
+        return Err(invalid("ChartSeries source range must be non-empty"));
+    }
+    Ok(())
+}
+
+fn quote_sheet_name(name: &str) -> String {
+    if name
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || character == '_')
+    {
+        name.to_string()
+    } else {
+        format!("'{}'", name.replace('\'', "''"))
+    }
+}
+
+fn unquote_sheet_name(name: &str) -> String {
+    let name = name.trim();
+    if name.len() >= 2 && name.starts_with('\'') && name.ends_with('\'') {
+        name[1..name.len() - 1].replace("''", "'")
+    } else {
+        name.to_string()
+    }
+}
+
+fn value_to_string(value: &Value) -> String {
+    match value {
+        Value::String(value) => value.clone(),
+        Value::Null => String::new(),
+        _ => value.to_string(),
+    }
+}
+
+fn checked_index(index: i64, length: usize) -> Result<usize, ChartSeriesError> {
+    let index = usize::try_from(index).map_err(|_| item_not_found(index))?;
+    if index >= length {
+        return Err(item_not_found(index));
+    }
+    Ok(index)
+}
+
+fn checked_insertion_index(index: i64, length: usize) -> Result<usize, ChartSeriesError> {
+    let index = usize::try_from(index)
+        .map_err(|_| invalid("ChartSeries.add index must be non-negative"))?;
+    if index > length {
+        return Err(invalid(format!(
+            "ChartSeries.add index {index} is outside the insertion range 0..={length}"
+        )));
+    }
+    Ok(index)
+}
+
+fn validate_series_name(name: &str) -> Result<&str, ChartSeriesError> {
+    if name.chars().count() > 255 {
+        return Err(invalid("ChartSeries.name cannot exceed 255 characters"));
+    }
+    Ok(name)
+}
+
+fn from_chart_error(error: ChartError) -> ChartSeriesError {
+    ChartSeriesError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn compute_error(error: compute_api::ComputeApiError) -> ChartSeriesError {
+    ChartSeriesError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn encoding(error: impl std::fmt::Display) -> ChartSeriesError {
+    ChartSeriesError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn item_not_found(index: impl std::fmt::Display) -> ChartSeriesError {
+    ChartSeriesError {
+        code: "ItemNotFound",
+        message: format!("The requested chart series index {index} does not exist"),
+    }
+}
+
+fn invalid(message: impl Into<String>) -> ChartSeriesError {
+    ChartSeriesError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn unsupported_collection_property(property: &str) -> ChartSeriesError {
+    invalid(format!(
+        "ChartSeriesCollection.{property} is unsupported or read-only"
+    ))
+}
+
+fn unsupported_series_property(property: &str) -> ChartSeriesError {
+    invalid(format!(
+        "ChartSeries.{property} is unsupported by this Office.js host"
+    ))
+}
+
+fn unsupported_dimension(dimension: &str) -> ChartSeriesError {
+    invalid(format!(
+        "Unsupported ChartSeriesDimension '{dimension}'; expected Categories, Values, XValues, YValues, or BubbleSizes"
+    ))
+}
+
+fn unsupported_source(message: &str) -> ChartSeriesError {
+    ChartSeriesError {
+        code: "NotSupported",
+        message: message.to_string(),
+    }
+}

--- a/compute/officejs/src/comments.js
+++ b/compute/officejs/src/comments.js
@@ -1,0 +1,757 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs;
+
+  function richError(code, message) {
+    var error = new OfficeExtension.Error({ code: code, message: message });
+    error.name = "RichApi.Error";
+    error.code = code;
+    return error;
+  }
+
+  function propertyNotLoaded(name) {
+    return richError(
+      "PropertyNotLoaded",
+      "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context."
+    );
+  }
+
+  function invalidArgument(message) {
+    return richError("InvalidArgument", message);
+  }
+
+  function invalidRequestContext() {
+    return richError(
+      "InvalidRequestContext",
+      "The object belongs to a different request context."
+    );
+  }
+
+  function requirePropertyObject(source) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+  }
+
+  function stringArgument(value, property) {
+    if (typeof value !== "string" || value.length === 0) {
+      throw invalidArgument(property + " must be a non-empty string");
+    }
+    return value;
+  }
+
+  function integerArgument(value, property) {
+    if (
+      typeof value !== "number" ||
+      !isFinite(value) ||
+      Math.floor(value) !== value ||
+      value < 0
+    ) {
+      throw invalidArgument(property + " must be a non-negative integer");
+    }
+    return value;
+  }
+
+  function normalizeContentType(contentType, property) {
+    if (contentType === undefined || contentType === null) return "Plain";
+    if (contentType === "Plain" || contentType === "plain") return "Plain";
+    if (contentType === "Mention" || contentType === "mention") return "Mention";
+    throw invalidArgument(
+      (property || "contentType") + " must be \"Plain\" or \"Mention\""
+    );
+  }
+
+  function normalizeContent(content, contentType, property) {
+    var type = normalizeContentType(contentType, property + " contentType");
+    if (typeof content === "string") {
+      return { wire: content, contentType: type };
+    }
+    if (
+      !content ||
+      typeof content !== "object" ||
+      typeof content.richContent !== "string"
+    ) {
+      throw invalidArgument(
+        property + " content must be a string or CommentRichContent object"
+      );
+    }
+    if (
+      content.mentions !== undefined &&
+      content.mentions !== null &&
+      !Array.isArray(content.mentions)
+    ) {
+      throw invalidArgument(property + " content.mentions must be an array");
+    }
+    return {
+      wire: {
+        richContent: content.richContent,
+        mentions: content.mentions || [],
+      },
+      contentType: type,
+    };
+  }
+
+  function requireCellAddress(address, property) {
+    if (address instanceof Excel.Range) return address;
+    if (typeof address !== "string" || address.length === 0) {
+      throw invalidArgument(property + " requires a Range or full cell address");
+    }
+    if (address.indexOf("!") < 0) {
+      throw invalidArgument(
+        property + " string addresses must include the worksheet name"
+      );
+    }
+    return address;
+  }
+
+  function queueCommentLookup(comment, collection, key, byIndex, orNullObject) {
+    comment._collection = collection;
+    comment._commentCollection = collection;
+    var operation = {
+      op: byIndex ? "commentCollectionGetItemAt" : "commentCollectionGetItem",
+      id: comment._id,
+      collectionId: collection._id,
+      orNullObject: orNullObject === true,
+    };
+    if (byIndex) operation.index = key;
+    else operation.key = String(key);
+    comment.context._queue.push(operation);
+    return comment;
+  }
+
+  function queueReplyLookup(reply, collection, key, byIndex, orNullObject) {
+    reply._collection = collection;
+    var operation = {
+      op: byIndex
+        ? "commentReplyCollectionGetItemAt"
+        : "commentReplyCollectionGetItem",
+      id: reply._id,
+      collectionId: collection._id,
+      orNullObject: orNullObject === true,
+    };
+    if (byIndex) operation.index = key;
+    else operation.key = String(key);
+    reply.context._queue.push(operation);
+    return reply;
+  }
+
+  function CommentCollection(context, worksheet) {
+    ClientObject.call(this, context);
+    this._worksheet = worksheet || null;
+    this._scalarProperties = ["items"];
+    this._navigationProperties = ["items"];
+    this._itemCache = Object.create(null);
+    context._queue.push({
+      op: "getCommentCollection",
+      id: this._id,
+      worksheetId: this._worksheet ? this._worksheet._id : null,
+    });
+    officeJs.configureCollection(this, function (key) {
+      return this.getItem(String(key));
+    });
+  }
+  CommentCollection.prototype = Object.create(ClientObject.prototype);
+  CommentCollection.prototype.constructor = CommentCollection;
+
+  Object.defineProperty(CommentCollection.prototype, "items", {
+    get: function () {
+      if (!this._loaded.items) throw propertyNotLoaded("items");
+      return this._items || [];
+    },
+    configurable: true,
+  });
+
+  CommentCollection.prototype.add = function (
+    cellAddress,
+    content,
+    contentType
+  ) {
+    var target = requireCellAddress(cellAddress, "CommentCollection.add cellAddress");
+    if (target instanceof Excel.Range && target.context !== this.context) {
+      throw invalidRequestContext();
+    }
+    var normalized = normalizeContent(
+      content,
+      contentType,
+      "CommentCollection.add"
+    );
+    var comment = new Comment(this.context, this);
+    var operation = {
+      op: "commentAdd",
+      id: comment._id,
+      collectionId: this._id,
+      content: normalized.wire,
+      contentType: normalized.contentType,
+    };
+    if (target instanceof Excel.Range) operation.rangeId = target._id;
+    else operation.address = target;
+    this.context._queue.push(operation);
+    return comment;
+  };
+
+  CommentCollection.prototype.getCount = function () {
+    var result = officeJs.createClientResult(this.context);
+    this.context._queue.push({
+      op: "commentCollectionGetCount",
+      collectionId: this._id,
+      resultId: result._id,
+    });
+    return result;
+  };
+
+  CommentCollection.prototype.getItem = function (commentId) {
+    var key = stringArgument(commentId, "CommentCollection.getItem commentId");
+    var cacheKey = "key:" + key.toLowerCase();
+    if (!this._itemCache[cacheKey]) {
+      this._itemCache[cacheKey] = queueCommentLookup(
+        new Comment(this.context, this),
+        this,
+        key,
+        false,
+        false
+      );
+    }
+    return this._itemCache[cacheKey];
+  };
+
+  CommentCollection.prototype.getItemAt = function (index) {
+    index = integerArgument(index, "CommentCollection.getItemAt index");
+    var cacheKey = "index:" + index;
+    if (!this._itemCache[cacheKey]) {
+      this._itemCache[cacheKey] = queueCommentLookup(
+        new Comment(this.context, this),
+        this,
+        index,
+        true,
+        false
+      );
+    }
+    return this._itemCache[cacheKey];
+  };
+
+  CommentCollection.prototype.getItemByCell = function (cellAddress) {
+    var target = requireCellAddress(
+      cellAddress,
+      "CommentCollection.getItemByCell cellAddress"
+    );
+    if (target instanceof Excel.Range && target.context !== this.context) {
+      throw invalidRequestContext();
+    }
+    var comment = new Comment(this.context, this);
+    var operation = {
+      op: "commentCollectionGetItemByCell",
+      id: comment._id,
+      collectionId: this._id,
+    };
+    if (target instanceof Excel.Range) operation.rangeId = target._id;
+    else operation.address = target;
+    this.context._queue.push(operation);
+    return comment;
+  };
+
+  CommentCollection.prototype.getItemByReplyId = function (replyId) {
+    var key = stringArgument(
+      replyId,
+      "CommentCollection.getItemByReplyId replyId"
+    );
+    var comment = new Comment(this.context, this);
+    this.context._queue.push({
+      op: "commentCollectionGetItemByReplyId",
+      id: comment._id,
+      collectionId: this._id,
+      replyId: key,
+    });
+    return comment;
+  };
+
+  CommentCollection.prototype.getItemOrNullObject = function (commentId) {
+    var key = stringArgument(
+      commentId,
+      "CommentCollection.getItemOrNullObject commentId"
+    );
+    var cacheKey = "null:" + key.toLowerCase();
+    if (!this._itemCache[cacheKey]) {
+      this._itemCache[cacheKey] = queueCommentLookup(
+        new Comment(this.context, this),
+        this,
+        key,
+        false,
+        true
+      );
+    }
+    return this._itemCache[cacheKey];
+  };
+
+  CommentCollection.prototype.toJSON = function () {
+    if (!this._loaded.items) return {};
+    return {
+      items: this.items.map(function (item) {
+        return item && typeof item.toJSON === "function" ? item.toJSON() : item;
+      }),
+    };
+  };
+
+  function Comment(context, collection) {
+    ClientObject.call(this, context);
+    this._collection = collection || null;
+    this._commentCollection = collection || null;
+    this._scalarProperties = [
+      "authorEmail",
+      "authorName",
+      "content",
+      "contentType",
+      "creationDate",
+      "id",
+      "mentions",
+      "resolved",
+      "richContent",
+    ];
+    this._navigationProperties = ["replies"];
+  }
+  Comment.prototype = Object.create(ClientObject.prototype);
+  Comment.prototype.constructor = Comment;
+
+  function readOnlyCommentProperty(name) {
+    Object.defineProperty(Comment.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      configurable: true,
+    });
+  }
+
+  [
+    "authorEmail",
+    "authorName",
+    "contentType",
+    "id",
+    "mentions",
+    "resolved",
+    "richContent",
+  ].forEach(readOnlyCommentProperty);
+
+  Object.defineProperty(Comment.prototype, "creationDate", {
+    get: function () {
+      if (!this._loaded.creationDate) throw propertyNotLoaded("creationDate");
+      if (this._creationDate === null || this._creationDate === undefined) {
+        return null;
+      }
+      if (this._creationDate instanceof Date) return this._creationDate;
+      return new Date(this._creationDate);
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(Comment.prototype, "content", {
+    get: function () {
+      if (!this._loaded.content) throw propertyNotLoaded("content");
+      return this._content;
+    },
+    set: function (value) {
+      if (typeof value !== "string") {
+        throw invalidArgument("Comment.content must be a string");
+      }
+      this._content = value;
+      this._loaded.content = true;
+      this.context._queue.push({
+        op: "set",
+        id: this._id,
+        property: "content",
+        value: value,
+      });
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(Comment.prototype, "resolved", {
+    get: function () {
+      if (!this._loaded.resolved) throw propertyNotLoaded("resolved");
+      return this._resolved;
+    },
+    set: function (value) {
+      if (typeof value !== "boolean") {
+        throw invalidArgument("Comment.resolved must be a boolean");
+      }
+      this._resolved = value;
+      this._loaded.resolved = true;
+      this.context._queue.push({
+        op: "set",
+        id: this._id,
+        property: "resolved",
+        value: value,
+      });
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(Comment.prototype, "replies", {
+    get: function () {
+      if (!this._replies) {
+        this._replies = new CommentReplyCollection(this.context, this);
+      }
+      return this._replies;
+    },
+    configurable: true,
+  });
+
+  Comment.prototype.set = function (source) {
+    requirePropertyObject(source);
+    if (source instanceof ClientObject && source.context !== this.context) {
+      throw invalidRequestContext();
+    }
+    if (Object.prototype.hasOwnProperty.call(source, "content")) {
+      this.content = source.content;
+    }
+    if (Object.prototype.hasOwnProperty.call(source, "resolved")) {
+      this.resolved = source.resolved;
+    }
+    return this;
+  };
+
+  Comment.prototype.delete = function () {
+    this.context._queue.push({ op: "commentDelete", id: this._id });
+  };
+
+  Comment.prototype.getLocation = function () {
+    var range = new Excel.Range(this.context, null, null);
+    range._commentSourceId = this._id;
+    this.context._queue.push({
+      op: "commentGetLocation",
+      id: range._id,
+      commentId: this._id,
+    });
+    return range;
+  };
+
+  Comment.prototype.updateMentions = function (contentWithMentions) {
+    var normalized = normalizeContent(
+      contentWithMentions,
+      "Mention",
+      "Comment.updateMentions"
+    );
+    var wire = normalized.wire;
+    if (typeof wire === "string") {
+      wire = { richContent: wire, mentions: [] };
+    }
+    this.context._queue.push({
+      op: "commentUpdateMentions",
+      id: this._id,
+      content: wire.richContent,
+      mentions: wire.mentions || [],
+    });
+  };
+
+  Comment.prototype.toJSON = function () {
+    var data = {};
+    [
+      "authorEmail",
+      "authorName",
+      "content",
+      "contentType",
+      "creationDate",
+      "id",
+      "mentions",
+      "resolved",
+      "richContent",
+    ].forEach(function (name) {
+      if (!this._loaded[name]) return;
+      data[name] = this[name];
+    }, this);
+    if (this._replies && this._replies._loaded.items) {
+      data.replies = this._replies.items.map(function (reply) {
+        return reply && typeof reply.toJSON === "function"
+          ? reply.toJSON()
+          : reply;
+      });
+    }
+    return data;
+  };
+
+  function CommentReplyCollection(context, comment) {
+    ClientObject.call(this, context);
+    this._comment = comment;
+    this._collection = comment ? comment._collection : null;
+    this._scalarProperties = ["items"];
+    this._navigationProperties = ["items"];
+    this._itemCache = Object.create(null);
+    context._queue.push({
+      op: "getCommentReplyCollection",
+      id: this._id,
+      commentId: comment._id,
+    });
+    officeJs.configureCollection(this, function (key) {
+      return this.getItem(String(key));
+    });
+  }
+  CommentReplyCollection.prototype = Object.create(ClientObject.prototype);
+  CommentReplyCollection.prototype.constructor = CommentReplyCollection;
+
+  Object.defineProperty(CommentReplyCollection.prototype, "items", {
+    get: function () {
+      if (!this._loaded.items) throw propertyNotLoaded("items");
+      return this._items || [];
+    },
+    configurable: true,
+  });
+
+  CommentReplyCollection.prototype.add = function (content, contentType) {
+    var normalized = normalizeContent(
+      content,
+      contentType,
+      "CommentReplyCollection.add"
+    );
+    var reply = new CommentReply(this.context, this);
+    this.context._queue.push({
+      op: "commentReplyAdd",
+      id: reply._id,
+      commentId: this._comment._id,
+      content: normalized.wire,
+      contentType: normalized.contentType,
+    });
+    return reply;
+  };
+
+  CommentReplyCollection.prototype.getCount = function () {
+    var result = officeJs.createClientResult(this.context);
+    this.context._queue.push({
+      op: "commentReplyCollectionGetCount",
+      collectionId: this._id,
+      resultId: result._id,
+    });
+    return result;
+  };
+
+  CommentReplyCollection.prototype.getItem = function (replyId) {
+    var key = stringArgument(
+      replyId,
+      "CommentReplyCollection.getItem commentReplyId"
+    );
+    var cacheKey = "key:" + key.toLowerCase();
+    if (!this._itemCache[cacheKey]) {
+      this._itemCache[cacheKey] = queueReplyLookup(
+        new CommentReply(this.context, this),
+        this,
+        key,
+        false,
+        false
+      );
+    }
+    return this._itemCache[cacheKey];
+  };
+
+  CommentReplyCollection.prototype.getItemAt = function (index) {
+    index = integerArgument(
+      index,
+      "CommentReplyCollection.getItemAt index"
+    );
+    var cacheKey = "index:" + index;
+    if (!this._itemCache[cacheKey]) {
+      this._itemCache[cacheKey] = queueReplyLookup(
+        new CommentReply(this.context, this),
+        this,
+        index,
+        true,
+        false
+      );
+    }
+    return this._itemCache[cacheKey];
+  };
+
+  CommentReplyCollection.prototype.getItemOrNullObject = function (replyId) {
+    var key = stringArgument(
+      replyId,
+      "CommentReplyCollection.getItemOrNullObject commentReplyId"
+    );
+    var cacheKey = "null:" + key.toLowerCase();
+    if (!this._itemCache[cacheKey]) {
+      this._itemCache[cacheKey] = queueReplyLookup(
+        new CommentReply(this.context, this),
+        this,
+        key,
+        false,
+        true
+      );
+    }
+    return this._itemCache[cacheKey];
+  };
+
+  CommentReplyCollection.prototype.toJSON = function () {
+    if (!this._loaded.items) return {};
+    return {
+      items: this.items.map(function (item) {
+        return item && typeof item.toJSON === "function" ? item.toJSON() : item;
+      }),
+    };
+  };
+
+  function CommentReply(context, collection) {
+    ClientObject.call(this, context);
+    this._collection = collection || null;
+    this._comment = collection ? collection._comment : null;
+    this._scalarProperties = [
+      "authorEmail",
+      "authorName",
+      "content",
+      "contentType",
+      "creationDate",
+      "id",
+      "mentions",
+      "resolved",
+      "richContent",
+    ];
+  }
+  CommentReply.prototype = Object.create(ClientObject.prototype);
+  CommentReply.prototype.constructor = CommentReply;
+
+  function readOnlyReplyProperty(name) {
+    Object.defineProperty(CommentReply.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      configurable: true,
+    });
+  }
+
+  [
+    "authorEmail",
+    "authorName",
+    "contentType",
+    "id",
+    "mentions",
+    "resolved",
+    "richContent",
+  ].forEach(readOnlyReplyProperty);
+
+  Object.defineProperty(CommentReply.prototype, "creationDate", {
+    get: function () {
+      if (!this._loaded.creationDate) throw propertyNotLoaded("creationDate");
+      if (this._creationDate === null || this._creationDate === undefined) {
+        return null;
+      }
+      if (this._creationDate instanceof Date) return this._creationDate;
+      return new Date(this._creationDate);
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(CommentReply.prototype, "content", {
+    get: function () {
+      if (!this._loaded.content) throw propertyNotLoaded("content");
+      return this._content;
+    },
+    set: function (value) {
+      if (typeof value !== "string") {
+        throw invalidArgument("CommentReply.content must be a string");
+      }
+      this._content = value;
+      this._loaded.content = true;
+      this.context._queue.push({
+        op: "set",
+        id: this._id,
+        property: "content",
+        value: value,
+      });
+    },
+    configurable: true,
+  });
+
+  CommentReply.prototype.set = function (source) {
+    requirePropertyObject(source);
+    if (source instanceof ClientObject && source.context !== this.context) {
+      throw invalidRequestContext();
+    }
+    if (Object.prototype.hasOwnProperty.call(source, "content")) {
+      this.content = source.content;
+    }
+    return this;
+  };
+
+  CommentReply.prototype.delete = function () {
+    this.context._queue.push({ op: "commentReplyDelete", id: this._id });
+  };
+
+  CommentReply.prototype.getLocation = function () {
+    var range = new Excel.Range(this.context, null, null);
+    range._commentSourceId = this._id;
+    this.context._queue.push({
+      op: "commentReplyGetLocation",
+      id: range._id,
+      replyId: this._id,
+    });
+    return range;
+  };
+
+  CommentReply.prototype.getParentComment = function () {
+    return this._comment;
+  };
+
+  CommentReply.prototype.updateMentions = function (contentWithMentions) {
+    var normalized = normalizeContent(
+      contentWithMentions,
+      "Mention",
+      "CommentReply.updateMentions"
+    );
+    var wire = normalized.wire;
+    if (typeof wire === "string") {
+      wire = { richContent: wire, mentions: [] };
+    }
+    this.context._queue.push({
+      op: "commentUpdateMentions",
+      id: this._id,
+      content: wire.richContent,
+      mentions: wire.mentions || [],
+    });
+  };
+
+  CommentReply.prototype.toJSON = function () {
+    var data = {};
+    [
+      "authorEmail",
+      "authorName",
+      "content",
+      "contentType",
+      "creationDate",
+      "id",
+      "mentions",
+      "resolved",
+      "richContent",
+    ].forEach(function (name) {
+      if (!this._loaded[name]) return;
+      data[name] = this[name];
+    }, this);
+    return data;
+  };
+
+  Object.defineProperty(Excel.Workbook.prototype, "comments", {
+    get: function () {
+      if (!this._comments) {
+        this._comments = new CommentCollection(this.context, null);
+      }
+      return this._comments;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(Excel.Worksheet.prototype, "comments", {
+    get: function () {
+      if (!this._comments) {
+        this._comments = new CommentCollection(this.context, this);
+      }
+      return this._comments;
+    },
+    configurable: true,
+  });
+
+  Excel.CommentCollection = CommentCollection;
+  Excel.Comment = Comment;
+  Excel.CommentReplyCollection = CommentReplyCollection;
+  Excel.CommentReply = CommentReply;
+})(globalThis);

--- a/compute/officejs/src/comments.rs
+++ b/compute/officejs/src/comments.rs
@@ -1,0 +1,1616 @@
+//! Office.js comment and reply adapters.
+//!
+//! The JavaScript proxies in comments.js use the extension dispatch hook
+//! rather than a second host-side workbook. All reads resolve the current
+//! comment from compute-api so updates made through another proxy are visible
+//! immediately. The adapter deliberately exposes only threaded comments;
+//! legacy notes remain available to the compute API's note-specific surface.
+//!
+//! Wire operations claimed by CommentHandler:
+//!
+//! * getCommentCollection { id, worksheetId: null|string }
+//! * commentCollectionGetCount { collectionId, resultId }
+//! * commentCollectionGetItem { id, collectionId, key, orNullObject }
+//! * commentCollectionGetItemAt { id, collectionId, index, orNullObject }
+//! * commentCollectionGetItemByCell { id, collectionId, rangeId?, address? }
+//! * commentCollectionGetItemByReplyId { id, collectionId, replyId }
+//! * commentAdd { id, collectionId, rangeId?, address?, content, contentType? }
+//! * getCommentReplyCollection { id, commentId }
+//! * commentReplyCollectionGetCount { collectionId, resultId }
+//! * commentReplyCollectionGetItem { id, collectionId, key, orNullObject }
+//! * commentReplyCollectionGetItemAt { id, collectionId, index, orNullObject }
+//! * commentReplyAdd { id, commentId, content, contentType? }
+//! * commentDelete { id }, commentReplyDelete { id }
+//! * commentUpdateMentions { id, content, mentions }
+//!
+//! Generic load and set operations are routed by the shared host extension
+//! binding to ExtensionObject implementations below.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use compute_api::{Sheet, Workbook, mutation::CellInput};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::dispatch::{ExtensionHandler, ExtensionObject, HostDispatchContext};
+use crate::host::BatchError;
+use crate::range_navigation::{RangeAddress, RangeNavigationError, parse_range_address};
+
+/// Office.js does not provide the current host user's identity to this
+/// headless runtime. New comments use this explicit value instead of
+/// masquerading as a human user; imported author names/emails are preserved.
+pub(crate) const UNAVAILABLE_HOST_AUTHOR: &str = "Unavailable";
+
+const DEFAULT_COMMENT_PROPERTIES: &[&str] = &[
+    "authorEmail",
+    "authorName",
+    "content",
+    "contentType",
+    "creationDate",
+    "id",
+    "mentions",
+    "resolved",
+    "richContent",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommentError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+impl CommentError {
+    fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            code: "InvalidArgument",
+            message: message.into(),
+        }
+    }
+
+    fn item_not_found(key: impl AsRef<str>) -> Self {
+        Self {
+            code: "ItemNotFound",
+            message: format!("Comment '{}' was not found.", key.as_ref()),
+        }
+    }
+
+    fn unsupported(message: impl Into<String>) -> Self {
+        Self {
+            code: "InvalidArgument",
+            message: message.into(),
+        }
+    }
+}
+
+fn batch_error(error: CommentError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn engine(error: impl std::fmt::Display) -> CommentError {
+    CommentError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn encoding(error: impl std::fmt::Display) -> CommentError {
+    CommentError {
+        code: "GeneralException",
+        message: format!("failed to decode persisted comment data: {error}"),
+    }
+}
+
+fn unsupported_load(object: &str, property: &str) -> CommentError {
+    CommentError {
+        code: "InvalidArgument",
+        message: format!("{object}.{property} is not supported"),
+    }
+}
+
+/// A small local projection of the persisted domain comment. Keeping this
+/// wire model in the officejs crate avoids making the runtime depend on the
+/// domain-types crate directly; compute-api remains the only production data
+/// boundary.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredComment {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    cell_ref: String,
+    #[serde(default)]
+    author: String,
+    #[serde(default)]
+    author_email: Option<String>,
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    runs: Vec<StoredRun>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    parent_id: Option<String>,
+    #[serde(default)]
+    resolved: Option<bool>,
+    #[serde(default)]
+    created_at: Option<u64>,
+    #[serde(default)]
+    content_type: Option<String>,
+    #[serde(default)]
+    mentions: Vec<StoredMention>,
+    #[serde(default)]
+    comment_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredRun {
+    #[serde(default)]
+    text: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredMention {
+    #[serde(default)]
+    display_text: String,
+    #[serde(default)]
+    email: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkbookCommentWire {
+    sheet_id: String,
+    comment: StoredComment,
+}
+
+#[derive(Debug, Clone)]
+struct CommentRecord {
+    sheet: Sheet,
+    comment: StoredComment,
+}
+
+fn decode_comment<T: Serialize>(value: &T) -> Result<StoredComment, CommentError> {
+    let value = serde_json::to_value(value).map_err(encoding)?;
+    serde_json::from_value(value).map_err(encoding)
+}
+
+fn plain_content(comment: &StoredComment) -> String {
+    comment
+        .content
+        .clone()
+        .unwrap_or_else(|| comment.runs.iter().map(|run| run.text.as_str()).collect())
+}
+
+fn is_threaded(comment: &StoredComment) -> bool {
+    comment
+        .comment_type
+        .as_deref()
+        .map(|kind| kind.eq_ignore_ascii_case("threadedComment"))
+        .unwrap_or(true)
+}
+
+fn is_root(comment: &StoredComment) -> bool {
+    is_threaded(comment) && comment.parent_id.is_none()
+}
+
+fn content_type(comment: &StoredComment) -> &'static str {
+    if comment
+        .content_type
+        .as_deref()
+        .is_some_and(|kind| kind.eq_ignore_ascii_case("mention"))
+    {
+        "Mention"
+    } else {
+        "Plain"
+    }
+}
+
+fn comment_properties(
+    comment: &StoredComment,
+    properties: &[String],
+) -> Result<HashMap<String, Value>, CommentError> {
+    let mut result = HashMap::new();
+    for property in properties {
+        let value = match property.as_str() {
+            "authorEmail" => Value::String(comment.author_email.clone().unwrap_or_default()),
+            "authorName" => Value::String(comment.author.clone()),
+            "content" => Value::String(plain_content(comment)),
+            "contentType" => Value::String(content_type(comment).to_string()),
+            // created_at is compute-api's lossless Unix-millisecond
+            // representation. The JavaScript proxy turns this into Date;
+            // notes imported from legacy comments correctly remain null.
+            "creationDate" => comment
+                .created_at
+                .map_or(Value::Null, |millis| json!(millis)),
+            "id" => Value::String(comment.id.clone()),
+            "mentions" => Value::Array(
+                comment
+                    .mentions
+                    .iter()
+                    .enumerate()
+                    .map(|(id, mention)| {
+                        json!({
+                            "id": id,
+                            "name": mention.display_text,
+                            "email": mention.email.clone().unwrap_or_default(),
+                        })
+                    })
+                    .collect(),
+            ),
+            "resolved" => Value::Bool(comment.resolved.unwrap_or(false)),
+            "richContent" => Value::String(plain_content(comment)),
+            other => return Err(unsupported_load("Comment", other)),
+        };
+        result.insert(property.clone(), value);
+    }
+    Ok(result)
+}
+
+fn collection_item_properties(properties: &[String]) -> Vec<String> {
+    let mut result = Vec::new();
+    for property in properties {
+        if let Some(item_property) = property.strip_prefix("items/") {
+            if !item_property.is_empty() && !result.iter().any(|p| p == item_property) {
+                result.push(item_property.to_string());
+            }
+        }
+    }
+    if result.is_empty() {
+        DEFAULT_COMMENT_PROPERTIES
+            .iter()
+            .map(|property| (*property).to_string())
+            .collect()
+    } else {
+        result
+    }
+}
+
+fn index_argument(index: i64, length: usize, object: &str) -> Result<usize, CommentError> {
+    if index < 0 {
+        return Err(CommentError::invalid(format!(
+            "{object}.getItemAt index must be non-negative"
+        )));
+    }
+    let index = index as usize;
+    if index >= length {
+        return Err(CommentError::item_not_found(index.to_string()));
+    }
+    Ok(index)
+}
+
+fn persisted_id(result: &compute_api::MutationResult) -> Result<String, CommentError> {
+    let value = result
+        .data
+        .clone()
+        .ok_or_else(|| encoding("the compute engine returned no comment data"))?;
+    let comment: StoredComment = serde_json::from_value(value).map_err(encoding)?;
+    if comment.id.is_empty() {
+        Err(encoding("the compute engine returned an empty comment id"))
+    } else {
+        Ok(comment.id)
+    }
+}
+
+/// The parsed content/contentType payload accepted by Office.js add and
+/// reply operations.
+#[derive(Debug, Clone)]
+pub(crate) struct CommentInput {
+    pub(crate) content: String,
+    pub(crate) content_type: CommentContentType,
+    pub(crate) mentions: Vec<OfficeMention>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CommentContentType {
+    Plain,
+    Mention,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct OfficeMention {
+    pub(crate) name: String,
+    pub(crate) email: Option<String>,
+}
+
+impl CommentInput {
+    pub(crate) fn from_wire(
+        content: &Value,
+        content_type: Option<&str>,
+    ) -> Result<Self, CommentError> {
+        let content_type = match content_type.unwrap_or("Plain") {
+            "Plain" | "plain" => CommentContentType::Plain,
+            "Mention" | "mention" => CommentContentType::Mention,
+            other => {
+                return Err(CommentError::invalid(format!(
+                    "Comment contentType must be 'Plain' or 'Mention', got '{other}'"
+                )));
+            }
+        };
+        match content {
+            Value::String(content) => Ok(Self {
+                content: content.clone(),
+                content_type,
+                mentions: Vec::new(),
+            }),
+            Value::Object(object) => {
+                let content = object
+                    .get("richContent")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        CommentError::invalid("CommentRichContent.richContent must be a string")
+                    })?
+                    .to_string();
+                let mentions = object
+                    .get("mentions")
+                    .map(parse_mentions)
+                    .transpose()?
+                    .unwrap_or_default();
+                Ok(Self {
+                    content,
+                    content_type,
+                    mentions,
+                })
+            }
+            _ => Err(CommentError::invalid(
+                "Comment content must be a string or CommentRichContent object",
+            )),
+        }
+    }
+
+    fn domain_mentions(&self) -> Result<Value, CommentError> {
+        let mentions = self
+            .mentions
+            .iter()
+            .map(|mention| {
+                let start_index = self.content.find(&mention.name).unwrap_or(0) as u32;
+                json!({
+                    "displayText": mention.name,
+                    // The Office.js mention id is an index into richContent,
+                    // not a user identity. Keep the domain's required
+                    // identity explicit when the host supplied no email.
+                    "userId": mention.email.clone().unwrap_or_else(|| UNAVAILABLE_HOST_AUTHOR.to_string()),
+                    "email": mention.email,
+                    "startIndex": start_index,
+                    "length": mention.name.chars().count() as u32,
+                })
+            })
+            .collect::<Vec<_>>();
+        Ok(Value::Array(mentions))
+    }
+}
+
+fn parse_mentions(value: &Value) -> Result<Vec<OfficeMention>, CommentError> {
+    let entries = value
+        .as_array()
+        .ok_or_else(|| CommentError::invalid("CommentRichContent.mentions must be an array"))?;
+    entries
+        .iter()
+        .map(|entry| {
+            let object = entry
+                .as_object()
+                .ok_or_else(|| CommentError::invalid("each CommentMention must be an object"))?;
+            let name = object
+                .get("name")
+                .and_then(Value::as_str)
+                .ok_or_else(|| CommentError::invalid("CommentMention.name must be a string"))?;
+            let email = match object.get("email") {
+                None | Some(Value::Null) => None,
+                Some(value) => Some(
+                    value
+                        .as_str()
+                        .ok_or_else(|| {
+                            CommentError::invalid("CommentMention.email must be a string")
+                        })?
+                        .to_string(),
+                ),
+            };
+            Ok(OfficeMention {
+                name: name.to_string(),
+                email,
+            })
+        })
+        .collect()
+}
+
+/// Resolve a collection's worksheet scope, if any, to persisted sheet data.
+#[derive(Clone)]
+pub(crate) struct CommentCollectionRef {
+    workbook: Workbook,
+    worksheet: Option<Sheet>,
+}
+
+impl CommentCollectionRef {
+    pub(crate) fn new(workbook: Workbook, worksheet: Option<Sheet>) -> Self {
+        Self {
+            workbook,
+            worksheet,
+        }
+    }
+
+    pub(crate) fn worksheet(&self) -> Option<Sheet> {
+        self.worksheet.clone()
+    }
+
+    fn records(&self) -> Result<Vec<CommentRecord>, CommentError> {
+        if let Some(sheet) = &self.worksheet {
+            let comments = sheet.comments().get_all().map_err(engine)?;
+            comments
+                .iter()
+                .map(|comment| {
+                    Ok(CommentRecord {
+                        sheet: sheet.clone(),
+                        comment: decode_comment(comment)?,
+                    })
+                })
+                .collect()
+        } else {
+            let comments = self.workbook.get_all_comments().map_err(engine)?;
+            comments
+                .iter()
+                .map(|comment| {
+                    let wire: WorkbookCommentWire =
+                        serde_json::from_value(serde_json::to_value(comment).map_err(encoding)?)
+                            .map_err(encoding)?;
+                    let sheet_id =
+                        compute_api::SheetId::from_uuid_str(&wire.sheet_id).map_err(engine)?;
+                    let sheet = self.workbook.sheet(&sheet_id).map_err(engine)?;
+                    Ok(CommentRecord {
+                        sheet,
+                        comment: wire.comment,
+                    })
+                })
+                .collect()
+        }
+    }
+
+    fn threaded_roots(&self) -> Result<Vec<CommentRecord>, CommentError> {
+        Ok(self
+            .records()?
+            .into_iter()
+            .filter(|r| is_root(&r.comment))
+            .collect())
+    }
+
+    pub(crate) fn count(&self) -> Result<usize, CommentError> {
+        Ok(self.threaded_roots()?.len())
+    }
+
+    pub(crate) fn collection_items(
+        &self,
+        properties: &[String],
+    ) -> Result<Vec<CommentCollectionItem>, CommentError> {
+        let item_properties = collection_item_properties(properties);
+        self.threaded_roots()?
+            .into_iter()
+            .map(|record| {
+                Ok(CommentCollectionItem {
+                    key: record.comment.id.clone(),
+                    worksheet_id: record.sheet.id().to_uuid_string(),
+                    properties: comment_properties(&record.comment, &item_properties)?,
+                })
+            })
+            .collect()
+    }
+
+    pub(crate) fn get_item(&self, id: &str) -> Result<CommentRef, CommentError> {
+        let record = self
+            .threaded_roots()?
+            .into_iter()
+            .find(|record| record.comment.id == id)
+            .ok_or_else(|| CommentError::item_not_found(id))?;
+        Ok(CommentRef::new(
+            self.workbook.clone(),
+            record.sheet,
+            record.comment.id,
+            false,
+        ))
+    }
+
+    pub(crate) fn get_item_at(&self, index: i64) -> Result<CommentRef, CommentError> {
+        let records = self.threaded_roots()?;
+        let index = index_argument(index, records.len(), "CommentCollection")?;
+        let record = &records[index];
+        Ok(CommentRef::new(
+            self.workbook.clone(),
+            record.sheet.clone(),
+            record.comment.id.clone(),
+            false,
+        ))
+    }
+
+    pub(crate) fn get_item_or_null_object(
+        &self,
+        id: &str,
+    ) -> Result<Option<CommentRef>, CommentError> {
+        match self.get_item(id) {
+            Ok(comment) => Ok(Some(comment)),
+            Err(error) if error.code == "ItemNotFound" => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub(crate) fn get_item_by_reply_id(&self, reply_id: &str) -> Result<CommentRef, CommentError> {
+        let record = self
+            .records()?
+            .into_iter()
+            .find(|record| is_threaded(&record.comment) && record.comment.id == reply_id)
+            .ok_or_else(|| CommentError::item_not_found(reply_id))?;
+        let root_id = record
+            .comment
+            .thread_id
+            .clone()
+            .or(record.comment.parent_id.clone())
+            .unwrap_or(record.comment.id.clone());
+        self.get_item(&root_id)
+    }
+
+    /// Resolve the address argument to a single cell and return its stable
+    /// cell identity. Existing data is never overwritten. A blank cell is
+    /// materialized as an empty literal only for CommentCollection.add,
+    /// because the compute-api comment primitive intentionally takes the
+    /// stable identity that backs persisted metadata.
+    pub(crate) fn resolve_target(
+        &self,
+        address: Option<&str>,
+        range: Option<&crate::host::RangeRef>,
+        materialize_blank: bool,
+    ) -> Result<(Sheet, String), CommentError> {
+        let (sheet, raw_address) = match range {
+            Some(range) => {
+                if range.is_null_object() {
+                    return Err(CommentError {
+                        code: "InvalidObjectPath",
+                        message: "The comment cell Range is a null object.".to_string(),
+                    });
+                }
+                if let Some(scope) = &self.worksheet
+                    && scope.id() != range.sheet().id()
+                {
+                    return Err(CommentError::invalid(
+                        "The comment cell belongs to a different worksheet",
+                    ));
+                }
+                (
+                    range.sheet(),
+                    range
+                        .address()
+                        .ok_or_else(|| {
+                            CommentError::invalid(
+                                "CommentCollection.add requires a single-cell bounded Range",
+                            )
+                        })?
+                        .to_string(),
+                )
+            }
+            None => {
+                let address = address.ok_or_else(|| {
+                    CommentError::invalid("CommentCollection.add requires a cell address")
+                })?;
+                let (sheet, reference) = self.resolve_text_address(address)?;
+                (sheet, reference)
+            }
+        };
+        let parsed = parse_range_address(&sheet, &raw_address).map_err(range_error)?;
+        let RangeAddress::Cells {
+            start_row,
+            start_column,
+            end_row,
+            end_column,
+        } = parsed
+        else {
+            return Err(CommentError::invalid(
+                "CommentCollection requires a single-cell address",
+            ));
+        };
+        if start_row != end_row || start_column != end_column {
+            return Err(CommentError::invalid(
+                "CommentCollection requires a single-cell address",
+            ));
+        }
+        let canonical = parsed.to_a1();
+        let data = sheet.get_cell_data(canonical.as_str()).map_err(engine)?;
+        if let Some(cell_id) = data
+            .as_ref()
+            .and_then(|data| data.get("cell_id"))
+            .and_then(Value::as_str)
+            .filter(|cell_id| !cell_id.is_empty())
+        {
+            return Ok((sheet, cell_id.to_string()));
+        }
+        if !materialize_blank {
+            return Ok((sheet, canonical));
+        }
+        if data.is_some() {
+            return Err(CommentError::invalid(
+                "The target cell has no stable identity and cannot be materialized without changing its data",
+            ));
+        }
+        sheet
+            .set_range_typed(
+                canonical.as_str(),
+                &[vec![Some(CellInput::Literal {
+                    text: String::new(),
+                })]],
+            )
+            .map_err(engine)?;
+        let data = sheet
+            .get_cell_data(canonical.as_str())
+            .map_err(engine)?
+            .ok_or_else(|| encoding("materialized comment target has no cell data"))?;
+        let cell_id = data
+            .get("cell_id")
+            .and_then(Value::as_str)
+            .filter(|cell_id| !cell_id.is_empty())
+            .ok_or_else(|| encoding("materialized comment target has no stable identity"))?;
+        Ok((sheet, cell_id.to_string()))
+    }
+
+    fn resolve_text_address(&self, address: &str) -> Result<(Sheet, String), CommentError> {
+        let separator = address.rfind('!').ok_or_else(|| {
+            CommentError::invalid(
+                "CommentCollection cellAddress strings must include the worksheet name",
+            )
+        })?;
+        let sheet_token = unquote_sheet_name(&address[..separator]).ok_or_else(|| {
+            CommentError::invalid("CommentCollection cellAddress has an invalid worksheet name")
+        })?;
+        let sheet = self.workbook.sheet_by_name(&sheet_token).map_err(engine)?;
+        if let Some(scope) = &self.worksheet
+            && scope.id() != sheet.id()
+        {
+            return Err(CommentError::invalid(
+                "The comment cell address belongs to a different worksheet",
+            ));
+        }
+        Ok((sheet, address[separator + 1..].to_string()))
+    }
+
+    pub(crate) fn add(
+        &self,
+        sheet: Sheet,
+        cell_id: &str,
+        input: &CommentInput,
+    ) -> Result<CommentRef, CommentError> {
+        if let Some(scope) = &self.worksheet
+            && scope.id() != sheet.id()
+        {
+            return Err(CommentError::invalid(
+                "The comment cell belongs to a different worksheet",
+            ));
+        }
+        let result = sheet
+            .comments()
+            .add(
+                cell_id,
+                UNAVAILABLE_HOST_AUTHOR,
+                &input.content,
+                None,
+                None,
+                Default::default(),
+            )
+            .map_err(engine)?;
+        let id = persisted_id(&result)?;
+        apply_mention_content(&sheet, &id, input)?;
+        Ok(CommentRef::new(self.workbook.clone(), sheet, id, false))
+    }
+}
+
+fn range_error(error: RangeNavigationError) -> CommentError {
+    CommentError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn unquote_sheet_name(token: &str) -> Option<String> {
+    let token = token.trim();
+    if token.is_empty() {
+        return None;
+    }
+    if token.starts_with('\'') {
+        if !token.ends_with('\'') || token.len() < 2 {
+            return None;
+        }
+        return Some(token[1..token.len() - 1].replace("''", "'"));
+    }
+    Some(token.to_string())
+}
+
+fn apply_mention_content(
+    sheet: &Sheet,
+    comment_id: &str,
+    input: &CommentInput,
+) -> Result<(), CommentError> {
+    if input.content_type != CommentContentType::Mention {
+        return Ok(());
+    }
+    let mention_value = input.domain_mentions()?;
+    let mentions = serde_json::from_value(mention_value).map_err(encoding)?;
+    sheet
+        .comments()
+        .update_mentions(comment_id, &input.content, mentions)
+        .map_err(engine)?;
+    Ok(())
+}
+
+/// One collection descriptor consumed by __mogOfficeJs.configureCollection.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CommentCollectionItem {
+    pub(crate) key: String,
+    pub(crate) worksheet_id: String,
+    pub(crate) properties: HashMap<String, Value>,
+}
+
+/// A live comment proxy bound to a specific worksheet and stable comment ID.
+#[derive(Clone)]
+pub(crate) struct CommentRef {
+    workbook: Workbook,
+    sheet: Sheet,
+    id: String,
+    null_object: bool,
+}
+
+impl CommentRef {
+    fn new(workbook: Workbook, sheet: Sheet, id: String, null_object: bool) -> Self {
+        Self {
+            workbook,
+            sheet,
+            id,
+            null_object,
+        }
+    }
+
+    pub(crate) fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub(crate) fn sheet(&self) -> Sheet {
+        self.sheet.clone()
+    }
+
+    pub(crate) fn is_null_object(&self) -> bool {
+        self.null_object
+    }
+
+    fn resolve(&self) -> Result<StoredComment, CommentError> {
+        if self.null_object {
+            return Err(CommentError {
+                code: "InvalidObjectPath",
+                message: "Comment is a null object.".to_string(),
+            });
+        }
+        let comment = self
+            .sheet
+            .comments()
+            .get(&self.id)
+            .map_err(engine)?
+            .ok_or_else(|| CommentError::item_not_found(&self.id))?;
+        decode_comment(&comment)
+    }
+
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, CommentError> {
+        if self.null_object {
+            let mut result = HashMap::new();
+            for property in properties {
+                if property == "isNullObject" {
+                    result.insert(property.clone(), Value::Bool(true));
+                } else {
+                    return Err(CommentError {
+                        code: "InvalidObjectPath",
+                        message: format!("Comment.{property} cannot be loaded from a null object"),
+                    });
+                }
+            }
+            return Ok(result);
+        }
+        let properties = properties
+            .iter()
+            .filter(|property| property.as_str() != "isNullObject")
+            .cloned()
+            .collect::<Vec<_>>();
+        comment_properties(&self.resolve()?, &properties)
+    }
+
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), CommentError> {
+        let _comment = self.resolve()?;
+        match property {
+            "content" => {
+                let content = value
+                    .as_str()
+                    .ok_or_else(|| CommentError::invalid("Comment.content must be a string"))?;
+                self.sheet
+                    .comments()
+                    .update(&self.id, content)
+                    .map_err(engine)?;
+                Ok(())
+            }
+            "resolved" => {
+                let resolved = value
+                    .as_bool()
+                    .ok_or_else(|| CommentError::invalid("Comment.resolved must be a boolean"))?;
+                self.sheet
+                    .comments()
+                    .set_thread_resolved(&self.id, resolved)
+                    .map_err(engine)?;
+                Ok(())
+            }
+            other => Err(CommentError::unsupported(format!(
+                "Comment.{other} is read-only or unsupported"
+            ))),
+        }
+    }
+
+    pub(crate) fn delete(&self) -> Result<(), CommentError> {
+        let comment = self.resolve()?;
+        // Office's Comment.delete removes the complete thread. Delete replies
+        // first so the root operation remains valid even if the backend later
+        // adds cascading deletion semantics of its own.
+        let thread_id = comment
+            .thread_id
+            .clone()
+            .unwrap_or_else(|| comment.id.clone());
+        let thread = self
+            .sheet
+            .comments()
+            .get_thread(&thread_id)
+            .map_err(engine)?;
+        for reply in thread.iter().filter_map(|reply| {
+            decode_comment(reply)
+                .ok()
+                .filter(|reply| reply.id != comment.id)
+                .map(|reply| reply.id)
+        }) {
+            self.sheet.comments().delete(&reply).map_err(engine)?;
+        }
+        self.sheet.comments().delete(&comment.id).map_err(engine)?;
+        Ok(())
+    }
+
+    pub(crate) fn update_mentions(
+        &self,
+        content: &Value,
+        mentions: Option<&Value>,
+    ) -> Result<(), CommentError> {
+        let content = content.as_str().ok_or_else(|| {
+            CommentError::invalid("CommentRichContent.richContent must be a string")
+        })?;
+        let mentions = mentions
+            .map(parse_mentions)
+            .transpose()?
+            .unwrap_or_default();
+        let input = CommentInput {
+            content: content.to_string(),
+            content_type: CommentContentType::Mention,
+            mentions,
+        };
+        apply_mention_content(&self.sheet, &self.id, &input)
+    }
+
+    pub(crate) fn replies(&self) -> CommentReplyCollectionRef {
+        CommentReplyCollectionRef {
+            parent: Arc::new(self.clone()),
+        }
+    }
+
+    /// Return the persisted cell reference. For live comments this is a
+    /// stable cell ID; imported comments may carry an A1 reference. The host
+    /// can use this to bind getLocation when a range reverse lookup exists.
+    pub(crate) fn cell_ref(&self) -> Result<String, CommentError> {
+        Ok(self.resolve()?.cell_ref)
+    }
+}
+
+impl ExtensionObject for CommentRef {
+    fn object_type(&self) -> &'static str {
+        "Comment"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        CommentRef::load(self, properties).map_err(batch_error)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        CommentRef::set(self, property, value).map_err(batch_error)
+    }
+}
+
+/// A collection of direct replies to a root comment.
+#[derive(Clone)]
+pub(crate) struct CommentReplyCollectionRef {
+    parent: Arc<CommentRef>,
+}
+
+impl CommentReplyCollectionRef {
+    pub(crate) fn parent(&self) -> Arc<CommentRef> {
+        self.parent.clone()
+    }
+
+    fn records(&self) -> Result<Vec<StoredComment>, CommentError> {
+        let root = self.parent.resolve()?;
+        self.parent
+            .sheet
+            .comments()
+            .get_thread(root.thread_id.as_deref().unwrap_or(root.id.as_str()))
+            .map_err(engine)?
+            .iter()
+            .map(decode_comment)
+            .filter_map(|result| match result {
+                Ok(comment) if comment.parent_id.as_deref() == Some(root.id.as_str()) => {
+                    Some(Ok(comment))
+                }
+                Ok(_) => None,
+                Err(error) => Some(Err(error)),
+            })
+            .collect()
+    }
+
+    pub(crate) fn count(&self) -> Result<usize, CommentError> {
+        Ok(self.records()?.len())
+    }
+
+    pub(crate) fn collection_items(
+        &self,
+        properties: &[String],
+    ) -> Result<Vec<CommentCollectionItem>, CommentError> {
+        let item_properties = collection_item_properties(properties);
+        self.records()?
+            .into_iter()
+            .map(|comment| {
+                Ok(CommentCollectionItem {
+                    key: comment.id.clone(),
+                    worksheet_id: self.parent.sheet.id().to_uuid_string(),
+                    properties: comment_properties(&comment, &item_properties)?,
+                })
+            })
+            .collect()
+    }
+
+    pub(crate) fn get_item(&self, id: &str) -> Result<CommentReplyRef, CommentError> {
+        if !self.records()?.iter().any(|comment| comment.id == id) {
+            return Err(CommentError::item_not_found(id));
+        }
+        Ok(CommentReplyRef {
+            parent: self.parent.clone(),
+            id: id.to_string(),
+            null_object: false,
+        })
+    }
+
+    pub(crate) fn get_item_at(&self, index: i64) -> Result<CommentReplyRef, CommentError> {
+        let records = self.records()?;
+        let index = index_argument(index, records.len(), "CommentReplyCollection")?;
+        Ok(CommentReplyRef {
+            parent: self.parent.clone(),
+            id: records[index].id.clone(),
+            null_object: false,
+        })
+    }
+
+    pub(crate) fn get_item_or_null_object(
+        &self,
+        id: &str,
+    ) -> Result<Option<CommentReplyRef>, CommentError> {
+        match self.get_item(id) {
+            Ok(reply) => Ok(Some(reply)),
+            Err(error) if error.code == "ItemNotFound" => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub(crate) fn add(&self, input: &CommentInput) -> Result<CommentReplyRef, CommentError> {
+        let root = self.parent.resolve()?;
+        let result = self
+            .parent
+            .sheet
+            .comments()
+            .add(
+                &root.cell_ref,
+                UNAVAILABLE_HOST_AUTHOR,
+                &input.content,
+                None,
+                Some(&root.id),
+                Default::default(),
+            )
+            .map_err(engine)?;
+        let id = persisted_id(&result)?;
+        apply_mention_content(&self.parent.sheet, &id, input)?;
+        Ok(CommentReplyRef {
+            parent: self.parent.clone(),
+            id,
+            null_object: false,
+        })
+    }
+}
+
+impl ExtensionObject for CommentReplyCollectionRef {
+    fn object_type(&self) -> &'static str {
+        "CommentReplyCollection"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        let mut result = HashMap::new();
+        let item_properties = properties
+            .iter()
+            .filter(|property| property.as_str() != "isNullObject")
+            .cloned()
+            .collect::<Vec<_>>();
+        if properties.iter().any(|property| property == "items")
+            || properties
+                .iter()
+                .any(|property| property.starts_with("items/"))
+        {
+            let items = self
+                .collection_items(&item_properties)
+                .map_err(batch_error)?;
+            result.insert(
+                "items".to_string(),
+                serde_json::to_value(items)
+                    .map_err(encoding)
+                    .map_err(batch_error)?,
+            );
+        } else if properties.iter().any(|property| property != "isNullObject") {
+            let property = properties
+                .iter()
+                .find(|property| property.as_str() != "isNullObject")
+                .expect("property exists");
+            return Err(batch_error(unsupported_load(
+                "CommentReplyCollection",
+                property,
+            )));
+        }
+        Ok(result)
+    }
+
+    fn set(&self, property: &str, _value: &Value) -> Result<(), BatchError> {
+        Err(batch_error(CommentError::unsupported(format!(
+            "CommentReplyCollection.{property} is read-only or unsupported"
+        ))))
+    }
+}
+
+/// A live reply proxy anchored to its root comment.
+#[derive(Clone)]
+pub(crate) struct CommentReplyRef {
+    parent: Arc<CommentRef>,
+    id: String,
+    null_object: bool,
+}
+
+impl CommentReplyRef {
+    pub(crate) fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub(crate) fn parent(&self) -> Arc<CommentRef> {
+        self.parent.clone()
+    }
+
+    pub(crate) fn is_null_object(&self) -> bool {
+        self.null_object
+    }
+
+    fn resolve(&self) -> Result<StoredComment, CommentError> {
+        if self.null_object {
+            return Err(CommentError {
+                code: "InvalidObjectPath",
+                message: "CommentReply is a null object.".to_string(),
+            });
+        }
+        let root = self.parent.resolve()?;
+        let comments = self
+            .parent
+            .sheet
+            .comments()
+            .get_thread(root.thread_id.as_deref().unwrap_or(root.id.as_str()))
+            .map_err(engine)?;
+        comments
+            .iter()
+            .map(decode_comment)
+            .filter_map(Result::ok)
+            .find(|comment| comment.id == self.id && comment.parent_id.is_some())
+            .ok_or_else(|| CommentError::item_not_found(&self.id))
+    }
+
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, CommentError> {
+        if self.null_object {
+            let mut result = HashMap::new();
+            for property in properties {
+                if property == "isNullObject" {
+                    result.insert(property.clone(), Value::Bool(true));
+                } else {
+                    return Err(CommentError {
+                        code: "InvalidObjectPath",
+                        message: format!(
+                            "CommentReply.{property} cannot be loaded from a null object"
+                        ),
+                    });
+                }
+            }
+            return Ok(result);
+        }
+        let properties = properties
+            .iter()
+            .filter(|property| property.as_str() != "isNullObject")
+            .cloned()
+            .collect::<Vec<_>>();
+        comment_properties(&self.resolve()?, &properties)
+    }
+
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), CommentError> {
+        let _reply = self.resolve()?;
+        match property {
+            "content" => {
+                let content = value.as_str().ok_or_else(|| {
+                    CommentError::invalid("CommentReply.content must be a string")
+                })?;
+                self.parent
+                    .sheet
+                    .comments()
+                    .update(&self.id, content)
+                    .map_err(engine)?;
+                Ok(())
+            }
+            other => Err(CommentError::unsupported(format!(
+                "CommentReply.{other} is read-only or unsupported"
+            ))),
+        }
+    }
+
+    pub(crate) fn delete(&self) -> Result<(), CommentError> {
+        self.resolve()?;
+        self.parent
+            .sheet
+            .comments()
+            .delete(&self.id)
+            .map_err(engine)?;
+        Ok(())
+    }
+
+    pub(crate) fn update_mentions(
+        &self,
+        content: &Value,
+        mentions: Option<&Value>,
+    ) -> Result<(), CommentError> {
+        let content = content.as_str().ok_or_else(|| {
+            CommentError::invalid("CommentRichContent.richContent must be a string")
+        })?;
+        let mentions = mentions
+            .map(parse_mentions)
+            .transpose()?
+            .unwrap_or_default();
+        let input = CommentInput {
+            content: content.to_string(),
+            content_type: CommentContentType::Mention,
+            mentions,
+        };
+        apply_mention_content(&self.parent.sheet, &self.id, &input)
+    }
+}
+
+impl ExtensionObject for CommentReplyRef {
+    fn object_type(&self) -> &'static str {
+        "CommentReply"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        CommentReplyRef::load(self, properties).map_err(batch_error)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        CommentReplyRef::set(self, property, value).map_err(batch_error)
+    }
+}
+
+impl ExtensionObject for CommentCollectionRef {
+    fn object_type(&self) -> &'static str {
+        "CommentCollection"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        let mut result = HashMap::new();
+        let item_properties = properties
+            .iter()
+            .filter(|property| property.as_str() != "isNullObject")
+            .cloned()
+            .collect::<Vec<_>>();
+        if properties.iter().any(|property| property == "items")
+            || properties
+                .iter()
+                .any(|property| property.starts_with("items/"))
+        {
+            let items = self
+                .collection_items(&item_properties)
+                .map_err(batch_error)?;
+            result.insert(
+                "items".to_string(),
+                serde_json::to_value(items)
+                    .map_err(encoding)
+                    .map_err(batch_error)?,
+            );
+        } else if properties.iter().any(|property| property != "isNullObject") {
+            let property = properties
+                .iter()
+                .find(|property| property.as_str() != "isNullObject")
+                .expect("property exists");
+            return Err(batch_error(unsupported_load("CommentCollection", property)));
+        }
+        Ok(result)
+    }
+
+    fn set(&self, property: &str, _value: &Value) -> Result<(), BatchError> {
+        Err(batch_error(CommentError::unsupported(format!(
+            "CommentCollection.{property} is read-only or unsupported"
+        ))))
+    }
+}
+
+/// Family handler used by Host::register_extension.
+pub(crate) struct CommentHandler;
+
+pub(crate) fn handler() -> CommentHandler {
+    CommentHandler
+}
+
+impl ExtensionHandler for CommentHandler {
+    fn can_handle(&self, operation: &str) -> bool {
+        matches!(
+            operation,
+            "getCommentCollection"
+                | "commentCollectionGetCount"
+                | "commentCollectionGetItem"
+                | "commentCollectionGetItemAt"
+                | "commentCollectionGetItemByCell"
+                | "commentCollectionGetItemByReplyId"
+                | "commentAdd"
+                | "getCommentReplyCollection"
+                | "commentReplyCollectionGetCount"
+                | "commentReplyCollectionGetItem"
+                | "commentReplyCollectionGetItemAt"
+                | "commentReplyAdd"
+                | "commentDelete"
+                | "commentReplyDelete"
+                | "commentUpdateMentions"
+        )
+    }
+
+    fn handle(
+        &self,
+        operation: &Value,
+        context: &mut HostDispatchContext<'_>,
+    ) -> Result<bool, BatchError> {
+        let op = operation
+            .get("op")
+            .and_then(Value::as_str)
+            .expect("can_handle only receives operations with an op");
+        match op {
+            "getCommentCollection" => {
+                let id = required_string(operation, "id")?;
+                let worksheet = optional_string(operation, "worksheetId")?
+                    .map(|worksheet_id| context.worksheet(worksheet_id).map(|ref_| ref_.sheet()))
+                    .transpose()?;
+                context.bind_object(
+                    id,
+                    Arc::new(CommentCollectionRef::new(context.workbook(), worksheet)),
+                );
+                Ok(true)
+            }
+            "commentCollectionGetCount" => {
+                let collection_id = required_string(operation, "collectionId")?;
+                let result_id = required_string(operation, "resultId")?;
+                let collection = context.extension_object::<CommentCollectionRef>(collection_id)?;
+                context.set_result(result_id, json!(collection.count().map_err(batch_error)?));
+                Ok(true)
+            }
+            "commentCollectionGetItem" | "commentCollectionGetItemAt" => {
+                let id = required_string(operation, "id")?;
+                let collection_id = required_string(operation, "collectionId")?;
+                let collection = context.extension_object::<CommentCollectionRef>(collection_id)?;
+                let or_null = operation
+                    .get("orNullObject")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let item = if op == "commentCollectionGetItem" {
+                    collection.get_item(required_string(operation, "key")?)
+                } else {
+                    collection.get_item_at(required_i64(operation, "index")?)
+                };
+                match item {
+                    Ok(item) => {
+                        context.bind_object(id, Arc::new(item));
+                    }
+                    Err(error) if or_null && error.code == "ItemNotFound" => {
+                        context.bind_null_object(id);
+                    }
+                    Err(error) => return Err(batch_error(error)),
+                }
+                Ok(true)
+            }
+            "commentCollectionGetItemByCell" => {
+                let id = required_string(operation, "id")?;
+                let collection_id = required_string(operation, "collectionId")?;
+                let collection = context.extension_object::<CommentCollectionRef>(collection_id)?;
+                let (sheet, canonical) = target_for_lookup(operation, context, &collection)?;
+                let cell_id = sheet
+                    .get_cell_data(canonical.as_str())
+                    .map_err(engine)
+                    .map_err(batch_error)?
+                    .and_then(|data| {
+                        data.get("cell_id")
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                    });
+                let record = collection
+                    .records()?
+                    .into_iter()
+                    .find(|record| {
+                        record.comment.cell_ref == canonical
+                            || cell_id
+                                .as_deref()
+                                .is_some_and(|cell_id| record.comment.cell_ref == cell_id)
+                    })
+                    .ok_or_else(|| CommentError::item_not_found(canonical.clone()));
+                context.bind_object(
+                    id,
+                    Arc::new(record.map(|record| {
+                        CommentRef::new(
+                            collection.workbook.clone(),
+                            record.sheet,
+                            record.comment.id,
+                            false,
+                        )
+                    })?),
+                );
+                Ok(true)
+            }
+            "commentCollectionGetItemByReplyId" => {
+                let id = required_string(operation, "id")?;
+                let collection_id = required_string(operation, "collectionId")?;
+                let reply_id = required_string(operation, "replyId")?;
+                let collection = context.extension_object::<CommentCollectionRef>(collection_id)?;
+                let item = collection
+                    .get_item_by_reply_id(reply_id)
+                    .map_err(batch_error)?;
+                context.bind_object(id, Arc::new(item));
+                Ok(true)
+            }
+            "commentAdd" => {
+                let id = required_string(operation, "id")?;
+                let collection_id = required_string(operation, "collectionId")?;
+                let collection = context.extension_object::<CommentCollectionRef>(collection_id)?;
+                let range_id = optional_string(operation, "rangeId")?;
+                let range = range_id
+                    .map(|range_id| context.range(range_id))
+                    .transpose()?;
+                let address = optional_string(operation, "address")?;
+                let input = CommentInput::from_wire(
+                    operation.get("content").ok_or_else(|| {
+                        batch_error(CommentError::invalid("Comment.add requires content"))
+                    })?,
+                    optional_string(operation, "contentType")?,
+                )
+                .map_err(batch_error)?;
+                let (sheet, cell_id) = collection
+                    .resolve_target(address, range.as_ref(), true)
+                    .map_err(batch_error)?;
+                let item = collection
+                    .add(sheet, &cell_id, &input)
+                    .map_err(batch_error)?;
+                context.bind_object(id, Arc::new(item));
+                Ok(true)
+            }
+            "getCommentReplyCollection" => {
+                let id = required_string(operation, "id")?;
+                let comment_id = required_string(operation, "commentId")?;
+                let comment = context.extension_object::<CommentRef>(comment_id)?;
+                context.bind_object(id, Arc::new(comment.replies()));
+                Ok(true)
+            }
+            "commentReplyCollectionGetCount" => {
+                let collection_id = required_string(operation, "collectionId")?;
+                let result_id = required_string(operation, "resultId")?;
+                let collection =
+                    context.extension_object::<CommentReplyCollectionRef>(collection_id)?;
+                context.set_result(result_id, json!(collection.count().map_err(batch_error)?));
+                Ok(true)
+            }
+            "commentReplyCollectionGetItem" | "commentReplyCollectionGetItemAt" => {
+                let id = required_string(operation, "id")?;
+                let collection_id = required_string(operation, "collectionId")?;
+                let collection =
+                    context.extension_object::<CommentReplyCollectionRef>(collection_id)?;
+                let or_null = operation
+                    .get("orNullObject")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let item = if op == "commentReplyCollectionGetItem" {
+                    collection.get_item(required_string(operation, "key")?)
+                } else {
+                    collection.get_item_at(required_i64(operation, "index")?)
+                };
+                match item {
+                    Ok(item) => context.bind_object(id, Arc::new(item)),
+                    Err(error) if or_null && error.code == "ItemNotFound" => {
+                        context.bind_null_object(id)
+                    }
+                    Err(error) => return Err(batch_error(error)),
+                }
+                Ok(true)
+            }
+            "commentReplyAdd" => {
+                let id = required_string(operation, "id")?;
+                let comment_id = required_string(operation, "commentId")?;
+                let comment = context.extension_object::<CommentRef>(comment_id)?;
+                let input = CommentInput::from_wire(
+                    operation.get("content").ok_or_else(|| {
+                        batch_error(CommentError::invalid(
+                            "CommentReplyCollection.add requires content",
+                        ))
+                    })?,
+                    optional_string(operation, "contentType")?,
+                )
+                .map_err(batch_error)?;
+                let item = comment.replies().add(&input).map_err(batch_error)?;
+                context.bind_object(id, Arc::new(item));
+                Ok(true)
+            }
+            "commentDelete" => {
+                let id = required_string(operation, "id")?;
+                let comment = context.extension_object::<CommentRef>(id)?;
+                comment.delete().map_err(batch_error)?;
+                Ok(true)
+            }
+            "commentReplyDelete" => {
+                let id = required_string(operation, "id")?;
+                let reply = context.extension_object::<CommentReplyRef>(id)?;
+                reply.delete().map_err(batch_error)?;
+                Ok(true)
+            }
+            "commentUpdateMentions" => {
+                let id = required_string(operation, "id")?;
+                let content = operation.get("content").ok_or_else(|| {
+                    batch_error(CommentError::invalid(
+                        "Comment.updateMentions requires content",
+                    ))
+                })?;
+                let mentions = operation.get("mentions");
+                if let Ok(comment) = context.extension_object::<CommentRef>(id) {
+                    comment
+                        .update_mentions(content, mentions)
+                        .map_err(batch_error)?;
+                } else {
+                    let reply = context.extension_object::<CommentReplyRef>(id)?;
+                    reply
+                        .update_mentions(content, mentions)
+                        .map_err(batch_error)?;
+                }
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+fn required_string<'a>(operation: &'a Value, name: &str) -> Result<&'a str, BatchError> {
+    operation
+        .get(name)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| BatchError {
+            code: "InvalidArgument",
+            message: format!("comment operation requires a non-empty string '{name}'"),
+        })
+}
+
+fn optional_string<'a>(operation: &'a Value, name: &str) -> Result<Option<&'a str>, BatchError> {
+    match operation.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value
+            .as_str()
+            .filter(|value| !value.is_empty())
+            .map(Some)
+            .ok_or_else(|| BatchError {
+                code: "InvalidArgument",
+                message: format!("comment operation field '{name}' must be a string"),
+            }),
+    }
+}
+
+fn required_i64(operation: &Value, name: &str) -> Result<i64, BatchError> {
+    operation
+        .get(name)
+        .and_then(Value::as_i64)
+        .ok_or_else(|| BatchError {
+            code: "InvalidArgument",
+            message: format!("comment operation requires integer '{name}'"),
+        })
+}
+
+fn target_for_lookup(
+    operation: &Value,
+    context: &HostDispatchContext<'_>,
+    collection: &CommentCollectionRef,
+) -> Result<(Sheet, String), BatchError> {
+    if let Some(range_id) = optional_string(operation, "rangeId")? {
+        let range = context.range(range_id)?;
+        if range.is_null_object() {
+            return Err(BatchError {
+                code: "InvalidObjectPath",
+                message: "The comment cell Range is a null object.".to_string(),
+            });
+        }
+        let address = range.address().ok_or_else(|| BatchError {
+            code: "InvalidArgument",
+            message: "CommentCollection.getItemByCell requires a single-cell Range".to_string(),
+        })?;
+        let sheet = range.sheet();
+        if let Some(scope) = collection.worksheet.as_ref()
+            && scope.id() != sheet.id()
+        {
+            return Err(BatchError {
+                code: "InvalidArgument",
+                message: "The comment cell belongs to a different worksheet".to_string(),
+            });
+        }
+        let parsed = parse_range_address(&sheet, address)
+            .map_err(range_error)
+            .map_err(batch_error)?;
+        let RangeAddress::Cells {
+            start_row,
+            start_column,
+            end_row,
+            end_column,
+        } = parsed
+        else {
+            return Err(BatchError {
+                code: "InvalidArgument",
+                message: "CommentCollection.getItemByCell requires a single-cell Range".to_string(),
+            });
+        };
+        if start_row != end_row || start_column != end_column {
+            return Err(BatchError {
+                code: "InvalidArgument",
+                message: "CommentCollection.getItemByCell requires a single-cell Range".to_string(),
+            });
+        }
+        return Ok((sheet, parsed.to_a1()));
+    }
+    let address = required_string(operation, "address")?;
+    let (sheet, reference) = collection
+        .resolve_text_address(address)
+        .map_err(batch_error)?;
+    let parsed = parse_range_address(&sheet, &reference)
+        .map_err(range_error)
+        .map_err(batch_error)?;
+    let RangeAddress::Cells {
+        start_row,
+        start_column,
+        end_row,
+        end_column,
+    } = parsed
+    else {
+        return Err(BatchError {
+            code: "InvalidArgument",
+            message: "CommentCollection.getItemByCell requires a single-cell address".to_string(),
+        });
+    };
+    if start_row != end_row || start_column != end_column {
+        return Err(BatchError {
+            code: "InvalidArgument",
+            message: "CommentCollection.getItemByCell requires a single-cell address".to_string(),
+        });
+    }
+    Ok((sheet, parsed.to_a1()))
+}

--- a/compute/officejs/src/conditional_basic.js
+++ b/compute/officejs/src/conditional_basic.js
@@ -1,0 +1,1137 @@
+(function (global) {
+  "use strict";
+
+  // The conditional-format implementation is intentionally split into this
+  // module and the scale-family module.  This file owns the collection, the
+  // common ConditionalFormat object, traditional rule families, and the
+  // shared range-format hierarchy.  The scale module registers richer
+  // constructors for colorScale, dataBar, and iconSet through the registry
+  // below.
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var hooks = global.__mogOfficeJs || {};
+  var configureCollection = hooks.configureCollection;
+  var createClientResult = hooks.createClientResult;
+
+  function richApiError(code, message) {
+    var error = new OfficeExtension.Error({ code: code, message: message });
+    error.name = "RichApi.Error";
+    error.code = code;
+    return error;
+  }
+
+  function propertyNotLoaded(name) {
+    return richApiError(
+      "PropertyNotLoaded",
+      "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context."
+    );
+  }
+
+  function invalid(message) {
+    return richApiError("InvalidArgument", message);
+  }
+
+  function unsupported(message) {
+    return richApiError("ApiNotFound", message);
+  }
+
+  function invalidContext() {
+    return invalid("The object belongs to a different request context.");
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object";
+  }
+
+  function isPlainObject(value) {
+    if (!isObject(value)) return false;
+    var prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  }
+
+  function own(object, name) {
+    return Object.prototype.hasOwnProperty.call(object, name);
+  }
+
+  function requirePlainObject(value, property) {
+    if (!isPlainObject(value)) throw invalid(property + " must be an object");
+    return value;
+  }
+
+  function readLoaded(object, name) {
+    if (!object._loaded[name]) throw propertyNotLoaded(name);
+    return name === "id" ? object._idValue : object["_" + name];
+  }
+
+  function queueScalar(object, name, value, wireValue) {
+    object["_" + name] = value;
+    object._loaded[name] = true;
+    object.context._queue.push({
+      op: "set",
+      id: object._id,
+      property: name,
+      value: wireValue === undefined ? value : wireValue,
+    });
+  }
+
+  function defineScalar(proto, name, normalizer, readOnly) {
+    Object.defineProperty(proto, name, {
+      get: function () {
+        return readLoaded(this, name);
+      },
+      set: readOnly
+        ? undefined
+        : function (value) {
+            var normalized = normalizer
+              ? normalizer.call(this, value)
+              : value;
+            queueScalar(this, name, normalized);
+          },
+      configurable: true,
+    });
+  }
+
+  function navigationProperties(object) {
+    var names = (object._navigationProperties || []).slice();
+    (object._additionalNavigationProperties || []).forEach(function (name) {
+      if (names.indexOf(name) < 0) names.push(name);
+    });
+    return names;
+  }
+
+  function objectProperties(source, target, options) {
+    if (source instanceof ClientObject) {
+      if (source.context !== target.context) throw invalidContext();
+      if (Object.getPrototypeOf(source) !== Object.getPrototypeOf(target)) {
+        throw invalid("The object passed to set must have the same type.");
+      }
+      source = source.toJSON();
+    } else if (!isPlainObject(source)) {
+      throw new TypeError("set requires a property object");
+    }
+
+    var suppressReadOnly = options && options.throwOnReadOnly === false;
+    var scalarNames = target._scalarProperties || [];
+    var navNames = navigationProperties(target);
+    Object.keys(source).forEach(function (name) {
+      if (scalarNames.indexOf(name) < 0 && navNames.indexOf(name) < 0) {
+        throw invalid("Unsupported " + target._objectName + " property '" + name + "'");
+      }
+      if ((name === "id" || name === "type") && !suppressReadOnly) {
+        throw invalid(target._objectName + "." + name + " is read-only");
+      }
+    });
+    scalarNames.forEach(function (name) {
+      if (!own(source, name) || source[name] === undefined) return;
+      if (name === "id" || name === "type") {
+        if (!suppressReadOnly) {
+          throw invalid(target._objectName + "." + name + " is read-only");
+        }
+        return;
+      }
+      target[name] = source[name];
+    });
+    navNames.forEach(function (name) {
+      if (!own(source, name) || source[name] === undefined) return;
+      target[name].set(source[name], options);
+    });
+    return target;
+  }
+
+  function toJSONObject() {
+    var result = {};
+    (this._scalarProperties || []).forEach(function (name) {
+      if (this._loaded[name]) {
+        result[name] = name === "id" ? this._idValue : this["_" + name];
+      }
+    }, this);
+    (this._children || []).forEach(function (name) {
+      var child = this["_" + name];
+      if (child === undefined && this._childCache) child = this._childCache[name];
+      if (child !== undefined) result[name] = child.toJSON();
+    }, this);
+    return result;
+  }
+
+  function queueChildBinding(object, root, kind, orNullObject, side) {
+    object.context._queue.push({
+      op: "conditionalFormatChild",
+      id: object._id,
+      parentId: root._id,
+      kind: kind,
+      orNullObject: !!orNullObject,
+      side: side === undefined ? undefined : side,
+    });
+  }
+
+  function rootConditionalFormat(object) {
+    if (object instanceof ConditionalFormat) return object;
+    if (object._conditionalFormat) return object._conditionalFormat;
+    if (object._parent) return rootConditionalFormat(object._parent);
+    throw invalid("The conditional-format child has no parent format");
+  }
+
+  function rootWorksheet(object) {
+    var format = rootConditionalFormat(object);
+    return format._worksheet;
+  }
+
+  function makeClientResult(context) {
+    if (typeof createClientResult === "function") return createClientResult(context);
+    return new OfficeExtension.ClientResult(context);
+  }
+
+  function normalizeString(value, property, allowEmpty) {
+    if (typeof value !== "string" || (!allowEmpty && value.length === 0)) {
+      throw invalid(property + " must be " + (allowEmpty ? "a string" : "a non-empty string"));
+    }
+    return value;
+  }
+
+  function normalizeInteger(value, property, min) {
+    if (typeof value !== "number" || !isFinite(value) || Math.floor(value) !== value) {
+      throw invalid(property + " must be an integer");
+    }
+    if (min !== undefined && value < min) {
+      throw invalid(property + " must be at least " + min);
+    }
+    return value;
+  }
+
+  var cellOperators = {
+    Between: "between",
+    NotBetween: "notBetween",
+    EqualTo: "equal",
+    NotEqualTo: "notEqual",
+    GreaterThan: "greaterThan",
+    LessThan: "lessThan",
+    GreaterThanOrEqual: "greaterThanOrEqual",
+    LessThanOrEqual: "lessThanOrEqual",
+  };
+
+  var textOperators = {
+    Contains: "containsText",
+    NotContains: "notContains",
+    BeginsWith: "beginsWith",
+    EndsWith: "endsWith",
+  };
+
+  var topBottomTypes = {
+    TopItems: { percent: false, bottom: false },
+    TopPercent: { percent: true, bottom: false },
+    BottomItems: { percent: false, bottom: true },
+    BottomPercent: { percent: true, bottom: true },
+  };
+
+  var presetCriteria = [
+    "Blanks",
+    "NonBlanks",
+    "Errors",
+    "NonErrors",
+    "Yesterday",
+    "Today",
+    "Tomorrow",
+    "LastSevenDays",
+    "LastWeek",
+    "ThisWeek",
+    "NextWeek",
+    "LastMonth",
+    "ThisMonth",
+    "NextMonth",
+    "AboveAverage",
+    "BelowAverage",
+    "EqualOrAboveAverage",
+    "EqualOrBelowAverage",
+    "OneStdDevAboveAverage",
+    "OneStdDevBelowAverage",
+    "TwoStdDevAboveAverage",
+    "TwoStdDevBelowAverage",
+    "ThreeStdDevAboveAverage",
+    "ThreeStdDevBelowAverage",
+    "UniqueValues",
+    "DuplicateValues",
+  ];
+
+  var timePeriods = {
+    Yesterday: "yesterday",
+    Today: "today",
+    Tomorrow: "tomorrow",
+    LastSevenDays: "last7Days",
+    LastWeek: "lastWeek",
+    ThisWeek: "thisWeek",
+    NextWeek: "nextWeek",
+    LastMonth: "lastMonth",
+    ThisMonth: "thisMonth",
+    NextMonth: "nextMonth",
+  };
+
+  function assertOnly(source, allowed, property) {
+    Object.keys(source).forEach(function (name) {
+      if (allowed.indexOf(name) < 0) {
+        throw invalid("Unsupported " + property + " property '" + name + "'");
+      }
+    });
+  }
+
+  function normalizeCellValueRule(value) {
+    var source = requirePlainObject(value, "ConditionalFormat.cellValue.rule");
+    assertOnly(source, ["formula1", "formula2", "operator"], "ConditionalFormat.cellValue.rule");
+    if (!own(source, "formula1")) {
+      throw invalid("ConditionalFormat.cellValue.rule requires formula1");
+    }
+    if (!own(source, "operator") || !own(cellOperators, source.operator)) {
+      throw invalid("ConditionalFormat.cellValue.rule.operator must be a supported enum value");
+    }
+    var between = source.operator === "Between" || source.operator === "NotBetween";
+    if (between && !own(source, "formula2")) {
+      throw invalid(source.operator + " requires formula2");
+    }
+    if (!between && own(source, "formula2")) {
+      throw invalid("formula2 is only valid with Between or NotBetween operators");
+    }
+    var result = {
+      operator: source.operator,
+      formula1: normalizeString(source.formula1, "ConditionalFormat.cellValue.rule.formula1", true),
+    };
+    if (own(source, "formula2")) {
+      result.formula2 = normalizeString(source.formula2, "ConditionalFormat.cellValue.rule.formula2", true);
+    }
+    return {
+      display: result,
+      wire: {
+        operator: cellOperators[source.operator],
+        value1: result.formula1,
+        ...(own(result, "formula2") ? { value2: result.formula2 } : {}),
+      },
+    };
+  }
+
+  function normalizeTextRule(value) {
+    var source = requirePlainObject(value, "ConditionalFormat.textComparison.rule");
+    assertOnly(source, ["operator", "text"], "ConditionalFormat.textComparison.rule");
+    if (!own(source, "operator") || !own(textOperators, source.operator)) {
+      throw invalid("ConditionalFormat.textComparison.rule.operator must be a supported enum value");
+    }
+    return {
+      display: {
+        operator: source.operator,
+        text: normalizeString(source.text, "ConditionalFormat.textComparison.rule.text", true),
+      },
+      wire: {
+        operator: textOperators[source.operator],
+        text: source.text,
+      },
+    };
+  }
+
+  function normalizeTopBottomRule(value) {
+    var source = requirePlainObject(value, "ConditionalFormat.topBottom.rule");
+    assertOnly(source, ["rank", "type"], "ConditionalFormat.topBottom.rule");
+    if (!own(source, "rank") || !own(source, "type")) {
+      throw invalid("ConditionalFormat.topBottom.rule requires rank and type");
+    }
+    if (!own(topBottomTypes, source.type)) {
+      throw invalid("ConditionalFormat.topBottom.rule.type must be a supported enum value");
+    }
+    var kind = topBottomTypes[source.type];
+    var rank = normalizeInteger(source.rank, "ConditionalFormat.topBottom.rule.rank", 1);
+    if (kind.percent && rank > 100) {
+      throw invalid("Percent top/bottom rank must be between 1 and 100");
+    }
+    if (!kind.percent && rank > 1000) {
+      throw invalid("Item top/bottom rank must be between 1 and 1000");
+    }
+    return {
+      display: { rank: rank, type: source.type },
+      wire: { type: "top10", rank: rank, percent: kind.percent, bottom: kind.bottom },
+    };
+  }
+
+  function normalizePresetRule(value) {
+    var source = requirePlainObject(value, "ConditionalFormat.preset.rule");
+    assertOnly(source, ["criterion"], "ConditionalFormat.preset.rule");
+    if (!own(source, "criterion") || presetCriteria.indexOf(source.criterion) < 0) {
+      throw invalid("ConditionalFormat.preset.rule.criterion must be a supported enum value");
+    }
+    var criterion = source.criterion;
+    var wire;
+    if (criterion === "Blanks" || criterion === "NonBlanks") {
+      wire = { type: "containsBlanks", blanks: criterion === "Blanks" };
+    } else if (criterion === "Errors" || criterion === "NonErrors") {
+      wire = { type: "containsErrors", errors: criterion === "Errors" };
+    } else if (criterion === "UniqueValues" || criterion === "DuplicateValues") {
+      wire = { type: "duplicateValues", unique: criterion === "UniqueValues" };
+    } else if (timePeriods[criterion]) {
+      wire = { type: "timePeriod", timePeriod: timePeriods[criterion] };
+    } else {
+      var above = criterion.indexOf("Above") >= 0;
+      var below = criterion.indexOf("Below") >= 0;
+      var equal = criterion.indexOf("EqualOr") === 0;
+      var stdDev = 0;
+      if (criterion.indexOf("OneStdDev") === 0) stdDev = 1;
+      if (criterion.indexOf("TwoStdDev") === 0) stdDev = 2;
+      if (criterion.indexOf("ThreeStdDev") === 0) stdDev = 3;
+      wire = {
+        type: "aboveAverage",
+        aboveAverage: above || !below,
+        equalAverage: equal,
+      };
+      if (stdDev) wire.stdDev = stdDev;
+    }
+    return { display: { criterion: criterion }, wire: wire };
+  }
+
+  function normalizeCustomFormula(value) {
+    return normalizeString(value, "ConditionalFormat.custom.rule.formula", true);
+  }
+
+  function normalizeOfficeType(type) {
+    var allowed = [
+      "Custom",
+      "DataBar",
+      "ColorScale",
+      "IconSet",
+      "TopBottom",
+      "PresetCriteria",
+      "ContainsText",
+      "CellValue",
+    ];
+    if (typeof type !== "string" || allowed.indexOf(type) < 0) {
+      throw invalid("ConditionalFormatCollection.add type must be a supported enum value");
+    }
+    return type;
+  }
+
+  function canonicalRuleForChild(kind, value) {
+    if (kind === "cellValue") return normalizeCellValueRule(value);
+    if (kind === "textComparison") return normalizeTextRule(value);
+    if (kind === "topBottom") return normalizeTopBottomRule(value);
+    if (kind === "preset") return normalizePresetRule(value);
+    throw invalid("The conditional-format child '" + kind + "' has no assignable rule");
+  }
+
+  function ruleDisplayForChild(kind, value) {
+    if (kind === "cellValue") return normalizeCellValueRule(value).display;
+    if (kind === "textComparison") return normalizeTextRule(value).display;
+    if (kind === "topBottom") return normalizeTopBottomRule(value).display;
+    if (kind === "preset") return normalizePresetRule(value).display;
+    return value;
+  }
+
+  function normalizeRangeSide(value) {
+    var map = {
+      EdgeTop: "top",
+      EdgeBottom: "bottom",
+      EdgeLeft: "left",
+      EdgeRight: "right",
+      top: "top",
+      bottom: "bottom",
+      left: "left",
+      right: "right",
+    };
+    if (typeof value !== "string" || !own(map, value)) {
+      throw invalid("ConditionalRangeBorderIndex must be EdgeTop, EdgeBottom, EdgeLeft, or EdgeRight");
+    }
+    return map[value] === "top"
+      ? "EdgeTop"
+      : map[value] === "bottom"
+        ? "EdgeBottom"
+        : map[value] === "left"
+          ? "EdgeLeft"
+          : "EdgeRight";
+  }
+
+  var underlineValues = ["None", "Single", "Double"];
+  var borderStyleValues = ["None", "Continuous", "Dash", "DashDot", "DashDotDot", "Dot"];
+
+  function normalizeColor(value, property) {
+    return normalizeString(value, property, true);
+  }
+
+  function normalizeBorderStyle(value) {
+    if (typeof value !== "string" || borderStyleValues.indexOf(value) < 0) {
+      throw invalid("ConditionalRangeBorder.style must be a supported enum value");
+    }
+    return value;
+  }
+
+  function normalizeUnderline(value) {
+    if (typeof value !== "string" || underlineValues.indexOf(value) < 0) {
+      throw invalid("ConditionalRangeFont.underline must be a supported enum value");
+    }
+    return value;
+  }
+
+  function normalizeBool(value, property) {
+    if (typeof value !== "boolean") throw invalid(property + " must be a boolean");
+    return value;
+  }
+
+  function styleSet(object, name, value, normalizer) {
+    var normalized = normalizer ? normalizer(value) : value;
+    queueScalar(object, name, normalized);
+  }
+
+  function ConditionalFormatCollection(context, range) {
+    ClientObject.call(this, context);
+    this._range = range;
+    this._worksheet = range._worksheet;
+    this._rangeId = range._id;
+    this._objectName = "ConditionalFormatCollection";
+    this._scalarProperties = ["items"];
+    this._children = [];
+    if (typeof configureCollection === "function") {
+      configureCollection(this, function (key, descriptor) {
+        var item = new ConditionalFormat(this.context, this, String(key), null, true);
+        var properties = descriptor && descriptor.properties;
+        if (properties && properties.type !== undefined) item._typeHint = properties.type;
+        return item;
+      });
+    }
+    this.context._queue.push({
+      op: "getConditionalFormatCollection",
+      id: this._id,
+      rangeId: range._id,
+    });
+  }
+  ConditionalFormatCollection.prototype = Object.create(ClientObject.prototype);
+  ConditionalFormatCollection.prototype.constructor = ConditionalFormatCollection;
+  ConditionalFormatCollection.prototype.toJSON = function () {
+    var result = {};
+    if (this._loaded.items) {
+      result.items = this._items.map(function (item) { return item.toJSON(); });
+    }
+    return result;
+  };
+  ConditionalFormatCollection.prototype.add = function (type) {
+    type = normalizeOfficeType(type);
+    var item = new ConditionalFormat(this.context, this, null, type, true);
+    this.context._queue.push({
+      op: "conditionalFormatCollectionAdd",
+      id: item._id,
+      collectionId: this._id,
+      type: type,
+    });
+    return item;
+  };
+  ConditionalFormatCollection.prototype.clearAll = function () {
+    this.context._queue.push({ op: "conditionalFormatCollectionClearAll", collectionId: this._id });
+  };
+  ConditionalFormatCollection.prototype.getCount = function () {
+    var result = makeClientResult(this.context);
+    this.context._queue.push({
+      op: "conditionalFormatCollectionGetCount",
+      collectionId: this._id,
+      resultId: result._id,
+    });
+    return result;
+  };
+  ConditionalFormatCollection.prototype.getItem = function (id) {
+    id = normalizeString(id, "ConditionalFormatCollection.getItem id", true);
+    var item = new ConditionalFormat(this.context, this, id, null, true);
+    this.context._queue.push({
+      op: "conditionalFormatCollectionGetItem",
+      id: item._id,
+      collectionId: this._id,
+      key: id,
+      byIndex: false,
+      orNullObject: false,
+    });
+    return item;
+  };
+  ConditionalFormatCollection.prototype.getItemAt = function (index) {
+    index = normalizeInteger(index, "ConditionalFormatCollection.getItemAt index", 0);
+    var item = new ConditionalFormat(this.context, this, String(index), null, true);
+    this.context._queue.push({
+      op: "conditionalFormatCollectionGetItem",
+      id: item._id,
+      collectionId: this._id,
+      key: String(index),
+      byIndex: true,
+      orNullObject: false,
+    });
+    return item;
+  };
+  ConditionalFormatCollection.prototype.getItemOrNullObject = function (id) {
+    id = normalizeString(id, "ConditionalFormatCollection.getItemOrNullObject id", true);
+    var item = new ConditionalFormat(this.context, this, id, null, true);
+    this.context._queue.push({
+      op: "conditionalFormatCollectionGetItem",
+      id: item._id,
+      collectionId: this._id,
+      key: id,
+      byIndex: false,
+      orNullObject: true,
+    });
+    return item;
+  };
+
+  function ConditionalFormat(context, collection, idHint, typeHint, skipBind) {
+    ClientObject.call(this, context);
+    this._collection = collection;
+    this._worksheet = collection._worksheet;
+    this._idHint = idHint;
+    this._typeHint = typeHint;
+    this._objectName = "ConditionalFormat";
+    this._scalarProperties = ["id", "priority", "stopIfTrue", "type"];
+    this._navigationProperties = [
+      "cellValue",
+      "cellValueOrNullObject",
+      "colorScale",
+      "colorScaleOrNullObject",
+      "custom",
+      "customOrNullObject",
+      "dataBar",
+      "dataBarOrNullObject",
+      "iconSet",
+      "iconSetOrNullObject",
+      "preset",
+      "presetOrNullObject",
+      "textComparison",
+      "textComparisonOrNullObject",
+      "topBottom",
+      "topBottomOrNullObject",
+    ];
+    this._children = this._navigationProperties.slice();
+    this._childCache = Object.create(null);
+    if (!skipBind && idHint !== null && idHint !== undefined) {
+      this.context._queue.push({
+        op: "conditionalFormatCollectionGetItem",
+        id: this._id,
+        collectionId: collection._id,
+        key: String(idHint),
+        byIndex: false,
+        orNullObject: false,
+      });
+    }
+  }
+  ConditionalFormat.prototype = Object.create(ClientObject.prototype);
+  ConditionalFormat.prototype.constructor = ConditionalFormat;
+  defineScalar(ConditionalFormat.prototype, "priority", function (value) {
+    if (typeof value !== "number" || !isFinite(value) || Math.floor(value) !== value) {
+      throw invalid("ConditionalFormat.priority must be an integer");
+    }
+    return value;
+  });
+  defineScalar(ConditionalFormat.prototype, "stopIfTrue", function (value) {
+    return normalizeBool(value, "ConditionalFormat.stopIfTrue");
+  });
+  defineScalar(ConditionalFormat.prototype, "id", null, true);
+  defineScalar(ConditionalFormat.prototype, "type", null, true);
+  ConditionalFormat.prototype.set = function (source, options) {
+    return objectProperties(source, this, options);
+  };
+  ConditionalFormat.prototype.toJSON = toJSONObject;
+  ConditionalFormat.prototype.delete = function () {
+    this.context._queue.push({ op: "conditionalFormatDelete", id: this._id });
+  };
+  ConditionalFormat.prototype.getRange = function () {
+    var range = new Excel.Range(this.context, this._worksheet, null);
+    this.context._queue.push({
+      op: "conditionalFormatGetRange",
+      id: this._id,
+      rangeId: range._id,
+      orNullObject: false,
+    });
+    return range;
+  };
+  ConditionalFormat.prototype.getRangeOrNullObject = function () {
+    var range = new Excel.Range(this.context, this._worksheet, null);
+    this.context._queue.push({
+      op: "conditionalFormatGetRange",
+      id: this._id,
+      rangeId: range._id,
+      orNullObject: true,
+    });
+    return range;
+  };
+  ConditionalFormat.prototype.getRanges = function () {
+    throw unsupported(
+      "ConditionalFormat.getRanges is unavailable because RangeAreas is not implemented by this host"
+    );
+  };
+  ConditionalFormat.prototype.setRanges = function (ranges) {
+    var value;
+    if (ranges instanceof Excel.Range) {
+      if (ranges.context !== this.context) throw invalidContext();
+      if (ranges._worksheet !== this._worksheet) {
+        throw invalid("ConditionalFormat.setRanges requires a range on the same worksheet");
+      }
+      value = [{ rangeId: ranges._id }];
+    } else if (typeof ranges === "string") {
+      if (ranges.length === 0) throw invalid("ConditionalFormat.setRanges requires a non-empty range");
+      value = [{ address: ranges }];
+    } else {
+      throw unsupported(
+        "ConditionalFormat.setRanges only supports Range or address string because RangeAreas is not implemented by this host"
+      );
+    }
+    this.context._queue.push({ op: "conditionalFormatSetRanges", id: this._id, ranges: value });
+  };
+
+  function queueRuleChange(object, type, rule) {
+    object.context._queue.push({
+      op: "conditionalFormatChangeRule",
+      id: object._id,
+      type: type,
+      rule: rule === undefined ? null : rule,
+    });
+  }
+  ConditionalFormat.prototype.changeRuleToCellValue = function (properties) {
+    queueRuleChange(this, "CellValue", normalizeCellValueRule(properties).wire);
+  };
+  ConditionalFormat.prototype.changeRuleToColorScale = function () {
+    queueRuleChange(this, "ColorScale", null);
+  };
+  ConditionalFormat.prototype.changeRuleToContainsText = function (properties) {
+    queueRuleChange(this, "ContainsText", normalizeTextRule(properties).wire);
+  };
+  ConditionalFormat.prototype.changeRuleToCustom = function (formula) {
+    queueRuleChange(this, "Custom", { type: "formula", formula: normalizeCustomFormula(formula) });
+  };
+  ConditionalFormat.prototype.changeRuleToDataBar = function () {
+    queueRuleChange(this, "DataBar", null);
+  };
+  ConditionalFormat.prototype.changeRuleToIconSet = function () {
+    queueRuleChange(this, "IconSet", null);
+  };
+  ConditionalFormat.prototype.changeRuleToPresetCriteria = function (properties) {
+    queueRuleChange(this, "PresetCriteria", normalizePresetRule(properties).wire);
+  };
+  ConditionalFormat.prototype.changeRuleToTopBottom = function (properties) {
+    queueRuleChange(this, "TopBottom", normalizeTopBottomRule(properties).wire);
+  };
+
+  var conditionalRegistry = global.__mogConditionalFormats || {};
+  conditionalRegistry.factories = conditionalRegistry.factories || Object.create(null);
+  conditionalRegistry.registerChild = function (kind, factory) {
+    if (typeof kind !== "string" || typeof factory !== "function") {
+      throw new TypeError("registerChild requires a child kind and factory");
+    }
+    conditionalRegistry.factories[kind] = factory;
+  };
+  conditionalRegistry.getFactory = function (kind) {
+    return conditionalRegistry.factories[kind];
+  };
+  global.__mogConditionalFormats = conditionalRegistry;
+
+  function makeTypedChild(format, name, kind, orNullObject) {
+    var cacheName = name + (orNullObject ? "OrNullObject" : "");
+    if (format._childCache[cacheName]) return format._childCache[cacheName];
+    var factory = conditionalRegistry.getFactory(kind);
+    var child;
+    if (factory) {
+      child = factory(format.context, format, !!orNullObject);
+    } else if (
+      (kind === "colorScale" || kind === "dataBar" || kind === "iconSet") &&
+      typeof hooks.createConditionalFormatChild === "function"
+    ) {
+      // Keep compatibility with the scale-family adapter while it migrates
+      // to the shared registry. New scale adapters should register a factory
+      // so the parent proxy ID can be used for add-before-sync object paths.
+      child = hooks.createConditionalFormatChild(
+        format.context,
+        format,
+        kind,
+        format._idHint,
+        null
+      );
+    } else {
+      child = new ConditionalScalePlaceholder(format.context, format, kind, !!orNullObject);
+    }
+    if (!(child instanceof ClientObject) || child.context !== format.context) {
+      throw invalidContext();
+    }
+    format._childCache[cacheName] = child;
+    return child;
+  }
+
+  [
+    ["cellValue", "cellValue", false],
+    ["cellValueOrNullObject", "cellValue", true],
+    ["colorScale", "colorScale", false],
+    ["colorScaleOrNullObject", "colorScale", true],
+    ["custom", "custom", false],
+    ["customOrNullObject", "custom", true],
+    ["dataBar", "dataBar", false],
+    ["dataBarOrNullObject", "dataBar", true],
+    ["iconSet", "iconSet", false],
+    ["iconSetOrNullObject", "iconSet", true],
+    ["preset", "preset", false],
+    ["presetOrNullObject", "preset", true],
+    ["textComparison", "textComparison", false],
+    ["textComparisonOrNullObject", "textComparison", true],
+    ["topBottom", "topBottom", false],
+    ["topBottomOrNullObject", "topBottom", true],
+  ].forEach(function (entry) {
+    Object.defineProperty(ConditionalFormat.prototype, entry[0], {
+      get: function () {
+        return makeTypedChild(this, entry[0], entry[1], entry[2]);
+      },
+      configurable: true,
+    });
+  });
+
+  function ConditionalChild(context, parent, kind, orNullObject, scalarRule) {
+    ClientObject.call(this, context);
+    this._parent = parent;
+    this._conditionalFormat = rootConditionalFormat(parent);
+    this._objectName = kind === "textComparison" ? "TextConditionalFormat" : kind + " conditional format";
+    this._kind = kind;
+    this._scalarProperties = scalarRule ? ["rule"] : [];
+    this._navigationProperties = ["format"];
+    this._children = ["format"];
+    this._childCache = Object.create(null);
+    if (kind === "custom") {
+      this._navigationProperties.push("rule");
+      this._children.push("rule");
+    }
+    queueChildBinding(this, this._conditionalFormat, kind, orNullObject);
+  }
+  ConditionalChild.prototype = Object.create(ClientObject.prototype);
+  ConditionalChild.prototype.constructor = ConditionalChild;
+  ConditionalChild.prototype.load = function (props) {
+    // An omitted load on these objects loads the rule and the format object,
+    // matching Office's generated proxy behavior for this small surface.
+    if (props === undefined) {
+      if (this._kind === "custom") return ClientObject.prototype.load.call(this, ["format", "rule"]);
+      if (this._scalarProperties.length) return ClientObject.prototype.load.call(this, ["rule", "format"]);
+    }
+    return ClientObject.prototype.load.call(this, props);
+  };
+  ConditionalChild.prototype.set = function (source, options) {
+    return objectProperties(source, this, options);
+  };
+  ConditionalChild.prototype.toJSON = toJSONObject;
+  Object.defineProperty(ConditionalChild.prototype, "format", {
+    get: function () {
+      if (!this._childCache.format) {
+        this._childCache.format = new ConditionalRangeFormat(this.context, this);
+      }
+      return this._childCache.format;
+    },
+    configurable: true,
+  });
+
+  function assignRule(child, value) {
+    var normalized = canonicalRuleForChild(child._kind, value);
+    queueScalar(child, "rule", normalized.display, normalized.wire);
+  }
+
+  [
+    ["CellValueConditionalFormat", "cellValue"],
+    ["TextConditionalFormat", "textComparison"],
+    ["TopBottomConditionalFormat", "topBottom"],
+    ["PresetCriteriaConditionalFormat", "preset"],
+  ].forEach(function (entry) {
+    var ctor = function (context, parent, orNullObject) {
+      ConditionalChild.call(this, context, parent, entry[1], orNullObject, true);
+    };
+    ctor.prototype = Object.create(ConditionalChild.prototype);
+    ctor.prototype.constructor = ctor;
+    Object.defineProperty(ctor.prototype, "rule", {
+      get: function () {
+        return readLoaded(this, "rule");
+      },
+      set: function (value) {
+        assignRule(this, value);
+      },
+      configurable: true,
+    });
+    Excel[entry[0]] = ctor;
+    conditionalRegistry.registerChild(entry[1], function (context, parent, orNullObject) {
+      return new ctor(context, parent, orNullObject);
+    });
+  });
+
+  function CustomConditionalFormat(context, parent, orNullObject) {
+    ConditionalChild.call(this, context, parent, "custom", orNullObject, false);
+  }
+  CustomConditionalFormat.prototype = Object.create(ConditionalChild.prototype);
+  CustomConditionalFormat.prototype.constructor = CustomConditionalFormat;
+  Object.defineProperty(CustomConditionalFormat.prototype, "rule", {
+    get: function () {
+      if (!this._childCache.rule) {
+        this._childCache.rule = new ConditionalFormatRule(this.context, this);
+      }
+      return this._childCache.rule;
+    },
+    configurable: true,
+  });
+  Excel.CustomConditionalFormat = CustomConditionalFormat;
+  conditionalRegistry.registerChild("custom", function (context, parent, orNullObject) {
+    return new CustomConditionalFormat(context, parent, orNullObject);
+  });
+
+  function ConditionalFormatRule(context, parent) {
+    ClientObject.call(this, context);
+    this._parent = parent;
+    this._conditionalFormat = rootConditionalFormat(parent);
+    this._objectName = "ConditionalFormatRule";
+    this._scalarProperties = ["formula", "formulaLocal", "formulaR1C1"];
+    this._children = [];
+    queueChildBinding(this, this._conditionalFormat, "rule", false);
+  }
+  ConditionalFormatRule.prototype = Object.create(ClientObject.prototype);
+  ConditionalFormatRule.prototype.constructor = ConditionalFormatRule;
+  ["formula", "formulaLocal", "formulaR1C1"].forEach(function (name) {
+    defineScalar(ConditionalFormatRule.prototype, name, function (value) {
+      return normalizeString(value, "ConditionalFormatRule." + name, true);
+    });
+  });
+  ConditionalFormatRule.prototype.set = function (source, options) {
+    return objectProperties(source, this, options);
+  };
+  ConditionalFormatRule.prototype.toJSON = toJSONObject;
+  Excel.ConditionalFormatRule = ConditionalFormatRule;
+
+  function ConditionalScalePlaceholder(context, parent, kind, orNullObject) {
+    ConditionalChild.call(this, context, parent, kind, orNullObject, false);
+  }
+  ConditionalScalePlaceholder.prototype = Object.create(ConditionalChild.prototype);
+  ConditionalScalePlaceholder.prototype.constructor = ConditionalScalePlaceholder;
+
+  function ConditionalRangeFormat(context, parent) {
+    ClientObject.call(this, context);
+    this._parent = parent;
+    this._conditionalFormat = rootConditionalFormat(parent);
+    this._objectName = "ConditionalRangeFormat";
+    this._scalarProperties = ["numberFormat"];
+    this._navigationProperties = ["borders", "fill", "font"];
+    this._children = ["borders", "fill", "font"];
+    this._childCache = Object.create(null);
+    queueChildBinding(this, this._conditionalFormat, "format", false);
+  }
+  ConditionalRangeFormat.prototype = Object.create(ClientObject.prototype);
+  ConditionalRangeFormat.prototype.constructor = ConditionalRangeFormat;
+  defineScalar(ConditionalRangeFormat.prototype, "numberFormat", null, false);
+  ConditionalRangeFormat.prototype.set = function (source, options) {
+    if (source instanceof ClientObject) {
+      if (source.context !== this.context || Object.getPrototypeOf(source) !== Object.getPrototypeOf(this)) {
+        throw invalid("The object passed to set must have the same type and request context.");
+      }
+      source = source.toJSON();
+    }
+    requirePlainObject(source, "ConditionalRangeFormat");
+    var borders = source.borders;
+    var scalarAndChildren = {};
+    Object.keys(source).forEach(function (name) {
+      if (name !== "borders") scalarAndChildren[name] = source[name];
+    });
+    objectProperties(scalarAndChildren, this, options);
+    if (borders !== undefined) {
+      requirePlainObject(borders, "ConditionalRangeFormat.borders");
+      Object.keys(borders).forEach(function (name) {
+        if (["top", "bottom", "left", "right"].indexOf(name) < 0) {
+          throw invalid("Unsupported ConditionalRangeFormat.borders property '" + name + "'");
+        }
+        if (borders[name] !== undefined) this.borders[name].set(borders[name], options);
+      }, this);
+    }
+    return this;
+  };
+  ConditionalRangeFormat.prototype.toJSON = toJSONObject;
+  ConditionalRangeFormat.prototype.clearFormat = function () {
+    this.context._queue.push({ op: "set", id: this._id, property: "clearFormat", value: null });
+  };
+  Object.defineProperty(ConditionalRangeFormat.prototype, "font", {
+    get: function () {
+      if (!this._childCache.font) this._childCache.font = new ConditionalRangeFont(this.context, this);
+      return this._childCache.font;
+    },
+    configurable: true,
+  });
+  Object.defineProperty(ConditionalRangeFormat.prototype, "fill", {
+    get: function () {
+      if (!this._childCache.fill) this._childCache.fill = new ConditionalRangeFill(this.context, this);
+      return this._childCache.fill;
+    },
+    configurable: true,
+  });
+  Object.defineProperty(ConditionalRangeFormat.prototype, "borders", {
+    get: function () {
+      if (!this._childCache.borders) this._childCache.borders = new ConditionalRangeBorderCollection(this.context, this);
+      return this._childCache.borders;
+    },
+    configurable: true,
+  });
+
+  function ConditionalRangeFont(context, parent) {
+    ClientObject.call(this, context);
+    this._parent = parent;
+    this._conditionalFormat = rootConditionalFormat(parent);
+    this._objectName = "ConditionalRangeFont";
+    this._scalarProperties = ["bold", "color", "italic", "strikethrough", "underline"];
+    this._children = [];
+    queueChildBinding(this, this._conditionalFormat, "font", false);
+  }
+  ConditionalRangeFont.prototype = Object.create(ClientObject.prototype);
+  ConditionalRangeFont.prototype.constructor = ConditionalRangeFont;
+  defineScalar(ConditionalRangeFont.prototype, "bold", function (value) { return normalizeBool(value, "ConditionalRangeFont.bold"); });
+  defineScalar(ConditionalRangeFont.prototype, "color", function (value) { return normalizeColor(value, "ConditionalRangeFont.color"); });
+  defineScalar(ConditionalRangeFont.prototype, "italic", function (value) { return normalizeBool(value, "ConditionalRangeFont.italic"); });
+  defineScalar(ConditionalRangeFont.prototype, "strikethrough", function (value) { return normalizeBool(value, "ConditionalRangeFont.strikethrough"); });
+  defineScalar(ConditionalRangeFont.prototype, "underline", normalizeUnderline);
+  ConditionalRangeFont.prototype.set = function (source, options) { return objectProperties(source, this, options); };
+  ConditionalRangeFont.prototype.toJSON = toJSONObject;
+  ConditionalRangeFont.prototype.clear = function () {
+    this.context._queue.push({ op: "set", id: this._id, property: "clear", value: null });
+  };
+
+  function ConditionalRangeFill(context, parent) {
+    ClientObject.call(this, context);
+    this._parent = parent;
+    this._conditionalFormat = rootConditionalFormat(parent);
+    this._objectName = "ConditionalRangeFill";
+    this._scalarProperties = ["color"];
+    this._children = [];
+    queueChildBinding(this, this._conditionalFormat, "fill", false);
+  }
+  ConditionalRangeFill.prototype = Object.create(ClientObject.prototype);
+  ConditionalRangeFill.prototype.constructor = ConditionalRangeFill;
+  defineScalar(ConditionalRangeFill.prototype, "color", function (value) { return normalizeColor(value, "ConditionalRangeFill.color"); });
+  ConditionalRangeFill.prototype.set = function (source, options) { return objectProperties(source, this, options); };
+  ConditionalRangeFill.prototype.toJSON = toJSONObject;
+  ConditionalRangeFill.prototype.clear = function () {
+    this.context._queue.push({ op: "set", id: this._id, property: "clear", value: null });
+  };
+
+  var borderSides = ["EdgeTop", "EdgeBottom", "EdgeLeft", "EdgeRight"];
+  var borderSideProperties = {
+    EdgeTop: "top",
+    EdgeBottom: "bottom",
+    EdgeLeft: "left",
+    EdgeRight: "right",
+  };
+
+  function ConditionalRangeBorderCollection(context, parent) {
+    ClientObject.call(this, context);
+    this._parent = parent;
+    this._conditionalFormat = rootConditionalFormat(parent);
+    this._objectName = "ConditionalRangeBorderCollection";
+    this._scalarProperties = ["items", "count"];
+    this._children = [];
+    this._childCache = Object.create(null);
+    if (typeof configureCollection === "function") {
+      configureCollection(this, function (key, descriptor) {
+        var side = normalizeRangeSide(String(key));
+        var item = new ConditionalRangeBorder(this.context, this, side, true);
+        var properties = descriptor && descriptor.properties;
+        if (properties) {
+          Object.keys(properties).forEach(function (name) {
+            if (hooks.hydrateProperty) hooks.hydrateProperty(item, name, properties[name]);
+            else {
+              item._loaded[name] = true;
+              item[name === "id" ? "_idValue" : "_" + name] = properties[name];
+            }
+          });
+        }
+        this._childCache[side] = item;
+        this._childCache[borderSideProperties[side]] = item;
+        return item;
+      });
+    }
+    queueChildBinding(this, this._conditionalFormat, "borderCollection", false);
+  }
+  ConditionalRangeBorderCollection.prototype = Object.create(ClientObject.prototype);
+  ConditionalRangeBorderCollection.prototype.constructor = ConditionalRangeBorderCollection;
+  ConditionalRangeBorderCollection.prototype.toJSON = function () {
+    var result = {};
+    if (this._loaded.items) result.items = this._items.map(function (item) { return item.toJSON(); });
+    if (this._loaded.count) result.count = this._count;
+    return result;
+  };
+  ConditionalRangeBorderCollection.prototype._getBorder = function (side) {
+    side = normalizeRangeSide(side);
+    var name = borderSideProperties[side];
+    if (!this._childCache[name]) {
+      this._childCache[name] = new ConditionalRangeBorder(this.context, this, side, false);
+    }
+    return this._childCache[name];
+  };
+  ["top", "bottom", "left", "right"].forEach(function (name) {
+    Object.defineProperty(ConditionalRangeBorderCollection.prototype, name, {
+      get: function () { return this._getBorder(name === "top" ? "EdgeTop" : name === "bottom" ? "EdgeBottom" : name === "left" ? "EdgeLeft" : "EdgeRight"); },
+      configurable: true,
+    });
+  });
+  Object.defineProperty(ConditionalRangeBorderCollection.prototype, "count", {
+    get: function () { return readLoaded(this, "count"); },
+    configurable: true,
+  });
+  ConditionalRangeBorderCollection.prototype.getItem = function (index) {
+    return this._getBorder(index);
+  };
+  ConditionalRangeBorderCollection.prototype.getItemAt = function (index) {
+    index = normalizeInteger(index, "ConditionalRangeBorderCollection.getItemAt index", 0);
+    if (index >= borderSides.length) throw invalid("ConditionalRangeBorderCollection index is out of range");
+    return this._getBorder(borderSides[index]);
+  };
+  function ConditionalRangeBorder(context, parent, side, skipBind) {
+    ClientObject.call(this, context);
+    this._parent = parent;
+    this._conditionalFormat = rootConditionalFormat(parent);
+    this._side = side;
+    this._objectName = "ConditionalRangeBorder";
+    this._scalarProperties = ["color", "sideIndex", "style"];
+    this._children = [];
+    if (!skipBind) queueChildBinding(this, this._conditionalFormat, "border", false, side);
+  }
+  ConditionalRangeBorder.prototype = Object.create(ClientObject.prototype);
+  ConditionalRangeBorder.prototype.constructor = ConditionalRangeBorder;
+  defineScalar(ConditionalRangeBorder.prototype, "color", function (value) { return normalizeColor(value, "ConditionalRangeBorder.color"); });
+  defineScalar(ConditionalRangeBorder.prototype, "sideIndex", null, true);
+  defineScalar(ConditionalRangeBorder.prototype, "style", normalizeBorderStyle);
+  ConditionalRangeBorder.prototype.set = function (source, options) {
+    if (source instanceof ClientObject) {
+      if (source.context !== this.context || Object.getPrototypeOf(source) !== Object.getPrototypeOf(this)) throw invalidContext();
+      source = source.toJSON();
+    }
+    requirePlainObject(source, "ConditionalRangeBorder");
+    Object.keys(source).forEach(function (name) {
+      if (["color", "style", "sideIndex"].indexOf(name) < 0) throw invalid("Unsupported ConditionalRangeBorder property '" + name + "'");
+      if (name === "sideIndex") throw invalid("ConditionalRangeBorder.sideIndex is read-only");
+    });
+    if (own(source, "color") && source.color !== undefined) this.color = source.color;
+    if (own(source, "style") && source.style !== undefined) this.style = source.style;
+    return this;
+  };
+  ConditionalRangeBorder.prototype.toJSON = toJSONObject;
+
+  Excel.ConditionalFormatCollection = ConditionalFormatCollection;
+  Excel.ConditionalFormat = ConditionalFormat;
+  Excel.ConditionalRangeFormat = ConditionalRangeFormat;
+  Excel.ConditionalRangeFont = ConditionalRangeFont;
+  Excel.ConditionalRangeFill = ConditionalRangeFill;
+  Excel.ConditionalRangeBorderCollection = ConditionalRangeBorderCollection;
+  Excel.ConditionalRangeBorder = ConditionalRangeBorder;
+
+  Object.defineProperty(Excel.Range.prototype, "conditionalFormats", {
+    get: function () {
+      if (!this._conditionalFormats) {
+        this._conditionalFormats = new ConditionalFormatCollection(this.context, this);
+      }
+      return this._conditionalFormats;
+    },
+    configurable: true,
+  });
+  if (hooks.addNavigationProperties) {
+    hooks.addNavigationProperties(Excel.Range.prototype, ["conditionalFormats"]);
+  } else {
+    Excel.Range.prototype._navigationProperties = Excel.Range.prototype._navigationProperties || [];
+    if (Excel.Range.prototype._navigationProperties.indexOf("conditionalFormats") < 0) {
+      Excel.Range.prototype._navigationProperties.push("conditionalFormats");
+    }
+  }
+
+  // Expose helpers for the scale-family adapter without making it depend on
+  // implementation details such as the operation queue format.
+  conditionalRegistry.ConditionalChild = ConditionalChild;
+  conditionalRegistry.ConditionalRangeFormat = ConditionalRangeFormat;
+  conditionalRegistry.rootConditionalFormat = rootConditionalFormat;
+  conditionalRegistry.queueChildBinding = queueChildBinding;
+  conditionalRegistry.toJSONObject = toJSONObject;
+})(globalThis);

--- a/compute/officejs/src/conditional_basic.rs
+++ b/compute/officejs/src/conditional_basic.rs
@@ -1,0 +1,1750 @@
+//! Office.js conditional-formatting adapters.
+//!
+//! The compute engine stores one `ConditionalFormat` record containing one or
+//! more canonical `CFRule`s.  Excel's Office.js object model presents a
+//! collection of format objects, each with a typed child (`cellValue`,
+//! `custom`, `textComparison`, and so on).  This module is the translation
+//! boundary between those two representations.  The host must keep the
+//! references below keyed by the *Office proxy id*; the `format_id` inside a
+//! reference is the persisted engine id and must never be used as a proxy id.
+//!
+//! Host routing contract (the JavaScript module queues these operations):
+//!
+//! * `getConditionalFormatCollection { id, rangeId }` binds a collection to a
+//!   real Range.  Generic `load` on that collection calls `collection_items`;
+//!   the response is `loaded[id].items = [{ key, properties }]`.
+//! * `conditionalFormatCollectionGetCount { collectionId, resultId }`,
+//!   `conditionalFormatCollectionGetItem { id, collectionId, key, byIndex,
+//!   orNullObject }`, `conditionalFormatCollectionAdd { id, collectionId,
+//!   type }`, and `conditionalFormatCollectionClearAll { collectionId }` map
+//!   to the collection methods below.
+//! * `conditionalFormatChild { id, parentId, kind, orNullObject, side }`
+//!   binds a typed child.  `kind` is one of the lower-case wire values emitted
+//!   by [`ConditionalChildKind::as_wire`].  Child refs use generic `load` and
+//!   `set` operations after this binding.
+//! * `conditionalFormatDelete { id }`, `conditionalFormatGetRange { id,
+//!   rangeId, orNullObject }`, `conditionalFormatSetRanges { id, ranges }`,
+//!   and `conditionalFormatChangeRule { id, type, rule }` implement the base
+//!   `ConditionalFormat` methods.  For `getRange`, the host stores a normal
+//!   `RangeRef` under `rangeId` using the address returned by
+//!   [`ConditionalFormatRef::get_range_address`].
+//!
+//! `ConditionalFormatChildRef::load` returns Office-shaped rule/style values;
+//! its `set` method accepts the canonical JSON rule object produced by
+//! `conditional_basic.js` for rule updates.  Style updates use the
+//! `backgroundColor`, `fontColor`, `underlineType`, `numberFormat`, and
+//! per-side border fields from `CFStyle`.  This means no shadow CF state is
+//! kept in the Office host.
+
+use std::collections::HashMap;
+
+use compute_api::{CellRange, ComputeApiError, Sheet};
+use domain_types::domain::conditional_format::{CFCellRange, CFRule, ConditionalFormat};
+use serde::Serialize;
+use serde_json::{Map, Value, json};
+
+/// Error returned by an Office.js conditional-formatting host operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConditionalFormatError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+/// Typed children of an Office conditional format.
+///
+/// The first group mirrors the public Office.js child classes.  The second
+/// group is the nested format object hierarchy.  Color scale, data bar, and
+/// icon set constructors are registered by the scale-family JavaScript
+/// adapter, while the same Rust child reference handles their persisted
+/// state and host operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConditionalChildKind {
+    CellValue,
+    Custom,
+    TextComparison,
+    TopBottom,
+    Preset,
+    ColorScale,
+    DataBar,
+    IconSet,
+    Format,
+    Font,
+    Fill,
+    BorderCollection,
+    Border,
+    Rule,
+}
+
+impl ConditionalChildKind {
+    pub(crate) fn from_wire(value: &str) -> Result<Self, ConditionalFormatError> {
+        match value {
+            "cellValue" => Ok(Self::CellValue),
+            "custom" => Ok(Self::Custom),
+            "textComparison" => Ok(Self::TextComparison),
+            "topBottom" => Ok(Self::TopBottom),
+            "preset" => Ok(Self::Preset),
+            "colorScale" => Ok(Self::ColorScale),
+            "dataBar" => Ok(Self::DataBar),
+            "iconSet" => Ok(Self::IconSet),
+            "format" => Ok(Self::Format),
+            "font" => Ok(Self::Font),
+            "fill" => Ok(Self::Fill),
+            "borderCollection" => Ok(Self::BorderCollection),
+            "border" => Ok(Self::Border),
+            "rule" => Ok(Self::Rule),
+            other => Err(invalid(format!(
+                "Unsupported conditional-format child kind '{other}'"
+            ))),
+        }
+    }
+
+    pub(crate) fn as_wire(self) -> &'static str {
+        match self {
+            Self::CellValue => "cellValue",
+            Self::Custom => "custom",
+            Self::TextComparison => "textComparison",
+            Self::TopBottom => "topBottom",
+            Self::Preset => "preset",
+            Self::ColorScale => "colorScale",
+            Self::DataBar => "dataBar",
+            Self::IconSet => "iconSet",
+            Self::Format => "format",
+            Self::Font => "font",
+            Self::Fill => "fill",
+            Self::BorderCollection => "borderCollection",
+            Self::Border => "border",
+            Self::Rule => "rule",
+        }
+    }
+
+    fn is_format_child(self) -> bool {
+        matches!(
+            self,
+            Self::Format | Self::Font | Self::Fill | Self::BorderCollection | Self::Border
+        )
+    }
+}
+
+/// A range-bound conditional-format collection.
+#[derive(Clone)]
+pub(crate) struct ConditionalFormatCollectionRef {
+    sheet: Sheet,
+    address: String,
+}
+
+/// One item in a conditional-format collection load response.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ConditionalFormatCollectionItem {
+    pub(crate) key: String,
+    pub(crate) properties: HashMap<String, Value>,
+}
+
+/// A proxy reference to a persisted conditional format.
+#[derive(Clone)]
+pub(crate) struct ConditionalFormatRef {
+    sheet: Sheet,
+    format_id: String,
+    null_object: bool,
+}
+
+/// A proxy reference to a typed conditional-format child or nested style
+/// object.  `side` is populated only for a `Border` child.
+#[derive(Clone)]
+pub(crate) struct ConditionalFormatChildRef {
+    parent: ConditionalFormatRef,
+    kind: ConditionalChildKind,
+    side: Option<ConditionalBorderSide>,
+    null_object: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConditionalBorderSide {
+    Top,
+    Bottom,
+    Left,
+    Right,
+}
+
+impl ConditionalBorderSide {
+    pub(crate) fn from_wire(value: Option<&str>) -> Result<Option<Self>, ConditionalFormatError> {
+        let Some(value) = value else { return Ok(None) };
+        let side = match value {
+            "top" | "EdgeTop" => Self::Top,
+            "bottom" | "EdgeBottom" => Self::Bottom,
+            "left" | "EdgeLeft" => Self::Left,
+            "right" | "EdgeRight" => Self::Right,
+            other => {
+                return Err(invalid(format!(
+                    "Unsupported conditional border side '{other}'"
+                )));
+            }
+        };
+        Ok(Some(side))
+    }
+
+    fn as_office(self) -> &'static str {
+        match self {
+            Self::Top => "EdgeTop",
+            Self::Bottom => "EdgeBottom",
+            Self::Left => "EdgeLeft",
+            Self::Right => "EdgeRight",
+        }
+    }
+
+    fn field(self, suffix: &str) -> String {
+        let side = match self {
+            Self::Top => "Top",
+            Self::Bottom => "Bottom",
+            Self::Left => "Left",
+            Self::Right => "Right",
+        };
+        format!("border{side}{suffix}")
+    }
+}
+
+impl ConditionalFormatCollectionRef {
+    /// Bind a collection to a bounded worksheet range.
+    pub(crate) fn new(
+        sheet: Sheet,
+        address: impl Into<String>,
+    ) -> Result<Self, ConditionalFormatError> {
+        let address = address.into();
+        bounded_range(&address)?;
+        Ok(Self { sheet, address })
+    }
+
+    pub(crate) fn sheet(&self) -> Sheet {
+        self.sheet.clone()
+    }
+
+    pub(crate) fn address(&self) -> &str {
+        &self.address
+    }
+
+    pub(crate) fn count(&self) -> Result<usize, ConditionalFormatError> {
+        Ok(self.matching_formats()?.len())
+    }
+
+    pub(crate) fn collection_items(
+        &self,
+        properties: &[String],
+    ) -> Result<Vec<ConditionalFormatCollectionItem>, ConditionalFormatError> {
+        let formats = self.matching_formats()?;
+        let item_properties = properties
+            .iter()
+            .filter_map(|property| {
+                if property == "items" || property == "items/$all" || property == "$all" {
+                    None
+                } else {
+                    Some(
+                        property
+                            .strip_prefix("items/")
+                            .unwrap_or(property)
+                            .to_string(),
+                    )
+                }
+            })
+            .collect::<Vec<_>>();
+        let item_properties = if item_properties.is_empty() {
+            vec![
+                "id".to_string(),
+                "priority".to_string(),
+                "stopIfTrue".to_string(),
+                "type".to_string(),
+            ]
+        } else {
+            item_properties
+        };
+        formats
+            .iter()
+            .map(|format| {
+                let format_id = format_id(format)?;
+                let reference = ConditionalFormatRef::new(self.sheet.clone(), format_id.clone());
+                let item_properties = reference.load(&item_properties)?;
+                Ok(ConditionalFormatCollectionItem {
+                    key: format_id,
+                    properties: item_properties,
+                })
+            })
+            .collect()
+    }
+
+    pub(crate) fn get_item(
+        &self,
+        key: &str,
+        by_index: bool,
+        or_null_object: bool,
+    ) -> Result<ConditionalFormatRef, ConditionalFormatError> {
+        let formats = self.matching_formats()?;
+        let selected = if by_index {
+            let index = parse_index(key)?;
+            formats.get(index)
+        } else {
+            formats.iter().find(|format| {
+                format_id(format)
+                    .ok()
+                    .is_some_and(|format_id| format_id.eq_ignore_ascii_case(key))
+            })
+        };
+        match selected {
+            Some(format) => Ok(ConditionalFormatRef::new(
+                self.sheet.clone(),
+                format_id(format)?,
+            )),
+            None if or_null_object => Ok(ConditionalFormatRef::null(self.sheet.clone(), key)),
+            None => Err(item_not_found(format!("Conditional format '{key}'"))),
+        }
+    }
+
+    /// Add a new format at the top priority for this collection's range.
+    pub(crate) fn add(
+        &self,
+        office_type: &str,
+    ) -> Result<ConditionalFormatRef, ConditionalFormatError> {
+        let formats = self.matching_formats()?;
+        let id = generated_format_id(&self.sheet, &formats)?;
+        let rule_id = format!("{id}-rule");
+        let bounds = bounded_range(&self.address)?;
+        let rule = default_rule_for_type(office_type, &rule_id)?;
+        let payload = json!({
+            "id": id,
+            "sheetId": self.sheet.id().to_uuid_string(),
+            "ranges": [range_json(bounds)],
+            "rules": [rule],
+        });
+        let conditional_format: ConditionalFormat =
+            serde_json::from_value(payload).map_err(encoding)?;
+        self.sheet
+            .conditional_formats()
+            .add_rule(conditional_format)
+            .map_err(engine)?;
+        Ok(ConditionalFormatRef::new(self.sheet.clone(), id))
+    }
+
+    pub(crate) fn clear_all(&self) -> Result<(), ConditionalFormatError> {
+        self.sheet
+            .conditional_formats()
+            .clear_all()
+            .map_err(engine)?;
+        Ok(())
+    }
+
+    fn matching_formats(&self) -> Result<Vec<ConditionalFormat>, ConditionalFormatError> {
+        let target = bounded_range(&self.address)?;
+        self.sheet
+            .conditional_formats()
+            .get_all_rules()
+            .map_err(engine)
+            .map(|formats| {
+                formats
+                    .into_iter()
+                    .filter(|format| {
+                        format.ranges.iter().any(|range| {
+                            ranges_intersect(
+                                target,
+                                Bounds {
+                                    start_row: range.start_row(),
+                                    start_col: range.start_col(),
+                                    end_row: range.end_row(),
+                                    end_col: range.end_col(),
+                                },
+                            )
+                        })
+                    })
+                    .collect()
+            })
+    }
+}
+
+impl ConditionalFormatRef {
+    pub(crate) fn new(sheet: Sheet, format_id: impl Into<String>) -> Self {
+        Self {
+            sheet,
+            format_id: format_id.into(),
+            null_object: false,
+        }
+    }
+
+    pub(crate) fn null(sheet: Sheet, format_id: &str) -> Self {
+        Self {
+            sheet,
+            format_id: format_id.to_string(),
+            null_object: true,
+        }
+    }
+
+    pub(crate) fn sheet(&self) -> Sheet {
+        self.sheet.clone()
+    }
+
+    pub(crate) fn id(&self) -> &str {
+        &self.format_id
+    }
+
+    pub(crate) fn is_null_object(&self) -> bool {
+        self.null_object
+    }
+
+    /// Resolve the current persisted format.  Every operation resolves by id
+    /// so a fresh request context sees changes made by an earlier context.
+    pub(crate) fn resolve(&self) -> Result<Option<ConditionalFormat>, ConditionalFormatError> {
+        if self.null_object {
+            return Ok(None);
+        }
+        self.sheet
+            .conditional_formats()
+            .get_all_rules()
+            .map_err(engine)
+            .map(|formats| {
+                formats
+                    .into_iter()
+                    .find(|format| format.id == self.format_id)
+            })
+    }
+
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, ConditionalFormatError> {
+        let mut result = HashMap::new();
+        if properties.iter().any(|property| property == "isNullObject") {
+            result.insert("isNullObject".to_string(), Value::Bool(self.null_object));
+        }
+        if self.null_object {
+            for property in properties {
+                if property != "isNullObject" {
+                    return Err(invalid(format!(
+                        "ConditionalFormat.{property} cannot be loaded from a null object"
+                    )));
+                }
+            }
+            return Ok(result);
+        }
+        let format = self
+            .resolve()?
+            .ok_or_else(|| item_not_found(format!("Conditional format '{}'", self.format_id)))?;
+        let rule = format.rules.first();
+        for property in properties {
+            let value = match property.as_str() {
+                "isNullObject" => Value::Bool(false),
+                "id" => Value::String(format.id.clone()),
+                "priority" => json!(rule.map(|rule| rule.priority()).unwrap_or(0)),
+                "stopIfTrue" => rule
+                    .and_then(|rule| rule_json(rule).ok())
+                    .map(|rule| stop_if_true_for_rule(&rule))
+                    .unwrap_or(Value::Bool(false)),
+                "type" => Value::String(
+                    rule.map(|rule| office_type_for_rule(rule).to_string())
+                        .unwrap_or("Invalid")
+                        .to_string(),
+                ),
+                other => {
+                    return Err(unsupported(format!(
+                        "Unsupported ConditionalFormat load property '{other}'"
+                    )));
+                }
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), ConditionalFormatError> {
+        let format = self
+            .resolve()?
+            .ok_or_else(|| item_not_found(format!("Conditional format '{}',", self.format_id)))?;
+        match property {
+            "priority" => {
+                let requested = value
+                    .as_i64()
+                    .ok_or_else(|| invalid("ConditionalFormat.priority must be an integer"))?;
+                reorder_priority(&self.sheet, &format, requested)?;
+            }
+            "stopIfTrue" => {
+                let requested = value
+                    .as_bool()
+                    .ok_or_else(|| invalid("ConditionalFormat.stopIfTrue must be a boolean"))?;
+                let mut rule = first_rule_json(&format)?;
+                if is_visual_rule(&rule) {
+                    return Err(invalid(
+                        "ConditionalFormat.stopIfTrue is not available for color scales, data bars, or icon sets",
+                    ));
+                }
+                rule["stopIfTrue"] = Value::Bool(requested);
+                self.update_rules(vec![rule])?;
+            }
+            "id" | "type" => {
+                return Err(invalid(format!(
+                    "ConditionalFormat.{property} is read-only"
+                )));
+            }
+            other => {
+                return Err(unsupported(format!(
+                    "Unsupported ConditionalFormat property '{other}'"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn delete(&self) -> Result<(), ConditionalFormatError> {
+        if self.null_object {
+            return Ok(());
+        }
+        self.sheet
+            .conditional_formats()
+            .delete_rule(&self.format_id)
+            .map_err(engine)?;
+        Ok(())
+    }
+
+    pub(crate) fn child(
+        &self,
+        kind: ConditionalChildKind,
+        side: Option<ConditionalBorderSide>,
+        or_null_object: bool,
+    ) -> Result<ConditionalFormatChildRef, ConditionalFormatError> {
+        if self.null_object {
+            if or_null_object {
+                return Ok(ConditionalFormatChildRef::null(self.clone(), kind, side));
+            }
+            return Err(invalid("The conditional format is a null object"));
+        }
+        let format = self
+            .resolve()?
+            .ok_or_else(|| item_not_found(format!("Conditional format '{}'", self.format_id)))?;
+        let exists = child_exists(&format, kind);
+        if !exists && !kind.is_format_child() && kind != ConditionalChildKind::Rule {
+            if or_null_object {
+                return Ok(ConditionalFormatChildRef::null(self.clone(), kind, side));
+            }
+            return Err(invalid(format!(
+                "ConditionalFormat does not expose a '{}' child for type '{}'",
+                kind.as_wire(),
+                format
+                    .rules
+                    .first()
+                    .map(office_type_for_rule)
+                    .unwrap_or("Invalid")
+            )));
+        }
+        if kind == ConditionalChildKind::Rule
+            && format.rules.first().map(office_type_for_rule) != Some("Custom")
+        {
+            if or_null_object {
+                return Ok(ConditionalFormatChildRef::null(self.clone(), kind, side));
+            }
+            return Err(invalid(
+                "ConditionalFormat.rule is only available for Custom",
+            ));
+        }
+        Ok(ConditionalFormatChildRef {
+            parent: self.clone(),
+            kind,
+            side,
+            null_object: false,
+        })
+    }
+
+    pub(crate) fn get_range_address(&self) -> Result<String, ConditionalFormatError> {
+        let format = self
+            .resolve()?
+            .ok_or_else(|| item_not_found(format!("Conditional format '{}'", self.format_id)))?;
+        if format.ranges.len() != 1 {
+            return Err(invalid(
+                "ConditionalFormat.getRange requires exactly one applied range",
+            ));
+        }
+        Ok(range_to_a1(&format.ranges[0]))
+    }
+
+    pub(crate) fn get_range_address_or_null(
+        &self,
+    ) -> Result<Option<String>, ConditionalFormatError> {
+        let format = self
+            .resolve()?
+            .ok_or_else(|| item_not_found(format!("Conditional format '{}'", self.format_id)))?;
+        Ok((format.ranges.len() == 1).then(|| range_to_a1(&format.ranges[0])))
+    }
+
+    pub(crate) fn set_ranges(
+        &self,
+        ranges: Vec<CFCellRange>,
+    ) -> Result<(), ConditionalFormatError> {
+        if ranges.is_empty() {
+            return Err(invalid(
+                "ConditionalFormat.setRanges requires at least one range",
+            ));
+        }
+        self.sheet
+            .conditional_formats()
+            .update_ranges(&self.format_id, ranges)
+            .map_err(engine)?;
+        Ok(())
+    }
+
+    pub(crate) fn change_rule(
+        &self,
+        office_type: &str,
+        rule: Option<&Value>,
+    ) -> Result<(), ConditionalFormatError> {
+        let format = self
+            .resolve()?
+            .ok_or_else(|| item_not_found(format!("Conditional format '{}'", self.format_id)))?;
+        let previous = first_rule_json(&format)?;
+        let id = previous
+            .get("id")
+            .and_then(Value::as_str)
+            .ok_or_else(|| encoding_message("conditional format rule has no id"))?;
+        let priority = previous
+            .get("priority")
+            .and_then(Value::as_i64)
+            .unwrap_or(1);
+        let stop = previous.get("stopIfTrue").cloned();
+        let style = previous.get("style").cloned().unwrap_or_else(|| json!({}));
+        let mut replacement = default_rule_for_type(office_type, id)?;
+        replacement["priority"] = json!(priority);
+        if let Some(stop) = stop {
+            replacement["stopIfTrue"] = stop;
+        }
+        replacement["style"] = style;
+        if let Some(rule) = rule {
+            merge_rule_properties(&mut replacement, rule)?;
+        }
+        self.update_rules(vec![replacement])
+    }
+
+    fn update_rules(&self, rules: Vec<Value>) -> Result<(), ConditionalFormatError> {
+        self.sheet
+            .conditional_formats()
+            .update_rule(&self.format_id, json!({ "rules": rules }))
+            .map_err(engine)?;
+        Ok(())
+    }
+}
+
+impl ConditionalFormatChildRef {
+    pub(crate) fn null(
+        parent: ConditionalFormatRef,
+        kind: ConditionalChildKind,
+        side: Option<ConditionalBorderSide>,
+    ) -> Self {
+        Self {
+            parent,
+            kind,
+            side,
+            null_object: true,
+        }
+    }
+
+    pub(crate) fn parent(&self) -> ConditionalFormatRef {
+        self.parent.clone()
+    }
+
+    pub(crate) fn kind(&self) -> ConditionalChildKind {
+        self.kind
+    }
+
+    pub(crate) fn side(&self) -> Option<ConditionalBorderSide> {
+        self.side
+    }
+
+    pub(crate) fn is_null_object(&self) -> bool {
+        self.null_object
+    }
+
+    pub(crate) fn child(
+        &self,
+        kind: ConditionalChildKind,
+        side: Option<ConditionalBorderSide>,
+        or_null_object: bool,
+    ) -> Result<Self, ConditionalFormatError> {
+        if self.null_object {
+            if or_null_object {
+                return Ok(Self::null(self.parent.clone(), kind, side));
+            }
+            return Err(invalid("The conditional-format child is a null object"));
+        }
+        let valid = match (self.kind, kind) {
+            (ConditionalChildKind::CellValue, ConditionalChildKind::Format)
+            | (ConditionalChildKind::Custom, ConditionalChildKind::Format)
+            | (ConditionalChildKind::TextComparison, ConditionalChildKind::Format)
+            | (ConditionalChildKind::TopBottom, ConditionalChildKind::Format)
+            | (ConditionalChildKind::Preset, ConditionalChildKind::Format)
+            | (ConditionalChildKind::ColorScale, ConditionalChildKind::Format)
+            | (ConditionalChildKind::DataBar, ConditionalChildKind::Format)
+            | (ConditionalChildKind::IconSet, ConditionalChildKind::Format)
+            | (ConditionalChildKind::Format, ConditionalChildKind::Font)
+            | (ConditionalChildKind::Format, ConditionalChildKind::Fill)
+            | (ConditionalChildKind::Format, ConditionalChildKind::BorderCollection)
+            | (ConditionalChildKind::BorderCollection, ConditionalChildKind::Border)
+            | (ConditionalChildKind::Custom, ConditionalChildKind::Rule) => true,
+            _ => false,
+        };
+        if !valid {
+            if or_null_object {
+                return Ok(Self::null(self.parent.clone(), kind, side));
+            }
+            return Err(invalid(format!(
+                "Conditional-format child '{}' is not available below '{}'",
+                kind.as_wire(),
+                self.kind.as_wire()
+            )));
+        }
+        Ok(Self {
+            parent: self.parent.clone(),
+            kind,
+            side,
+            null_object: false,
+        })
+    }
+
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, ConditionalFormatError> {
+        let mut result = HashMap::new();
+        if properties.iter().any(|property| property == "isNullObject") {
+            result.insert("isNullObject".to_string(), Value::Bool(self.null_object));
+        }
+        if self.null_object {
+            for property in properties {
+                if property != "isNullObject" {
+                    return Err(invalid(format!(
+                        "Conditional-format child {} cannot be loaded from a null object",
+                        self.kind.as_wire()
+                    )));
+                }
+            }
+            return Ok(result);
+        }
+        let format = self
+            .parent
+            .resolve()?
+            .ok_or_else(|| item_not_found(format!("Conditional format '{}'", self.parent.id())))?;
+        let rule = first_rule_json(&format)?;
+        for property in properties {
+            let value = match self.kind {
+                ConditionalChildKind::CellValue
+                | ConditionalChildKind::TextComparison
+                | ConditionalChildKind::TopBottom
+                | ConditionalChildKind::Preset => {
+                    if property == "rule" {
+                        office_rule_for_child(&rule, self.kind)?
+                    } else if property == "isNullObject" {
+                        Value::Bool(false)
+                    } else {
+                        return Err(unsupported(format!(
+                            "Unsupported {} conditional-format load property '{property}'",
+                            self.kind.as_wire()
+                        )));
+                    }
+                }
+                ConditionalChildKind::Custom => {
+                    if property == "isNullObject" {
+                        Value::Bool(false)
+                    } else {
+                        return Err(unsupported(format!(
+                            "CustomConditionalFormat.{property} is a navigation property"
+                        )));
+                    }
+                }
+                ConditionalChildKind::Rule => match property.as_str() {
+                    "formula" | "formulaLocal" | "formulaR1C1" => Value::String(
+                        rule.get("formula")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .to_string(),
+                    ),
+                    "isNullObject" => Value::Bool(false),
+                    other => {
+                        return Err(unsupported(format!(
+                            "ConditionalFormatRule.{other} is unsupported"
+                        )));
+                    }
+                },
+                ConditionalChildKind::Format => match property.as_str() {
+                    "numberFormat" => style_value(&rule, "numberFormat"),
+                    "isNullObject" => Value::Bool(false),
+                    other => {
+                        return Err(unsupported(format!(
+                            "ConditionalRangeFormat.{other} is a navigation property or unsupported"
+                        )));
+                    }
+                },
+                ConditionalChildKind::Font => match property.as_str() {
+                    "bold" => style_value_or(&rule, "bold", Value::Bool(false)),
+                    "color" => style_value_or(&rule, "fontColor", Value::String(String::new())),
+                    "italic" => style_value_or(&rule, "italic", Value::Bool(false)),
+                    "strikethrough" => style_value_or(&rule, "strikethrough", Value::Bool(false)),
+                    "underline" => office_underline(&rule),
+                    "isNullObject" => Value::Bool(false),
+                    other => {
+                        return Err(unsupported(format!(
+                            "ConditionalRangeFont.{other} is unsupported"
+                        )));
+                    }
+                },
+                ConditionalChildKind::Fill => match property.as_str() {
+                    "color" => {
+                        style_value_or(&rule, "backgroundColor", Value::String(String::new()))
+                    }
+                    "isNullObject" => Value::Bool(false),
+                    other => {
+                        return Err(unsupported(format!(
+                            "ConditionalRangeFill.{other} is unsupported"
+                        )));
+                    }
+                },
+                ConditionalChildKind::BorderCollection => match property.as_str() {
+                    "count" => json!(4),
+                    "items" | "items/$all" | "$all" => Value::Array(self.border_items(&rule)?),
+                    property if property.starts_with("items/") => {
+                        let child_property = property.trim_start_matches("items/");
+                        if child_property.is_empty() || child_property == "$all" {
+                            Value::Array(self.border_items(&rule)?)
+                        } else {
+                            let mut items = Vec::new();
+                            for item in self.border_items(&rule)? {
+                                let key = item.get("key").cloned().unwrap_or(Value::Null);
+                                let value = item
+                                    .get("properties")
+                                    .and_then(Value::as_object)
+                                    .and_then(|properties| properties.get(child_property))
+                                    .cloned()
+                                    .unwrap_or(Value::Null);
+                                let mut selected = Map::new();
+                                selected.insert(child_property.to_string(), value);
+                                items.push(json!({
+                                    "key": key,
+                                    "properties": selected,
+                                }));
+                            }
+                            Value::Array(items)
+                        }
+                    }
+                    "isNullObject" => Value::Bool(false),
+                    other => {
+                        return Err(unsupported(format!(
+                            "ConditionalRangeBorderCollection.{other} is unsupported"
+                        )));
+                    }
+                },
+                ConditionalChildKind::Border => match property.as_str() {
+                    "color" => {
+                        let side = self
+                            .side
+                            .ok_or_else(|| invalid("ConditionalRangeBorder has no side"))?;
+                        style_value_or(&rule, &side.field("Color"), Value::String(String::new()))
+                    }
+                    "style" => {
+                        let side = self
+                            .side
+                            .ok_or_else(|| invalid("ConditionalRangeBorder has no side"))?;
+                        office_border_style(&rule, side)
+                    }
+                    "sideIndex" => self
+                        .side
+                        .map(|side| Value::String(side.as_office().to_string()))
+                        .unwrap_or(Value::Null),
+                    "isNullObject" => Value::Bool(false),
+                    other => {
+                        return Err(unsupported(format!(
+                            "ConditionalRangeBorder.{other} is unsupported"
+                        )));
+                    }
+                },
+                ConditionalChildKind::ColorScale
+                | ConditionalChildKind::DataBar
+                | ConditionalChildKind::IconSet => {
+                    return Err(unsupported(format!(
+                        "Conditional child '{}' is implemented by the scale-family adapter",
+                        self.kind.as_wire()
+                    )));
+                }
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), ConditionalFormatError> {
+        if self.null_object {
+            return Err(invalid("Cannot set a null conditional-format child"));
+        }
+        let format = self
+            .parent
+            .resolve()?
+            .ok_or_else(|| item_not_found(format!("Conditional format '{}'", self.parent.id())))?;
+        match self.kind {
+            ConditionalChildKind::CellValue
+            | ConditionalChildKind::TextComparison
+            | ConditionalChildKind::TopBottom
+            | ConditionalChildKind::Preset => {
+                if property != "rule" {
+                    return Err(unsupported(format!(
+                        "Unsupported {} conditional-format property '{property}'",
+                        self.kind.as_wire()
+                    )));
+                }
+                let mut rule = first_rule_json(&format)?;
+                merge_rule_properties(&mut rule, value)?;
+                self.parent.update_rules(vec![rule])?;
+            }
+            ConditionalChildKind::Custom => {
+                if property != "rule" {
+                    return Err(unsupported(format!(
+                        "CustomConditionalFormat.{property} is a navigation property"
+                    )));
+                }
+                let mut rule = first_rule_json(&format)?;
+                merge_rule_properties(&mut rule, value)?;
+                self.parent.update_rules(vec![rule])?;
+            }
+            ConditionalChildKind::Rule => {
+                let mut rule = first_rule_json(&format)?;
+                match property {
+                    "formula" | "formulaLocal" | "formulaR1C1" => {
+                        let formula = value.as_str().ok_or_else(|| {
+                            invalid(format!("ConditionalFormatRule.{property} must be a string"))
+                        })?;
+                        rule["formula"] = Value::String(formula.to_string());
+                    }
+                    "clear" => rule["formula"] = Value::String(String::new()),
+                    other => {
+                        return Err(unsupported(format!(
+                            "ConditionalFormatRule.{other} is read-only or unsupported"
+                        )));
+                    }
+                }
+                self.parent.update_rules(vec![rule])?;
+            }
+            ConditionalChildKind::Format => {
+                if property == "clearFormat" || property == "clear" {
+                    let mut rule = first_rule_json(&format)?;
+                    rule["style"] = json!({});
+                    self.parent.update_rules(vec![rule])?;
+                } else if property == "numberFormat" {
+                    self.update_style_field("numberFormat", value.clone())?;
+                } else {
+                    return Err(unsupported(format!(
+                        "ConditionalRangeFormat.{property} is a navigation property or unsupported"
+                    )));
+                }
+            }
+            ConditionalChildKind::Font => {
+                if property == "clear" {
+                    self.clear_style_fields(&[
+                        "bold",
+                        "fontColor",
+                        "italic",
+                        "strikethrough",
+                        "underlineType",
+                    ])?;
+                } else {
+                    let (field, mapped) = match property {
+                        "bold" | "italic" | "strikethrough" => {
+                            (property, required_bool(value, property)?)
+                        }
+                        "color" => (
+                            "fontColor",
+                            Value::String(required_string(value, property)?),
+                        ),
+                        "underline" => ("underlineType", office_to_underline(value)?),
+                        other => {
+                            return Err(unsupported(format!(
+                                "ConditionalRangeFont.{other} is unsupported"
+                            )));
+                        }
+                    };
+                    self.update_style_field(field, mapped)?;
+                }
+            }
+            ConditionalChildKind::Fill => {
+                if property == "clear" {
+                    self.clear_style_fields(&["backgroundColor"])?;
+                } else if property == "color" {
+                    self.update_style_field(
+                        "backgroundColor",
+                        Value::String(required_string(value, property)?),
+                    )?;
+                } else {
+                    return Err(unsupported(format!(
+                        "ConditionalRangeFill.{property} is unsupported"
+                    )));
+                }
+            }
+            ConditionalChildKind::BorderCollection => {
+                if property == "clear" {
+                    self.clear_style_fields(&[
+                        "borderColor",
+                        "borderStyle",
+                        "borderTopColor",
+                        "borderTopStyle",
+                        "borderBottomColor",
+                        "borderBottomStyle",
+                        "borderLeftColor",
+                        "borderLeftStyle",
+                        "borderRightColor",
+                        "borderRightStyle",
+                    ])?;
+                } else {
+                    return Err(unsupported(format!(
+                        "ConditionalRangeBorderCollection.{property} is unsupported"
+                    )));
+                }
+            }
+            ConditionalChildKind::Border => {
+                let side = self
+                    .side
+                    .ok_or_else(|| invalid("ConditionalRangeBorder has no side"))?;
+                let field = match property {
+                    "color" => side.field("Color"),
+                    "style" => side.field("Style"),
+                    "clear" => {
+                        self.clear_style_fields(&[&side.field("Color"), &side.field("Style")])?;
+                        return Ok(());
+                    }
+                    "sideIndex" => {
+                        return Err(invalid("ConditionalRangeBorder.sideIndex is read-only"));
+                    }
+                    other => {
+                        return Err(unsupported(format!(
+                            "ConditionalRangeBorder.{other} is unsupported"
+                        )));
+                    }
+                };
+                let mapped = if property == "style" {
+                    office_to_border_style(value)?
+                } else {
+                    Value::String(required_string(value, property)?)
+                };
+                self.update_style_field(field, mapped)?;
+            }
+            ConditionalChildKind::ColorScale
+            | ConditionalChildKind::DataBar
+            | ConditionalChildKind::IconSet => {
+                return Err(unsupported(format!(
+                    "Conditional child '{}' is implemented by the scale-family adapter",
+                    self.kind.as_wire()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn update_style_field(&self, field: &str, value: Value) -> Result<(), ConditionalFormatError> {
+        let format = self
+            .parent
+            .resolve()?
+            .ok_or_else(|| item_not_found(format!("Conditional format '{}'", self.parent.id())))?;
+        let mut rule = first_rule_json(&format)?;
+        let style = rule
+            .as_object_mut()
+            .expect("rule object")
+            .entry("style")
+            .or_insert_with(|| json!({}));
+        let style = style
+            .as_object_mut()
+            .ok_or_else(|| encoding_message("conditional format style is not an object"))?;
+        if value.is_null() {
+            style.remove(field);
+        } else {
+            style.insert(field.to_string(), value);
+        }
+        self.parent.update_rules(vec![rule])
+    }
+
+    fn clear_style_fields(&self, fields: &[&str]) -> Result<(), ConditionalFormatError> {
+        let format = self
+            .parent
+            .resolve()?
+            .ok_or_else(|| item_not_found(format!("Conditional format '{}'", self.parent.id())))?;
+        let mut rule = first_rule_json(&format)?;
+        if let Some(style) = rule.get_mut("style").and_then(Value::as_object_mut) {
+            for field in fields {
+                style.remove(*field);
+            }
+        }
+        self.parent.update_rules(vec![rule])
+    }
+
+    fn border_items(&self, rule: &Value) -> Result<Vec<Value>, ConditionalFormatError> {
+        let sides = [
+            ConditionalBorderSide::Top,
+            ConditionalBorderSide::Bottom,
+            ConditionalBorderSide::Left,
+            ConditionalBorderSide::Right,
+        ];
+        Ok(sides
+            .iter()
+            .map(|side| {
+                json!({
+                    "key": side.as_office(),
+                    "properties": {
+                        "sideIndex": side.as_office(),
+                        "color": style_value_or(rule, &side.field("Color"), Value::String(String::new())),
+                        "style": office_border_style(rule, *side),
+                    }
+                })
+            })
+            .collect())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Bounds {
+    start_row: u32,
+    start_col: u32,
+    end_row: u32,
+    end_col: u32,
+}
+
+fn bounded_range(address: &str) -> Result<Bounds, ConditionalFormatError> {
+    let (start_row, start_col, end_row, end_col) = CellRange::from(address)
+        .resolve()
+        .map_err(|error| invalid(error.to_string()))?;
+    Ok(Bounds {
+        start_row,
+        start_col,
+        end_row,
+        end_col,
+    })
+}
+
+fn ranges_intersect(a: Bounds, b: Bounds) -> bool {
+    a.start_row <= b.end_row
+        && a.end_row >= b.start_row
+        && a.start_col <= b.end_col
+        && a.end_col >= b.start_col
+}
+
+fn range_json(bounds: Bounds) -> Value {
+    json!({
+        "startRow": bounds.start_row,
+        "startCol": bounds.start_col,
+        "endRow": bounds.end_row,
+        "endCol": bounds.end_col,
+    })
+}
+
+fn range_to_a1(range: &CFCellRange) -> String {
+    let start = format!(
+        "{}{}",
+        column_name(range.start_col()),
+        range.start_row() + 1
+    );
+    let end = format!("{}{}", column_name(range.end_col()), range.end_row() + 1);
+    if start == end {
+        start
+    } else {
+        format!("{start}:{end}")
+    }
+}
+
+fn column_name(mut column: u32) -> String {
+    let mut result = String::new();
+    loop {
+        let digit = (column % 26) as u8;
+        result.insert(0, (b'A' + digit) as char);
+        if column < 26 {
+            break;
+        }
+        column = column / 26 - 1;
+    }
+    result
+}
+
+fn parse_index(value: &str) -> Result<usize, ConditionalFormatError> {
+    let index = value
+        .parse::<i64>()
+        .map_err(|_| invalid("ConditionalFormatCollection.getItemAt index must be an integer"))?;
+    if index < 0 {
+        return Err(item_not_found(format!("Conditional format index {index}")));
+    }
+    usize::try_from(index).map_err(|_| item_not_found(format!("Conditional format index {index}")))
+}
+
+fn generated_format_id(
+    sheet: &Sheet,
+    formats: &[ConditionalFormat],
+) -> Result<String, ConditionalFormatError> {
+    let mut next = 1u32;
+    loop {
+        let candidate = format!("cf-officejs-{next}");
+        if !formats.iter().any(|format| format.id == candidate) {
+            return Ok(candidate);
+        }
+        next = next
+            .checked_add(1)
+            .ok_or_else(|| invalid("Conditional format id space is exhausted"))?;
+        if next == u32::MAX {
+            // The sheet argument is intentionally used in the signature so
+            // callers cannot accidentally generate IDs for another workbook;
+            // avoid an unused-argument warning without inventing global state.
+            let _ = sheet.id();
+        }
+    }
+}
+
+fn format_id(format: &ConditionalFormat) -> Result<String, ConditionalFormatError> {
+    if format.id.is_empty() {
+        Err(encoding_message("conditional format has no id"))
+    } else {
+        Ok(format.id.clone())
+    }
+}
+
+fn rule_json(rule: &CFRule) -> Result<Value, ConditionalFormatError> {
+    serde_json::to_value(rule).map_err(encoding)
+}
+
+fn first_rule_json(format: &ConditionalFormat) -> Result<Value, ConditionalFormatError> {
+    format
+        .rules
+        .first()
+        .ok_or_else(|| invalid("Conditional format has no rule"))
+        .and_then(rule_json)
+}
+
+fn office_type_for_rule(rule: &CFRule) -> &'static str {
+    match rule {
+        CFRule::CellValue { .. } => "CellValue",
+        CFRule::Formula { .. } => "Custom",
+        CFRule::ColorScale { .. } => "ColorScale",
+        CFRule::DataBar { .. } => "DataBar",
+        CFRule::IconSet { .. } => "IconSet",
+        CFRule::Top10 { .. } => "TopBottom",
+        CFRule::AboveAverage { .. }
+        | CFRule::DuplicateValues { .. }
+        | CFRule::ContainsBlanks { .. }
+        | CFRule::ContainsErrors { .. }
+        | CFRule::TimePeriod { .. } => "PresetCriteria",
+        CFRule::ContainsText { .. } => "ContainsText",
+    }
+}
+
+fn child_exists(format: &ConditionalFormat, kind: ConditionalChildKind) -> bool {
+    let Some(rule) = format.rules.first() else {
+        return false;
+    };
+    match kind {
+        ConditionalChildKind::CellValue => matches!(rule, CFRule::CellValue { .. }),
+        ConditionalChildKind::Custom => matches!(rule, CFRule::Formula { .. }),
+        ConditionalChildKind::TextComparison => {
+            matches!(rule, CFRule::ContainsText { .. })
+        }
+        ConditionalChildKind::TopBottom => matches!(rule, CFRule::Top10 { .. }),
+        ConditionalChildKind::Preset => matches!(
+            rule,
+            CFRule::AboveAverage { .. }
+                | CFRule::DuplicateValues { .. }
+                | CFRule::ContainsBlanks { .. }
+                | CFRule::ContainsErrors { .. }
+                | CFRule::TimePeriod { .. }
+        ),
+        ConditionalChildKind::ColorScale => matches!(rule, CFRule::ColorScale { .. }),
+        ConditionalChildKind::DataBar => matches!(rule, CFRule::DataBar { .. }),
+        ConditionalChildKind::IconSet => matches!(rule, CFRule::IconSet { .. }),
+        ConditionalChildKind::Format => true,
+        ConditionalChildKind::Rule => matches!(rule, CFRule::Formula { .. }),
+        ConditionalChildKind::Font
+        | ConditionalChildKind::Fill
+        | ConditionalChildKind::BorderCollection
+        | ConditionalChildKind::Border => true,
+    }
+}
+
+fn is_visual_rule(rule: &Value) -> bool {
+    matches!(
+        rule.get("type").and_then(Value::as_str),
+        Some("colorScale") | Some("dataBar") | Some("iconSet")
+    )
+}
+
+fn stop_if_true_for_rule(rule: &Value) -> Value {
+    if is_visual_rule(rule) {
+        Value::Null
+    } else {
+        rule.get("stopIfTrue")
+            .cloned()
+            .unwrap_or(Value::Bool(false))
+    }
+}
+
+fn default_rule_for_type(
+    office_type: &str,
+    rule_id: &str,
+) -> Result<Value, ConditionalFormatError> {
+    let base = |type_name: &str, style: Value| {
+        json!({
+            "type": type_name,
+            "id": rule_id,
+            "priority": 1,
+            "stopIfTrue": false,
+            "style": style,
+        })
+    };
+    let rule = match office_type {
+        "CellValue" => {
+            let mut rule = base("cellValue", json!({}));
+            rule["operator"] = json!("greaterThan");
+            rule["value1"] = json!("0");
+            rule
+        }
+        "Custom" => {
+            let mut rule = base("formula", json!({}));
+            rule["formula"] = json!("=FALSE()");
+            rule
+        }
+        "ContainsText" => {
+            let mut rule = base("containsText", json!({}));
+            rule["operator"] = json!("containsText");
+            rule["text"] = json!("");
+            rule
+        }
+        "TopBottom" => {
+            let mut rule = base("top10", json!({}));
+            rule["rank"] = json!(10);
+            rule["percent"] = json!(false);
+            rule["bottom"] = json!(false);
+            rule
+        }
+        "PresetCriteria" => {
+            let mut rule = base("containsBlanks", json!({}));
+            rule["blanks"] = json!(true);
+            rule
+        }
+        "ColorScale" => {
+            json!({
+                "type": "colorScale",
+                "id": rule_id,
+                "priority": 1,
+                "colorScale": {
+                    "points": [],
+                    "minPoint": {"value": {"kind": "min"}, "color": "#F8696B"},
+                    "maxPoint": {"value": {"kind": "max"}, "color": "#63BE7B"}
+                }
+            })
+        }
+        "DataBar" => {
+            json!({
+                "type": "dataBar",
+                "id": rule_id,
+                "priority": 1,
+                "dataBar": {
+                    "minPoint": {"value": {"kind": "min"}, "color": ""},
+                    "maxPoint": {"value": {"kind": "max"}, "color": ""},
+                    "positiveColor": "#638EC6",
+                    "showValue": true
+                }
+            })
+        }
+        "IconSet" => {
+            json!({
+                "type": "iconSet",
+                "id": rule_id,
+                "priority": 1,
+                "iconSet": {
+                    "iconSetName": "3TrafficLights1",
+                    "thresholds": [],
+                    "customIcons": []
+                }
+            })
+        }
+        other => {
+            return Err(invalid(format!(
+                "Unsupported ConditionalFormatType '{other}'"
+            )));
+        }
+    };
+    Ok(rule)
+}
+
+fn office_rule_for_child(
+    rule: &Value,
+    kind: ConditionalChildKind,
+) -> Result<Value, ConditionalFormatError> {
+    let object = rule
+        .as_object()
+        .ok_or_else(|| encoding_message("conditional format rule is not an object"))?;
+    match kind {
+        ConditionalChildKind::CellValue => {
+            let operator = object
+                .get("operator")
+                .and_then(Value::as_str)
+                .ok_or_else(|| encoding_message("cell value rule has no operator"))?;
+            let mut result = Map::new();
+            result.insert(
+                "operator".to_string(),
+                Value::String(office_cell_operator(operator)?.to_string()),
+            );
+            result.insert(
+                "formula1".to_string(),
+                office_formula_value(object.get("value1")),
+            );
+            if let Some(value2) = object.get("value2") {
+                result.insert("formula2".to_string(), office_formula_value(Some(value2)));
+            }
+            Ok(Value::Object(result))
+        }
+        ConditionalChildKind::TextComparison => {
+            let operator = object
+                .get("operator")
+                .and_then(Value::as_str)
+                .ok_or_else(|| encoding_message("text rule has no operator"))?;
+            Ok(json!({
+                "operator": office_text_operator(operator)?,
+                "text": object.get("text").and_then(Value::as_str).unwrap_or("")
+            }))
+        }
+        ConditionalChildKind::TopBottom => {
+            let rank = object.get("rank").cloned().unwrap_or_else(|| json!(10));
+            let percent = object
+                .get("percent")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let bottom = object
+                .get("bottom")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let type_name = match (bottom, percent) {
+                (false, false) => "TopItems",
+                (false, true) => "TopPercent",
+                (true, false) => "BottomItems",
+                (true, true) => "BottomPercent",
+            };
+            Ok(json!({"rank": rank, "type": type_name}))
+        }
+        ConditionalChildKind::Preset => Ok(json!({
+            "criterion": preset_criterion(object)?
+        })),
+        _ => Err(unsupported(format!(
+            "Rule projection is unsupported for '{}'",
+            kind.as_wire()
+        ))),
+    }
+}
+
+fn office_formula_value(value: Option<&Value>) -> Value {
+    match value {
+        Some(Value::String(value)) => Value::String(value.clone()),
+        Some(Value::Number(value)) => Value::String(value.to_string()),
+        Some(Value::Bool(value)) => Value::String(value.to_string().to_uppercase()),
+        Some(Value::Null) | None => Value::String(String::new()),
+        Some(value) => Value::String(value.to_string()),
+    }
+}
+
+fn office_cell_operator(value: &str) -> Result<&'static str, ConditionalFormatError> {
+    match value {
+        "between" => Ok("Between"),
+        "notBetween" => Ok("NotBetween"),
+        "equal" => Ok("EqualTo"),
+        "notEqual" => Ok("NotEqualTo"),
+        "greaterThan" => Ok("GreaterThan"),
+        "lessThan" => Ok("LessThan"),
+        "greaterThanOrEqual" => Ok("GreaterThanOrEqual"),
+        "lessThanOrEqual" => Ok("LessThanOrEqual"),
+        other => Err(invalid(format!(
+            "Unsupported cell value operator '{other}'"
+        ))),
+    }
+}
+
+fn office_text_operator(value: &str) -> Result<&'static str, ConditionalFormatError> {
+    match value {
+        "containsText" => Ok("Contains"),
+        "notContains" => Ok("NotContains"),
+        "beginsWith" => Ok("BeginsWith"),
+        "endsWith" => Ok("EndsWith"),
+        other => Err(invalid(format!("Unsupported text operator '{other}'"))),
+    }
+}
+
+fn preset_criterion(rule: &Map<String, Value>) -> Result<&'static str, ConditionalFormatError> {
+    let type_name = rule.get("type").and_then(Value::as_str).unwrap_or_default();
+    match type_name {
+        "containsBlanks" => Ok(
+            if rule.get("blanks").and_then(Value::as_bool).unwrap_or(true) {
+                "Blanks"
+            } else {
+                "NonBlanks"
+            },
+        ),
+        "containsErrors" => Ok(
+            if rule.get("errors").and_then(Value::as_bool).unwrap_or(true) {
+                "Errors"
+            } else {
+                "NonErrors"
+            },
+        ),
+        "duplicateValues" => Ok(
+            if rule.get("unique").and_then(Value::as_bool).unwrap_or(false) {
+                "UniqueValues"
+            } else {
+                "DuplicateValues"
+            },
+        ),
+        "aboveAverage" => {
+            let above = rule
+                .get("aboveAverage")
+                .and_then(Value::as_bool)
+                .unwrap_or(true);
+            let equal = rule
+                .get("equalAverage")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let std_dev = rule.get("stdDev").and_then(Value::as_i64);
+            Ok(match (above, equal, std_dev) {
+                (true, true, None) => "EqualOrAboveAverage",
+                (false, true, None) => "EqualOrBelowAverage",
+                (true, false, Some(1)) => "OneStdDevAboveAverage",
+                (false, false, Some(1)) => "OneStdDevBelowAverage",
+                (true, false, Some(2)) => "TwoStdDevAboveAverage",
+                (false, false, Some(2)) => "TwoStdDevBelowAverage",
+                (true, false, Some(3)) => "ThreeStdDevAboveAverage",
+                (false, false, Some(3)) => "ThreeStdDevBelowAverage",
+                (true, _, _) => "AboveAverage",
+                (false, _, _) => "BelowAverage",
+            })
+        }
+        "timePeriod" => rule
+            .get("timePeriod")
+            .and_then(Value::as_str)
+            .map(time_period_office)
+            .ok_or_else(|| encoding_message("time period rule has no period")),
+        other => Err(invalid(format!("Unsupported preset rule type '{other}'"))),
+    }
+}
+
+fn time_period_office(value: &str) -> &'static str {
+    match value {
+        "yesterday" => "Yesterday",
+        "today" => "Today",
+        "tomorrow" => "Tomorrow",
+        "last7Days" => "LastSevenDays",
+        "lastWeek" => "LastWeek",
+        "thisWeek" => "ThisWeek",
+        "nextWeek" => "NextWeek",
+        "lastMonth" => "LastMonth",
+        "thisMonth" => "ThisMonth",
+        "nextMonth" => "NextMonth",
+        _ => "Invalid",
+    }
+}
+
+fn merge_rule_properties(rule: &mut Value, updates: &Value) -> Result<(), ConditionalFormatError> {
+    let updates = updates
+        .as_object()
+        .ok_or_else(|| invalid("Conditional-format rule must be an object"))?;
+    let rule = rule
+        .as_object_mut()
+        .ok_or_else(|| encoding_message("conditional format rule is not an object"))?;
+    for (key, value) in updates {
+        match key.as_str() {
+            // JS normalizes these to canonical fields.  Keep this whitelist
+            // explicit so a typo cannot silently become persisted state.
+            "operator" | "value1" | "value2" | "text" | "formula" | "rank" | "percent"
+            | "bottom" | "criterion" | "blanks" | "errors" | "unique" | "aboveAverage"
+            | "equalAverage" | "stdDev" | "timePeriod" | "style" | "stopIfTrue" => {
+                rule.insert(key.clone(), value.clone());
+            }
+            "type" => {
+                // The JavaScript normalizer emits the canonical variant here
+                // for preset criteria (for example `containsBlanks` ->
+                // `duplicateValues`).  Other typed children emit their
+                // existing variant.  Keeping the field lets one Preset
+                // object change from blanks to averages without inventing a
+                // second public operation.
+                rule.insert(key.clone(), value.clone());
+            }
+            "id" | "priority" => {
+                // Id and priority are controlled by the parent object.
+                // Ignore them in a typed child update just as Office ignores
+                // read-only fields passed to set when throwOnReadOnly=false.
+            }
+            other => {
+                return Err(invalid(format!(
+                    "Unsupported conditional-format rule property '{other}'"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn reorder_priority(
+    sheet: &Sheet,
+    current: &ConditionalFormat,
+    requested: i64,
+) -> Result<(), ConditionalFormatError> {
+    let formats = sheet
+        .conditional_formats()
+        .get_all_rules()
+        .map_err(engine)?;
+    let Some(current_index) = formats.iter().position(|format| format.id == current.id) else {
+        return Err(item_not_found(format!(
+            "Conditional format '{}'",
+            current.id
+        )));
+    };
+    let count = formats.len();
+    if count == 0 {
+        return Ok(());
+    }
+    let mut target = if requested < 0 {
+        let distance = requested.unsigned_abs() as usize;
+        count.saturating_sub(distance.max(1))
+    } else {
+        usize::try_from(requested.saturating_sub(1)).unwrap_or(0)
+    };
+    target = target.min(count - 1);
+    if target == current_index {
+        return Ok(());
+    }
+    let mut ids = formats
+        .into_iter()
+        .map(|format| format.id)
+        .collect::<Vec<_>>();
+    let id = ids.remove(current_index);
+    ids.insert(target, id);
+    sheet
+        .conditional_formats()
+        .reorder_rules(ids)
+        .map_err(engine)?;
+    Ok(())
+}
+
+fn style_value(rule: &Value, field: &str) -> Value {
+    rule.get("style")
+        .and_then(|style| style.get(field))
+        .cloned()
+        .unwrap_or(Value::Null)
+}
+
+fn style_value_or(rule: &Value, field: &str, default: Value) -> Value {
+    let value = style_value(rule, field);
+    if value.is_null() { default } else { value }
+}
+
+fn office_underline(rule: &Value) -> Value {
+    match style_value(rule, "underlineType") {
+        Value::String(value) => Value::String(match value.as_str() {
+            "single" => "Single".to_string(),
+            "double" => "Double".to_string(),
+            _ => "None".to_string(),
+        }),
+        _ => match rule
+            .get("style")
+            .and_then(|style| style.get("underline"))
+            .and_then(Value::as_bool)
+        {
+            Some(true) => Value::String("Single".to_string()),
+            _ => Value::String("None".to_string()),
+        },
+    }
+}
+
+fn office_border_style(rule: &Value, side: ConditionalBorderSide) -> Value {
+    let field = side.field("Style");
+    let value = style_value(rule, &field);
+    let value = if value.is_null() {
+        style_value(rule, "borderStyle")
+    } else {
+        value
+    };
+    Value::String(match value.as_str().unwrap_or("none") {
+        "none" => "None",
+        "thin" | "hair" => "Continuous",
+        "medium" | "thick" => "Continuous",
+        "dashed" | "mediumDashed" => "Dash",
+        "dotted" => "Dot",
+        "dashDot" | "mediumDashDot" => "DashDot",
+        "dashDotDot" | "mediumDashDotDot" => "DashDotDot",
+        _ => "None",
+    })
+}
+
+fn office_to_underline(value: &Value) -> Result<Value, ConditionalFormatError> {
+    let value = required_string(value, "underline")?;
+    match value.as_str() {
+        "None" => Ok(json!("none")),
+        "Single" => Ok(json!("single")),
+        "Double" => Ok(json!("double")),
+        other => Err(invalid(format!(
+            "Unsupported conditional underline '{other}'"
+        ))),
+    }
+}
+
+fn office_to_border_style(value: &Value) -> Result<Value, ConditionalFormatError> {
+    let value = required_string(value, "style")?;
+    let mapped = match value.as_str() {
+        "None" => "none",
+        "Continuous" => "thin",
+        "Dash" => "dashed",
+        "DashDot" => "dashDot",
+        "DashDotDot" => "dashDotDot",
+        "Dot" => "dotted",
+        other => {
+            return Err(invalid(format!(
+                "Unsupported conditional border style '{other}'"
+            )));
+        }
+    };
+    Ok(Value::String(mapped.to_string()))
+}
+
+fn required_string(value: &Value, property: &str) -> Result<String, ConditionalFormatError> {
+    value
+        .as_str()
+        .map(ToString::to_string)
+        .ok_or_else(|| invalid(format!("{property} must be a string")))
+}
+
+fn required_bool(value: &Value, property: &str) -> Result<Value, ConditionalFormatError> {
+    value
+        .as_bool()
+        .map(Value::Bool)
+        .ok_or_else(|| invalid(format!("{property} must be a boolean")))
+}
+
+fn engine(error: ComputeApiError) -> ConditionalFormatError {
+    ConditionalFormatError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn encoding(error: serde_json::Error) -> ConditionalFormatError {
+    encoding_message(error.to_string())
+}
+
+fn encoding_message(message: impl Into<String>) -> ConditionalFormatError {
+    ConditionalFormatError {
+        code: "GeneralException",
+        message: message.into(),
+    }
+}
+
+fn invalid(message: impl Into<String>) -> ConditionalFormatError {
+    ConditionalFormatError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn unsupported(message: impl Into<String>) -> ConditionalFormatError {
+    ConditionalFormatError {
+        code: "ApiNotFound",
+        message: message.into(),
+    }
+}
+
+fn item_not_found(message: impl Into<String>) -> ConditionalFormatError {
+    ConditionalFormatError {
+        code: "ItemNotFound",
+        message: message.into(),
+    }
+}

--- a/compute/officejs/src/conditional_scales.js
+++ b/compute/officejs/src/conditional_scales.js
@@ -1,0 +1,637 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs || {};
+
+  function invalid(message) {
+    var error = new OfficeExtension.Error({ code: "InvalidArgument", message: message });
+    error.name = "RichApi.Error";
+    error.code = "InvalidArgument";
+    return error;
+  }
+
+  function propertyNotLoaded(name) {
+    var error = new OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function invalidContext() {
+    var error = new OfficeExtension.Error({
+      code: "InvalidRequestContext",
+      message: "The object belongs to a different request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidRequestContext";
+    return error;
+  }
+
+  function own(object, name) {
+    return Object.prototype.hasOwnProperty.call(object, name);
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object";
+  }
+
+  function isPlainObject(value) {
+    if (!isObject(value) || Array.isArray(value)) return false;
+    var prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  }
+
+  function requireObject(value, property) {
+    if (!isPlainObject(value)) throw invalid(property + " must be an object");
+    return value;
+  }
+
+  function requireSetObject(value, property) {
+    if (!isObject(value) || Array.isArray(value)) {
+      throw new TypeError(property + " requires a property object");
+    }
+    return value;
+  }
+
+  function checkKeys(value, allowed, property) {
+    Object.keys(value).forEach(function (name) {
+      if (allowed.indexOf(name) < 0) {
+        throw invalid("Unsupported " + property + " property '" + name + "'");
+      }
+    });
+  }
+
+  function requireString(value, property, allowEmpty) {
+    if (typeof value !== "string" || (!allowEmpty && value.length === 0)) {
+      throw invalid(property + " must be " + (allowEmpty ? "a string" : "a non-empty string"));
+    }
+    return value;
+  }
+
+  function requireBoolean(value, property) {
+    if (typeof value !== "boolean") throw invalid(property + " must be a boolean");
+    return value;
+  }
+
+  function requireInteger(value, property) {
+    if (
+      typeof value !== "number" ||
+      !isFinite(value) ||
+      Math.floor(value) !== value ||
+      value < 0
+    ) {
+      throw invalid(property + " must be a non-negative integer");
+    }
+    return value;
+  }
+
+  var COLOR_TYPES = [
+    "Invalid",
+    "LowestValue",
+    "HighestValue",
+    "Number",
+    "Percent",
+    "Formula",
+    "Percentile",
+  ];
+  var BAR_TYPES = [
+    "Invalid",
+    "Automatic",
+    "LowestValue",
+    "HighestValue",
+    "Number",
+    "Percent",
+    "Formula",
+    "Percentile",
+  ];
+  var ICON_TYPES = ["Invalid", "Number", "Percent", "Formula", "Percentile"];
+  var ICON_OPERATORS = ["Invalid", "GreaterThan", "GreaterThanOrEqual"];
+  var AXIS_FORMATS = ["Automatic", "None", "CellMidPoint"];
+  var BAR_DIRECTIONS = ["Context", "LeftToRight", "RightToLeft"];
+  var ICON_STYLES = [
+    "Invalid",
+    "ThreeArrows",
+    "ThreeArrowsGray",
+    "ThreeFlags",
+    "ThreeTrafficLights1",
+    "ThreeTrafficLights2",
+    "ThreeSigns",
+    "ThreeSymbols",
+    "ThreeSymbols2",
+    "FourArrows",
+    "FourArrowsGray",
+    "FourRedToBlack",
+    "FourRating",
+    "FourTrafficLights",
+    "FiveArrows",
+    "FiveArrowsGray",
+    "FiveRating",
+    "FiveQuarters",
+    "ThreeStars",
+    "ThreeTriangles",
+    "FiveBoxes",
+  ];
+
+  function enumValue(value, property, allowed) {
+    if (typeof value !== "string" || allowed.indexOf(value) < 0) {
+      throw invalid(
+        property +
+          " must be one of " +
+          allowed.join(", ") +
+          "; received " +
+          String(value)
+      );
+    }
+    return value;
+  }
+
+  function normalizeColorCriterion(value, property) {
+    var source = requireObject(value, property);
+    checkKeys(source, ["color", "formula", "type"], property);
+    var type = enumValue(source.type, property + ".type", COLOR_TYPES);
+    var result = { type: type, formula: null };
+    if (own(source, "color")) {
+      result.color = requireString(source.color, property + ".color", false);
+    }
+    if (own(source, "formula") && source.formula !== null && source.formula !== undefined) {
+      result.formula = requireString(source.formula, property + ".formula", false);
+    } else if (type !== "LowestValue" && type !== "HighestValue") {
+      throw invalid(property + ".formula is required for type " + type);
+    }
+    if (
+      (type === "LowestValue" || type === "HighestValue") &&
+      result.formula !== null
+    ) {
+      throw invalid(property + ".formula must be null for type " + type);
+    }
+    return result;
+  }
+
+  function normalizeColorCriteria(value, property) {
+    var source = requireObject(value, property);
+    checkKeys(source, ["minimum", "midpoint", "maximum"], property);
+    if (!own(source, "minimum")) throw invalid(property + ".minimum is required");
+    if (!own(source, "maximum")) throw invalid(property + ".maximum is required");
+    var result = {
+      minimum: normalizeColorCriterion(source.minimum, property + ".minimum"),
+      maximum: normalizeColorCriterion(source.maximum, property + ".maximum"),
+    };
+    if (own(source, "midpoint") && source.midpoint !== null && source.midpoint !== undefined) {
+      result.midpoint = normalizeColorCriterion(source.midpoint, property + ".midpoint");
+    }
+    return result;
+  }
+
+  function normalizeBoundRule(value, property) {
+    var source = requireObject(value, property);
+    checkKeys(source, ["formula", "type"], property);
+    var type = enumValue(source.type, property + ".type", BAR_TYPES);
+    var formula = null;
+    if (own(source, "formula") && source.formula !== null && source.formula !== undefined) {
+      formula = requireString(source.formula, property + ".formula", false);
+    }
+    if (
+      formula === null &&
+      type !== "Automatic" &&
+      type !== "LowestValue" &&
+      type !== "HighestValue"
+    ) {
+      throw invalid(property + ".formula is required for type " + type);
+    }
+    if (
+      formula !== null &&
+      (type === "Automatic" || type === "LowestValue" || type === "HighestValue")
+    ) {
+      throw invalid(property + ".formula must be null for type " + type);
+    }
+    return { type: type, formula: formula };
+  }
+
+  function normalizeIcon(value, property) {
+    if (value === null || value === undefined) return null;
+    var source = requireObject(value, property);
+    checkKeys(source, ["index", "set"], property);
+    if (!own(source, "set")) throw invalid(property + ".set is required");
+    if (!own(source, "index")) throw invalid(property + ".index is required");
+    return {
+      set: enumValue(source.set, property + ".set", ICON_STYLES),
+      index: requireInteger(source.index, property + ".index"),
+    };
+  }
+
+  function normalizeIconCriterion(value, property) {
+    var source = requireObject(value, property);
+    checkKeys(source, ["customIcon", "formula", "operator", "type"], property);
+    return {
+      customIcon: own(source, "customIcon")
+        ? normalizeIcon(source.customIcon, property + ".customIcon")
+        : null,
+      formula: requireString(source.formula, property + ".formula", false),
+      operator: enumValue(source.operator, property + ".operator", ICON_OPERATORS),
+      type: enumValue(source.type, property + ".type", ICON_TYPES),
+    };
+  }
+
+  function normalizeIconCriteria(value, property) {
+    if (!Array.isArray(value)) throw invalid(property + " must be an array");
+    if (value.length < 2 || value.length > 5) {
+      throw invalid(property + " must contain between two and five criteria");
+    }
+    return value.map(function (entry, index) {
+      return normalizeIconCriterion(entry, property + "[" + index + "]");
+    });
+  }
+
+  function resolveFormatId(owner, explicit) {
+    if (explicit !== undefined && explicit !== null && String(explicit) !== "") {
+      return String(explicit);
+    }
+    if (!owner) return null;
+    var candidates = [
+      owner._formatId,
+      owner._conditionalFormatId,
+      owner._idValue,
+      owner._key,
+      owner._formatKey,
+    ];
+    for (var i = 0; i < candidates.length; i++) {
+      if (candidates[i] !== undefined && candidates[i] !== null && String(candidates[i]) !== "") {
+        return String(candidates[i]);
+      }
+    }
+    return null;
+  }
+
+  function resolveRuleId(owner, explicit) {
+    if (explicit !== undefined && explicit !== null && String(explicit) !== "") {
+      return String(explicit);
+    }
+    if (owner && owner._ruleId !== undefined && owner._ruleId !== null) {
+      return String(owner._ruleId);
+    }
+    return null;
+  }
+
+  function resolveWorksheetId(owner) {
+    if (!owner) return null;
+    if (owner._worksheet && owner._worksheet._id) return owner._worksheet._id;
+    if (owner._worksheetId !== undefined && owner._worksheetId !== null) {
+      return String(owner._worksheetId);
+    }
+    if (owner._sheetId !== undefined && owner._sheetId !== null) {
+      return String(owner._sheetId);
+    }
+    // Nested data-bar format objects are owned by the visual child.  The
+    // worksheet binding lives on the ConditionalFormat parent, so carry it
+    // through the client object ownership chain instead of emitting a child
+    // request that the host cannot resolve.
+    if (owner._owner) return resolveWorksheetId(owner._owner);
+    return null;
+  }
+
+  function queueChild(object, owner, explicitFormatId, explicitRuleId, kind) {
+    object._owner = owner || null;
+    object._formatId = resolveFormatId(owner, explicitFormatId);
+    object._ruleId = resolveRuleId(owner, explicitRuleId);
+    object._kind = kind;
+
+    var operation = {
+      op: "getConditionalFormatChild",
+      id: object._id,
+      kind: kind,
+    };
+    if (object._formatId !== null) operation.formatId = object._formatId;
+    if (object._ruleId !== null) operation.ruleId = object._ruleId;
+    var worksheetId = resolveWorksheetId(owner);
+    if (worksheetId !== null) operation.worksheetId = worksheetId;
+    object.context._queue.push(operation);
+  }
+
+  function VisualConditionalFormat(context, owner, formatId, ruleId, kind) {
+    ClientObject.call(this, context);
+    queueChild(this, owner, formatId, ruleId, kind);
+  }
+  VisualConditionalFormat.prototype = Object.create(ClientObject.prototype);
+  VisualConditionalFormat.prototype.constructor = VisualConditionalFormat;
+
+  function defineScalar(ctor, name, normalizer) {
+    Object.defineProperty(ctor.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        var normalized = normalizer ? normalizer(value, name) : value;
+        this["_" + name] = normalized;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: normalized,
+        });
+      },
+      configurable: true,
+    });
+  }
+
+  function defineReadonly(ctor, name) {
+    Object.defineProperty(ctor.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      configurable: true,
+    });
+  }
+
+  function setProperties(source, options, propertyNames, readonlyNames) {
+    requireSetObject(source, this.constructor && this.constructor.name
+      ? this.constructor.name + ".set"
+      : "set");
+    var isClientObject = source instanceof ClientObject;
+    if (isClientObject && source.context !== this.context) throw invalidContext();
+    var properties = isClientObject ? source.toJSON() : source;
+    if (isClientObject && Object.getPrototypeOf(source) !== Object.getPrototypeOf(this)) {
+      throw invalid("The object passed to set must have the same type.");
+    }
+    checkKeys(properties, propertyNames.concat(readonlyNames || []), this._kind + " conditional format");
+    (readonlyNames || []).forEach(function (name) {
+      if (!own(properties, name) || properties[name] === undefined) return;
+      if (!options || options.throwOnReadOnly !== false) {
+        throw invalid("The property '" + name + "' is read-only.");
+      }
+    });
+    propertyNames.forEach(function (name) {
+      if (!own(properties, name) || properties[name] === undefined) return;
+      if (this._navigationProperties.indexOf(name) >= 0) {
+        var child = isClientObject ? source[name] : properties[name];
+        this[name].set(child, options);
+      } else {
+        this[name] = properties[name];
+      }
+    }, this);
+    return this;
+  }
+
+  function visualToJSON() {
+    var data = {};
+    (this._scalarProperties || []).forEach(function (name) {
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }, this);
+    (this._navigationProperties || []).forEach(function (name) {
+      var child = this["_" + name];
+      if (child && typeof child.toJSON === "function") data[name] = child.toJSON();
+    }, this);
+    return data;
+  }
+
+  function DataBarConditionalFormat(context, owner, formatId, ruleId) {
+    VisualConditionalFormat.call(this, context, owner, formatId, ruleId, "dataBar");
+    this._scalarProperties = [
+      "axisColor",
+      "axisFormat",
+      "barDirection",
+      "lowerBoundRule",
+      "showDataBarOnly",
+      "upperBoundRule",
+    ];
+    this._navigationProperties = ["negativeFormat", "positiveFormat"];
+  }
+  DataBarConditionalFormat.prototype = Object.create(VisualConditionalFormat.prototype);
+  DataBarConditionalFormat.prototype.constructor = DataBarConditionalFormat;
+  DataBarConditionalFormat.prototype.set = function (properties, options) {
+    return setProperties.call(
+      this,
+      properties,
+      options,
+      [
+        "axisColor",
+        "axisFormat",
+        "barDirection",
+        "lowerBoundRule",
+        "showDataBarOnly",
+        "upperBoundRule",
+        "negativeFormat",
+        "positiveFormat",
+      ],
+      []
+    );
+  };
+  DataBarConditionalFormat.prototype.toJSON = visualToJSON;
+  defineScalar(DataBarConditionalFormat, "axisColor", function (value, property) {
+    return requireString(value, property, true);
+  });
+  defineScalar(DataBarConditionalFormat, "axisFormat", function (value, property) {
+    return enumValue(value, property, AXIS_FORMATS);
+  });
+  defineScalar(DataBarConditionalFormat, "barDirection", function (value, property) {
+    return enumValue(value, property, BAR_DIRECTIONS);
+  });
+  defineScalar(DataBarConditionalFormat, "lowerBoundRule", normalizeBoundRule);
+  defineScalar(DataBarConditionalFormat, "showDataBarOnly", requireBoolean);
+  defineScalar(DataBarConditionalFormat, "upperBoundRule", normalizeBoundRule);
+
+  Object.defineProperty(DataBarConditionalFormat.prototype, "negativeFormat", {
+    get: function () {
+      if (!this._negativeFormat) {
+        this._negativeFormat = new ConditionalDataBarNegativeFormat(
+          this.context,
+          this,
+          this._formatId,
+          this._ruleId
+        );
+      }
+      return this._negativeFormat;
+    },
+    configurable: true,
+  });
+  Object.defineProperty(DataBarConditionalFormat.prototype, "positiveFormat", {
+    get: function () {
+      if (!this._positiveFormat) {
+        this._positiveFormat = new ConditionalDataBarPositiveFormat(
+          this.context,
+          this,
+          this._formatId,
+          this._ruleId
+        );
+      }
+      return this._positiveFormat;
+    },
+    configurable: true,
+  });
+
+  function ConditionalDataBarPositiveFormat(context, owner, formatId, ruleId) {
+    VisualConditionalFormat.call(
+      this,
+      context,
+      owner,
+      formatId,
+      ruleId,
+      "dataBarPositive"
+    );
+    this._scalarProperties = ["borderColor", "fillColor", "gradientFill"];
+    this._navigationProperties = [];
+  }
+  ConditionalDataBarPositiveFormat.prototype = Object.create(VisualConditionalFormat.prototype);
+  ConditionalDataBarPositiveFormat.prototype.constructor = ConditionalDataBarPositiveFormat;
+  ConditionalDataBarPositiveFormat.prototype.set = function (properties, options) {
+    return setProperties.call(
+      this,
+      properties,
+      options,
+      ["borderColor", "fillColor", "gradientFill"],
+      []
+    );
+  };
+  ConditionalDataBarPositiveFormat.prototype.toJSON = visualToJSON;
+  defineScalar(ConditionalDataBarPositiveFormat, "borderColor", function (value, property) {
+    return requireString(value, property, true);
+  });
+  defineScalar(ConditionalDataBarPositiveFormat, "fillColor", function (value, property) {
+    return requireString(value, property, false);
+  });
+  defineScalar(ConditionalDataBarPositiveFormat, "gradientFill", requireBoolean);
+
+  function ConditionalDataBarNegativeFormat(context, owner, formatId, ruleId) {
+    VisualConditionalFormat.call(
+      this,
+      context,
+      owner,
+      formatId,
+      ruleId,
+      "dataBarNegative"
+    );
+    this._scalarProperties = [
+      "borderColor",
+      "fillColor",
+      "matchPositiveBorderColor",
+      "matchPositiveFillColor",
+    ];
+    this._navigationProperties = [];
+  }
+  ConditionalDataBarNegativeFormat.prototype = Object.create(VisualConditionalFormat.prototype);
+  ConditionalDataBarNegativeFormat.prototype.constructor = ConditionalDataBarNegativeFormat;
+  ConditionalDataBarNegativeFormat.prototype.set = function (properties, options) {
+    return setProperties.call(
+      this,
+      properties,
+      options,
+      [
+        "borderColor",
+        "fillColor",
+        "matchPositiveBorderColor",
+        "matchPositiveFillColor",
+      ],
+      []
+    );
+  };
+  ConditionalDataBarNegativeFormat.prototype.toJSON = visualToJSON;
+  defineScalar(ConditionalDataBarNegativeFormat, "borderColor", function (value, property) {
+    return requireString(value, property, true);
+  });
+  defineScalar(ConditionalDataBarNegativeFormat, "fillColor", function (value, property) {
+    return requireString(value, property, true);
+  });
+  defineScalar(ConditionalDataBarNegativeFormat, "matchPositiveBorderColor", requireBoolean);
+  defineScalar(ConditionalDataBarNegativeFormat, "matchPositiveFillColor", requireBoolean);
+
+  function ColorScaleConditionalFormat(context, owner, formatId, ruleId) {
+    VisualConditionalFormat.call(this, context, owner, formatId, ruleId, "colorScale");
+    this._scalarProperties = ["criteria"];
+    this._additionalScalarProperties = ["threeColorScale"];
+    this._navigationProperties = [];
+  }
+  ColorScaleConditionalFormat.prototype = Object.create(VisualConditionalFormat.prototype);
+  ColorScaleConditionalFormat.prototype.constructor = ColorScaleConditionalFormat;
+  ColorScaleConditionalFormat.prototype.set = function (properties, options) {
+    return setProperties.call(this, properties, options, ["criteria"], ["threeColorScale"]);
+  };
+  ColorScaleConditionalFormat.prototype.toJSON = visualToJSON;
+  defineScalar(ColorScaleConditionalFormat, "criteria", function (value, property) {
+    return normalizeColorCriteria(value, "ColorScaleConditionalFormat." + property);
+  });
+  defineReadonly(ColorScaleConditionalFormat, "threeColorScale");
+
+  function IconSetConditionalFormat(context, owner, formatId, ruleId) {
+    VisualConditionalFormat.call(this, context, owner, formatId, ruleId, "iconSet");
+    this._scalarProperties = ["criteria", "reverseIconOrder", "showIconOnly", "style"];
+    this._navigationProperties = [];
+  }
+  IconSetConditionalFormat.prototype = Object.create(VisualConditionalFormat.prototype);
+  IconSetConditionalFormat.prototype.constructor = IconSetConditionalFormat;
+  IconSetConditionalFormat.prototype.set = function (properties, options) {
+    return setProperties.call(
+      this,
+      properties,
+      options,
+      ["criteria", "reverseIconOrder", "showIconOnly", "style"],
+      []
+    );
+  };
+  IconSetConditionalFormat.prototype.toJSON = visualToJSON;
+  defineScalar(IconSetConditionalFormat, "criteria", function (value, property) {
+    return normalizeIconCriteria(value, "IconSetConditionalFormat." + property);
+  });
+  defineScalar(IconSetConditionalFormat, "reverseIconOrder", requireBoolean);
+  defineScalar(IconSetConditionalFormat, "showIconOnly", requireBoolean);
+  defineScalar(IconSetConditionalFormat, "style", function (value, property) {
+    return enumValue(value, property, ICON_STYLES);
+  });
+
+  function createChild(context, owner, kind, formatId, ruleId) {
+    if (kind === "colorScale") return new ColorScaleConditionalFormat(context, owner, formatId, ruleId);
+    if (kind === "dataBar") return new DataBarConditionalFormat(context, owner, formatId, ruleId);
+    if (kind === "dataBarPositive") {
+      return new ConditionalDataBarPositiveFormat(context, owner, formatId, ruleId);
+    }
+    if (kind === "dataBarNegative") {
+      return new ConditionalDataBarNegativeFormat(context, owner, formatId, ruleId);
+    }
+    if (kind === "iconSet") return new IconSetConditionalFormat(context, owner, formatId, ruleId);
+    throw invalid("Unsupported conditional-format visual kind '" + kind + "'");
+  }
+
+  // The base conditional-format adapter can use this factory to avoid
+  // depending on constructor details. Direct constructors remain available
+  // for Office.js-compatible object paths.
+  officeJs.createConditionalFormatChild = createChild;
+  officeJs.queueConditionalFormatChild = queueChild;
+  officeJs.conditionalFormatVisualKinds = {
+    colorScale: ColorScaleConditionalFormat,
+    dataBar: DataBarConditionalFormat,
+    dataBarPositive: ConditionalDataBarPositiveFormat,
+    dataBarNegative: ConditionalDataBarNegativeFormat,
+    iconSet: IconSetConditionalFormat,
+  };
+
+  // conditional_basic.js owns the common ConditionalFormat navigation
+  // properties.  Register these factories when that module has already
+  // installed its registry so `.colorScale`, `.dataBar`, and `.iconSet`
+  // materialize the typed children rather than a placeholder.  Runtime setup
+  // loads the base adapter before this file; the direct registry assignment
+  // keeps the module safe for embedders that evaluate the files separately.
+  var conditionalRegistry = global.__mogConditionalFormats;
+  if (conditionalRegistry && typeof conditionalRegistry.registerChild === "function") {
+    ["colorScale", "dataBar", "iconSet"].forEach(function (kind) {
+      conditionalRegistry.registerChild(kind, function (context, parent, orNullObject) {
+        return createChild(context, parent, undefined, undefined, kind);
+      });
+    });
+  }
+
+  Excel.DataBarConditionalFormat = DataBarConditionalFormat;
+  Excel.ConditionalDataBarPositiveFormat = ConditionalDataBarPositiveFormat;
+  Excel.ConditionalDataBarNegativeFormat = ConditionalDataBarNegativeFormat;
+  Excel.ColorScaleConditionalFormat = ColorScaleConditionalFormat;
+  Excel.IconSetConditionalFormat = IconSetConditionalFormat;
+})(globalThis);

--- a/compute/officejs/src/conditional_scales.rs
+++ b/compute/officejs/src/conditional_scales.rs
@@ -1,0 +1,1401 @@
+//! Office.js conditional-format visual children.
+//!
+//! Reads resolve the current canonical conditional-format document and writes
+//! go through SheetConditionalFormats. There is deliberately no cached JSON
+//! shadow: a fresh request context observes the durable engine state and the
+//! engine remains responsible for evaluation and recalculation.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use compute_api::Sheet;
+use serde_json::{Map, Value, json};
+
+use crate::dispatch::{ExtensionHandler, ExtensionObject, HostDispatchContext};
+use crate::host::BatchError;
+
+/// Error returned by a conditional-format visual child operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConditionalScaleError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+impl ConditionalScaleError {
+    fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            code: "InvalidArgument",
+            message: message.into(),
+        }
+    }
+
+    fn unsupported(message: impl Into<String>) -> Self {
+        Self {
+            code: "InvalidArgument",
+            message: message.into(),
+        }
+    }
+
+    fn not_found(message: impl Into<String>) -> Self {
+        Self {
+            code: "ItemNotFound",
+            message: message.into(),
+        }
+    }
+
+    fn engine(error: impl std::fmt::Display) -> Self {
+        Self {
+            code: "GeneralException",
+            message: error.to_string(),
+        }
+    }
+
+    fn encoding(error: impl std::fmt::Display) -> Self {
+        Self {
+            code: "GeneralException",
+            message: format!("conditional-format conversion failed: {error}"),
+        }
+    }
+}
+
+/// The visual object represented by a proxy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConditionalScaleKind {
+    ColorScale,
+    DataBar,
+    DataBarPositive,
+    DataBarNegative,
+    IconSet,
+}
+
+impl ConditionalScaleKind {
+    pub(crate) fn parse(value: &str) -> Result<Self, ConditionalScaleError> {
+        match value {
+            "colorScale" | "ColorScale" | "colorScaleConditionalFormat" => Ok(Self::ColorScale),
+            "dataBar" | "DataBar" | "dataBarConditionalFormat" => Ok(Self::DataBar),
+            "dataBarPositive" | "positiveFormat" | "ConditionalDataBarPositiveFormat" => {
+                Ok(Self::DataBarPositive)
+            }
+            "dataBarNegative" | "negativeFormat" | "ConditionalDataBarNegativeFormat" => {
+                Ok(Self::DataBarNegative)
+            }
+            "iconSet" | "IconSet" | "iconSetConditionalFormat" => Ok(Self::IconSet),
+            other => Err(Self::invalid(format!(
+                "Unsupported conditional-format visual kind '{other}'"
+            ))),
+        }
+    }
+
+    fn invalid(message: impl Into<String>) -> ConditionalScaleError {
+        ConditionalScaleError::invalid(message)
+    }
+
+    fn parent_rule_type(self) -> &'static str {
+        match self {
+            Self::ColorScale => "colorScale",
+            Self::DataBar | Self::DataBarPositive | Self::DataBarNegative => "dataBar",
+            Self::IconSet => "iconSet",
+        }
+    }
+
+    fn object_type(self) -> &'static str {
+        match self {
+            Self::ColorScale => "ColorScaleConditionalFormat",
+            Self::DataBar => "DataBarConditionalFormat",
+            Self::DataBarPositive => "ConditionalDataBarPositiveFormat",
+            Self::DataBarNegative => "ConditionalDataBarNegativeFormat",
+            Self::IconSet => "IconSetConditionalFormat",
+        }
+    }
+}
+
+/// A host-side visual conditional-format proxy.
+#[derive(Clone)]
+pub(crate) struct ConditionalFormatRef {
+    sheet: Sheet,
+    format_id: String,
+    rule_id: Option<String>,
+    kind: ConditionalScaleKind,
+}
+
+#[derive(Clone)]
+struct LocatedRule {
+    format_id: String,
+    format: Value,
+    rule_index: usize,
+    rule: Value,
+}
+
+impl ConditionalFormatRef {
+    pub(crate) fn new(
+        sheet: Sheet,
+        format_id: impl Into<String>,
+        rule_id: Option<String>,
+        kind: &str,
+    ) -> Result<Self, ConditionalScaleError> {
+        let format_id = format_id.into();
+        if format_id.trim().is_empty() {
+            return Err(ConditionalScaleError::invalid(
+                "Conditional-format visual child requires a format ID",
+            ));
+        }
+        Ok(Self {
+            sheet,
+            format_id,
+            rule_id,
+            kind: ConditionalScaleKind::parse(kind)?,
+        })
+    }
+
+    pub(crate) fn kind(&self) -> ConditionalScaleKind {
+        self.kind
+    }
+
+    pub(crate) fn format_id(&self) -> &str {
+        &self.format_id
+    }
+
+    pub(crate) fn rule_id(&self) -> Option<&str> {
+        self.rule_id.as_deref()
+    }
+
+    pub(crate) fn exists(&self) -> Result<bool, ConditionalScaleError> {
+        Ok(self.resolve_rule().is_ok())
+    }
+
+    /// Project Office.js properties from the current canonical rule.
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, ConditionalScaleError> {
+        let located = self.resolve_rule()?;
+        let mut result = HashMap::new();
+        for property in properties {
+            if property == "isNullObject" {
+                result.insert(property.clone(), Value::Bool(false));
+            } else {
+                result.insert(
+                    property.clone(),
+                    read_property(self.kind, &located.rule, property)?,
+                );
+            }
+        }
+        Ok(result)
+    }
+
+    /// Apply one Office.js property through the real engine API.
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), ConditionalScaleError> {
+        if property == "isNullObject" {
+            return Err(ConditionalScaleError::invalid(
+                "Conditional-format visual isNullObject is read-only",
+            ));
+        }
+        let located = self.resolve_rule()?;
+        let mut rule = located.rule;
+        apply_property(self.kind, &mut rule, property, value)?;
+        self.persist_rule(located, rule)
+    }
+
+    fn resolve_rule(&self) -> Result<LocatedRule, ConditionalScaleError> {
+        let formats = self
+            .sheet
+            .conditional_formats()
+            .get_all_rules()
+            .map_err(ConditionalScaleError::engine)?;
+        let mut by_rule_id = None;
+        let mut by_format_id = None;
+
+        for format in formats {
+            let value = serde_json::to_value(format).map_err(ConditionalScaleError::encoding)?;
+            let Some(format_object) = value.as_object() else {
+                continue;
+            };
+            let Some(current_format_id) = format_object.get("id").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(rules) = format_object.get("rules").and_then(Value::as_array) else {
+                continue;
+            };
+
+            for (rule_index, rule) in rules.iter().enumerate() {
+                if rule_type(rule) != Some(self.kind.parent_rule_type()) {
+                    continue;
+                }
+                let current_rule_id = rule.get("id").and_then(Value::as_str);
+                let matches_rule_id = self
+                    .rule_id
+                    .as_deref()
+                    .is_none_or(|requested| current_rule_id == Some(requested));
+                if !matches_rule_id {
+                    continue;
+                }
+                let located = LocatedRule {
+                    format_id: current_format_id.to_string(),
+                    format: value.clone(),
+                    rule_index,
+                    rule: rule.clone(),
+                };
+                if current_format_id == self.format_id {
+                    return Ok(located);
+                }
+                if self
+                    .rule_id
+                    .as_deref()
+                    .is_some_and(|requested| current_rule_id == Some(requested))
+                {
+                    by_rule_id = Some(located);
+                } else if by_format_id.is_none() {
+                    by_format_id = Some(located);
+                }
+            }
+        }
+
+        by_rule_id.or(by_format_id).ok_or_else(|| {
+            ConditionalScaleError::not_found(format!(
+                "Conditional-format visual '{}' was not found",
+                self.format_id
+            ))
+        })
+    }
+
+    fn persist_rule(&self, located: LocatedRule, rule: Value) -> Result<(), ConditionalScaleError> {
+        let mut format = located.format.as_object().cloned().ok_or_else(|| {
+            ConditionalScaleError::encoding("conditional format is not an object")
+        })?;
+        let rules = format
+            .get_mut("rules")
+            .and_then(Value::as_array_mut)
+            .ok_or_else(|| ConditionalScaleError::encoding("conditional format has no rules"))?;
+        let Some(slot) = rules.get_mut(located.rule_index) else {
+            return Err(ConditionalScaleError::encoding(
+                "conditional format rule index is no longer valid",
+            ));
+        };
+        *slot = rule;
+        self.sheet
+            .conditional_formats()
+            .update_rule(&located.format_id, json!({ "rules": rules }))
+            .map_err(ConditionalScaleError::engine)?;
+        Ok(())
+    }
+}
+
+/// Extension handler for visual child binding operations.
+///
+/// The JS adapter queues getConditionalFormatChild with
+/// {worksheetId, formatId, ruleId?, kind}. Aliases are accepted while the
+/// conditional-format base object is integrated by the host owner.
+pub(crate) struct ConditionalFormatHandler;
+
+impl ExtensionHandler for ConditionalFormatHandler {
+    fn can_handle(&self, operation: &str) -> bool {
+        matches!(
+            operation,
+            "getConditionalFormatChild"
+                | "conditionalFormatGetChild"
+                | "getConditionalFormatVisual"
+                | "getConditionalFormatChildOrNullObject"
+        )
+    }
+
+    fn handle(
+        &self,
+        operation: &Value,
+        context: &mut HostDispatchContext<'_>,
+    ) -> Result<bool, BatchError> {
+        let id = required_string(operation, "id")?;
+        let worksheet_id = operation
+            .get("worksheetId")
+            .or_else(|| operation.get("sheetId"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| batch_invalid("conditional-format child requires worksheetId"))?;
+        let format_id = operation
+            .get("formatId")
+            .or_else(|| operation.get("conditionalFormatId"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| batch_invalid("conditional-format child requires formatId"))?;
+        let rule_id = operation
+            .get("ruleId")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let kind = operation
+            .get("childKind")
+            .or_else(|| operation.get("kind"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| batch_invalid("conditional-format child requires kind"))?;
+
+        let reference = ConditionalFormatRef::new(
+            context.worksheet(worksheet_id)?.sheet(),
+            format_id,
+            rule_id,
+            kind,
+        )
+        .map_err(scale_error)?;
+        let or_null = operation
+            .get("orNullObject")
+            .or_else(|| operation.get("nullObject"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+            || operation
+                .get("op")
+                .and_then(Value::as_str)
+                .is_some_and(|name| name.ends_with("OrNullObject"));
+
+        if or_null && !reference.exists().map_err(scale_error)? {
+            context.bind_null_object(&id);
+        } else {
+            context.bind_object(&id, Arc::new(reference));
+        }
+        Ok(true)
+    }
+}
+
+impl ExtensionObject for ConditionalFormatRef {
+    fn object_type(&self) -> &'static str {
+        self.kind.object_type()
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        ConditionalFormatRef::load(self, properties).map_err(scale_error)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        ConditionalFormatRef::set(self, property, value).map_err(scale_error)
+    }
+}
+
+fn rule_type(value: &Value) -> Option<&str> {
+    value.get("type").and_then(Value::as_str)
+}
+
+fn read_property(
+    kind: ConditionalScaleKind,
+    rule: &Value,
+    property: &str,
+) -> Result<Value, ConditionalScaleError> {
+    let payload = rule_payload(rule, kind.parent_rule_type())?;
+    match (kind, property) {
+        (ConditionalScaleKind::ColorScale, "criteria") => color_scale_criteria(payload),
+        (ConditionalScaleKind::ColorScale, "threeColorScale") => Ok(Value::Bool(
+            payload
+                .get("midPoint")
+                .or_else(|| payload.get("midpoint"))
+                .is_some_and(|value| !value.is_null()),
+        )),
+
+        (ConditionalScaleKind::DataBar, "negativeFormat") => negative_format(payload),
+        (ConditionalScaleKind::DataBar, "positiveFormat") => positive_format(payload),
+        (ConditionalScaleKind::DataBar, "axisColor") => Ok(string_or_default(payload, "axisColor")),
+        (ConditionalScaleKind::DataBar, "axisFormat") => Ok(json!(axis_format_token(
+            payload
+                .get("axisPosition")
+                .or_else(|| payload.get("axisFormat"))
+                .and_then(Value::as_str),
+        ))),
+        (ConditionalScaleKind::DataBar, "barDirection") => Ok(json!(bar_direction_token(
+            payload
+                .get("direction")
+                .or_else(|| payload.get("barDirection"))
+                .and_then(Value::as_str),
+        ))),
+        (ConditionalScaleKind::DataBar, "lowerBoundRule") => {
+            point_to_bound_rule(payload.get("minPoint"))
+        }
+        (ConditionalScaleKind::DataBar, "showDataBarOnly") => Ok(Value::Bool(
+            !payload
+                .get("showValue")
+                .and_then(Value::as_bool)
+                .unwrap_or(true),
+        )),
+        (ConditionalScaleKind::DataBar, "upperBoundRule") => {
+            point_to_bound_rule(payload.get("maxPoint"))
+        }
+
+        (ConditionalScaleKind::DataBarPositive, "borderColor") => {
+            Ok(string_or_default(payload, "borderColor"))
+        }
+        (ConditionalScaleKind::DataBarPositive, "fillColor") => {
+            Ok(string_or_default(payload, "positiveColor"))
+        }
+        (ConditionalScaleKind::DataBarPositive, "gradientFill") => Ok(Value::Bool(
+            payload
+                .get("gradient")
+                .and_then(Value::as_bool)
+                .unwrap_or(true),
+        )),
+
+        (ConditionalScaleKind::DataBarNegative, "borderColor") => {
+            Ok(string_or_default(payload, "negativeBorderColor"))
+        }
+        (ConditionalScaleKind::DataBarNegative, "fillColor") => {
+            Ok(string_or_default(payload, "negativeColor"))
+        }
+        (ConditionalScaleKind::DataBarNegative, "matchPositiveBorderColor") => Ok(Value::Bool(
+            payload
+                .get("matchPositiveBorderColor")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        )),
+        (ConditionalScaleKind::DataBarNegative, "matchPositiveFillColor") => Ok(Value::Bool(
+            payload
+                .get("matchPositiveFillColor")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        )),
+
+        (ConditionalScaleKind::IconSet, "criteria") => icon_criteria(payload),
+        (ConditionalScaleKind::IconSet, "reverseIconOrder") => Ok(Value::Bool(
+            payload
+                .get("reverseOrder")
+                .or_else(|| payload.get("reverseIconOrder"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        )),
+        (ConditionalScaleKind::IconSet, "showIconOnly") => Ok(Value::Bool(
+            payload
+                .get("showIconOnly")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        )),
+        (ConditionalScaleKind::IconSet, "style") => Ok(json!(icon_style_token(
+            payload
+                .get("iconSetName")
+                .or_else(|| payload.get("style"))
+                .and_then(Value::as_str),
+        ))),
+
+        (_, other) => Err(ConditionalScaleError::unsupported(format!(
+            "Unsupported {} property '{other}'",
+            kind.object_type()
+        ))),
+    }
+}
+
+fn apply_property(
+    kind: ConditionalScaleKind,
+    rule: &mut Value,
+    property: &str,
+    value: &Value,
+) -> Result<(), ConditionalScaleError> {
+    let payload = rule_payload_mut(rule, kind.parent_rule_type())?;
+    match (kind, property) {
+        (ConditionalScaleKind::ColorScale, "criteria") => {
+            let criteria = value.as_object().ok_or_else(|| {
+                ConditionalScaleError::invalid("ColorScale.criteria must be an object")
+            })?;
+            for name in criteria.keys() {
+                if !matches!(name.as_str(), "minimum" | "midpoint" | "maximum") {
+                    return Err(ConditionalScaleError::invalid(format!(
+                        "Unsupported ColorScale.criteria property '{name}'"
+                    )));
+                }
+            }
+            let minimum = criteria.get("minimum").ok_or_else(|| {
+                ConditionalScaleError::invalid("ColorScale.criteria.minimum is required")
+            })?;
+            let maximum = criteria.get("maximum").ok_or_else(|| {
+                ConditionalScaleError::invalid("ColorScale.criteria.maximum is required")
+            })?;
+            let old_min_color = point_color(payload.get("minPoint"));
+            let old_max_color = point_color(payload.get("maxPoint"));
+            let min_point = criterion_to_point(
+                minimum,
+                old_min_color.unwrap_or_default(),
+                CriterionFamily::ColorScale,
+            )?;
+            let max_point = criterion_to_point(
+                maximum,
+                old_max_color.unwrap_or_default(),
+                CriterionFamily::ColorScale,
+            )?;
+            let midpoint = match criteria.get("midpoint") {
+                Some(Value::Null) | None => None,
+                Some(value) => Some(criterion_to_point(
+                    value,
+                    point_color(payload.get("midPoint").or_else(|| payload.get("midpoint")))
+                        .unwrap_or_default(),
+                    CriterionFamily::ColorScale,
+                )?),
+            };
+            payload.insert("minPoint".to_string(), min_point.clone());
+            payload.insert("maxPoint".to_string(), max_point.clone());
+            if let Some(midpoint) = midpoint.clone() {
+                payload.insert("midPoint".to_string(), midpoint);
+            } else {
+                payload.remove("midPoint");
+                payload.remove("midpoint");
+            }
+            let mut points = vec![min_point];
+            if let Some(midpoint) = midpoint {
+                points.push(midpoint);
+            }
+            points.push(max_point);
+            payload.insert("points".to_string(), Value::Array(points));
+        }
+        (ConditionalScaleKind::ColorScale, "threeColorScale") => {
+            return Err(ConditionalScaleError::invalid(
+                "ColorScale.threeColorScale is read-only",
+            ));
+        }
+
+        (ConditionalScaleKind::DataBar, "negativeFormat") => {
+            apply_negative_format(payload, value)?;
+        }
+        (ConditionalScaleKind::DataBar, "positiveFormat") => {
+            apply_positive_format(payload, value)?;
+        }
+        (ConditionalScaleKind::DataBar, "axisColor") => {
+            payload.insert("axisColor".to_string(), string_value(value, property)?);
+        }
+        (ConditionalScaleKind::DataBar, "axisFormat") => {
+            let token = enum_string(value, property)?;
+            let internal = match token {
+                "Automatic" => "automatic",
+                "None" => "none",
+                "CellMidPoint" => "middle",
+                other => {
+                    return Err(ConditionalScaleError::invalid(format!(
+                        "Unsupported {property} value '{other}'"
+                    )));
+                }
+            };
+            payload.insert("axisPosition".to_string(), json!(internal));
+        }
+        (ConditionalScaleKind::DataBar, "barDirection") => {
+            let token = enum_string(value, property)?;
+            let internal = match token {
+                "Context" => "context",
+                "LeftToRight" => "leftToRight",
+                "RightToLeft" => "rightToLeft",
+                other => {
+                    return Err(ConditionalScaleError::invalid(format!(
+                        "Unsupported {property} value '{other}'"
+                    )));
+                }
+            };
+            payload.insert("direction".to_string(), json!(internal));
+        }
+        (ConditionalScaleKind::DataBar, "lowerBoundRule") => {
+            let color = point_color(payload.get("minPoint"))
+                .or_else(|| {
+                    payload
+                        .get("positiveColor")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+                .unwrap_or_default();
+            payload.insert(
+                "minPoint".to_string(),
+                bound_rule_to_point(value, true, color)?,
+            );
+        }
+        (ConditionalScaleKind::DataBar, "showDataBarOnly") => {
+            payload.insert(
+                "showValue".to_string(),
+                Value::Bool(!bool_value(value, property)?),
+            );
+        }
+        (ConditionalScaleKind::DataBar, "upperBoundRule") => {
+            let color = point_color(payload.get("maxPoint"))
+                .or_else(|| {
+                    payload
+                        .get("positiveColor")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+                .unwrap_or_default();
+            payload.insert(
+                "maxPoint".to_string(),
+                bound_rule_to_point(value, false, color)?,
+            );
+        }
+
+        (ConditionalScaleKind::DataBarPositive, "borderColor") => {
+            payload.insert("borderColor".to_string(), optional_color(value, property)?);
+        }
+        (ConditionalScaleKind::DataBarPositive, "fillColor") => {
+            payload.insert("positiveColor".to_string(), string_value(value, property)?);
+        }
+        (ConditionalScaleKind::DataBarPositive, "gradientFill") => {
+            payload.insert("gradient".to_string(), bool_value(value, property)?.into());
+        }
+
+        (ConditionalScaleKind::DataBarNegative, "borderColor") => {
+            payload.insert(
+                "negativeBorderColor".to_string(),
+                optional_color(value, property)?,
+            );
+        }
+        (ConditionalScaleKind::DataBarNegative, "fillColor") => {
+            payload.insert(
+                "negativeColor".to_string(),
+                optional_color(value, property)?,
+            );
+        }
+        (ConditionalScaleKind::DataBarNegative, "matchPositiveBorderColor") => {
+            payload.insert(
+                "matchPositiveBorderColor".to_string(),
+                bool_value(value, property)?.into(),
+            );
+        }
+        (ConditionalScaleKind::DataBarNegative, "matchPositiveFillColor") => {
+            payload.insert(
+                "matchPositiveFillColor".to_string(),
+                bool_value(value, property)?.into(),
+            );
+        }
+
+        (ConditionalScaleKind::IconSet, "criteria") => {
+            let criteria = value.as_array().ok_or_else(|| {
+                ConditionalScaleError::invalid("IconSet.criteria must be an array")
+            })?;
+            if !(2..=5).contains(&criteria.len()) {
+                return Err(ConditionalScaleError::invalid(
+                    "IconSet.criteria must contain between two and five criteria",
+                ));
+            }
+            let mut custom_icons = Vec::with_capacity(criteria.len());
+            for criterion in criteria {
+                custom_icons.push(icon_from_criterion(criterion)?);
+            }
+            let thresholds = criteria[1..]
+                .iter()
+                .map(criterion_to_icon_threshold)
+                .collect::<Result<Vec<_>, _>>()?;
+            let all_percent = thresholds.iter().all(|threshold| {
+                threshold
+                    .get("type")
+                    .and_then(Value::as_str)
+                    .is_some_and(|value| value == "percent")
+            });
+            payload.insert("thresholds".to_string(), Value::Array(thresholds));
+            payload.insert("customIcons".to_string(), Value::Array(custom_icons));
+            payload.insert("percent".to_string(), Value::Bool(all_percent));
+        }
+        (ConditionalScaleKind::IconSet, "reverseIconOrder") => {
+            payload.insert(
+                "reverseOrder".to_string(),
+                bool_value(value, property)?.into(),
+            );
+        }
+        (ConditionalScaleKind::IconSet, "showIconOnly") => {
+            payload.insert(
+                "showIconOnly".to_string(),
+                bool_value(value, property)?.into(),
+            );
+        }
+        (ConditionalScaleKind::IconSet, "style") => {
+            let token = enum_string(value, property)?;
+            let internal = office_icon_style_to_internal(token).ok_or_else(|| {
+                ConditionalScaleError::invalid(format!("Unsupported {property} value '{token}'"))
+            })?;
+            payload.insert("iconSetName".to_string(), json!(internal));
+        }
+
+        (_, other) => {
+            return Err(ConditionalScaleError::unsupported(format!(
+                "Unsupported {} property '{other}'",
+                kind.object_type()
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CriterionFamily {
+    ColorScale,
+    DataBar,
+}
+
+fn rule_payload<'a>(
+    rule: &'a Value,
+    expected_type: &str,
+) -> Result<&'a Map<String, Value>, ConditionalScaleError> {
+    if rule_type(rule) != Some(expected_type) {
+        return Err(ConditionalScaleError::invalid(format!(
+            "Expected a {expected_type} conditional-format rule"
+        )));
+    }
+    rule.get(expected_type)
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            ConditionalScaleError::encoding(format!(
+                "{expected_type} conditional-format rule has no payload"
+            ))
+        })
+}
+
+fn rule_payload_mut<'a>(
+    rule: &'a mut Value,
+    expected_type: &str,
+) -> Result<&'a mut Map<String, Value>, ConditionalScaleError> {
+    if rule_type(rule) != Some(expected_type) {
+        return Err(ConditionalScaleError::invalid(format!(
+            "Expected a {expected_type} conditional-format rule"
+        )));
+    }
+    rule.get_mut(expected_type)
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| {
+            ConditionalScaleError::encoding(format!(
+                "{expected_type} conditional-format rule has no payload"
+            ))
+        })
+}
+
+fn color_scale_criteria(payload: &Map<String, Value>) -> Result<Value, ConditionalScaleError> {
+    let minimum = color_criterion(payload.get("minPoint"))?;
+    let maximum = color_criterion(payload.get("maxPoint"))?;
+    let mut criteria = Map::new();
+    criteria.insert("minimum".to_string(), minimum);
+    if let Some(midpoint) = payload.get("midPoint").or_else(|| payload.get("midpoint"))
+        && !midpoint.is_null()
+    {
+        criteria.insert("midpoint".to_string(), color_criterion(Some(midpoint))?);
+    }
+    criteria.insert("maximum".to_string(), maximum);
+    Ok(Value::Object(criteria))
+}
+
+fn color_criterion(point: Option<&Value>) -> Result<Value, ConditionalScaleError> {
+    let point =
+        point.ok_or_else(|| ConditionalScaleError::encoding("color scale point is missing"))?;
+    let object = point
+        .as_object()
+        .ok_or_else(|| ConditionalScaleError::encoding("color scale point is not an object"))?;
+    let value = object
+        .get("value")
+        .ok_or_else(|| ConditionalScaleError::encoding("color scale point has no value"))?;
+    let (kind, formula) = value_ref_to_office(value)?;
+    let mut output = Map::new();
+    output.insert("type".to_string(), Value::String(kind));
+    output.insert("formula".to_string(), formula);
+    if let Some(color) = object.get("color") {
+        output.insert("color".to_string(), color.clone());
+    }
+    Ok(Value::Object(output))
+}
+
+fn point_to_bound_rule(point: Option<&Value>) -> Result<Value, ConditionalScaleError> {
+    let point =
+        point.ok_or_else(|| ConditionalScaleError::encoding("data bar bound is missing"))?;
+    let object = point
+        .as_object()
+        .ok_or_else(|| ConditionalScaleError::encoding("data bar bound is not an object"))?;
+    let value = object
+        .get("value")
+        .ok_or_else(|| ConditionalScaleError::encoding("data bar bound has no value"))?;
+    let (kind, formula) = value_ref_to_office(value)?;
+    Ok(json!({ "type": kind, "formula": formula }))
+}
+
+fn value_ref_to_office(value: &Value) -> Result<(String, Value), ConditionalScaleError> {
+    let object = value.as_object().ok_or_else(|| {
+        ConditionalScaleError::encoding("conditional-format value is not an object")
+    })?;
+    let kind = object
+        .get("kind")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ConditionalScaleError::encoding("conditional-format value has no kind"))?;
+    match kind {
+        "num" => Ok((
+            "Number".to_string(),
+            number_to_formula(object.get("value"))?,
+        )),
+        "percent" => Ok((
+            "Percent".to_string(),
+            number_to_formula(object.get("value"))?,
+        )),
+        "percentile" => Ok((
+            "Percentile".to_string(),
+            number_to_formula(object.get("value"))?,
+        )),
+        "formula" => Ok((
+            "Formula".to_string(),
+            required_string_value(object.get("source"), "formula")?,
+        )),
+        "min" | "autoMin" => Ok(("LowestValue".to_string(), Value::Null)),
+        "max" | "autoMax" => Ok(("HighestValue".to_string(), Value::Null)),
+        other => Err(ConditionalScaleError::encoding(format!(
+            "unsupported conditional-format value kind '{other}'"
+        ))),
+    }
+}
+
+fn number_to_formula(value: Option<&Value>) -> Result<Value, ConditionalScaleError> {
+    let number = value.and_then(Value::as_f64).ok_or_else(|| {
+        ConditionalScaleError::encoding("numeric conditional-format value is invalid")
+    })?;
+    if !number.is_finite() {
+        return Err(ConditionalScaleError::encoding(
+            "numeric conditional-format value is not finite",
+        ));
+    }
+    Ok(Value::String(format_f64(number)))
+}
+
+fn criterion_to_point(
+    criterion: &Value,
+    fallback_color: String,
+    family: CriterionFamily,
+) -> Result<Value, ConditionalScaleError> {
+    let object = criterion.as_object().ok_or_else(|| {
+        ConditionalScaleError::invalid("conditional-format criterion must be an object")
+    })?;
+    let kind = object.get("type").and_then(Value::as_str).ok_or_else(|| {
+        ConditionalScaleError::invalid("conditional-format criterion.type is required")
+    })?;
+    let value = office_criterion_value(object.get("formula"), kind, family)?;
+    let color = object
+        .get("color")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or(fallback_color);
+    Ok(json!({ "value": value, "color": color }))
+}
+
+fn bound_rule_to_point(
+    value: &Value,
+    lower: bool,
+    color: String,
+) -> Result<Value, ConditionalScaleError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| ConditionalScaleError::invalid("data bar bound rule must be an object"))?;
+    let kind = object
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ConditionalScaleError::invalid("data bar bound rule.type is required"))?;
+    let effective_kind = if kind == "Automatic" {
+        if lower { "LowestValue" } else { "HighestValue" }
+    } else {
+        kind
+    };
+    let value = office_criterion_value(
+        object.get("formula"),
+        effective_kind,
+        CriterionFamily::DataBar,
+    )?;
+    Ok(json!({ "value": value, "color": color }))
+}
+
+fn office_criterion_value(
+    formula: Option<&Value>,
+    kind: &str,
+    family: CriterionFamily,
+) -> Result<Value, ConditionalScaleError> {
+    let value_kind = match kind {
+        "LowestValue" => "min",
+        "HighestValue" => "max",
+        "Number" => "num",
+        "Percent" => "percent",
+        "Percentile" => "percentile",
+        "Formula" => "formula",
+        "Automatic" if matches!(family, CriterionFamily::DataBar) => "min",
+        "Invalid" => {
+            return Err(ConditionalScaleError::invalid(
+                "Invalid is not a usable conditional-format criterion type",
+            ));
+        }
+        other => {
+            return Err(ConditionalScaleError::invalid(format!(
+                "Unsupported conditional-format criterion type '{other}'"
+            )));
+        }
+    };
+
+    match value_kind {
+        "min" => Ok(json!({ "kind": "min" })),
+        "max" => Ok(json!({ "kind": "max" })),
+        "formula" => Ok(json!({
+            "kind": "formula",
+            "source": required_string_value(formula, "formula")?,
+        })),
+        "num" | "percent" | "percentile" => {
+            let raw = required_string_value(formula, "formula")?;
+            let raw = raw.as_str().unwrap_or_default().trim();
+            let raw = raw.strip_prefix('=').unwrap_or(raw).trim();
+            let number = raw.parse::<f64>().map_err(|_| {
+                ConditionalScaleError::invalid(format!(
+                    "conditional-format {kind} formula must be numeric"
+                ))
+            })?;
+            if !number.is_finite() {
+                return Err(ConditionalScaleError::invalid(
+                    "conditional-format numeric formula must be finite",
+                ));
+            }
+            Ok(json!({ "kind": value_kind, "value": number }))
+        }
+        _ => Err(ConditionalScaleError::encoding(
+            "unhandled conditional-format value kind",
+        )),
+    }
+}
+
+fn positive_format(payload: &Map<String, Value>) -> Result<Value, ConditionalScaleError> {
+    Ok(json!({
+        "borderColor": string_or_default(payload, "borderColor"),
+        "fillColor": string_or_default(payload, "positiveColor"),
+        "gradientFill": payload.get("gradient").and_then(Value::as_bool).unwrap_or(true),
+    }))
+}
+
+fn negative_format(payload: &Map<String, Value>) -> Result<Value, ConditionalScaleError> {
+    Ok(json!({
+        "borderColor": string_or_default(payload, "negativeBorderColor"),
+        "fillColor": string_or_default(payload, "negativeColor"),
+        "matchPositiveBorderColor": payload.get("matchPositiveBorderColor").and_then(Value::as_bool).unwrap_or(false),
+        "matchPositiveFillColor": payload.get("matchPositiveFillColor").and_then(Value::as_bool).unwrap_or(false),
+    }))
+}
+
+fn apply_positive_format(
+    payload: &mut Map<String, Value>,
+    value: &Value,
+) -> Result<(), ConditionalScaleError> {
+    let object = value.as_object().ok_or_else(|| {
+        ConditionalScaleError::invalid("DataBar.positiveFormat must be an object")
+    })?;
+    for (name, value) in object {
+        match name.as_str() {
+            "borderColor" => {
+                payload.insert("borderColor".to_string(), optional_color(value, name)?);
+            }
+            "fillColor" => {
+                payload.insert("positiveColor".to_string(), string_value(value, name)?);
+            }
+            "gradientFill" => {
+                payload.insert("gradient".to_string(), bool_value(value, name)?.into());
+            }
+            other => {
+                return Err(ConditionalScaleError::invalid(format!(
+                    "Unsupported DataBar.positiveFormat property '{other}'"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn apply_negative_format(
+    payload: &mut Map<String, Value>,
+    value: &Value,
+) -> Result<(), ConditionalScaleError> {
+    let object = value.as_object().ok_or_else(|| {
+        ConditionalScaleError::invalid("DataBar.negativeFormat must be an object")
+    })?;
+    for (name, value) in object {
+        match name.as_str() {
+            "borderColor" => {
+                payload.insert(
+                    "negativeBorderColor".to_string(),
+                    optional_color(value, name)?,
+                );
+            }
+            "fillColor" => {
+                payload.insert("negativeColor".to_string(), optional_color(value, name)?);
+            }
+            "matchPositiveBorderColor" => {
+                payload.insert(
+                    "matchPositiveBorderColor".to_string(),
+                    bool_value(value, name)?.into(),
+                );
+            }
+            "matchPositiveFillColor" => {
+                payload.insert(
+                    "matchPositiveFillColor".to_string(),
+                    bool_value(value, name)?.into(),
+                );
+            }
+            other => {
+                return Err(ConditionalScaleError::invalid(format!(
+                    "Unsupported DataBar.negativeFormat property '{other}'"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn icon_criteria(payload: &Map<String, Value>) -> Result<Value, ConditionalScaleError> {
+    let style = payload
+        .get("iconSetName")
+        .or_else(|| payload.get("style"))
+        .and_then(Value::as_str)
+        .unwrap_or("3TrafficLights1");
+    let expected = icon_count(style);
+    let thresholds = payload
+        .get("thresholds")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let custom_icons = payload
+        .get("customIcons")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let has_baseline =
+        thresholds.len() == expected && thresholds.first().is_some_and(is_zero_baseline);
+
+    let mut criteria = Vec::new();
+    if has_baseline {
+        for (index, threshold) in thresholds.iter().enumerate() {
+            criteria.push(icon_criterion(threshold, custom_icons.get(index))?);
+        }
+    } else if thresholds.is_empty() {
+        criteria.push(json!({
+            "formula": "=0",
+            "operator": "GreaterThanOrEqual",
+            "type": "Percent",
+            "customIcon": custom_icon_to_office(custom_icons.first()),
+        }));
+        for index in 1..expected {
+            let pct = (index as f64 / expected as f64 * 100.0).round();
+            criteria.push(json!({
+                "formula": format!("={}", format_f64(pct)),
+                "operator": "GreaterThanOrEqual",
+                "type": "Percent",
+                "customIcon": custom_icon_to_office(custom_icons.get(index)),
+            }));
+        }
+    } else {
+        criteria.push(json!({
+            "formula": "=0",
+            "operator": "GreaterThanOrEqual",
+            "type": "Percent",
+            "customIcon": custom_icon_to_office(custom_icons.first()),
+        }));
+        for (index, threshold) in thresholds.iter().enumerate() {
+            criteria.push(icon_criterion(threshold, custom_icons.get(index + 1))?);
+        }
+    }
+    Ok(Value::Array(criteria))
+}
+
+fn icon_criterion(
+    threshold: &Value,
+    custom_icon: Option<&Value>,
+) -> Result<Value, ConditionalScaleError> {
+    let object = threshold
+        .as_object()
+        .ok_or_else(|| ConditionalScaleError::encoding("icon threshold is not an object"))?;
+    let value_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("percent");
+    let kind = office_icon_type(value_type);
+    let formula = match object.get("value") {
+        Some(Value::String(value)) if kind == "Formula" => value.clone(),
+        Some(Value::String(value)) => format!("={value}"),
+        Some(Value::Number(value)) => format!("={value}"),
+        _ => "=0".to_string(),
+    };
+    Ok(json!({
+        "formula": formula,
+        "operator": if object.get("gte").and_then(Value::as_bool).unwrap_or(true) { "GreaterThanOrEqual" } else { "GreaterThan" },
+        "type": kind,
+        "customIcon": custom_icon_to_office(custom_icon),
+    }))
+}
+
+fn criterion_to_icon_threshold(value: &Value) -> Result<Value, ConditionalScaleError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| ConditionalScaleError::invalid("IconSet criterion must be an object"))?;
+    let kind = object
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ConditionalScaleError::invalid("IconSet criterion.type is required"))?;
+    let internal = icon_type_to_internal(kind).ok_or_else(|| {
+        ConditionalScaleError::invalid(format!("Unsupported IconSet criterion type '{kind}'"))
+    })?;
+    let formula = object
+        .get("formula")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ConditionalScaleError::invalid("IconSet criterion.formula is required"))?;
+    let raw = if internal == "formula" {
+        Value::String(formula.to_string())
+    } else {
+        let stripped = formula.trim().strip_prefix('=').unwrap_or(formula.trim());
+        let number = stripped.parse::<f64>().map_err(|_| {
+            ConditionalScaleError::invalid(format!(
+                "IconSet criterion formula '{formula}' must be numeric for type {kind}"
+            ))
+        })?;
+        if !number.is_finite() {
+            return Err(ConditionalScaleError::invalid(
+                "IconSet criterion formula must be finite",
+            ));
+        }
+        Value::String(format_f64(number))
+    };
+    let operator = object
+        .get("operator")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ConditionalScaleError::invalid("IconSet criterion.operator is required"))?;
+    let gte = match operator {
+        "GreaterThanOrEqual" => true,
+        "GreaterThan" => false,
+        other => {
+            return Err(ConditionalScaleError::invalid(format!(
+                "Unsupported IconSet criterion.operator '{other}'"
+            )));
+        }
+    };
+    Ok(json!({ "type": internal, "value": raw, "gte": gte }))
+}
+
+fn icon_from_criterion(value: &Value) -> Result<Value, ConditionalScaleError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| ConditionalScaleError::invalid("IconSet criterion must be an object"))?;
+    let Some(icon) = object.get("customIcon") else {
+        return Ok(Value::Null);
+    };
+    if icon.is_null() {
+        return Ok(Value::Null);
+    }
+    let icon = icon
+        .as_object()
+        .ok_or_else(|| ConditionalScaleError::invalid("IconSet customIcon must be an object"))?;
+    let set = icon
+        .get("set")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ConditionalScaleError::invalid("IconSet customIcon.set is required"))?;
+    let index = icon.get("index").and_then(Value::as_u64).ok_or_else(|| {
+        ConditionalScaleError::invalid("IconSet customIcon.index must be a non-negative integer")
+    })?;
+    let icon_set = office_icon_style_to_internal(set).ok_or_else(|| {
+        ConditionalScaleError::invalid(format!("Unsupported IconSet customIcon.set '{set}'"))
+    })?;
+    Ok(json!({ "iconSet": icon_set, "iconId": index }))
+}
+
+fn custom_icon_to_office(value: Option<&Value>) -> Value {
+    let Some(object) = value.and_then(Value::as_object) else {
+        return Value::Null;
+    };
+    let Some(set) = object.get("iconSet").and_then(Value::as_str) else {
+        return Value::Null;
+    };
+    let index = object.get("iconId").cloned().unwrap_or_else(|| json!(0));
+    json!({ "set": icon_style_token(Some(set)), "index": index })
+}
+
+fn is_zero_baseline(value: &Value) -> bool {
+    value
+        .as_object()
+        .and_then(|object| object.get("value"))
+        .and_then(Value::as_str)
+        .is_some_and(|value| value.trim().trim_start_matches('=').parse::<f64>().ok() == Some(0.0))
+}
+
+fn icon_type_to_internal(value: &str) -> Option<&'static str> {
+    match value {
+        "Number" => Some("num"),
+        "Percent" => Some("percent"),
+        "Formula" => Some("formula"),
+        "Percentile" => Some("percentile"),
+        _ => None,
+    }
+}
+
+fn office_icon_type(value: &str) -> &'static str {
+    match value {
+        "num" => "Number",
+        "formula" => "Formula",
+        "percentile" => "Percentile",
+        _ => "Percent",
+    }
+}
+
+fn icon_count(style: &str) -> usize {
+    if style.starts_with('3') {
+        3
+    } else if style.starts_with('4') {
+        4
+    } else if style.starts_with('5') {
+        5
+    } else {
+        3
+    }
+}
+
+fn axis_format_token(value: Option<&str>) -> &'static str {
+    match value.unwrap_or("automatic") {
+        "none" | "None" => "None",
+        "middle" | "midpoint" | "CellMidPoint" => "CellMidPoint",
+        _ => "Automatic",
+    }
+}
+
+fn bar_direction_token(value: Option<&str>) -> &'static str {
+    match value.unwrap_or("context") {
+        "leftToRight" | "LeftToRight" => "LeftToRight",
+        "rightToLeft" | "RightToLeft" => "RightToLeft",
+        _ => "Context",
+    }
+}
+
+fn icon_style_token(value: Option<&str>) -> &'static str {
+    match value.unwrap_or("3TrafficLights1") {
+        "3Arrows" => "ThreeArrows",
+        "3ArrowsGray" => "ThreeArrowsGray",
+        "3Flags" => "ThreeFlags",
+        "3TrafficLights1" => "ThreeTrafficLights1",
+        "3TrafficLights2" => "ThreeTrafficLights2",
+        "3Signs" => "ThreeSigns",
+        "3Symbols" => "ThreeSymbols",
+        "3Symbols2" => "ThreeSymbols2",
+        "4Arrows" => "FourArrows",
+        "4ArrowsGray" => "FourArrowsGray",
+        "4RedToBlack" => "FourRedToBlack",
+        "4Rating" => "FourRating",
+        "4TrafficLights" => "FourTrafficLights",
+        "5Arrows" => "FiveArrows",
+        "5ArrowsGray" => "FiveArrowsGray",
+        "5Rating" => "FiveRating",
+        "5Quarters" => "FiveQuarters",
+        "3Stars" => "ThreeStars",
+        "3Triangles" => "ThreeTriangles",
+        "5Boxes" => "FiveBoxes",
+        "ThreeArrows" => "ThreeArrows",
+        "ThreeArrowsGray" => "ThreeArrowsGray",
+        "ThreeFlags" => "ThreeFlags",
+        "ThreeTrafficLights1" => "ThreeTrafficLights1",
+        "ThreeTrafficLights2" => "ThreeTrafficLights2",
+        "ThreeSigns" => "ThreeSigns",
+        "ThreeSymbols" => "ThreeSymbols",
+        "ThreeSymbols2" => "ThreeSymbols2",
+        "FourArrows" => "FourArrows",
+        "FourArrowsGray" => "FourArrowsGray",
+        "FourRedToBlack" => "FourRedToBlack",
+        "FourRating" => "FourRating",
+        "FourTrafficLights" => "FourTrafficLights",
+        "FiveArrows" => "FiveArrows",
+        "FiveArrowsGray" => "FiveArrowsGray",
+        "FiveRating" => "FiveRating",
+        "FiveQuarters" => "FiveQuarters",
+        "ThreeStars" => "ThreeStars",
+        "ThreeTriangles" => "ThreeTriangles",
+        "FiveBoxes" => "FiveBoxes",
+        _ => "Invalid",
+    }
+}
+
+fn office_icon_style_to_internal(value: &str) -> Option<&'static str> {
+    Some(match value {
+        "Invalid" => "NoIcons",
+        "ThreeArrows" => "3Arrows",
+        "ThreeArrowsGray" => "3ArrowsGray",
+        "ThreeFlags" => "3Flags",
+        "ThreeTrafficLights1" => "3TrafficLights1",
+        "ThreeTrafficLights2" => "3TrafficLights2",
+        "ThreeSigns" => "3Signs",
+        "ThreeSymbols" => "3Symbols",
+        "ThreeSymbols2" => "3Symbols2",
+        "FourArrows" => "4Arrows",
+        "FourArrowsGray" => "4ArrowsGray",
+        "FourRedToBlack" => "4RedToBlack",
+        "FourRating" => "4Rating",
+        "FourTrafficLights" => "4TrafficLights",
+        "FiveArrows" => "5Arrows",
+        "FiveArrowsGray" => "5ArrowsGray",
+        "FiveRating" => "5Rating",
+        "FiveQuarters" => "5Quarters",
+        "ThreeStars" => "3Stars",
+        "ThreeTriangles" => "3Triangles",
+        "FiveBoxes" => "5Boxes",
+        _ => return None,
+    })
+}
+
+fn point_color(point: Option<&Value>) -> Option<String> {
+    point
+        .and_then(Value::as_object)
+        .and_then(|object| object.get("color"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn string_or_default(payload: &Map<String, Value>, name: &str) -> Value {
+    payload
+        .get(name)
+        .filter(|value| value.is_string())
+        .cloned()
+        .unwrap_or_else(|| json!(""))
+}
+
+fn enum_string<'a>(value: &'a Value, property: &str) -> Result<&'a str, ConditionalScaleError> {
+    value.as_str().ok_or_else(|| {
+        ConditionalScaleError::invalid(format!("{property} must be a string enum value"))
+    })
+}
+
+fn string_value(value: &Value, property: &str) -> Result<Value, ConditionalScaleError> {
+    value
+        .as_str()
+        .map(|value| Value::String(value.to_string()))
+        .ok_or_else(|| ConditionalScaleError::invalid(format!("{property} must be a string")))
+}
+
+fn optional_color(value: &Value, property: &str) -> Result<Value, ConditionalScaleError> {
+    if value.is_null() {
+        return Ok(Value::Null);
+    }
+    string_value(value, property)
+}
+
+fn bool_value(value: &Value, property: &str) -> Result<bool, ConditionalScaleError> {
+    value
+        .as_bool()
+        .ok_or_else(|| ConditionalScaleError::invalid(format!("{property} must be a boolean")))
+}
+
+fn required_string_value(
+    value: Option<&Value>,
+    property: &str,
+) -> Result<Value, ConditionalScaleError> {
+    let value = value
+        .and_then(Value::as_str)
+        .ok_or_else(|| ConditionalScaleError::invalid(format!("{property} must be a string")))?;
+    if value.is_empty() {
+        return Err(ConditionalScaleError::invalid(format!(
+            "{property} cannot be empty"
+        )));
+    }
+    Ok(Value::String(value.to_string()))
+}
+
+fn format_f64(value: f64) -> String {
+    if value.is_finite() && value.fract() == 0.0 && value.abs() < 1e16 {
+        format!("{}", value as i64)
+    } else {
+        value.to_string()
+    }
+}
+
+fn required_string(value: &Value, property: &str) -> Result<String, BatchError> {
+    value
+        .get(property)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| batch_invalid(format!("conditional-format child requires {property}")))
+}
+
+fn batch_invalid(message: impl Into<String>) -> BatchError {
+    BatchError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn scale_error(error: ConditionalScaleError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}

--- a/compute/officejs/src/context.rs
+++ b/compute/officejs/src/context.rs
@@ -1,0 +1,503 @@
+//! Host-side support for the `ClientRequestContext` recursive-load action.
+//!
+//! The JavaScript request context owns the Office.js query-option parser and
+//! emits one bounded `loadRecursive` operation.  This module owns the host
+//! side of that operation: it applies the normalized per-type projections to
+//! already-bound object IDs and respects the depth attached to each cached
+//! target.  It deliberately does not walk arbitrary proxy fields.  The
+//! central host can add object-family target discovery later without changing
+//! the wire or this bounded dispatcher.
+
+use std::collections::HashMap;
+
+use compute_api::{CellAddress, CellRange, Sheet};
+use serde_json::{json, Value};
+use value_types::CellValue;
+
+use crate::dispatch::{ExtensionHandler, HostDispatchContext};
+use crate::format::FormatError;
+use crate::host::{BatchError, RangeRef};
+use crate::range_content;
+use crate::range_navigation::{parse_range_address, RangeAddress};
+use crate::worksheets::WorksheetError;
+
+/// Register the request-context handler with a host.  The host owner calls
+/// this while assembling the extension registry, before script batches run.
+pub(crate) fn register(host: &crate::host::Host) {
+    host.register_extension(ContextHandler);
+}
+
+/// Dispatches the request-context operation that is outside the core `Op`
+/// enum.  Trace actions remain owned by the central host loop because their
+/// response timing spans every operation in a batch.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct ContextHandler;
+
+impl ExtensionHandler for ContextHandler {
+    fn can_handle(&self, operation: &str) -> bool {
+        operation == "loadRecursive"
+    }
+
+    fn handle(
+        &self,
+        operation: &Value,
+        context: &mut HostDispatchContext<'_>,
+    ) -> Result<bool, BatchError> {
+        let id = required_string(operation, "id")?;
+        let queries = operation
+            .get("queries")
+            .and_then(Value::as_object)
+            .ok_or_else(|| invalid("loadRecursive requires a queries object"))?;
+        let max_depth = parse_max_depth(operation.get("maxDepth"))?;
+        let targets = parse_targets(operation.get("targets"))?;
+        let root_type = infer_root_type(context, &id);
+
+        for (type_name, raw_query) in queries {
+            let query = QuerySpec::parse(raw_query, type_name)?;
+            let target_list = target_ids_for_type(&targets, type_name, &id, root_type);
+            if target_list.is_empty() {
+                // A type with no materialized target is not a successful
+                // recursive load.  Returning an explicit capability error
+                // prevents a later property read from looking loaded when no
+                // host object was hydrated.
+                return Err(unsupported_type(type_name));
+            }
+            for target in target_list {
+                if max_depth.is_some_and(|limit| target.depth > limit) {
+                    continue;
+                }
+                match type_name {
+                    "Range" => load_range(context, &target.id, &query)?,
+                    "RangeFormat" => load_range_format(context, &target.id, &query)?,
+                    "Worksheet" => load_worksheet(context, &target.id, &query)?,
+                    _ => return Err(unsupported_type(type_name)),
+                }
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct QuerySpec {
+    select: Vec<String>,
+    expand: Vec<String>,
+}
+
+impl QuerySpec {
+    fn parse(value: &Value, type_name: &str) -> Result<Self, BatchError> {
+        let object = value.as_object().ok_or_else(|| {
+            invalid(format!(
+                "loadRecursive query for {type_name} must be a normalized object"
+            ))
+        })?;
+
+        let select = parse_property_list(object.get("Select"), type_name, "Select")?;
+        let expand = parse_property_list(object.get("Expand"), type_name, "Expand")?;
+        for key in object.keys() {
+            if !matches!(key.as_str(), "Select" | "Expand" | "Top" | "Skip") {
+                return Err(invalid(format!(
+                    "loadRecursive query for {type_name} contains unsupported key '{key}'"
+                )));
+            }
+            if matches!(key.as_str(), "Top" | "Skip") && !object[key].is_number() {
+                return Err(invalid(format!(
+                    "loadRecursive query {type_name}.{key} must be a number"
+                )));
+            }
+        }
+
+        Ok(Self { select, expand })
+    }
+
+    fn selected(&self, name: &str) -> bool {
+        self.select.iter().any(|property| property == name)
+    }
+
+    fn selected_paths(&self, prefix: &str) -> Vec<String> {
+        let prefix = format!("{prefix}/");
+        self.select
+            .iter()
+            .filter_map(|property| property.strip_prefix(&prefix).map(str::to_owned))
+            .collect()
+    }
+}
+
+fn parse_property_list(
+    value: Option<&Value>,
+    type_name: &str,
+    property: &str,
+) -> Result<Vec<String>, BatchError> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    match value {
+        Value::String(value) => Ok(vec![value.clone()]),
+        Value::Array(values) => values
+            .iter()
+            .map(|value| {
+                value.as_str().map(str::to_owned).ok_or_else(|| {
+                    invalid(format!(
+                        "loadRecursive query {type_name}.{property} must contain strings"
+                    ))
+                })
+            })
+            .collect(),
+        _ => Err(invalid(format!(
+            "loadRecursive query {type_name}.{property} must be a string or array"
+        ))),
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Target {
+    id: String,
+    depth: u32,
+}
+
+fn parse_targets(value: Option<&Value>) -> Result<HashMap<String, Vec<Target>>, BatchError> {
+    let Some(value) = value else {
+        return Ok(HashMap::new());
+    };
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid("loadRecursive targets must be an object"))?;
+    let mut targets = HashMap::new();
+    for (type_name, entries) in object {
+        let entries = entries.as_array().ok_or_else(|| {
+            invalid(format!(
+                "loadRecursive targets.{type_name} must be an array"
+            ))
+        })?;
+        let mut parsed = Vec::with_capacity(entries.len());
+        for entry in entries {
+            let (id, depth) = match entry {
+                Value::String(id) => (id.clone(), 0),
+                Value::Object(entry) => {
+                    let id = entry
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| invalid("loadRecursive target is missing an id"))?;
+                    let depth = entry
+                        .get("depth")
+                        .and_then(|value| {
+                            value.as_u64().and_then(|depth| u32::try_from(depth).ok())
+                        })
+                        .unwrap_or(0);
+                    (id.to_owned(), depth)
+                }
+                _ => return Err(invalid("loadRecursive target must be a string or object")),
+            };
+            parsed.push(Target { id, depth });
+        }
+        targets.insert(type_name.clone(), parsed);
+    }
+    Ok(targets)
+}
+
+fn parse_max_depth(value: Option<&Value>) -> Result<Option<u32>, BatchError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let depth = value
+        .as_u64()
+        .and_then(|depth| u32::try_from(depth).ok())
+        .ok_or_else(|| invalid("loadRecursive maxDepth must be a non-negative integer"))?;
+    Ok(Some(depth))
+}
+
+fn target_ids_for_type(
+    targets: &HashMap<String, Vec<Target>>,
+    type_name: &str,
+    root_id: &str,
+    root_type: Option<&str>,
+) -> Vec<Target> {
+    if let Some(targets) = targets.get(type_name) {
+        return targets.clone();
+    }
+    if root_type == Some(type_name) {
+        return vec![Target {
+            id: root_id.to_owned(),
+            depth: 0,
+        }];
+    }
+    Vec::new()
+}
+
+fn infer_root_type(context: &HostDispatchContext<'_>, id: &str) -> Option<&'static str> {
+    // The returned string literals are static; keeping this probe in one
+    // place makes the unsupported-family boundary obvious.
+    if context.range(id).is_ok() {
+        return Some("Range");
+    }
+    if context.format(id).is_ok() {
+        return Some("RangeFormat");
+    }
+    if context.worksheet(id).is_ok() {
+        return Some("Worksheet");
+    }
+    None
+}
+
+fn load_range(
+    context: &mut HostDispatchContext<'_>,
+    id: &str,
+    query: &QuerySpec,
+) -> Result<(), BatchError> {
+    let range = context.range(id)?;
+    if range.is_null_object() {
+        if query
+            .select
+            .iter()
+            .all(|property| property == "isNullObject")
+        {
+            context.set_loaded(id, "isNullObject", Value::Bool(true));
+            return Ok(());
+        }
+        return Err(BatchError {
+            code: "InvalidObjectPath",
+            message: "Range properties cannot be loaded from a null object".to_string(),
+        });
+    }
+
+    let parsed = parsed_range(&range)?;
+    let unbounded = parsed.is_whole_sheet() || parsed.is_entire_row() || parsed.is_entire_column();
+    let mut loaded = HashMap::new();
+    for property in &query.select {
+        if property.contains('/') || property == "format" {
+            continue;
+        }
+        let value = match property.as_str() {
+            "isNullObject" => Value::Bool(false),
+            "address" => Value::String(range_address(&range, &parsed)?),
+            "rowIndex" => json!(parsed.bounds().0),
+            "columnIndex" => json!(parsed.bounds().1),
+            "rowCount" => json!(parsed.row_count()),
+            "columnCount" => json!(parsed.column_count()),
+            "cellCount" => json!(parsed.cell_count()),
+            "values" => {
+                if unbounded {
+                    Value::Null
+                } else {
+                    range_values_json(&range.sheet(), range.address().expect("bounded range"))?
+                }
+            }
+            "formulas" => {
+                if unbounded {
+                    Value::Null
+                } else {
+                    range_formulas_json(&range.sheet(), range.address().expect("bounded range"))?
+                }
+            }
+            "numberFormat" | "text" | "valueTypes" => {
+                if unbounded {
+                    Value::Null
+                } else {
+                    range_content::load(
+                        &range.sheet(),
+                        range.address().expect("bounded range"),
+                        std::slice::from_ref(property),
+                    )
+                    .map_err(range_content_error)?
+                    .remove(property)
+                    .unwrap_or(Value::Null)
+                }
+            }
+            other => return Err(unsupported_property("Range", other)),
+        };
+        loaded.insert(property.clone(), value);
+    }
+    context.extend_loaded(id, loaded);
+    load_nested_format(context, &range, query)
+}
+
+fn load_nested_format(
+    context: &mut HostDispatchContext<'_>,
+    _range: &RangeRef,
+    query: &QuerySpec,
+) -> Result<(), BatchError> {
+    // The JavaScript side includes cached navigation IDs in `targets`.  The
+    // handler processes RangeFormat through its own query entry, so this
+    // helper only documents the select-path case and leaves target discovery
+    // to the host registry.
+    let _ = query.expand.iter().any(|property| property == "format");
+    let _ = query.selected_paths("format");
+    let _ = context;
+    Ok(())
+}
+
+fn load_range_format(
+    context: &mut HostDispatchContext<'_>,
+    id: &str,
+    query: &QuerySpec,
+) -> Result<(), BatchError> {
+    let format = context.format(id)?;
+    let properties: Vec<String> = query
+        .select
+        .iter()
+        .filter(|property| property.as_str() != "isNullObject" && !property.contains('/'))
+        .cloned()
+        .collect();
+    let mut loaded = format.load(&properties).map_err(format_error)?;
+    if query.selected("isNullObject") {
+        loaded.insert("isNullObject".to_string(), Value::Bool(false));
+    }
+    context.extend_loaded(id, loaded);
+    Ok(())
+}
+
+fn load_worksheet(
+    context: &mut HostDispatchContext<'_>,
+    id: &str,
+    query: &QuerySpec,
+) -> Result<(), BatchError> {
+    let worksheet = context.worksheet(id)?;
+    let properties: Vec<String> = query
+        .select
+        .iter()
+        .filter(|property| !property.contains('/'))
+        .cloned()
+        .collect();
+    let loaded = worksheet.load(&properties).map_err(worksheet_error)?;
+    context.extend_loaded(id, loaded);
+    Ok(())
+}
+
+fn parsed_range(range: &RangeRef) -> Result<RangeAddress, BatchError> {
+    match range.address() {
+        Some(address) => {
+            parse_range_address(&range.sheet(), address).map_err(range_navigation_error)
+        }
+        None => Ok(RangeAddress::WholeSheet),
+    }
+}
+
+fn range_address(range: &RangeRef, parsed: &RangeAddress) -> Result<String, BatchError> {
+    let sheet_name = range.sheet().name().map_err(engine_error)?;
+    Ok(format!(
+        "{}!{}",
+        qualified_sheet_name(&sheet_name),
+        parsed.to_a1()
+    ))
+}
+
+fn qualified_sheet_name(name: &str) -> String {
+    if name
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || character == '_')
+    {
+        name.to_string()
+    } else {
+        format!("'{}'", name.replace('\'', "''"))
+    }
+}
+
+fn range_values_json(sheet: &Sheet, address: &str) -> Result<Value, BatchError> {
+    let (start_row, start_col, end_row, end_col) =
+        CellRange::from(address).resolve().map_err(engine_error)?;
+    let values = sheet
+        .get_range_values_2d(CellRange::Bounds(start_row, start_col, end_row, end_col))
+        .map_err(engine_error)?;
+    Ok(Value::Array(
+        values
+            .into_iter()
+            .map(|row| Value::Array(row.into_iter().map(cell_to_js).collect()))
+            .collect(),
+    ))
+}
+
+fn range_formulas_json(sheet: &Sheet, address: &str) -> Result<Value, BatchError> {
+    let (start_row, start_col, end_row, end_col) =
+        CellRange::from(address).resolve().map_err(engine_error)?;
+    let mut rows = Vec::new();
+    for row in start_row..=end_row {
+        let mut cells = Vec::new();
+        for column in start_col..=end_col {
+            let address = CellAddress::Position(row, column);
+            if let Some(formula) = sheet.get_formula(address.clone()).map_err(engine_error)? {
+                cells.push(Value::String(formula));
+            } else {
+                cells.push(cell_to_js(
+                    sheet.get_cell_value(address).map_err(engine_error)?,
+                ));
+            }
+        }
+        rows.push(Value::Array(cells));
+    }
+    Ok(Value::Array(rows))
+}
+
+fn cell_to_js(value: CellValue) -> Value {
+    match value {
+        CellValue::Null => Value::String(String::new()),
+        CellValue::Boolean(value) => Value::Bool(value),
+        CellValue::Number(value) => value.as_number().map_or(Value::Null, |value| json!(value)),
+        CellValue::Text(value) => Value::String(value.to_string()),
+        CellValue::Error(error, _) => Value::String(error.to_string()),
+        other => Value::String(other.to_string()),
+    }
+}
+
+fn required_string<'a>(value: &'a Value, field: &str) -> Result<&'a str, BatchError> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid(format!("loadRecursive requires string field '{field}'")))
+}
+
+fn invalid(message: impl Into<String>) -> BatchError {
+    BatchError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn unsupported_type(type_name: &str) -> BatchError {
+    BatchError {
+        code: "ApiNotFound",
+        message: format!("loadRecursive does not support the {type_name} object family"),
+    }
+}
+
+fn unsupported_property(object: &str, property: &str) -> BatchError {
+    BatchError {
+        code: "InvalidArgument",
+        message: format!("Unsupported {object} load property '{property}'"),
+    }
+}
+
+fn engine_error(error: impl std::fmt::Display) -> BatchError {
+    BatchError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn range_navigation_error(error: crate::range_navigation::RangeNavigationError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn range_content_error(error: crate::range_content::RangeContentError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn format_error(error: FormatError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn worksheet_error(error: WorksheetError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}

--- a/compute/officejs/src/dispatch.rs
+++ b/compute/officejs/src/dispatch.rs
@@ -22,7 +22,7 @@ use compute_api::Workbook;
 use serde_json::Value;
 
 use crate::format::FormatRef;
-use crate::host::{BatchError, Host, RangeRef, mark_object};
+use crate::host::{mark_object, BatchError, Host, RangeRef};
 use crate::worksheets::WorksheetRef;
 
 /// A host-side object exposed by an extension family.
@@ -337,7 +337,11 @@ impl<'a> HostDispatchContext<'a> {
         id: &str,
         properties: &[String],
     ) -> Result<(), BatchError> {
-        if self.delegated_load.replace((id.to_string(), properties.to_vec())).is_some() {
+        if self
+            .delegated_load
+            .replace((id.to_string(), properties.to_vec()))
+            .is_some()
+        {
             return Err(BatchError {
                 code: "InvalidArgument",
                 message: "A family load handler delegated properties more than once.".to_string(),
@@ -357,7 +361,7 @@ mod tests {
     use std::sync::Arc;
 
     use compute_api::Workbook;
-    use serde_json::{Value, json};
+    use serde_json::{json, Value};
 
     use super::{BatchError, ExtensionHandler, ExtensionObject, HostDispatchContext};
     use crate::host::Host;
@@ -416,7 +420,7 @@ mod tests {
         let response: Value = serde_json::from_str(&host.apply_json(
             r#"[
                     {"op":"bindTestObject","id":"test"},
-                    {"op":"load","id":"test","properties":["value"]},
+                    {"op":"load","id":"test","properties":["value","isNullObject"]},
                     {"op":"set","id":"test","property":"value","value":3}
                 ]"#,
         ))

--- a/compute/officejs/src/dispatch.rs
+++ b/compute/officejs/src/dispatch.rs
@@ -1,0 +1,429 @@
+//! Shared host extension dispatch and object binding contracts.
+//!
+//! The Office.js host is intentionally split between a small central router
+//! and independently-owned object families.  A family handler claims its
+//! operation names, performs the family-specific translation, and binds a
+//! typed object through [`HostDispatchContext`].  Once bound, the normal
+//! `load` and `set` operations are handled by the host for every family.
+//! Handlers may also claim `load` or `set`, inspect the target ID/property,
+//! and return `false` to let the existing core object path continue.  This is
+//! the hook for adding scalar members to an existing Range, Worksheet, or
+//! RangeFormat proxy without changing the central enum.
+//!
+//! Extension operation payloads are raw JSON objects with an `op` string and
+//! family-defined fields.  This keeps the central `Op` enum stable while
+//! retaining the existing wire protocol and sync ordering.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use compute_api::Workbook;
+use serde_json::Value;
+
+use crate::format::FormatRef;
+use crate::host::{BatchError, Host, RangeRef, mark_object};
+use crate::worksheets::WorksheetRef;
+
+/// A host-side object exposed by an extension family.
+///
+/// Implementors own the family-specific reference and translation to/from
+/// JSON.  The host invokes these methods for generic Office.js `load` and
+/// `set` operations after a handler has bound the object ID.
+pub(crate) trait ExtensionObject: Any + Send + Sync {
+    /// The Office.js object name used in generic null-object diagnostics.
+    fn object_type(&self) -> &'static str {
+        "Object"
+    }
+
+    /// Project the requested scalar properties into the sync response.
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError>;
+
+    /// Apply one queued property mutation.
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError>;
+}
+
+/// A host binding for an extension object ID.
+#[derive(Clone)]
+pub(crate) struct ExtensionBinding {
+    object: Option<Arc<dyn ExtensionObject>>,
+    typed: Option<Arc<dyn Any + Send + Sync>>,
+    is_null_object: bool,
+}
+
+impl ExtensionBinding {
+    pub(crate) fn object<T>(object: Arc<T>) -> Self
+    where
+        T: ExtensionObject + 'static,
+    {
+        let typed: Arc<dyn Any + Send + Sync> = object.clone();
+        let object: Arc<dyn ExtensionObject> = object;
+        Self {
+            object: Some(object),
+            typed: Some(typed),
+            is_null_object: false,
+        }
+    }
+
+    pub(crate) fn null() -> Self {
+        Self {
+            object: None,
+            typed: None,
+            is_null_object: true,
+        }
+    }
+
+    pub(crate) fn is_null_object(&self) -> bool {
+        self.is_null_object
+    }
+
+    pub(crate) fn downcast<T>(&self) -> Option<Arc<T>>
+    where
+        T: Any + Send + Sync,
+    {
+        self.typed.as_ref()?.clone().downcast::<T>().ok()
+    }
+
+    pub(crate) fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        let object_name = self
+            .object
+            .as_ref()
+            .map(|object| object.object_type())
+            .unwrap_or("Object");
+        if self.is_null_object {
+            let mut result = HashMap::new();
+            for property in properties {
+                if property == "isNullObject" {
+                    result.insert(property.clone(), Value::Bool(true));
+                } else {
+                    return Err(BatchError {
+                        code: "InvalidObjectPath",
+                        message: format!(
+                            "{object_name}.{property} cannot be loaded from a null object"
+                        ),
+                    });
+                }
+            }
+            return Ok(result);
+        }
+
+        let object = self.object.as_ref().expect("non-null extension object");
+        // `isNullObject` belongs to OfficeExtension's inherited object
+        // contract.  Family objects only receive their declared properties;
+        // forwarding it would make strict family adapters reject an
+        // otherwise valid load projection.
+        let delegated_properties: Vec<String> = properties
+            .iter()
+            .filter(|property| property.as_str() != "isNullObject")
+            .cloned()
+            .collect();
+        let mut result = object.load(&delegated_properties)?;
+        if properties.iter().any(|property| property == "isNullObject") {
+            result.insert("isNullObject".to_string(), Value::Bool(false));
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        if self.is_null_object {
+            let object_name = self
+                .object
+                .as_ref()
+                .map(|object| object.object_type())
+                .unwrap_or("Object");
+            return Err(BatchError {
+                code: "InvalidObjectPath",
+                message: format!("{object_name}.{property} cannot be set on a null object"),
+            });
+        }
+        self.object
+            .as_ref()
+            .expect("non-null extension object")
+            .set(property, value)
+    }
+}
+
+/// A family handler participating in host sync dispatch.
+///
+/// `can_handle` must be deterministic and should claim only the operation
+/// names owned by the family.  Handlers are consulted in registration order;
+/// registration should therefore reject or avoid overlapping names.
+pub(crate) trait ExtensionHandler: Send + Sync {
+    fn can_handle(&self, operation: &str) -> bool;
+
+    /// Return `true` when the operation was consumed.  Returning `false`
+    /// leaves the operation for the core router or the next handler.
+    fn handle(
+        &self,
+        operation: &Value,
+        context: &mut HostDispatchContext<'_>,
+    ) -> Result<bool, BatchError>;
+}
+
+/// Registry of independently-owned family handlers.
+#[derive(Default)]
+pub(crate) struct ExtensionRegistry {
+    handlers: Mutex<Vec<Arc<dyn ExtensionHandler>>>,
+}
+
+impl ExtensionRegistry {
+    /// Register one handler.  Registration happens while a host is being
+    /// assembled, before any script batch is evaluated.
+    pub(crate) fn register<H>(&self, handler: H)
+    where
+        H: ExtensionHandler + 'static,
+    {
+        self.handlers
+            .lock()
+            .expect("extension handlers lock")
+            .push(Arc::new(handler));
+    }
+
+    /// Register a handler that is already shared by another host owner.
+    pub(crate) fn register_arc(&self, handler: Arc<dyn ExtensionHandler>) {
+        self.handlers
+            .lock()
+            .expect("extension handlers lock")
+            .push(handler);
+    }
+
+    pub(crate) fn dispatch(
+        &self,
+        operation: &Value,
+        context: &mut HostDispatchContext<'_>,
+    ) -> Result<bool, BatchError> {
+        let Some(name) = operation.get("op").and_then(Value::as_str) else {
+            return Ok(false);
+        };
+        let handlers = self
+            .handlers
+            .lock()
+            .expect("extension handlers lock")
+            .clone();
+        for handler in handlers {
+            if handler.can_handle(name) && handler.handle(operation, context)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+/// Shared context passed to a family operation handler.
+///
+/// The context deliberately exposes only stable host hooks: workbook and
+/// existing worksheet/range lookup, range/worksheet rebinding, object
+/// binding, loaded-property projection, and deferred result completion.
+pub(crate) struct HostDispatchContext<'a> {
+    host: &'a Host,
+    loaded: &'a mut HashMap<String, HashMap<String, Value>>,
+    results: &'a mut HashMap<String, Value>,
+    delegated_load: Option<(String, Vec<String>)>,
+}
+
+impl<'a> HostDispatchContext<'a> {
+    pub(crate) fn new(
+        host: &'a Host,
+        loaded: &'a mut HashMap<String, HashMap<String, Value>>,
+        results: &'a mut HashMap<String, Value>,
+    ) -> Self {
+        Self {
+            host,
+            loaded,
+            results,
+            delegated_load: None,
+        }
+    }
+
+    /// Clone the workbook handle for family engine calls.
+    pub(crate) fn workbook(&self) -> Workbook {
+        self.host.workbook()
+    }
+
+    /// Resolve an already-bound Worksheet proxy.
+    pub(crate) fn worksheet(&self, id: &str) -> Result<WorksheetRef, BatchError> {
+        self.host.lookup_worksheet(id)
+    }
+
+    /// Resolve an already-bound Range proxy.
+    pub(crate) fn range(&self, id: &str) -> Result<RangeRef, BatchError> {
+        self.host.lookup_range(id)
+    }
+
+    /// Resolve an existing RangeFormat-family binding when a new family adds
+    /// scalar properties to it.
+    pub(crate) fn format(&self, id: &str) -> Result<FormatRef, BatchError> {
+        self.host.lookup_format(id)
+    }
+
+    /// Bind a family-produced Worksheet reference and mark it present in the
+    /// current sync response.
+    pub(crate) fn bind_worksheet(&mut self, id: &str, worksheet: WorksheetRef) {
+        self.host.bind_worksheet(id, worksheet);
+        mark_object(self.loaded, id, false);
+    }
+
+    /// Bind a family-produced Range reference and mark it present in the
+    /// current sync response.  This reuses the core Range host map, so all
+    /// existing range navigation/content/format handlers can consume it.
+    pub(crate) fn bind_range(&mut self, id: &str, range: RangeRef) {
+        self.host.bind_range(id, range);
+        mark_object(self.loaded, id, false);
+    }
+
+    /// Bind a typed extension object.  Generic `load`/`set` operations are
+    /// automatically routed to its [`ExtensionObject`] implementation.
+    pub(crate) fn bind_object<T>(&mut self, id: &str, object: Arc<T>)
+    where
+        T: ExtensionObject + 'static,
+    {
+        self.host
+            .bind_extension_object(id, ExtensionBinding::object(object));
+        mark_object(self.loaded, id, false);
+    }
+
+    /// Retrieve a typed parent locator previously bound by this or another
+    /// family.  Child handlers can share one canonical object identity rather
+    /// than maintaining a parallel map keyed by proxy ID.
+    pub(crate) fn extension_object<T>(&self, id: &str) -> Result<Arc<T>, BatchError>
+    where
+        T: Any + Send + Sync,
+    {
+        self.host
+            .extension_binding(id)
+            .and_then(|binding| binding.downcast::<T>())
+            .ok_or_else(|| BatchError {
+                code: "InvalidObjectPath",
+                message: "The extension object is not available.".to_string(),
+            })
+    }
+
+    /// Bind an Office.js `OrNullObject` result.
+    pub(crate) fn bind_null_object(&mut self, id: &str) {
+        self.host
+            .bind_extension_object(id, ExtensionBinding::null());
+        mark_object(self.loaded, id, true);
+    }
+
+    /// Add one loaded property to the response for an object bound by this
+    /// or another family operation in the same batch.
+    pub(crate) fn set_loaded(&mut self, id: &str, property: &str, value: Value) {
+        self.loaded
+            .entry(id.to_string())
+            .or_default()
+            .insert(property.to_string(), value);
+    }
+
+    /// Merge a loaded-property projection into the response.
+    pub(crate) fn extend_loaded(&mut self, id: &str, properties: HashMap<String, Value>) {
+        self.loaded
+            .entry(id.to_string())
+            .or_default()
+            .extend(properties);
+    }
+
+    /// Complete a deferred `ClientResult` queued by a family proxy.
+    pub(crate) fn set_result(&mut self, result_id: &str, value: Value) {
+        self.results.insert(result_id.to_string(), value);
+    }
+
+    /// Leave selected properties of a `load` operation for the central host
+    /// loader.  A family handler can therefore project its own properties
+    /// into `loaded`, delegate the remaining properties here, and return
+    /// `true` without swallowing a mixed request such as
+    /// `Range.load(["hyperlink", "values"])`.
+    pub(crate) fn delegate_load(
+        &mut self,
+        id: &str,
+        properties: &[String],
+    ) -> Result<(), BatchError> {
+        if self.delegated_load.replace((id.to_string(), properties.to_vec())).is_some() {
+            return Err(BatchError {
+                code: "InvalidArgument",
+                message: "A family load handler delegated properties more than once.".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    pub(crate) fn take_delegated_load(&mut self) -> Option<(String, Vec<String>)> {
+        self.delegated_load.take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use compute_api::Workbook;
+    use serde_json::{Value, json};
+
+    use super::{BatchError, ExtensionHandler, ExtensionObject, HostDispatchContext};
+    use crate::host::Host;
+
+    struct TestObject;
+
+    impl ExtensionObject for TestObject {
+        fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+            if properties.iter().any(|property| property == "isNullObject") {
+                return Err(BatchError {
+                    code: "InvalidArgument",
+                    message: "isNullObject must not be delegated to a family object".to_string(),
+                });
+            }
+            Ok(properties
+                .iter()
+                .map(|property| (property.clone(), json!("loaded")))
+                .collect())
+        }
+
+        fn set(&self, _property: &str, _value: &Value) -> Result<(), BatchError> {
+            Ok(())
+        }
+    }
+
+    struct TestHandler;
+
+    impl ExtensionHandler for TestHandler {
+        fn can_handle(&self, operation: &str) -> bool {
+            operation == "bindTestObject"
+        }
+
+        fn handle(
+            &self,
+            operation: &Value,
+            context: &mut HostDispatchContext<'_>,
+        ) -> Result<bool, BatchError> {
+            let id = operation
+                .get("id")
+                .and_then(Value::as_str)
+                .ok_or_else(|| BatchError {
+                    code: "InvalidArgument",
+                    message: "bindTestObject requires an id".to_string(),
+                })?;
+            context.bind_object(id, Arc::new(TestObject));
+            Ok(true)
+        }
+    }
+
+    #[test]
+    fn extension_binding_reuses_generic_load_and_set_wire_operations() {
+        let (workbook, _) = Workbook::blank().expect("blank workbook");
+        let host = Host::new(workbook);
+        host.register_extension(TestHandler);
+
+        let response: Value = serde_json::from_str(&host.apply_json(
+            r#"[
+                    {"op":"bindTestObject","id":"test"},
+                    {"op":"load","id":"test","properties":["value"]},
+                    {"op":"set","id":"test","property":"value","value":3}
+                ]"#,
+        ))
+        .expect("valid sync response");
+
+        assert_eq!(response["error"], Value::Null);
+        assert_eq!(response["loaded"]["test"]["isNullObject"], json!(false));
+        assert_eq!(response["loaded"]["test"]["value"], json!("loaded"));
+    }
+}

--- a/compute/officejs/src/enums.js
+++ b/compute/officejs/src/enums.js
@@ -1,0 +1,2564 @@
+// Generated file. Do not edit by hand.
+// Source: @types/office-js@1.0.608 (MIT)
+// Declaration SHA-256: fbdaf0ccec04ee8e310f9ba17599c18d70da538a27dc11be1e70c58a13be1095
+// npm integrity: sha512-ik/H3UiuLCtLOm2NTQyN0kGmDPFO/VkXnqDvJ5JK3yTlxdZKLJy06G6h4GcgjWoy0190MuMiNDO501Ve20yIfw==
+// Enum names and values are copied from the pinned OfficeJS declarations.
+(function (global) {
+  "use strict";
+
+  function install(namespace, name, values) {
+    var current = namespace[name];
+    if (current === undefined || current === null) {
+      current = {};
+      namespace[name] = current;
+    }
+    // A runtime class may already use this name. Preserve its identity and
+    // add enum members only when doing so is safe and non-destructive.
+    if (typeof current !== "object" && typeof current !== "function") return;
+    for (var member in values) {
+      if (Object.prototype.hasOwnProperty.call(values, member) && !Object.prototype.hasOwnProperty.call(current, member)) {
+        current[member] = values[member];
+      }
+    }
+  }
+
+  var Excel = global.Excel || (global.Excel = {});
+  var OfficeExtension = global.OfficeExtension || (global.OfficeExtension = {});
+
+  install(Excel, "AggregationFunction", {
+    "unknown": "Unknown",
+    "automatic": "Automatic",
+    "sum": "Sum",
+    "count": "Count",
+    "average": "Average",
+    "max": "Max",
+    "min": "Min",
+    "product": "Product",
+    "countNumbers": "CountNumbers",
+    "standardDeviation": "StandardDeviation",
+    "standardDeviationP": "StandardDeviationP",
+    "variance": "Variance",
+    "varianceP": "VarianceP",
+  });
+
+  install(Excel, "ArrowheadLength", {
+    "short": "Short",
+    "medium": "Medium",
+    "long": "Long",
+  });
+
+  install(Excel, "ArrowheadStyle", {
+    "none": "None",
+    "triangle": "Triangle",
+    "stealth": "Stealth",
+    "diamond": "Diamond",
+    "oval": "Oval",
+    "open": "Open",
+  });
+
+  install(Excel, "ArrowheadWidth", {
+    "narrow": "Narrow",
+    "medium": "Medium",
+    "wide": "Wide",
+  });
+
+  install(Excel, "AutoFillType", {
+    "fillDefault": "FillDefault",
+    "fillCopy": "FillCopy",
+    "fillSeries": "FillSeries",
+    "fillFormats": "FillFormats",
+    "fillValues": "FillValues",
+    "fillDays": "FillDays",
+    "fillWeekdays": "FillWeekdays",
+    "fillMonths": "FillMonths",
+    "fillYears": "FillYears",
+    "linearTrend": "LinearTrend",
+    "growthTrend": "GrowthTrend",
+    "flashFill": "FlashFill",
+  });
+
+  install(Excel, "BindingType", {
+    "range": "Range",
+    "table": "Table",
+    "text": "Text",
+  });
+
+  install(Excel, "BlockedErrorCellValueSubType", {
+    "unknown": "Unknown",
+    "dataTypeRestrictedDomain": "DataTypeRestrictedDomain",
+    "dataTypePrivacySetting": "DataTypePrivacySetting",
+    "dataTypeUnsupportedApp": "DataTypeUnsupportedApp",
+    "externalLinksGeneric": "ExternalLinksGeneric",
+    "richDataLinkDisabled": "RichDataLinkDisabled",
+    "signInError": "SignInError",
+    "noLicense": "NoLicense",
+  });
+
+  install(Excel, "BorderIndex", {
+    "edgeTop": "EdgeTop",
+    "edgeBottom": "EdgeBottom",
+    "edgeLeft": "EdgeLeft",
+    "edgeRight": "EdgeRight",
+    "insideVertical": "InsideVertical",
+    "insideHorizontal": "InsideHorizontal",
+    "diagonalDown": "DiagonalDown",
+    "diagonalUp": "DiagonalUp",
+  });
+
+  install(Excel, "BorderLineStyle", {
+    "none": "None",
+    "continuous": "Continuous",
+    "dash": "Dash",
+    "dashDot": "DashDot",
+    "dashDotDot": "DashDotDot",
+    "dot": "Dot",
+    "double": "Double",
+    "slantDashDot": "SlantDashDot",
+  });
+
+  install(Excel, "BorderWeight", {
+    "hairline": "Hairline",
+    "thin": "Thin",
+    "medium": "Medium",
+    "thick": "Thick",
+  });
+
+  install(Excel, "BuiltInStyle", {
+    "normal": "Normal",
+    "comma": "Comma",
+    "currency": "Currency",
+    "percent": "Percent",
+    "wholeComma": "WholeComma",
+    "wholeDollar": "WholeDollar",
+    "hlink": "Hlink",
+    "hlinkTrav": "HlinkTrav",
+    "note": "Note",
+    "warningText": "WarningText",
+    "emphasis1": "Emphasis1",
+    "emphasis2": "Emphasis2",
+    "emphasis3": "Emphasis3",
+    "sheetTitle": "SheetTitle",
+    "heading1": "Heading1",
+    "heading2": "Heading2",
+    "heading3": "Heading3",
+    "heading4": "Heading4",
+    "input": "Input",
+    "output": "Output",
+    "calculation": "Calculation",
+    "checkCell": "CheckCell",
+    "linkedCell": "LinkedCell",
+    "total": "Total",
+    "good": "Good",
+    "bad": "Bad",
+    "neutral": "Neutral",
+    "accent1": "Accent1",
+    "accent1_20": "Accent1_20",
+    "accent1_40": "Accent1_40",
+    "accent1_60": "Accent1_60",
+    "accent2": "Accent2",
+    "accent2_20": "Accent2_20",
+    "accent2_40": "Accent2_40",
+    "accent2_60": "Accent2_60",
+    "accent3": "Accent3",
+    "accent3_20": "Accent3_20",
+    "accent3_40": "Accent3_40",
+    "accent3_60": "Accent3_60",
+    "accent4": "Accent4",
+    "accent4_20": "Accent4_20",
+    "accent4_40": "Accent4_40",
+    "accent4_60": "Accent4_60",
+    "accent5": "Accent5",
+    "accent5_20": "Accent5_20",
+    "accent5_40": "Accent5_40",
+    "accent5_60": "Accent5_60",
+    "accent6": "Accent6",
+    "accent6_20": "Accent6_20",
+    "accent6_40": "Accent6_40",
+    "accent6_60": "Accent6_60",
+    "explanatoryText": "ExplanatoryText",
+  });
+
+  install(Excel, "BusyErrorCellValueSubType", {
+    "unknown": "Unknown",
+    "externalLinksGeneric": "ExternalLinksGeneric",
+    "loadingImage": "LoadingImage",
+  });
+
+  install(Excel, "CalcErrorCellValueSubType", {
+    "unknown": "Unknown",
+    "arrayOfArrays": "ArrayOfArrays",
+    "arrayOfRanges": "ArrayOfRanges",
+    "emptyArray": "EmptyArray",
+    "unsupportedLifting": "UnsupportedLifting",
+    "dataTableReferencedPendingFormula": "DataTableReferencedPendingFormula",
+    "tooManyCells": "TooManyCells",
+    "lambdaInCell": "LambdaInCell",
+    "tooDeeplyNested": "TooDeeplyNested",
+    "textOverflow": "TextOverflow",
+  });
+
+  install(Excel, "CalculationMode", {
+    "automatic": "Automatic",
+    "automaticExceptTables": "AutomaticExceptTables",
+    "manual": "Manual",
+  });
+
+  install(Excel, "CalculationState", {
+    "done": "Done",
+    "calculating": "Calculating",
+    "pending": "Pending",
+  });
+
+  install(Excel, "CalculationType", {
+    "recalculate": "Recalculate",
+    "full": "Full",
+    "fullRebuild": "FullRebuild",
+  });
+
+  install(Excel, "CellControlType", {
+    "unknown": "Unknown",
+    "empty": "Empty",
+    "mixed": "Mixed",
+    "checkbox": "Checkbox",
+  });
+
+  install(Excel, "CellValueType", {
+    "array": "Array",
+    "boolean": "Boolean",
+    "double": "Double",
+    "entity": "Entity",
+    "empty": "Empty",
+    "error": "Error",
+    "formattedNumber": "FormattedNumber",
+    "function": "Function",
+    "linkedEntity": "LinkedEntity",
+    "reference": "Reference",
+    "string": "String",
+    "notAvailable": "NotAvailable",
+    "webImage": "WebImage",
+  });
+
+  install(Excel, "ChartAxisCategoryType", {
+    "automatic": "Automatic",
+    "textAxis": "TextAxis",
+    "dateAxis": "DateAxis",
+  });
+
+  install(Excel, "ChartAxisDisplayUnit", {
+    "none": "None",
+    "hundreds": "Hundreds",
+    "thousands": "Thousands",
+    "tenThousands": "TenThousands",
+    "hundredThousands": "HundredThousands",
+    "millions": "Millions",
+    "tenMillions": "TenMillions",
+    "hundredMillions": "HundredMillions",
+    "billions": "Billions",
+    "trillions": "Trillions",
+    "custom": "Custom",
+  });
+
+  install(Excel, "ChartAxisGroup", {
+    "primary": "Primary",
+    "secondary": "Secondary",
+  });
+
+  install(Excel, "ChartAxisPosition", {
+    "automatic": "Automatic",
+    "maximum": "Maximum",
+    "minimum": "Minimum",
+    "custom": "Custom",
+  });
+
+  install(Excel, "ChartAxisScaleType", {
+    "linear": "Linear",
+    "logarithmic": "Logarithmic",
+  });
+
+  install(Excel, "ChartAxisTickLabelPosition", {
+    "nextToAxis": "NextToAxis",
+    "high": "High",
+    "low": "Low",
+    "none": "None",
+  });
+
+  install(Excel, "ChartAxisTickMark", {
+    "none": "None",
+    "cross": "Cross",
+    "inside": "Inside",
+    "outside": "Outside",
+  });
+
+  install(Excel, "ChartAxisTimeUnit", {
+    "days": "Days",
+    "months": "Months",
+    "years": "Years",
+  });
+
+  install(Excel, "ChartAxisType", {
+    "invalid": "Invalid",
+    "category": "Category",
+    "value": "Value",
+    "series": "Series",
+  });
+
+  install(Excel, "ChartBinType", {
+    "category": "Category",
+    "auto": "Auto",
+    "binWidth": "BinWidth",
+    "binCount": "BinCount",
+  });
+
+  install(Excel, "ChartBoxQuartileCalculation", {
+    "inclusive": "Inclusive",
+    "exclusive": "Exclusive",
+  });
+
+  install(Excel, "ChartColorScheme", {
+    "colorfulPalette1": "ColorfulPalette1",
+    "colorfulPalette2": "ColorfulPalette2",
+    "colorfulPalette3": "ColorfulPalette3",
+    "colorfulPalette4": "ColorfulPalette4",
+    "monochromaticPalette1": "MonochromaticPalette1",
+    "monochromaticPalette2": "MonochromaticPalette2",
+    "monochromaticPalette3": "MonochromaticPalette3",
+    "monochromaticPalette4": "MonochromaticPalette4",
+    "monochromaticPalette5": "MonochromaticPalette5",
+    "monochromaticPalette6": "MonochromaticPalette6",
+    "monochromaticPalette7": "MonochromaticPalette7",
+    "monochromaticPalette8": "MonochromaticPalette8",
+    "monochromaticPalette9": "MonochromaticPalette9",
+    "monochromaticPalette10": "MonochromaticPalette10",
+    "monochromaticPalette11": "MonochromaticPalette11",
+    "monochromaticPalette12": "MonochromaticPalette12",
+    "monochromaticPalette13": "MonochromaticPalette13",
+  });
+
+  install(Excel, "ChartDataLabelPosition", {
+    "invalid": "Invalid",
+    "none": "None",
+    "center": "Center",
+    "insideEnd": "InsideEnd",
+    "insideBase": "InsideBase",
+    "outsideEnd": "OutsideEnd",
+    "left": "Left",
+    "right": "Right",
+    "top": "Top",
+    "bottom": "Bottom",
+    "bestFit": "BestFit",
+    "callout": "Callout",
+  });
+
+  install(Excel, "ChartDataSourceType", {
+    "localRange": "LocalRange",
+    "externalRange": "ExternalRange",
+    "list": "List",
+    "unknown": "Unknown",
+  });
+
+  install(Excel, "ChartDisplayBlanksAs", {
+    "notPlotted": "NotPlotted",
+    "zero": "Zero",
+    "interplotted": "Interplotted",
+  });
+
+  install(Excel, "ChartErrorBarsInclude", {
+    "both": "Both",
+    "minusValues": "MinusValues",
+    "plusValues": "PlusValues",
+  });
+
+  install(Excel, "ChartErrorBarsType", {
+    "fixedValue": "FixedValue",
+    "percent": "Percent",
+    "stDev": "StDev",
+    "stError": "StError",
+    "custom": "Custom",
+  });
+
+  install(Excel, "ChartGradientStyle", {
+    "twoPhaseColor": "TwoPhaseColor",
+    "threePhaseColor": "ThreePhaseColor",
+  });
+
+  install(Excel, "ChartGradientStyleType", {
+    "extremeValue": "ExtremeValue",
+    "number": "Number",
+    "percent": "Percent",
+  });
+
+  install(Excel, "ChartLegendPosition", {
+    "invalid": "Invalid",
+    "top": "Top",
+    "bottom": "Bottom",
+    "left": "Left",
+    "right": "Right",
+    "corner": "Corner",
+    "custom": "Custom",
+  });
+
+  install(Excel, "ChartLineStyle", {
+    "none": "None",
+    "continuous": "Continuous",
+    "dash": "Dash",
+    "dashDot": "DashDot",
+    "dashDotDot": "DashDotDot",
+    "dot": "Dot",
+    "grey25": "Grey25",
+    "grey50": "Grey50",
+    "grey75": "Grey75",
+    "automatic": "Automatic",
+    "roundDot": "RoundDot",
+  });
+
+  install(Excel, "ChartMapAreaLevel", {
+    "automatic": "Automatic",
+    "dataOnly": "DataOnly",
+    "city": "City",
+    "county": "County",
+    "state": "State",
+    "country": "Country",
+    "continent": "Continent",
+    "world": "World",
+  });
+
+  install(Excel, "ChartMapLabelStrategy", {
+    "none": "None",
+    "bestFit": "BestFit",
+    "showAll": "ShowAll",
+  });
+
+  install(Excel, "ChartMapProjectionType", {
+    "automatic": "Automatic",
+    "mercator": "Mercator",
+    "miller": "Miller",
+    "robinson": "Robinson",
+    "albers": "Albers",
+  });
+
+  install(Excel, "ChartMarkerStyle", {
+    "invalid": "Invalid",
+    "automatic": "Automatic",
+    "none": "None",
+    "square": "Square",
+    "diamond": "Diamond",
+    "triangle": "Triangle",
+    "x": "X",
+    "star": "Star",
+    "dot": "Dot",
+    "dash": "Dash",
+    "circle": "Circle",
+    "plus": "Plus",
+    "picture": "Picture",
+  });
+
+  install(Excel, "ChartParentLabelStrategy", {
+    "none": "None",
+    "banner": "Banner",
+    "overlapping": "Overlapping",
+  });
+
+  install(Excel, "ChartPlotAreaPosition", {
+    "automatic": "Automatic",
+    "custom": "Custom",
+  });
+
+  install(Excel, "ChartPlotBy", {
+    "rows": "Rows",
+    "columns": "Columns",
+  });
+
+  install(Excel, "ChartSeriesBy", {
+    "auto": "Auto",
+    "columns": "Columns",
+    "rows": "Rows",
+  });
+
+  install(Excel, "ChartSeriesDimension", {
+    "categories": "Categories",
+    "values": "Values",
+    "xvalues": "XValues",
+    "yvalues": "YValues",
+    "bubbleSizes": "BubbleSizes",
+  });
+
+  install(Excel, "ChartSplitType", {
+    "splitByPosition": "SplitByPosition",
+    "splitByValue": "SplitByValue",
+    "splitByPercentValue": "SplitByPercentValue",
+    "splitByCustomSplit": "SplitByCustomSplit",
+  });
+
+  install(Excel, "ChartTextHorizontalAlignment", {
+    "center": "Center",
+    "left": "Left",
+    "right": "Right",
+    "justify": "Justify",
+    "distributed": "Distributed",
+  });
+
+  install(Excel, "ChartTextVerticalAlignment", {
+    "center": "Center",
+    "bottom": "Bottom",
+    "top": "Top",
+    "justify": "Justify",
+    "distributed": "Distributed",
+  });
+
+  install(Excel, "ChartTickLabelAlignment", {
+    "center": "Center",
+    "left": "Left",
+    "right": "Right",
+  });
+
+  install(Excel, "ChartTitlePosition", {
+    "automatic": "Automatic",
+    "top": "Top",
+    "bottom": "Bottom",
+    "left": "Left",
+    "right": "Right",
+  });
+
+  install(Excel, "ChartTrendlineType", {
+    "linear": "Linear",
+    "exponential": "Exponential",
+    "logarithmic": "Logarithmic",
+    "movingAverage": "MovingAverage",
+    "polynomial": "Polynomial",
+    "power": "Power",
+  });
+
+  install(Excel, "ChartType", {
+    "invalid": "Invalid",
+    "columnClustered": "ColumnClustered",
+    "columnStacked": "ColumnStacked",
+    "columnStacked100": "ColumnStacked100",
+    "_3DColumnClustered": "3DColumnClustered",
+    "_3DColumnStacked": "3DColumnStacked",
+    "_3DColumnStacked100": "3DColumnStacked100",
+    "barClustered": "BarClustered",
+    "barStacked": "BarStacked",
+    "barStacked100": "BarStacked100",
+    "_3DBarClustered": "3DBarClustered",
+    "_3DBarStacked": "3DBarStacked",
+    "_3DBarStacked100": "3DBarStacked100",
+    "lineStacked": "LineStacked",
+    "lineStacked100": "LineStacked100",
+    "lineMarkers": "LineMarkers",
+    "lineMarkersStacked": "LineMarkersStacked",
+    "lineMarkersStacked100": "LineMarkersStacked100",
+    "pieOfPie": "PieOfPie",
+    "pieExploded": "PieExploded",
+    "_3DPieExploded": "3DPieExploded",
+    "barOfPie": "BarOfPie",
+    "xyscatterSmooth": "XYScatterSmooth",
+    "xyscatterSmoothNoMarkers": "XYScatterSmoothNoMarkers",
+    "xyscatterLines": "XYScatterLines",
+    "xyscatterLinesNoMarkers": "XYScatterLinesNoMarkers",
+    "areaStacked": "AreaStacked",
+    "areaStacked100": "AreaStacked100",
+    "_3DAreaStacked": "3DAreaStacked",
+    "_3DAreaStacked100": "3DAreaStacked100",
+    "doughnutExploded": "DoughnutExploded",
+    "radarMarkers": "RadarMarkers",
+    "radarFilled": "RadarFilled",
+    "surface": "Surface",
+    "surfaceWireframe": "SurfaceWireframe",
+    "surfaceTopView": "SurfaceTopView",
+    "surfaceTopViewWireframe": "SurfaceTopViewWireframe",
+    "bubble": "Bubble",
+    "bubble3DEffect": "Bubble3DEffect",
+    "stockHLC": "StockHLC",
+    "stockOHLC": "StockOHLC",
+    "stockVHLC": "StockVHLC",
+    "stockVOHLC": "StockVOHLC",
+    "cylinderColClustered": "CylinderColClustered",
+    "cylinderColStacked": "CylinderColStacked",
+    "cylinderColStacked100": "CylinderColStacked100",
+    "cylinderBarClustered": "CylinderBarClustered",
+    "cylinderBarStacked": "CylinderBarStacked",
+    "cylinderBarStacked100": "CylinderBarStacked100",
+    "cylinderCol": "CylinderCol",
+    "coneColClustered": "ConeColClustered",
+    "coneColStacked": "ConeColStacked",
+    "coneColStacked100": "ConeColStacked100",
+    "coneBarClustered": "ConeBarClustered",
+    "coneBarStacked": "ConeBarStacked",
+    "coneBarStacked100": "ConeBarStacked100",
+    "coneCol": "ConeCol",
+    "pyramidColClustered": "PyramidColClustered",
+    "pyramidColStacked": "PyramidColStacked",
+    "pyramidColStacked100": "PyramidColStacked100",
+    "pyramidBarClustered": "PyramidBarClustered",
+    "pyramidBarStacked": "PyramidBarStacked",
+    "pyramidBarStacked100": "PyramidBarStacked100",
+    "pyramidCol": "PyramidCol",
+    "_3DColumn": "3DColumn",
+    "line": "Line",
+    "_3DLine": "3DLine",
+    "_3DPie": "3DPie",
+    "pie": "Pie",
+    "xyscatter": "XYScatter",
+    "_3DArea": "3DArea",
+    "area": "Area",
+    "doughnut": "Doughnut",
+    "radar": "Radar",
+    "histogram": "Histogram",
+    "boxwhisker": "Boxwhisker",
+    "pareto": "Pareto",
+    "regionMap": "RegionMap",
+    "treemap": "Treemap",
+    "waterfall": "Waterfall",
+    "sunburst": "Sunburst",
+    "funnel": "Funnel",
+  });
+
+  install(Excel, "ChartUnderlineStyle", {
+    "none": "None",
+    "single": "Single",
+  });
+
+  install(Excel, "ClearApplyTo", {
+    "all": "All",
+    "formats": "Formats",
+    "contents": "Contents",
+    "hyperlinks": "Hyperlinks",
+    "removeHyperlinks": "RemoveHyperlinks",
+    "resetContents": "ResetContents",
+  });
+
+  install(Excel, "CloseBehavior", {
+    "save": "Save",
+    "skipSave": "SkipSave",
+  });
+
+  install(Excel, "CommentChangeType", {
+    "commentEdited": "CommentEdited",
+    "commentResolved": "CommentResolved",
+    "commentReopened": "CommentReopened",
+    "replyAdded": "ReplyAdded",
+    "replyDeleted": "ReplyDeleted",
+    "replyEdited": "ReplyEdited",
+  });
+
+  install(Excel, "ConditionalCellValueOperator", {
+    "invalid": "Invalid",
+    "between": "Between",
+    "notBetween": "NotBetween",
+    "equalTo": "EqualTo",
+    "notEqualTo": "NotEqualTo",
+    "greaterThan": "GreaterThan",
+    "lessThan": "LessThan",
+    "greaterThanOrEqual": "GreaterThanOrEqual",
+    "lessThanOrEqual": "LessThanOrEqual",
+  });
+
+  install(Excel, "ConditionalDataBarAxisFormat", {
+    "automatic": "Automatic",
+    "none": "None",
+    "cellMidPoint": "CellMidPoint",
+  });
+
+  install(Excel, "ConditionalDataBarDirection", {
+    "context": "Context",
+    "leftToRight": "LeftToRight",
+    "rightToLeft": "RightToLeft",
+  });
+
+  install(Excel, "ConditionalFormatColorCriterionType", {
+    "invalid": "Invalid",
+    "lowestValue": "LowestValue",
+    "highestValue": "HighestValue",
+    "number": "Number",
+    "percent": "Percent",
+    "formula": "Formula",
+    "percentile": "Percentile",
+  });
+
+  install(Excel, "ConditionalFormatDirection", {
+    "top": "Top",
+    "bottom": "Bottom",
+  });
+
+  install(Excel, "ConditionalFormatIconRuleType", {
+    "invalid": "Invalid",
+    "number": "Number",
+    "percent": "Percent",
+    "formula": "Formula",
+    "percentile": "Percentile",
+  });
+
+  install(Excel, "ConditionalFormatPresetCriterion", {
+    "invalid": "Invalid",
+    "blanks": "Blanks",
+    "nonBlanks": "NonBlanks",
+    "errors": "Errors",
+    "nonErrors": "NonErrors",
+    "yesterday": "Yesterday",
+    "today": "Today",
+    "tomorrow": "Tomorrow",
+    "lastSevenDays": "LastSevenDays",
+    "lastWeek": "LastWeek",
+    "thisWeek": "ThisWeek",
+    "nextWeek": "NextWeek",
+    "lastMonth": "LastMonth",
+    "thisMonth": "ThisMonth",
+    "nextMonth": "NextMonth",
+    "aboveAverage": "AboveAverage",
+    "belowAverage": "BelowAverage",
+    "equalOrAboveAverage": "EqualOrAboveAverage",
+    "equalOrBelowAverage": "EqualOrBelowAverage",
+    "oneStdDevAboveAverage": "OneStdDevAboveAverage",
+    "oneStdDevBelowAverage": "OneStdDevBelowAverage",
+    "twoStdDevAboveAverage": "TwoStdDevAboveAverage",
+    "twoStdDevBelowAverage": "TwoStdDevBelowAverage",
+    "threeStdDevAboveAverage": "ThreeStdDevAboveAverage",
+    "threeStdDevBelowAverage": "ThreeStdDevBelowAverage",
+    "uniqueValues": "UniqueValues",
+    "duplicateValues": "DuplicateValues",
+  });
+
+  install(Excel, "ConditionalFormatRuleType", {
+    "invalid": "Invalid",
+    "automatic": "Automatic",
+    "lowestValue": "LowestValue",
+    "highestValue": "HighestValue",
+    "number": "Number",
+    "percent": "Percent",
+    "formula": "Formula",
+    "percentile": "Percentile",
+  });
+
+  install(Excel, "ConditionalFormatType", {
+    "custom": "Custom",
+    "dataBar": "DataBar",
+    "colorScale": "ColorScale",
+    "iconSet": "IconSet",
+    "topBottom": "TopBottom",
+    "presetCriteria": "PresetCriteria",
+    "containsText": "ContainsText",
+    "cellValue": "CellValue",
+  });
+
+  install(Excel, "ConditionalIconCriterionOperator", {
+    "invalid": "Invalid",
+    "greaterThan": "GreaterThan",
+    "greaterThanOrEqual": "GreaterThanOrEqual",
+  });
+
+  install(Excel, "ConditionalRangeBorderIndex", {
+    "edgeTop": "EdgeTop",
+    "edgeBottom": "EdgeBottom",
+    "edgeLeft": "EdgeLeft",
+    "edgeRight": "EdgeRight",
+  });
+
+  install(Excel, "ConditionalRangeBorderLineStyle", {
+    "none": "None",
+    "continuous": "Continuous",
+    "dash": "Dash",
+    "dashDot": "DashDot",
+    "dashDotDot": "DashDotDot",
+    "dot": "Dot",
+  });
+
+  install(Excel, "ConditionalRangeFontUnderlineStyle", {
+    "none": "None",
+    "single": "Single",
+    "double": "Double",
+  });
+
+  install(Excel, "ConditionalTextOperator", {
+    "invalid": "Invalid",
+    "contains": "Contains",
+    "notContains": "NotContains",
+    "beginsWith": "BeginsWith",
+    "endsWith": "EndsWith",
+  });
+
+  install(Excel, "ConditionalTopBottomCriterionType", {
+    "invalid": "Invalid",
+    "topItems": "TopItems",
+    "topPercent": "TopPercent",
+    "bottomItems": "BottomItems",
+    "bottomPercent": "BottomPercent",
+  });
+
+  install(Excel, "ConnectErrorCellValueSubType", {
+    "unknown": "Unknown",
+    "serviceError": "ServiceError",
+    "externalLinks": "ExternalLinks",
+    "externalLinksNonCloudLocation": "ExternalLinksNonCloudLocation",
+    "dataTypeNoConnection": "DataTypeNoConnection",
+    "dataTypeServiceError": "DataTypeServiceError",
+    "missingContent": "MissingContent",
+    "requestThrottle": "RequestThrottle",
+    "externalLinksFailedToRefresh": "ExternalLinksFailedToRefresh",
+    "externalLinksAccessFailed": "ExternalLinksAccessFailed",
+    "externalLinksServerError": "ExternalLinksServerError",
+    "externalLinksInvalidRequest": "ExternalLinksInvalidRequest",
+    "externalLinksUnAuthenticated": "ExternalLinksUnAuthenticated",
+    "externalLinksThrottledByHost": "ExternalLinksThrottledByHost",
+    "externalLinksFileTooLarge": "ExternalLinksFileTooLarge",
+    "outdatedLinkedEntity": "OutdatedLinkedEntity",
+    "genericServerError": "GenericServerError",
+  });
+
+  install(Excel, "ConnectorType", {
+    "straight": "Straight",
+    "elbow": "Elbow",
+    "curve": "Curve",
+  });
+
+  install(Excel, "ContentType", {
+    "plain": "Plain",
+    "mention": "Mention",
+  });
+
+  install(Excel, "DataChangeType", {
+    "unknown": "Unknown",
+    "rangeEdited": "RangeEdited",
+    "rowInserted": "RowInserted",
+    "rowDeleted": "RowDeleted",
+    "columnInserted": "ColumnInserted",
+    "columnDeleted": "ColumnDeleted",
+    "cellInserted": "CellInserted",
+    "cellDeleted": "CellDeleted",
+  });
+
+  install(Excel, "DataSourceType", {
+    "unknown": "Unknown",
+    "localRange": "LocalRange",
+    "localTable": "LocalTable",
+  });
+
+  install(Excel, "DataValidationAlertStyle", {
+    "stop": "Stop",
+    "warning": "Warning",
+    "information": "Information",
+  });
+
+  install(Excel, "DataValidationOperator", {
+    "between": "Between",
+    "notBetween": "NotBetween",
+    "equalTo": "EqualTo",
+    "notEqualTo": "NotEqualTo",
+    "greaterThan": "GreaterThan",
+    "lessThan": "LessThan",
+    "greaterThanOrEqualTo": "GreaterThanOrEqualTo",
+    "lessThanOrEqualTo": "LessThanOrEqualTo",
+  });
+
+  install(Excel, "DataValidationType", {
+    "none": "None",
+    "wholeNumber": "WholeNumber",
+    "decimal": "Decimal",
+    "list": "List",
+    "date": "Date",
+    "time": "Time",
+    "textLength": "TextLength",
+    "custom": "Custom",
+    "inconsistent": "Inconsistent",
+    "mixedCriteria": "MixedCriteria",
+  });
+
+  install(Excel, "DateFilterCondition", {
+    "unknown": "Unknown",
+    "equals": "Equals",
+    "before": "Before",
+    "beforeOrEqualTo": "BeforeOrEqualTo",
+    "after": "After",
+    "afterOrEqualTo": "AfterOrEqualTo",
+    "between": "Between",
+    "tomorrow": "Tomorrow",
+    "today": "Today",
+    "yesterday": "Yesterday",
+    "nextWeek": "NextWeek",
+    "thisWeek": "ThisWeek",
+    "lastWeek": "LastWeek",
+    "nextMonth": "NextMonth",
+    "thisMonth": "ThisMonth",
+    "lastMonth": "LastMonth",
+    "nextQuarter": "NextQuarter",
+    "thisQuarter": "ThisQuarter",
+    "lastQuarter": "LastQuarter",
+    "nextYear": "NextYear",
+    "thisYear": "ThisYear",
+    "lastYear": "LastYear",
+    "yearToDate": "YearToDate",
+    "allDatesInPeriodQuarter1": "AllDatesInPeriodQuarter1",
+    "allDatesInPeriodQuarter2": "AllDatesInPeriodQuarter2",
+    "allDatesInPeriodQuarter3": "AllDatesInPeriodQuarter3",
+    "allDatesInPeriodQuarter4": "AllDatesInPeriodQuarter4",
+    "allDatesInPeriodJanuary": "AllDatesInPeriodJanuary",
+    "allDatesInPeriodFebruary": "AllDatesInPeriodFebruary",
+    "allDatesInPeriodMarch": "AllDatesInPeriodMarch",
+    "allDatesInPeriodApril": "AllDatesInPeriodApril",
+    "allDatesInPeriodMay": "AllDatesInPeriodMay",
+    "allDatesInPeriodJune": "AllDatesInPeriodJune",
+    "allDatesInPeriodJuly": "AllDatesInPeriodJuly",
+    "allDatesInPeriodAugust": "AllDatesInPeriodAugust",
+    "allDatesInPeriodSeptember": "AllDatesInPeriodSeptember",
+    "allDatesInPeriodOctober": "AllDatesInPeriodOctober",
+    "allDatesInPeriodNovember": "AllDatesInPeriodNovember",
+    "allDatesInPeriodDecember": "AllDatesInPeriodDecember",
+  });
+
+  install(Excel, "DeleteShiftDirection", {
+    "up": "Up",
+    "left": "Left",
+  });
+
+  install(Excel, "DocumentPropertyItem", {
+    "title": "Title",
+    "subject": "Subject",
+    "author": "Author",
+    "keywords": "Keywords",
+    "comments": "Comments",
+    "template": "Template",
+    "lastAuth": "LastAuth",
+    "revision": "Revision",
+    "appName": "AppName",
+    "lastPrint": "LastPrint",
+    "creation": "Creation",
+    "lastSave": "LastSave",
+    "category": "Category",
+    "format": "Format",
+    "manager": "Manager",
+    "company": "Company",
+  });
+
+  install(Excel, "DocumentPropertyType", {
+    "number": "Number",
+    "boolean": "Boolean",
+    "date": "Date",
+    "string": "String",
+    "float": "Float",
+  });
+
+  install(Excel, "DynamicFilterCriteria", {
+    "unknown": "Unknown",
+    "aboveAverage": "AboveAverage",
+    "allDatesInPeriodApril": "AllDatesInPeriodApril",
+    "allDatesInPeriodAugust": "AllDatesInPeriodAugust",
+    "allDatesInPeriodDecember": "AllDatesInPeriodDecember",
+    "allDatesInPeriodFebruray": "AllDatesInPeriodFebruray",
+    "allDatesInPeriodJanuary": "AllDatesInPeriodJanuary",
+    "allDatesInPeriodJuly": "AllDatesInPeriodJuly",
+    "allDatesInPeriodJune": "AllDatesInPeriodJune",
+    "allDatesInPeriodMarch": "AllDatesInPeriodMarch",
+    "allDatesInPeriodMay": "AllDatesInPeriodMay",
+    "allDatesInPeriodNovember": "AllDatesInPeriodNovember",
+    "allDatesInPeriodOctober": "AllDatesInPeriodOctober",
+    "allDatesInPeriodQuarter1": "AllDatesInPeriodQuarter1",
+    "allDatesInPeriodQuarter2": "AllDatesInPeriodQuarter2",
+    "allDatesInPeriodQuarter3": "AllDatesInPeriodQuarter3",
+    "allDatesInPeriodQuarter4": "AllDatesInPeriodQuarter4",
+    "allDatesInPeriodSeptember": "AllDatesInPeriodSeptember",
+    "belowAverage": "BelowAverage",
+    "lastMonth": "LastMonth",
+    "lastQuarter": "LastQuarter",
+    "lastWeek": "LastWeek",
+    "lastYear": "LastYear",
+    "nextMonth": "NextMonth",
+    "nextQuarter": "NextQuarter",
+    "nextWeek": "NextWeek",
+    "nextYear": "NextYear",
+    "thisMonth": "ThisMonth",
+    "thisQuarter": "ThisQuarter",
+    "thisWeek": "ThisWeek",
+    "thisYear": "ThisYear",
+    "today": "Today",
+    "tomorrow": "Tomorrow",
+    "yearToDate": "YearToDate",
+    "yesterday": "Yesterday",
+  });
+
+  install(Excel, "EntityCardLayoutType", {
+    "entity": "Entity",
+  });
+
+  install(Excel, "EntityCompactLayoutIcons", {
+    "generic": "Generic",
+    "accessibility": "Accessibility",
+    "airplane": "Airplane",
+    "airplaneTakeOff": "AirplaneTakeOff",
+    "album": "Album",
+    "alert": "Alert",
+    "alertUrgent": "AlertUrgent",
+    "animal": "Animal",
+    "animalCat": "AnimalCat",
+    "animalDog": "AnimalDog",
+    "animalRabbit": "AnimalRabbit",
+    "animalTurtle": "AnimalTurtle",
+    "appFolder": "AppFolder",
+    "appGeneric": "AppGeneric",
+    "apple": "Apple",
+    "approvalsApp": "ApprovalsApp",
+    "archive": "Archive",
+    "archiveMultiple": "ArchiveMultiple",
+    "arrowTrendingLines": "ArrowTrendingLines",
+    "art": "Art",
+    "atom": "Atom",
+    "attach": "Attach",
+    "automobile": "Automobile",
+    "autosum": "Autosum",
+    "backpack": "Backpack",
+    "badge": "Badge",
+    "balloon": "Balloon",
+    "bank": "Bank",
+    "barcodeScanner": "BarcodeScanner",
+    "basketball": "Basketball",
+    "battery0": "Battery0",
+    "battery10": "Battery10",
+    "beach": "Beach",
+    "beaker": "Beaker",
+    "bed": "Bed",
+    "binFull": "BinFull",
+    "bird": "Bird",
+    "bluetooth": "Bluetooth",
+    "board": "Board",
+    "boardGames": "BoardGames",
+    "book": "Book",
+    "bookmark": "Bookmark",
+    "bookmarkMultiple": "BookmarkMultiple",
+    "bot": "Bot",
+    "bowlChopsticks": "BowlChopsticks",
+    "box": "Box",
+    "boxMultiple": "BoxMultiple",
+    "brainCircuit": "BrainCircuit",
+    "branch": "Branch",
+    "branchFork": "BranchFork",
+    "branchRequest": "BranchRequest",
+    "bridge": "Bridge",
+    "briefcase": "Briefcase",
+    "briefcaseMedical": "BriefcaseMedical",
+    "broadActivityFeed": "BroadActivityFeed",
+    "broom": "Broom",
+    "bug": "Bug",
+    "building": "Building",
+    "buildingBank": "BuildingBank",
+    "buildingFactory": "BuildingFactory",
+    "buildingGovernment": "BuildingGovernment",
+    "buildingHome": "BuildingHome",
+    "buildingLighthouse": "BuildingLighthouse",
+    "buildingMultiple": "BuildingMultiple",
+    "buildingRetail": "BuildingRetail",
+    "buildingRetailMore": "BuildingRetailMore",
+    "buildingRetailToolbox": "BuildingRetailToolbox",
+    "buildingShop": "BuildingShop",
+    "buildingSkyscraper": "BuildingSkyscraper",
+    "calculator": "Calculator",
+    "calendarLtr": "CalendarLtr",
+    "calendarRtl": "CalendarRtl",
+    "call": "Call",
+    "calligraphyPen": "CalligraphyPen",
+    "camera": "Camera",
+    "cameraDome": "CameraDome",
+    "car": "Car",
+    "cart": "Cart",
+    "cat": "Cat",
+    "certificate": "Certificate",
+    "chartMultiple": "ChartMultiple",
+    "chat": "Chat",
+    "chatMultiple": "ChatMultiple",
+    "chatVideo": "ChatVideo",
+    "check": "Check",
+    "checkboxChecked": "CheckboxChecked",
+    "checkboxUnchecked": "CheckboxUnchecked",
+    "checkmark": "Checkmark",
+    "chess": "Chess",
+    "city": "City",
+    "class": "Class",
+    "classification": "Classification",
+    "clipboard": "Clipboard",
+    "clipboardDataBar": "ClipboardDataBar",
+    "clipboardPulse": "ClipboardPulse",
+    "clipboardTask": "ClipboardTask",
+    "clock": "Clock",
+    "clockAlarm": "ClockAlarm",
+    "cloud": "Cloud",
+    "cloudWords": "CloudWords",
+    "code": "Code",
+    "collections": "Collections",
+    "comment": "Comment",
+    "commentMultiple": "CommentMultiple",
+    "communication": "Communication",
+    "compassNorthwest": "CompassNorthwest",
+    "conferenceRoom": "ConferenceRoom",
+    "connector": "Connector",
+    "constellation": "Constellation",
+    "contactCard": "ContactCard",
+    "cookies": "Cookies",
+    "couch": "Couch",
+    "creditCardPerson": "CreditCardPerson",
+    "creditCardToolbox": "CreditCardToolbox",
+    "cube": "Cube",
+    "cubeMultiple": "CubeMultiple",
+    "cubeTree": "CubeTree",
+    "currencyDollarEuro": "CurrencyDollarEuro",
+    "currencyDollarRupee": "CurrencyDollarRupee",
+    "dataArea": "DataArea",
+    "database": "Database",
+    "databaseMultiple": "DatabaseMultiple",
+    "dataFunnel": "DataFunnel",
+    "dataHistogram": "DataHistogram",
+    "dataLine": "DataLine",
+    "dataPie": "DataPie",
+    "dataScatter": "DataScatter",
+    "dataSunburst": "DataSunburst",
+    "dataTreemap": "DataTreemap",
+    "dataWaterfall": "DataWaterfall",
+    "dataWhisker": "DataWhisker",
+    "dentist": "Dentist",
+    "designIdeas": "DesignIdeas",
+    "desktop": "Desktop",
+    "desktopMac": "DesktopMac",
+    "developerBoard": "DeveloperBoard",
+    "deviceMeetingRoom": "DeviceMeetingRoom",
+    "diagram": "Diagram",
+    "dialpad": "Dialpad",
+    "diamond": "Diamond",
+    "dinosaur": "Dinosaur",
+    "directions": "Directions",
+    "disaster": "Disaster",
+    "diversity": "Diversity",
+    "dNA": "DNA",
+    "doctor": "Doctor",
+    "document": "Document",
+    "documentData": "DocumentData",
+    "documentLandscape": "DocumentLandscape",
+    "documentMultiple": "DocumentMultiple",
+    "documentPdf": "DocumentPdf",
+    "documentQueue": "DocumentQueue",
+    "documentText": "DocumentText",
+    "dog": "Dog",
+    "door": "Door",
+    "doorTag": "DoorTag",
+    "drafts": "Drafts",
+    "drama": "Drama",
+    "drinkBeer": "DrinkBeer",
+    "drinkCoffee": "DrinkCoffee",
+    "drinkMargarita": "DrinkMargarita",
+    "drinkToGo": "DrinkToGo",
+    "drinkWine": "DrinkWine",
+    "driveTrain": "DriveTrain",
+    "drop": "Drop",
+    "dualScreen": "DualScreen",
+    "dumbbell": "Dumbbell",
+    "earth": "Earth",
+    "emoji": "Emoji",
+    "emojiAngry": "EmojiAngry",
+    "emojiHand": "EmojiHand",
+    "emojiLaugh": "EmojiLaugh",
+    "emojiMeh": "EmojiMeh",
+    "emojiMultiple": "EmojiMultiple",
+    "emojiSad": "EmojiSad",
+    "emojiSadSlight": "EmojiSadSlight",
+    "emojiSmileSlight": "EmojiSmileSlight",
+    "emojiSparkle": "EmojiSparkle",
+    "emojiSurprise": "EmojiSurprise",
+    "engine": "Engine",
+    "eraser": "Eraser",
+    "eye": "Eye",
+    "eyedropper": "Eyedropper",
+    "fax": "Fax",
+    "fingerprint": "Fingerprint",
+    "firstAid": "FirstAid",
+    "flag": "Flag",
+    "flash": "Flash",
+    "flashlight": "Flashlight",
+    "flow": "Flow",
+    "flowchart": "Flowchart",
+    "folder": "Folder",
+    "folderOpen": "FolderOpen",
+    "folderOpenVertical": "FolderOpenVertical",
+    "folderPerson": "FolderPerson",
+    "folderZip": "FolderZip",
+    "food": "Food",
+    "foodApple": "FoodApple",
+    "foodCake": "FoodCake",
+    "foodEgg": "FoodEgg",
+    "foodGrains": "FoodGrains",
+    "foodPizza": "FoodPizza",
+    "foodToast": "FoodToast",
+    "galaxy": "Galaxy",
+    "games": "Games",
+    "ganttChart": "GanttChart",
+    "gas": "Gas",
+    "gasPump": "GasPump",
+    "gauge": "Gauge",
+    "gavel": "Gavel",
+    "gift": "Gift",
+    "giftCard": "GiftCard",
+    "glasses": "Glasses",
+    "globe": "Globe",
+    "globeSurface": "GlobeSurface",
+    "grid": "Grid",
+    "gridDots": "GridDots",
+    "gridKanban": "GridKanban",
+    "guardian": "Guardian",
+    "guest": "Guest",
+    "guitar": "Guitar",
+    "handLeft": "HandLeft",
+    "handRight": "HandRight",
+    "handshake": "Handshake",
+    "hardDrive": "HardDrive",
+    "hatGraduation": "HatGraduation",
+    "headphones": "Headphones",
+    "headphonesSoundWave": "HeadphonesSoundWave",
+    "headset": "Headset",
+    "headsetVr": "HeadsetVr",
+    "heart": "Heart",
+    "heartBroken": "HeartBroken",
+    "heartCircle": "HeartCircle",
+    "heartHuman": "HeartHuman",
+    "heartPulse": "HeartPulse",
+    "history": "History",
+    "home": "Home",
+    "homeMore": "HomeMore",
+    "homePerson": "HomePerson",
+    "icons": "Icons",
+    "image": "Image",
+    "imageGlobe": "ImageGlobe",
+    "imageMultiple": "ImageMultiple",
+    "iot": "Iot",
+    "joystick": "Joystick",
+    "justice": "Justice",
+    "key": "Key",
+    "keyboard": "Keyboard",
+    "keyboardLayoutSplit": "KeyboardLayoutSplit",
+    "keyMultiple": "KeyMultiple",
+    "languages": "Languages",
+    "laptop": "Laptop",
+    "lasso": "Lasso",
+    "launcherSettings": "LauncherSettings",
+    "layer": "Layer",
+    "leaf": "Leaf",
+    "leafOne": "LeafOne",
+    "leafThree": "LeafThree",
+    "leafTwo": "LeafTwo",
+    "library": "Library",
+    "lightbulb": "Lightbulb",
+    "lightbulbFilament": "LightbulbFilament",
+    "likert": "Likert",
+    "link": "Link",
+    "localLanguage": "LocalLanguage",
+    "location": "Location",
+    "lockClosed": "LockClosed",
+    "lockMultiple": "LockMultiple",
+    "lockOpen": "LockOpen",
+    "lottery": "Lottery",
+    "luggage": "Luggage",
+    "mail": "Mail",
+    "mailInbox": "MailInbox",
+    "mailMultiple": "MailMultiple",
+    "map": "Map",
+    "mapPin": "MapPin",
+    "markdown": "Markdown",
+    "mathFormula": "MathFormula",
+    "mathSymbols": "MathSymbols",
+    "max": "Max",
+    "megaphone": "Megaphone",
+    "megaphoneLoud": "MegaphoneLoud",
+    "mention": "Mention",
+    "mic": "Mic",
+    "microscope": "Microscope",
+    "midi": "Midi",
+    "molecule": "Molecule",
+    "money": "Money",
+    "moneyHand": "MoneyHand",
+    "mountain": "Mountain",
+    "movieCamera": "MovieCamera",
+    "moviesAndTv": "MoviesAndTv",
+    "musicNote": "MusicNote",
+    "musicNote1": "MusicNote1",
+    "musicNote2": "MusicNote2",
+    "myLocation": "MyLocation",
+    "nByN": "NByN",
+    "nByOne": "NByOne",
+    "news": "News",
+    "notablePeople": "NotablePeople",
+    "note": "Note",
+    "notebook": "Notebook",
+    "notepad": "Notepad",
+    "notepadPerson": "NotepadPerson",
+    "oneByN": "OneByN",
+    "oneByOne": "OneByOne",
+    "options": "Options",
+    "organization": "Organization",
+    "organizationHorizontal": "OrganizationHorizontal",
+    "oval": "Oval",
+    "paintBrush": "PaintBrush",
+    "paintBucket": "PaintBucket",
+    "partlySunnyWeather": "PartlySunnyWeather",
+    "password": "Password",
+    "patch": "Patch",
+    "patient": "Patient",
+    "payment": "Payment",
+    "pen": "Pen",
+    "pentagon": "Pentagon",
+    "people": "People",
+    "peopleAudience": "PeopleAudience",
+    "peopleCall": "PeopleCall",
+    "peopleCommunity": "PeopleCommunity",
+    "peopleMoney": "PeopleMoney",
+    "peopleQueue": "PeopleQueue",
+    "peopleTeam": "PeopleTeam",
+    "peopleToolbox": "PeopleToolbox",
+    "person": "Person",
+    "personBoard": "PersonBoard",
+    "personCall": "PersonCall",
+    "personChat": "PersonChat",
+    "personFeedback": "PersonFeedback",
+    "personSupport": "PersonSupport",
+    "personVoice": "PersonVoice",
+    "phone": "Phone",
+    "phoneDesktop": "PhoneDesktop",
+    "phoneLaptop": "PhoneLaptop",
+    "phoneShake": "PhoneShake",
+    "phoneTablet": "PhoneTablet",
+    "phoneVibrate": "PhoneVibrate",
+    "photoFilter": "PhotoFilter",
+    "pi": "Pi",
+    "pictureInPicture": "PictureInPicture",
+    "pilates": "Pilates",
+    "pill": "Pill",
+    "pin": "Pin",
+    "pipeline": "Pipeline",
+    "planet": "Planet",
+    "playingCards": "PlayingCards",
+    "plugConnected": "PlugConnected",
+    "plugDisconnected": "PlugDisconnected",
+    "pointScan": "PointScan",
+    "poll": "Poll",
+    "power": "Power",
+    "predictions": "Predictions",
+    "premium": "Premium",
+    "presenter": "Presenter",
+    "previewLink": "PreviewLink",
+    "print": "Print",
+    "production": "Production",
+    "prohibited": "Prohibited",
+    "projectionScreen": "ProjectionScreen",
+    "protocolHandler": "ProtocolHandler",
+    "pulse": "Pulse",
+    "pulseSquare": "PulseSquare",
+    "puzzlePiece": "PuzzlePiece",
+    "qrCode": "QrCode",
+    "radar": "Radar",
+    "ram": "Ram",
+    "readingList": "ReadingList",
+    "realEstate": "RealEstate",
+    "receipt": "Receipt",
+    "reward": "Reward",
+    "rhombus": "Rhombus",
+    "ribbon": "Ribbon",
+    "ribbonStar": "RibbonStar",
+    "roadCone": "RoadCone",
+    "rocket": "Rocket",
+    "router": "Router",
+    "rss": "Rss",
+    "ruler": "Ruler",
+    "run": "Run",
+    "running": "Running",
+    "satellite": "Satellite",
+    "save": "Save",
+    "savings": "Savings",
+    "scales": "Scales",
+    "scan": "Scan",
+    "scratchpad": "Scratchpad",
+    "screenPerson": "ScreenPerson",
+    "screenshot": "Screenshot",
+    "search": "Search",
+    "serialPort": "SerialPort",
+    "server": "Server",
+    "serverMultiple": "ServerMultiple",
+    "serviceBell": "ServiceBell",
+    "settings": "Settings",
+    "shapes": "Shapes",
+    "shield": "Shield",
+    "shieldTask": "ShieldTask",
+    "shoppingBag": "ShoppingBag",
+    "signature": "Signature",
+    "sim": "Sim",
+    "sleep": "Sleep",
+    "smartwatch": "Smartwatch",
+    "soundSource": "SoundSource",
+    "soundWaveCircle": "SoundWaveCircle",
+    "sparkle": "Sparkle",
+    "speaker0": "Speaker0",
+    "speaker2": "Speaker2",
+    "sport": "Sport",
+    "sportAmericanFootball": "SportAmericanFootball",
+    "sportBaseball": "SportBaseball",
+    "sportBasketball": "SportBasketball",
+    "sportHockey": "SportHockey",
+    "sportSoccer": "SportSoccer",
+    "squareMultiple": "SquareMultiple",
+    "squareShadow": "SquareShadow",
+    "squaresNested": "SquaresNested",
+    "stack": "Stack",
+    "stackStar": "StackStar",
+    "star": "Star",
+    "starFilled": "StarFilled",
+    "starHalf": "StarHalf",
+    "starLineHorizontal3": "StarLineHorizontal3",
+    "starOneQuarter": "StarOneQuarter",
+    "starThreeQuarter": "StarThreeQuarter",
+    "status": "Status",
+    "steps": "Steps",
+    "stethoscope": "Stethoscope",
+    "sticker": "Sticker",
+    "storage": "Storage",
+    "stream": "Stream",
+    "streamInput": "StreamInput",
+    "streamInputOutput": "StreamInputOutput",
+    "streamOutput": "StreamOutput",
+    "styleGuide": "StyleGuide",
+    "subGrid": "SubGrid",
+    "subtitles": "Subtitles",
+    "surfaceEarbuds": "SurfaceEarbuds",
+    "surfaceHub": "SurfaceHub",
+    "symbols": "Symbols",
+    "syringe": "Syringe",
+    "system": "System",
+    "tabDesktop": "TabDesktop",
+    "tabInprivateAccount": "TabInprivateAccount",
+    "table": "Table",
+    "tableImage": "TableImage",
+    "tableMultiple": "TableMultiple",
+    "tablet": "Tablet",
+    "tabs": "Tabs",
+    "tag": "Tag",
+    "tagCircle": "TagCircle",
+    "tagMultiple": "TagMultiple",
+    "target": "Target",
+    "targetArrow": "TargetArrow",
+    "teddy": "Teddy",
+    "temperature": "Temperature",
+    "tent": "Tent",
+    "tetrisApp": "TetrisApp",
+    "textbox": "Textbox",
+    "textQuote": "TextQuote",
+    "thinking": "Thinking",
+    "thumbDislike": "ThumbDislike",
+    "thumbLike": "ThumbLike",
+    "ticketDiagonal": "TicketDiagonal",
+    "ticketHorizontal": "TicketHorizontal",
+    "timeAndWeather": "TimeAndWeather",
+    "timeline": "Timeline",
+    "timer": "Timer",
+    "toolbox": "Toolbox",
+    "topSpeed": "TopSpeed",
+    "translate": "Translate",
+    "transmission": "Transmission",
+    "treeDeciduous": "TreeDeciduous",
+    "treeEvergreen": "TreeEvergreen",
+    "trophy": "Trophy",
+    "tv": "Tv",
+    "tvUsb": "TvUsb",
+    "umbrella": "Umbrella",
+    "usbPlug": "UsbPlug",
+    "usbStick": "UsbStick",
+    "vault": "Vault",
+    "vehicleBicycle": "VehicleBicycle",
+    "vehicleBus": "VehicleBus",
+    "vehicleCab": "VehicleCab",
+    "vehicleCar": "VehicleCar",
+    "vehicleCarCollision": "VehicleCarCollision",
+    "vehicleCarProfileLtr": "VehicleCarProfileLtr",
+    "vehicleCarProfileRtl": "VehicleCarProfileRtl",
+    "vehicleShip": "VehicleShip",
+    "vehicleSubway": "VehicleSubway",
+    "vehicleTruck": "VehicleTruck",
+    "vehicleTruckBag": "VehicleTruckBag",
+    "vehicleTruckCube": "VehicleTruckCube",
+    "vehicleTruckProfile": "VehicleTruckProfile",
+    "video": "Video",
+    "video360": "Video360",
+    "videoChat": "VideoChat",
+    "videoClip": "VideoClip",
+    "videoClipMultiple": "VideoClipMultiple",
+    "videoPerson": "VideoPerson",
+    "videoRecording": "VideoRecording",
+    "videoSecurity": "VideoSecurity",
+    "viewDesktop": "ViewDesktop",
+    "viewDesktopMobile": "ViewDesktopMobile",
+    "violin": "Violin",
+    "virtualNetwork": "VirtualNetwork",
+    "voicemail": "Voicemail",
+    "vote": "Vote",
+    "walkieTalkie": "WalkieTalkie",
+    "wallet": "Wallet",
+    "walletCreditCard": "WalletCreditCard",
+    "wallpaper": "Wallpaper",
+    "wand": "Wand",
+    "warning": "Warning",
+    "weatherBlowingSnow": "WeatherBlowingSnow",
+    "weatherCloudy": "WeatherCloudy",
+    "weatherDrizzle": "WeatherDrizzle",
+    "weatherDuststorm": "WeatherDuststorm",
+    "weatherFog": "WeatherFog",
+    "weatherHailDay": "WeatherHailDay",
+    "weatherHailNight": "WeatherHailNight",
+    "weatherHaze": "WeatherHaze",
+    "weatherMoon": "WeatherMoon",
+    "weatherPartlyCloudyDay": "WeatherPartlyCloudyDay",
+    "weatherPartlyCloudyNight": "WeatherPartlyCloudyNight",
+    "weatherRain": "WeatherRain",
+    "weatherRainShowersDay": "WeatherRainShowersDay",
+    "weatherRainShowersNight": "WeatherRainShowersNight",
+    "weatherRainSnow": "WeatherRainSnow",
+    "weatherSnow": "WeatherSnow",
+    "weatherSnowflake": "WeatherSnowflake",
+    "weatherSnowShowerDay": "WeatherSnowShowerDay",
+    "weatherSnowShowerNight": "WeatherSnowShowerNight",
+    "weatherSqualls": "WeatherSqualls",
+    "weatherSunnyHigh": "WeatherSunnyHigh",
+    "weatherSunnyLow": "WeatherSunnyLow",
+    "weatherThunderstorm": "WeatherThunderstorm",
+    "webAsset": "WebAsset",
+    "whiteboard": "Whiteboard",
+    "wifi1": "Wifi1",
+    "wifi2": "Wifi2",
+    "window": "Window",
+    "windowMultiple": "WindowMultiple",
+    "windowWrench": "WindowWrench",
+    "wrench": "Wrench",
+    "wrenchScrewdriver": "WrenchScrewdriver",
+    "xray": "Xray",
+    "yoga": "Yoga",
+  });
+
+  install(Excel, "ErrorCellValueType", {
+    "blocked": "Blocked",
+    "busy": "Busy",
+    "calc": "Calc",
+    "connect": "Connect",
+    "div0": "Div0",
+    "external": "External",
+    "field": "Field",
+    "gettingData": "GettingData",
+    "notAvailable": "NotAvailable",
+    "name": "Name",
+    "null": "Null",
+    "num": "Num",
+    "placeholder": "Placeholder",
+    "ref": "Ref",
+    "spill": "Spill",
+    "value": "Value",
+  });
+
+  install(Excel, "ErrorCodes", {
+    "accessDenied": "AccessDenied",
+    "apiNotFound": "ApiNotFound",
+    "conflict": "Conflict",
+    "emptyChartSeries": "EmptyChartSeries",
+    "filteredRangeConflict": "FilteredRangeConflict",
+    "formulaLengthExceedsLimit": "FormulaLengthExceedsLimit",
+    "generalException": "GeneralException",
+    "inactiveWorkbook": "InactiveWorkbook",
+    "insertDeleteConflict": "InsertDeleteConflict",
+    "invalidArgument": "InvalidArgument",
+    "invalidBinding": "InvalidBinding",
+    "invalidOperation": "InvalidOperation",
+    "invalidReference": "InvalidReference",
+    "invalidSelection": "InvalidSelection",
+    "itemAlreadyExists": "ItemAlreadyExists",
+    "itemNotFound": "ItemNotFound",
+    "mergedRangeConflict": "MergedRangeConflict",
+    "nonBlankCellOffSheet": "NonBlankCellOffSheet",
+    "notImplemented": "NotImplemented",
+    "openWorkbookLinksBlocked": "OpenWorkbookLinksBlocked",
+    "operationCellsExceedLimit": "OperationCellsExceedLimit",
+    "pivotTableRangeConflict": "PivotTableRangeConflict",
+    "powerQueryRefreshResourceChallenge": "PowerQueryRefreshResourceChallenge",
+    "rangeExceedsLimit": "RangeExceedsLimit",
+    "rangeImageExceedsLimit": "RangeImageExceedsLimit",
+    "refreshWorkbookLinksBlocked": "RefreshWorkbookLinksBlocked",
+    "requestAborted": "RequestAborted",
+    "responsePayloadSizeLimitExceeded": "ResponsePayloadSizeLimitExceeded",
+    "unsupportedFeature": "UnsupportedFeature",
+    "unsupportedFillType": "UnsupportedFillType",
+    "unsupportedOperation": "UnsupportedOperation",
+    "unsupportedSheet": "UnsupportedSheet",
+    "invalidOperationInCellEditMode": "InvalidOperationInCellEditMode",
+  });
+
+  install(Excel, "EventSource", {
+    "local": "Local",
+    "remote": "Remote",
+  });
+
+  install(Excel, "EventTriggerSource", {
+    "unknown": "Unknown",
+    "thisLocalAddin": "ThisLocalAddin",
+  });
+
+  install(Excel, "EventType", {
+    "worksheetChanged": "WorksheetChanged",
+    "worksheetSelectionChanged": "WorksheetSelectionChanged",
+    "worksheetAdded": "WorksheetAdded",
+    "worksheetActivated": "WorksheetActivated",
+    "worksheetDeactivated": "WorksheetDeactivated",
+    "tableChanged": "TableChanged",
+    "tableSelectionChanged": "TableSelectionChanged",
+    "worksheetDeleted": "WorksheetDeleted",
+    "chartAdded": "ChartAdded",
+    "chartActivated": "ChartActivated",
+    "chartDeactivated": "ChartDeactivated",
+    "chartDeleted": "ChartDeleted",
+    "worksheetCalculated": "WorksheetCalculated",
+    "visualSelectionChanged": "VisualSelectionChanged",
+    "tableAdded": "TableAdded",
+    "tableDeleted": "TableDeleted",
+    "tableFiltered": "TableFiltered",
+    "worksheetFiltered": "WorksheetFiltered",
+    "shapeActivated": "ShapeActivated",
+    "shapeDeactivated": "ShapeDeactivated",
+    "visualChange": "VisualChange",
+    "workbookAutoSaveSettingChanged": "WorkbookAutoSaveSettingChanged",
+    "worksheetFormatChanged": "WorksheetFormatChanged",
+    "ribbonCommandExecuted": "RibbonCommandExecuted",
+    "worksheetRowSorted": "WorksheetRowSorted",
+    "worksheetColumnSorted": "WorksheetColumnSorted",
+    "worksheetSingleClicked": "WorksheetSingleClicked",
+    "worksheetRowHiddenChanged": "WorksheetRowHiddenChanged",
+    "commentAdded": "CommentAdded",
+    "commentDeleted": "CommentDeleted",
+    "commentChanged": "CommentChanged",
+    "worksheetFormulaChanged": "WorksheetFormulaChanged",
+    "workbookActivated": "WorkbookActivated",
+    "linkedWorkbookWorkbookLinksChanged": "LinkedWorkbookWorkbookLinksChanged",
+    "linkedWorkbookRefreshCompleted": "LinkedWorkbookRefreshCompleted",
+    "worksheetProtectionChanged": "WorksheetProtectionChanged",
+    "worksheetNameChanged": "WorksheetNameChanged",
+    "worksheetVisibilityChanged": "WorksheetVisibilityChanged",
+    "worksheetMoved": "WorksheetMoved",
+    "linkedEntityDataDomainLinkedEntityDataDomainAdded": "LinkedEntityDataDomainLinkedEntityDataDomainAdded",
+    "linkedEntityDataDomainRefreshCompleted": "LinkedEntityDataDomainRefreshCompleted",
+    "linkedEntityDataDomainRefreshModeChanged": "LinkedEntityDataDomainRefreshModeChanged",
+  });
+
+  install(Excel, "ExternalErrorCellValueSubType", {
+    "unknown": "Unknown",
+  });
+
+  install(Excel, "FieldErrorCellValueSubType", {
+    "unknown": "Unknown",
+    "webImageMissingFilePart": "WebImageMissingFilePart",
+    "dataProviderError": "DataProviderError",
+    "richValueRelMissingFilePart": "RichValueRelMissingFilePart",
+  });
+
+  install(Excel, "FillPattern", {
+    "none": "None",
+    "solid": "Solid",
+    "gray50": "Gray50",
+    "gray75": "Gray75",
+    "gray25": "Gray25",
+    "horizontal": "Horizontal",
+    "vertical": "Vertical",
+    "down": "Down",
+    "up": "Up",
+    "checker": "Checker",
+    "semiGray75": "SemiGray75",
+    "lightHorizontal": "LightHorizontal",
+    "lightVertical": "LightVertical",
+    "lightDown": "LightDown",
+    "lightUp": "LightUp",
+    "grid": "Grid",
+    "crissCross": "CrissCross",
+    "gray16": "Gray16",
+    "gray8": "Gray8",
+    "linearGradient": "LinearGradient",
+    "rectangularGradient": "RectangularGradient",
+  });
+
+  install(Excel, "FilterDatetimeSpecificity", {
+    "year": "Year",
+    "month": "Month",
+    "day": "Day",
+    "hour": "Hour",
+    "minute": "Minute",
+    "second": "Second",
+  });
+
+  install(Excel, "FilterOn", {
+    "bottomItems": "BottomItems",
+    "bottomPercent": "BottomPercent",
+    "cellColor": "CellColor",
+    "dynamic": "Dynamic",
+    "fontColor": "FontColor",
+    "values": "Values",
+    "topItems": "TopItems",
+    "topPercent": "TopPercent",
+    "icon": "Icon",
+    "custom": "Custom",
+  });
+
+  install(Excel, "FilterOperator", {
+    "and": "And",
+    "or": "Or",
+  });
+
+  install(Excel, "FunctionCellValueType", {
+    "javaScriptReference": "JavaScriptReference",
+  });
+
+  install(Excel, "GeometricShapeType", {
+    "lineInverse": "LineInverse",
+    "triangle": "Triangle",
+    "rightTriangle": "RightTriangle",
+    "rectangle": "Rectangle",
+    "diamond": "Diamond",
+    "parallelogram": "Parallelogram",
+    "trapezoid": "Trapezoid",
+    "nonIsoscelesTrapezoid": "NonIsoscelesTrapezoid",
+    "pentagon": "Pentagon",
+    "hexagon": "Hexagon",
+    "heptagon": "Heptagon",
+    "octagon": "Octagon",
+    "decagon": "Decagon",
+    "dodecagon": "Dodecagon",
+    "star4": "Star4",
+    "star5": "Star5",
+    "star6": "Star6",
+    "star7": "Star7",
+    "star8": "Star8",
+    "star10": "Star10",
+    "star12": "Star12",
+    "star16": "Star16",
+    "star24": "Star24",
+    "star32": "Star32",
+    "roundRectangle": "RoundRectangle",
+    "round1Rectangle": "Round1Rectangle",
+    "round2SameRectangle": "Round2SameRectangle",
+    "round2DiagonalRectangle": "Round2DiagonalRectangle",
+    "snipRoundRectangle": "SnipRoundRectangle",
+    "snip1Rectangle": "Snip1Rectangle",
+    "snip2SameRectangle": "Snip2SameRectangle",
+    "snip2DiagonalRectangle": "Snip2DiagonalRectangle",
+    "plaque": "Plaque",
+    "ellipse": "Ellipse",
+    "teardrop": "Teardrop",
+    "homePlate": "HomePlate",
+    "chevron": "Chevron",
+    "pieWedge": "PieWedge",
+    "pie": "Pie",
+    "blockArc": "BlockArc",
+    "donut": "Donut",
+    "noSmoking": "NoSmoking",
+    "rightArrow": "RightArrow",
+    "leftArrow": "LeftArrow",
+    "upArrow": "UpArrow",
+    "downArrow": "DownArrow",
+    "stripedRightArrow": "StripedRightArrow",
+    "notchedRightArrow": "NotchedRightArrow",
+    "bentUpArrow": "BentUpArrow",
+    "leftRightArrow": "LeftRightArrow",
+    "upDownArrow": "UpDownArrow",
+    "leftUpArrow": "LeftUpArrow",
+    "leftRightUpArrow": "LeftRightUpArrow",
+    "quadArrow": "QuadArrow",
+    "leftArrowCallout": "LeftArrowCallout",
+    "rightArrowCallout": "RightArrowCallout",
+    "upArrowCallout": "UpArrowCallout",
+    "downArrowCallout": "DownArrowCallout",
+    "leftRightArrowCallout": "LeftRightArrowCallout",
+    "upDownArrowCallout": "UpDownArrowCallout",
+    "quadArrowCallout": "QuadArrowCallout",
+    "bentArrow": "BentArrow",
+    "uturnArrow": "UturnArrow",
+    "circularArrow": "CircularArrow",
+    "leftCircularArrow": "LeftCircularArrow",
+    "leftRightCircularArrow": "LeftRightCircularArrow",
+    "curvedRightArrow": "CurvedRightArrow",
+    "curvedLeftArrow": "CurvedLeftArrow",
+    "curvedUpArrow": "CurvedUpArrow",
+    "curvedDownArrow": "CurvedDownArrow",
+    "swooshArrow": "SwooshArrow",
+    "cube": "Cube",
+    "can": "Can",
+    "lightningBolt": "LightningBolt",
+    "heart": "Heart",
+    "sun": "Sun",
+    "moon": "Moon",
+    "smileyFace": "SmileyFace",
+    "irregularSeal1": "IrregularSeal1",
+    "irregularSeal2": "IrregularSeal2",
+    "foldedCorner": "FoldedCorner",
+    "bevel": "Bevel",
+    "frame": "Frame",
+    "halfFrame": "HalfFrame",
+    "corner": "Corner",
+    "diagonalStripe": "DiagonalStripe",
+    "chord": "Chord",
+    "arc": "Arc",
+    "leftBracket": "LeftBracket",
+    "rightBracket": "RightBracket",
+    "leftBrace": "LeftBrace",
+    "rightBrace": "RightBrace",
+    "bracketPair": "BracketPair",
+    "bracePair": "BracePair",
+    "callout1": "Callout1",
+    "callout2": "Callout2",
+    "callout3": "Callout3",
+    "accentCallout1": "AccentCallout1",
+    "accentCallout2": "AccentCallout2",
+    "accentCallout3": "AccentCallout3",
+    "borderCallout1": "BorderCallout1",
+    "borderCallout2": "BorderCallout2",
+    "borderCallout3": "BorderCallout3",
+    "accentBorderCallout1": "AccentBorderCallout1",
+    "accentBorderCallout2": "AccentBorderCallout2",
+    "accentBorderCallout3": "AccentBorderCallout3",
+    "wedgeRectCallout": "WedgeRectCallout",
+    "wedgeRRectCallout": "WedgeRRectCallout",
+    "wedgeEllipseCallout": "WedgeEllipseCallout",
+    "cloudCallout": "CloudCallout",
+    "cloud": "Cloud",
+    "ribbon": "Ribbon",
+    "ribbon2": "Ribbon2",
+    "ellipseRibbon": "EllipseRibbon",
+    "ellipseRibbon2": "EllipseRibbon2",
+    "leftRightRibbon": "LeftRightRibbon",
+    "verticalScroll": "VerticalScroll",
+    "horizontalScroll": "HorizontalScroll",
+    "wave": "Wave",
+    "doubleWave": "DoubleWave",
+    "plus": "Plus",
+    "flowChartProcess": "FlowChartProcess",
+    "flowChartDecision": "FlowChartDecision",
+    "flowChartInputOutput": "FlowChartInputOutput",
+    "flowChartPredefinedProcess": "FlowChartPredefinedProcess",
+    "flowChartInternalStorage": "FlowChartInternalStorage",
+    "flowChartDocument": "FlowChartDocument",
+    "flowChartMultidocument": "FlowChartMultidocument",
+    "flowChartTerminator": "FlowChartTerminator",
+    "flowChartPreparation": "FlowChartPreparation",
+    "flowChartManualInput": "FlowChartManualInput",
+    "flowChartManualOperation": "FlowChartManualOperation",
+    "flowChartConnector": "FlowChartConnector",
+    "flowChartPunchedCard": "FlowChartPunchedCard",
+    "flowChartPunchedTape": "FlowChartPunchedTape",
+    "flowChartSummingJunction": "FlowChartSummingJunction",
+    "flowChartOr": "FlowChartOr",
+    "flowChartCollate": "FlowChartCollate",
+    "flowChartSort": "FlowChartSort",
+    "flowChartExtract": "FlowChartExtract",
+    "flowChartMerge": "FlowChartMerge",
+    "flowChartOfflineStorage": "FlowChartOfflineStorage",
+    "flowChartOnlineStorage": "FlowChartOnlineStorage",
+    "flowChartMagneticTape": "FlowChartMagneticTape",
+    "flowChartMagneticDisk": "FlowChartMagneticDisk",
+    "flowChartMagneticDrum": "FlowChartMagneticDrum",
+    "flowChartDisplay": "FlowChartDisplay",
+    "flowChartDelay": "FlowChartDelay",
+    "flowChartAlternateProcess": "FlowChartAlternateProcess",
+    "flowChartOffpageConnector": "FlowChartOffpageConnector",
+    "actionButtonBlank": "ActionButtonBlank",
+    "actionButtonHome": "ActionButtonHome",
+    "actionButtonHelp": "ActionButtonHelp",
+    "actionButtonInformation": "ActionButtonInformation",
+    "actionButtonForwardNext": "ActionButtonForwardNext",
+    "actionButtonBackPrevious": "ActionButtonBackPrevious",
+    "actionButtonEnd": "ActionButtonEnd",
+    "actionButtonBeginning": "ActionButtonBeginning",
+    "actionButtonReturn": "ActionButtonReturn",
+    "actionButtonDocument": "ActionButtonDocument",
+    "actionButtonSound": "ActionButtonSound",
+    "actionButtonMovie": "ActionButtonMovie",
+    "gear6": "Gear6",
+    "gear9": "Gear9",
+    "funnel": "Funnel",
+    "mathPlus": "MathPlus",
+    "mathMinus": "MathMinus",
+    "mathMultiply": "MathMultiply",
+    "mathDivide": "MathDivide",
+    "mathEqual": "MathEqual",
+    "mathNotEqual": "MathNotEqual",
+    "cornerTabs": "CornerTabs",
+    "squareTabs": "SquareTabs",
+    "plaqueTabs": "PlaqueTabs",
+    "chartX": "ChartX",
+    "chartStar": "ChartStar",
+    "chartPlus": "ChartPlus",
+  });
+
+  install(Excel, "GroupOption", {
+    "byRows": "ByRows",
+    "byColumns": "ByColumns",
+  });
+
+  install(Excel, "HeaderFooterState", {
+    "default": "Default",
+    "firstAndDefault": "FirstAndDefault",
+    "oddAndEven": "OddAndEven",
+    "firstOddAndEven": "FirstOddAndEven",
+  });
+
+  install(Excel, "HorizontalAlignment", {
+    "general": "General",
+    "left": "Left",
+    "center": "Center",
+    "right": "Right",
+    "fill": "Fill",
+    "justify": "Justify",
+    "centerAcrossSelection": "CenterAcrossSelection",
+    "distributed": "Distributed",
+  });
+
+  install(Excel, "IconSet", {
+    "invalid": "Invalid",
+    "threeArrows": "ThreeArrows",
+    "threeArrowsGray": "ThreeArrowsGray",
+    "threeFlags": "ThreeFlags",
+    "threeTrafficLights1": "ThreeTrafficLights1",
+    "threeTrafficLights2": "ThreeTrafficLights2",
+    "threeSigns": "ThreeSigns",
+    "threeSymbols": "ThreeSymbols",
+    "threeSymbols2": "ThreeSymbols2",
+    "fourArrows": "FourArrows",
+    "fourArrowsGray": "FourArrowsGray",
+    "fourRedToBlack": "FourRedToBlack",
+    "fourRating": "FourRating",
+    "fourTrafficLights": "FourTrafficLights",
+    "fiveArrows": "FiveArrows",
+    "fiveArrowsGray": "FiveArrowsGray",
+    "fiveRating": "FiveRating",
+    "fiveQuarters": "FiveQuarters",
+    "threeStars": "ThreeStars",
+    "threeTriangles": "ThreeTriangles",
+    "fiveBoxes": "FiveBoxes",
+  });
+
+  install(Excel, "ImageFittingMode", {
+    "fit": "Fit",
+    "fitAndCenter": "FitAndCenter",
+    "fill": "Fill",
+  });
+
+  install(Excel, "InsertShiftDirection", {
+    "down": "Down",
+    "right": "Right",
+  });
+
+  install(Excel, "KeyboardDirection", {
+    "left": "Left",
+    "right": "Right",
+    "up": "Up",
+    "down": "Down",
+  });
+
+  install(Excel, "LabelFilterCondition", {
+    "unknown": "Unknown",
+    "equals": "Equals",
+    "beginsWith": "BeginsWith",
+    "endsWith": "EndsWith",
+    "contains": "Contains",
+    "greaterThan": "GreaterThan",
+    "greaterThanOrEqualTo": "GreaterThanOrEqualTo",
+    "lessThan": "LessThan",
+    "lessThanOrEqualTo": "LessThanOrEqualTo",
+    "between": "Between",
+  });
+
+  install(Excel, "LinkedDataTypeState", {
+    "none": "None",
+    "validLinkedData": "ValidLinkedData",
+    "disambiguationNeeded": "DisambiguationNeeded",
+    "brokenLinkedData": "BrokenLinkedData",
+    "fetchingData": "FetchingData",
+  });
+
+  install(Excel, "LinkedEntityDataDomainRefreshMode", {
+    "unknown": "Unknown",
+    "manual": "Manual",
+    "onLoad": "OnLoad",
+    "periodic": "Periodic",
+  });
+
+  install(Excel, "LoadToType", {
+    "connectionOnly": "ConnectionOnly",
+    "table": "Table",
+    "pivotTable": "PivotTable",
+    "pivotChart": "PivotChart",
+  });
+
+  install(Excel, "NamedItemScope", {
+    "worksheet": "Worksheet",
+    "workbook": "Workbook",
+  });
+
+  install(Excel, "NamedItemType", {
+    "string": "String",
+    "integer": "Integer",
+    "double": "Double",
+    "boolean": "Boolean",
+    "range": "Range",
+    "error": "Error",
+    "array": "Array",
+  });
+
+  install(Excel, "NumberFormatCategory", {
+    "general": "General",
+    "number": "Number",
+    "currency": "Currency",
+    "accounting": "Accounting",
+    "date": "Date",
+    "time": "Time",
+    "percentage": "Percentage",
+    "fraction": "Fraction",
+    "scientific": "Scientific",
+    "text": "Text",
+    "special": "Special",
+    "custom": "Custom",
+  });
+
+  install(Excel, "NumErrorCellValueSubType", {
+    "unknown": "Unknown",
+    "arrayTooLarge": "ArrayTooLarge",
+  });
+
+  install(Excel, "PageOrientation", {
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+  });
+
+  install(Excel, "PaperType", {
+    "letter": "Letter",
+    "letterSmall": "LetterSmall",
+    "tabloid": "Tabloid",
+    "ledger": "Ledger",
+    "legal": "Legal",
+    "statement": "Statement",
+    "executive": "Executive",
+    "a3": "A3",
+    "a4": "A4",
+    "a4Small": "A4Small",
+    "a5": "A5",
+    "b4": "B4",
+    "b5": "B5",
+    "folio": "Folio",
+    "quatro": "Quatro",
+    "paper10x14": "Paper10x14",
+    "paper11x17": "Paper11x17",
+    "note": "Note",
+    "envelope9": "Envelope9",
+    "envelope10": "Envelope10",
+    "envelope11": "Envelope11",
+    "envelope12": "Envelope12",
+    "envelope14": "Envelope14",
+    "csheet": "Csheet",
+    "dsheet": "Dsheet",
+    "esheet": "Esheet",
+    "envelopeDL": "EnvelopeDL",
+    "envelopeC5": "EnvelopeC5",
+    "envelopeC3": "EnvelopeC3",
+    "envelopeC4": "EnvelopeC4",
+    "envelopeC6": "EnvelopeC6",
+    "envelopeC65": "EnvelopeC65",
+    "envelopeB4": "EnvelopeB4",
+    "envelopeB5": "EnvelopeB5",
+    "envelopeB6": "EnvelopeB6",
+    "envelopeItaly": "EnvelopeItaly",
+    "envelopeMonarch": "EnvelopeMonarch",
+    "envelopePersonal": "EnvelopePersonal",
+    "fanfoldUS": "FanfoldUS",
+    "fanfoldStdGerman": "FanfoldStdGerman",
+    "fanfoldLegalGerman": "FanfoldLegalGerman",
+  });
+
+  install(Excel, "PictureColorType", {
+    "mixed": "Mixed",
+    "automatic": "Automatic",
+    "grayScale": "GrayScale",
+    "blackAndWhite": "BlackAndWhite",
+    "watermark": "Watermark",
+  });
+
+  install(Excel, "PictureFormat", {
+    "unknown": "UNKNOWN",
+    "bmp": "BMP",
+    "jpeg": "JPEG",
+    "gif": "GIF",
+    "png": "PNG",
+    "svg": "SVG",
+  });
+
+  install(Excel, "PivotAxis", {
+    "unknown": "Unknown",
+    "row": "Row",
+    "column": "Column",
+    "data": "Data",
+    "filter": "Filter",
+  });
+
+  install(Excel, "PivotFilterTopBottomCriterion", {
+    "invalid": "Invalid",
+    "topItems": "TopItems",
+    "topPercent": "TopPercent",
+    "topSum": "TopSum",
+    "bottomItems": "BottomItems",
+    "bottomPercent": "BottomPercent",
+    "bottomSum": "BottomSum",
+  });
+
+  install(Excel, "PivotFilterType", {
+    "unknown": "Unknown",
+    "value": "Value",
+    "manual": "Manual",
+    "label": "Label",
+    "date": "Date",
+  });
+
+  install(Excel, "PivotLayoutType", {
+    "compact": "Compact",
+    "tabular": "Tabular",
+    "outline": "Outline",
+  });
+
+  install(Excel, "Placement", {
+    "twoCell": "TwoCell",
+    "oneCell": "OneCell",
+    "absolute": "Absolute",
+  });
+
+  install(Excel, "PrintComments", {
+    "noComments": "NoComments",
+    "endSheet": "EndSheet",
+    "inPlace": "InPlace",
+  });
+
+  install(Excel, "PrintErrorType", {
+    "asDisplayed": "AsDisplayed",
+    "blank": "Blank",
+    "dash": "Dash",
+    "notAvailable": "NotAvailable",
+  });
+
+  install(Excel, "PrintMarginUnit", {
+    "points": "Points",
+    "inches": "Inches",
+    "centimeters": "Centimeters",
+  });
+
+  install(Excel, "PrintOrder", {
+    "downThenOver": "DownThenOver",
+    "overThenDown": "OverThenDown",
+  });
+
+  install(Excel, "ProtectionSelectionMode", {
+    "normal": "Normal",
+    "unlocked": "Unlocked",
+    "none": "None",
+  });
+
+  install(Excel, "QueryError", {
+    "unknown": "Unknown",
+    "none": "None",
+    "failedLoadToWorksheet": "FailedLoadToWorksheet",
+    "failedLoadToDataModel": "FailedLoadToDataModel",
+    "failedDownload": "FailedDownload",
+    "failedToCompleteDownload": "FailedToCompleteDownload",
+  });
+
+  install(Excel, "RangeCopyType", {
+    "all": "All",
+    "formulas": "Formulas",
+    "values": "Values",
+    "formats": "Formats",
+    "link": "Link",
+  });
+
+  install(Excel, "RangeUnderlineStyle", {
+    "none": "None",
+    "single": "Single",
+    "double": "Double",
+    "singleAccountant": "SingleAccountant",
+    "doubleAccountant": "DoubleAccountant",
+  });
+
+  install(Excel, "RangeValueType", {
+    "unknown": "Unknown",
+    "empty": "Empty",
+    "string": "String",
+    "integer": "Integer",
+    "double": "Double",
+    "boolean": "Boolean",
+    "error": "Error",
+    "richValue": "RichValue",
+  });
+
+  install(Excel, "ReadingOrder", {
+    "context": "Context",
+    "leftToRight": "LeftToRight",
+    "rightToLeft": "RightToLeft",
+  });
+
+  install(Excel, "ReferenceValueType", {
+    "array": "Array",
+    "entity": "Entity",
+    "root": "Root",
+    "double": "Double",
+    "string": "String",
+    "boolean": "Boolean",
+  });
+
+  install(Excel, "RefErrorCellValueSubType", {
+    "unknown": "Unknown",
+    "externalLinksStructuredRef": "ExternalLinksStructuredRef",
+    "externalLinksCalculatedRef": "ExternalLinksCalculatedRef",
+  });
+
+  install(Excel, "RibbonTab", {
+    "others": "Others",
+    "home": "Home",
+    "insert": "Insert",
+    "draw": "Draw",
+    "pageLayout": "PageLayout",
+    "formulas": "Formulas",
+    "data": "Data",
+    "review": "Review",
+    "view": "View",
+    "developer": "Developer",
+    "addIns": "AddIns",
+    "help": "Help",
+  });
+
+  install(Excel, "RowHiddenChangeType", {
+    "unhidden": "Unhidden",
+    "hidden": "Hidden",
+  });
+
+  install(Excel, "SaveBehavior", {
+    "save": "Save",
+    "prompt": "Prompt",
+  });
+
+  install(Excel, "ScrollWorkbookTabPosition", {
+    "first": "First",
+    "last": "Last",
+  });
+
+  install(Excel, "SearchDirection", {
+    "forward": "Forward",
+    "backwards": "Backwards",
+  });
+
+  install(Excel, "ShapeAutoSize", {
+    "autoSizeNone": "AutoSizeNone",
+    "autoSizeTextToFitShape": "AutoSizeTextToFitShape",
+    "autoSizeShapeToFitText": "AutoSizeShapeToFitText",
+    "autoSizeMixed": "AutoSizeMixed",
+  });
+
+  install(Excel, "ShapeFillType", {
+    "noFill": "NoFill",
+    "solid": "Solid",
+    "gradient": "Gradient",
+    "pattern": "Pattern",
+    "pictureAndTexture": "PictureAndTexture",
+    "mixed": "Mixed",
+  });
+
+  install(Excel, "ShapeFontUnderlineStyle", {
+    "none": "None",
+    "single": "Single",
+    "double": "Double",
+    "heavy": "Heavy",
+    "dotted": "Dotted",
+    "dottedHeavy": "DottedHeavy",
+    "dash": "Dash",
+    "dashHeavy": "DashHeavy",
+    "dashLong": "DashLong",
+    "dashLongHeavy": "DashLongHeavy",
+    "dotDash": "DotDash",
+    "dotDashHeavy": "DotDashHeavy",
+    "dotDotDash": "DotDotDash",
+    "dotDotDashHeavy": "DotDotDashHeavy",
+    "wavy": "Wavy",
+    "wavyHeavy": "WavyHeavy",
+    "wavyDouble": "WavyDouble",
+  });
+
+  install(Excel, "ShapeLineDashStyle", {
+    "dash": "Dash",
+    "dashDot": "DashDot",
+    "dashDotDot": "DashDotDot",
+    "longDash": "LongDash",
+    "longDashDot": "LongDashDot",
+    "roundDot": "RoundDot",
+    "solid": "Solid",
+    "squareDot": "SquareDot",
+    "longDashDotDot": "LongDashDotDot",
+    "systemDash": "SystemDash",
+    "systemDot": "SystemDot",
+    "systemDashDot": "SystemDashDot",
+  });
+
+  install(Excel, "ShapeLineStyle", {
+    "single": "Single",
+    "thickBetweenThin": "ThickBetweenThin",
+    "thickThin": "ThickThin",
+    "thinThick": "ThinThick",
+    "thinThin": "ThinThin",
+  });
+
+  install(Excel, "ShapeScaleFrom", {
+    "scaleFromTopLeft": "ScaleFromTopLeft",
+    "scaleFromMiddle": "ScaleFromMiddle",
+    "scaleFromBottomRight": "ScaleFromBottomRight",
+  });
+
+  install(Excel, "ShapeScaleType", {
+    "currentSize": "CurrentSize",
+    "originalSize": "OriginalSize",
+  });
+
+  install(Excel, "ShapeTextHorizontalAlignment", {
+    "left": "Left",
+    "center": "Center",
+    "right": "Right",
+    "justify": "Justify",
+    "justifyLow": "JustifyLow",
+    "distributed": "Distributed",
+    "thaiDistributed": "ThaiDistributed",
+  });
+
+  install(Excel, "ShapeTextHorizontalOverflow", {
+    "overflow": "Overflow",
+    "clip": "Clip",
+  });
+
+  install(Excel, "ShapeTextOrientation", {
+    "horizontal": "Horizontal",
+    "vertical": "Vertical",
+    "vertical270": "Vertical270",
+    "wordArtVertical": "WordArtVertical",
+    "eastAsianVertical": "EastAsianVertical",
+    "mongolianVertical": "MongolianVertical",
+    "wordArtVerticalRTL": "WordArtVerticalRTL",
+  });
+
+  install(Excel, "ShapeTextReadingOrder", {
+    "leftToRight": "LeftToRight",
+    "rightToLeft": "RightToLeft",
+  });
+
+  install(Excel, "ShapeTextVerticalAlignment", {
+    "top": "Top",
+    "middle": "Middle",
+    "bottom": "Bottom",
+    "justified": "Justified",
+    "distributed": "Distributed",
+  });
+
+  install(Excel, "ShapeTextVerticalOverflow", {
+    "overflow": "Overflow",
+    "ellipsis": "Ellipsis",
+    "clip": "Clip",
+  });
+
+  install(Excel, "ShapeType", {
+    "unsupported": "Unsupported",
+    "image": "Image",
+    "geometricShape": "GeometricShape",
+    "group": "Group",
+    "line": "Line",
+  });
+
+  install(Excel, "ShapeZOrder", {
+    "bringToFront": "BringToFront",
+    "bringForward": "BringForward",
+    "sendToBack": "SendToBack",
+    "sendBackward": "SendBackward",
+  });
+
+  install(Excel, "SheetVisibility", {
+    "visible": "Visible",
+    "hidden": "Hidden",
+    "veryHidden": "VeryHidden",
+  });
+
+  install(Excel, "ShowAsCalculation", {
+    "unknown": "Unknown",
+    "none": "None",
+    "percentOfGrandTotal": "PercentOfGrandTotal",
+    "percentOfRowTotal": "PercentOfRowTotal",
+    "percentOfColumnTotal": "PercentOfColumnTotal",
+    "percentOfParentRowTotal": "PercentOfParentRowTotal",
+    "percentOfParentColumnTotal": "PercentOfParentColumnTotal",
+    "percentOfParentTotal": "PercentOfParentTotal",
+    "percentOf": "PercentOf",
+    "runningTotal": "RunningTotal",
+    "percentRunningTotal": "PercentRunningTotal",
+    "differenceFrom": "DifferenceFrom",
+    "percentDifferenceFrom": "PercentDifferenceFrom",
+    "rankAscending": "RankAscending",
+    "rankDecending": "RankDecending",
+    "index": "Index",
+  });
+
+  install(Excel, "SlicerSortType", {
+    "dataSourceOrder": "DataSourceOrder",
+    "ascending": "Ascending",
+    "descending": "Descending",
+  });
+
+  install(Excel, "SortBy", {
+    "ascending": "Ascending",
+    "descending": "Descending",
+  });
+
+  install(Excel, "SortDataOption", {
+    "normal": "Normal",
+    "textAsNumber": "TextAsNumber",
+  });
+
+  install(Excel, "SortMethod", {
+    "pinYin": "PinYin",
+    "strokeCount": "StrokeCount",
+  });
+
+  install(Excel, "SortOn", {
+    "value": "Value",
+    "cellColor": "CellColor",
+    "fontColor": "FontColor",
+    "icon": "Icon",
+  });
+
+  install(Excel, "SortOrientation", {
+    "rows": "Rows",
+    "columns": "Columns",
+  });
+
+  install(Excel, "SpecialCellType", {
+    "conditionalFormats": "ConditionalFormats",
+    "dataValidations": "DataValidations",
+    "blanks": "Blanks",
+    "constants": "Constants",
+    "formulas": "Formulas",
+    "sameConditionalFormat": "SameConditionalFormat",
+    "sameDataValidation": "SameDataValidation",
+    "visible": "Visible",
+  });
+
+  install(Excel, "SpecialCellValueType", {
+    "all": "All",
+    "errors": "Errors",
+    "errorsLogical": "ErrorsLogical",
+    "errorsNumbers": "ErrorsNumbers",
+    "errorsText": "ErrorsText",
+    "errorsLogicalNumber": "ErrorsLogicalNumber",
+    "errorsLogicalText": "ErrorsLogicalText",
+    "errorsNumberText": "ErrorsNumberText",
+    "logical": "Logical",
+    "logicalNumbers": "LogicalNumbers",
+    "logicalText": "LogicalText",
+    "logicalNumbersText": "LogicalNumbersText",
+    "numbers": "Numbers",
+    "numbersText": "NumbersText",
+    "text": "Text",
+  });
+
+  install(Excel, "SpillErrorCellValueSubType", {
+    "unknown": "Unknown",
+    "collision": "Collision",
+    "indeterminateSize": "IndeterminateSize",
+    "worksheetEdge": "WorksheetEdge",
+    "outOfMemoryWhileCalc": "OutOfMemoryWhileCalc",
+    "table": "Table",
+    "mergedCell": "MergedCell",
+  });
+
+  install(Excel, "SubtotalLocationType", {
+    "atTop": "AtTop",
+    "atBottom": "AtBottom",
+    "off": "Off",
+  });
+
+  install(Excel, "TopBottomSelectionType", {
+    "items": "Items",
+    "percent": "Percent",
+    "sum": "Sum",
+  });
+
+  install(Excel, "ValueErrorCellValueSubType", {
+    "unknown": "Unknown",
+    "vlookupColumnIndexLessThanOne": "VlookupColumnIndexLessThanOne",
+    "vlookupResultNotFound": "VlookupResultNotFound",
+    "hlookupRowIndexLessThanOne": "HlookupRowIndexLessThanOne",
+    "hlookupResultNotFound": "HlookupResultNotFound",
+    "coerceStringToNumberInvalid": "CoerceStringToNumberInvalid",
+    "coerceStringToBoolInvalid": "CoerceStringToBoolInvalid",
+    "coerceStringToInvalidType": "CoerceStringToInvalidType",
+    "subArrayStartRowMissingEndRowNot": "SubArrayStartRowMissingEndRowNot",
+    "subArrayStartColumnMissingEndColumnNot": "SubArrayStartColumnMissingEndColumnNot",
+    "invalidImageUrl": "InvalidImageUrl",
+    "stockHistoryNonTradingDays": "StockHistoryNonTradingDays",
+    "stockHistoryNotAStock": "StockHistoryNotAStock",
+    "stockHistoryInvalidDate": "StockHistoryInvalidDate",
+    "stockHistoryEndBeforeStart": "StockHistoryEndBeforeStart",
+    "stockHistoryStartInFuture": "StockHistoryStartInFuture",
+    "stockHistoryInvalidEnum": "StockHistoryInvalidEnum",
+    "stockHistoryOnlyDateRequested": "StockHistoryOnlyDateRequested",
+    "stockHistoryNotFound": "StockHistoryNotFound",
+    "lambdaWrongParamCount": "LambdaWrongParamCount",
+  });
+
+  install(Excel, "ValueFilterCondition", {
+    "unknown": "Unknown",
+    "equals": "Equals",
+    "greaterThan": "GreaterThan",
+    "greaterThanOrEqualTo": "GreaterThanOrEqualTo",
+    "lessThan": "LessThan",
+    "lessThanOrEqualTo": "LessThanOrEqualTo",
+    "between": "Between",
+    "topN": "TopN",
+    "bottomN": "BottomN",
+  });
+
+  install(Excel, "VerticalAlignment", {
+    "top": "Top",
+    "center": "Center",
+    "bottom": "Bottom",
+    "justify": "Justify",
+    "distributed": "Distributed",
+  });
+
+  install(Excel, "WindowState", {
+    "maximized": "maximized",
+    "minimized": "minimized",
+    "normal": "normal",
+  });
+
+  install(Excel, "WindowType", {
+    "chartAsWindow": "chartAsWindow",
+    "chartInPlace": "chartInPlace",
+    "clipboard": "clipboard",
+    "workbook": "workbook",
+  });
+
+  install(Excel, "WindowView", {
+    "normalView": "normalView",
+    "pageBreakPreview": "pageBreakPreview",
+    "pageLayoutView": "pageLayoutView",
+  });
+
+  install(Excel, "WorkbookLinksRefreshMode", {
+    "manual": "Manual",
+    "automatic": "Automatic",
+  });
+
+  install(Excel, "WorksheetPositionType", {
+    "none": "None",
+    "before": "Before",
+    "after": "After",
+    "beginning": "Beginning",
+    "end": "End",
+  });
+
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/compute/officejs/src/format.js
+++ b/compute/officejs/src/format.js
@@ -1,0 +1,310 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var ClientObject = global.OfficeExtension.ClientObject;
+
+  function propertyNotLoaded(name) {
+    var error = new global.OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function invalidArgument(message) {
+    var error = new global.OfficeExtension.Error({
+      code: "InvalidArgument",
+      message: message,
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidArgument";
+    return error;
+  }
+
+  function queueProxy(object, range, kind) {
+    object._range = range;
+    object._rangeId = range._id;
+    object.context._queue.push({
+      op: "getRangeFormat",
+      id: object._id,
+      rangeId: range._id,
+      kind: kind,
+    });
+  }
+
+  function defineScalars(ctor, properties) {
+    properties.forEach(function (name) {
+      Object.defineProperty(ctor.prototype, name, {
+        get: function () {
+          if (!this._loaded[name]) throw propertyNotLoaded(name);
+          return this["_" + name];
+        },
+        set: function (value) {
+          this["_" + name] = value;
+          this._loaded[name] = true;
+          this.context._queue.push({
+            op: "set",
+            id: this._id,
+            property: name,
+            value: value,
+          });
+        },
+      });
+    });
+  }
+
+  function combinedProperties(object, primary, additional) {
+    var names = (object[primary] || []).slice();
+    (object[additional] || []).forEach(function (name) {
+      if (names.indexOf(name) < 0) names.push(name);
+    });
+    return names;
+  }
+
+  function scalarProperties(object) {
+    return combinedProperties(
+      object,
+      "_scalarProperties",
+      "_additionalScalarProperties"
+    );
+  }
+
+  function navigationProperties(object) {
+    return combinedProperties(
+      object,
+      "_navigationProperties",
+      "_additionalNavigationProperties"
+    );
+  }
+
+  function typeName(object) {
+    return (
+      object._typeName ||
+      (object.constructor && object.constructor.name) ||
+      "ClientObject"
+    );
+  }
+
+  function setProperties(source, options) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+
+    var isClientObject = source instanceof ClientObject;
+    var properties = source;
+    if (isClientObject) {
+      if (Object.getPrototypeOf(this) !== Object.getPrototypeOf(source)) {
+        throw invalidArgument("The object passed to set must have the same type.");
+      }
+      if (source.context !== this.context) {
+        throw invalidArgument("The object passed to set must use the same context.");
+      }
+      properties = source.toJSON();
+    }
+
+    var scalarNames = scalarProperties(this);
+    var navigationNames = navigationProperties(this);
+    var readOnlyNames = this._readOnlyProperties || [];
+    var throwOnReadOnly = !options || options.throwOnReadOnly !== false;
+
+    // Validate the complete update object before queueing any member.  The
+    // generated Office.js setters reject unknown names instead of silently
+    // dropping them.  Client-object copies contain only loaded, settable
+    // fields in toJSON(), so read-only fields are ignored for that overload.
+    Object.keys(properties).forEach(function (name) {
+      var known =
+        scalarNames.indexOf(name) >= 0 || navigationNames.indexOf(name) >= 0;
+      if (!known) {
+        throw invalidArgument("Unknown " + typeName(this) + " property: " + name);
+      }
+      if (
+        readOnlyNames.indexOf(name) >= 0 &&
+        !isClientObject &&
+        properties[name] !== undefined &&
+        throwOnReadOnly
+      ) {
+        throw invalidArgument("The property '" + name + "' is read-only.");
+      }
+    }, this);
+
+    for (var i = 0; i < scalarNames.length; i++) {
+      var name = scalarNames[i];
+      if (
+        !Object.prototype.hasOwnProperty.call(properties, name) ||
+        properties[name] === undefined ||
+        readOnlyNames.indexOf(name) >= 0
+      ) {
+        continue;
+      }
+      this[name] = properties[name];
+    }
+
+    for (i = 0; i < navigationNames.length; i++) {
+      name = navigationNames[i];
+      if (
+        !Object.prototype.hasOwnProperty.call(properties, name) ||
+        properties[name] === undefined ||
+        readOnlyNames.indexOf(name) >= 0
+      ) {
+        continue;
+      }
+      var child = isClientObject ? source[name] : properties[name];
+      this[name].set(child, options);
+    }
+  }
+
+  function toJSON() {
+    var data = {};
+    var scalarNames = scalarProperties(this);
+    for (var i = 0; i < scalarNames.length; i++) {
+      var name = scalarNames[i];
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }
+
+    var navigationNames = navigationProperties(this);
+    for (i = 0; i < navigationNames.length; i++) {
+      var navigationName = navigationNames[i];
+      var child = this["_" + navigationName];
+      if (child !== undefined && child !== null) {
+        data[navigationName] =
+          typeof child.toJSON === "function" ? child.toJSON() : child;
+      }
+    }
+    return data;
+  }
+
+  function RangeFormat(context, range) {
+    ClientObject.call(this, context);
+    this._typeName = "RangeFormat";
+    this._scalarProperties = [
+      "horizontalAlignment",
+      "verticalAlignment",
+      "wrapText",
+      "autoIndent",
+      "indentLevel",
+      "shrinkToFit",
+      "textOrientation",
+      "readingOrder",
+    ];
+    this._navigationProperties = ["font", "fill", "protection"];
+    queueProxy(this, range, "format");
+  }
+  RangeFormat.prototype = Object.create(ClientObject.prototype);
+  RangeFormat.prototype.constructor = RangeFormat;
+  RangeFormat.prototype.set = setProperties;
+  RangeFormat.prototype.toJSON = toJSON;
+  defineScalars(RangeFormat, RangeFormat.prototype._scalarProperties || [
+    "horizontalAlignment",
+    "verticalAlignment",
+    "wrapText",
+    "autoIndent",
+    "indentLevel",
+    "shrinkToFit",
+    "textOrientation",
+    "readingOrder",
+  ]);
+
+  function RangeFont(context, range) {
+    ClientObject.call(this, context);
+    this._typeName = "RangeFont";
+    this._scalarProperties = [
+      "bold",
+      "color",
+      "italic",
+      "name",
+      "size",
+      "underline",
+      "strikethrough",
+      "subscript",
+      "superscript",
+      "tintAndShade",
+    ];
+    queueProxy(this, range, "font");
+  }
+  RangeFont.prototype = Object.create(ClientObject.prototype);
+  RangeFont.prototype.constructor = RangeFont;
+  RangeFont.prototype.set = setProperties;
+  RangeFont.prototype.toJSON = toJSON;
+  defineScalars(RangeFont, [
+    "bold", "color", "italic", "name", "size", "underline",
+    "strikethrough", "subscript", "superscript", "tintAndShade",
+  ]);
+
+  function RangeFill(context, range) {
+    ClientObject.call(this, context);
+    this._typeName = "RangeFill";
+    this._scalarProperties = [
+      "color",
+      "pattern",
+      "patternColor",
+      "patternTintAndShade",
+      "tintAndShade",
+    ];
+    queueProxy(this, range, "fill");
+  }
+  RangeFill.prototype = Object.create(ClientObject.prototype);
+  RangeFill.prototype.constructor = RangeFill;
+  RangeFill.prototype.set = setProperties;
+  RangeFill.prototype.toJSON = toJSON;
+  RangeFill.prototype.clear = function () {
+    this.context._queue.push({
+      op: "set",
+      id: this._id,
+      property: "clear",
+      value: null,
+    });
+  };
+  defineScalars(RangeFill, [
+    "color", "pattern", "patternColor", "patternTintAndShade", "tintAndShade",
+  ]);
+
+  function FormatProtection(context, range) {
+    ClientObject.call(this, context);
+    this._typeName = "FormatProtection";
+    this._scalarProperties = ["locked", "formulaHidden"];
+    queueProxy(this, range, "protection");
+  }
+  FormatProtection.prototype = Object.create(ClientObject.prototype);
+  FormatProtection.prototype.constructor = FormatProtection;
+  FormatProtection.prototype.set = setProperties;
+  FormatProtection.prototype.toJSON = toJSON;
+  defineScalars(FormatProtection, ["locked", "formulaHidden"]);
+
+  Object.defineProperty(RangeFormat.prototype, "font", {
+    get: function () {
+      if (!this._font) this._font = new RangeFont(this.context, this._range);
+      return this._font;
+    },
+  });
+  Object.defineProperty(RangeFormat.prototype, "fill", {
+    get: function () {
+      if (!this._fill) this._fill = new RangeFill(this.context, this._range);
+      return this._fill;
+    },
+  });
+  Object.defineProperty(RangeFormat.prototype, "protection", {
+    get: function () {
+      if (!this._protection) {
+        this._protection = new FormatProtection(this.context, this._range);
+      }
+      return this._protection;
+    },
+  });
+  Object.defineProperty(Excel.Range.prototype, "format", {
+    get: function () {
+      if (!this._format) this._format = new RangeFormat(this.context, this);
+      return this._format;
+    },
+  });
+
+  Excel.RangeFormat = RangeFormat;
+  Excel.RangeFont = RangeFont;
+  Excel.RangeFill = RangeFill;
+  Excel.FormatProtection = FormatProtection;
+})(globalThis);

--- a/compute/officejs/src/format.rs
+++ b/compute/officejs/src/format.rs
@@ -1,0 +1,469 @@
+use std::collections::HashMap;
+
+use compute_api::{CellRange, Sheet};
+use serde_json::{Map, Value, json};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FormatError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FormatKind {
+    Format,
+    Font,
+    Fill,
+    Protection,
+}
+
+#[derive(Clone)]
+pub(crate) struct FormatRef {
+    sheet: Sheet,
+    address: String,
+    kind: FormatKind,
+}
+
+impl FormatRef {
+    pub(crate) fn new(sheet: Sheet, address: String, kind: &str) -> Result<Self, FormatError> {
+        let kind = match kind {
+            "format" => FormatKind::Format,
+            "font" => FormatKind::Font,
+            "fill" => FormatKind::Fill,
+            "protection" => FormatKind::Protection,
+            _ => return Err(invalid(format!("Unsupported range format kind '{kind}'"))),
+        };
+        CellRange::from(address.as_str())
+            .resolve()
+            .map_err(|error| invalid(error.to_string()))?;
+        Ok(Self {
+            sheet,
+            address,
+            kind,
+        })
+    }
+
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, FormatError> {
+        let (start_row, start_col, end_row, end_col) = self.bounds()?;
+        let mut result = HashMap::new();
+        for property in properties {
+            let mut aggregate: Option<Value> = None;
+            let mut mixed = false;
+            'cells: for row in start_row..=end_row {
+                for col in start_col..=end_col {
+                    let format = self
+                        .sheet
+                        .formats()
+                        .get_cell_format(row, col)
+                        .map_err(engine)?;
+                    let format = serde_json::to_value(format).map_err(encoding)?;
+                    let value = read_property(self.kind, property, &format)?;
+                    match &aggregate {
+                        None => aggregate = Some(value),
+                        Some(first) if first == &value => {}
+                        Some(_) => {
+                            mixed = true;
+                            break 'cells;
+                        }
+                    }
+                }
+            }
+            result.insert(
+                property.clone(),
+                if mixed {
+                    Value::Null
+                } else {
+                    aggregate.unwrap_or(Value::Null)
+                },
+            );
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), FormatError> {
+        if self.kind == FormatKind::Fill && property == "clear" {
+            self.sheet
+                .formats()
+                .patch_format_for_ranges(
+                    vec![self.bounds()?],
+                    serde_json::from_value(json!({})).map_err(encoding)?,
+                    vec![
+                        "backgroundColor".to_string(),
+                        "backgroundColorTint".to_string(),
+                        "patternType".to_string(),
+                        "patternForegroundColor".to_string(),
+                        "patternForegroundColorTint".to_string(),
+                        "gradientFill".to_string(),
+                    ],
+                )
+                .map_err(engine)?;
+            return Ok(());
+        }
+
+        let (field, value) = write_property(self.kind, property, value)?;
+        let mut patch = Map::new();
+        patch.insert(field.to_string(), value);
+        self.sheet
+            .formats()
+            .patch_format_for_ranges(
+                vec![self.bounds()?],
+                serde_json::from_value(Value::Object(patch)).map_err(encoding)?,
+                Vec::new(),
+            )
+            .map_err(engine)?;
+        Ok(())
+    }
+
+    fn bounds(&self) -> Result<(u32, u32, u32, u32), FormatError> {
+        CellRange::from(self.address.as_str())
+            .resolve()
+            .map_err(|error| invalid(error.to_string()))
+    }
+}
+
+fn read_property(kind: FormatKind, property: &str, format: &Value) -> Result<Value, FormatError> {
+    let get = |field: &str, default: Value| {
+        format
+            .get(field)
+            .filter(|value| !value.is_null())
+            .cloned()
+            .unwrap_or(default)
+    };
+    let value = match (kind, property) {
+        (FormatKind::Format, "horizontalAlignment") => map_token(
+            get("horizontalAlign", json!("general")),
+            &[
+                ("general", "General"),
+                ("left", "Left"),
+                ("center", "Center"),
+                ("right", "Right"),
+                ("fill", "Fill"),
+                ("justify", "Justify"),
+                ("centerContinuous", "CenterAcrossSelection"),
+                ("distributed", "Distributed"),
+            ],
+        )?,
+        (FormatKind::Format, "verticalAlignment") => map_token(
+            get("verticalAlign", json!("bottom")),
+            &[
+                ("top", "Top"),
+                ("middle", "Center"),
+                ("bottom", "Bottom"),
+                ("justify", "Justify"),
+                ("distributed", "Distributed"),
+            ],
+        )?,
+        (FormatKind::Format, "wrapText") => get("wrapText", json!(false)),
+        (FormatKind::Format, "autoIndent") => get("autoIndent", json!(false)),
+        (FormatKind::Format, "indentLevel") => get("indent", json!(0)),
+        (FormatKind::Format, "shrinkToFit") => get("shrinkToFit", json!(false)),
+        (FormatKind::Format, "textOrientation") => get("textRotation", json!(0)),
+        (FormatKind::Format, "readingOrder") => map_token(
+            get("readingOrder", json!("context")),
+            &[
+                ("context", "Context"),
+                ("ltr", "LeftToRight"),
+                ("rtl", "RightToLeft"),
+            ],
+        )?,
+        (FormatKind::Font, "bold") => get("bold", json!(false)),
+        (FormatKind::Font, "color") => get("fontColor", json!("#000000")),
+        (FormatKind::Font, "italic") => get("italic", json!(false)),
+        (FormatKind::Font, "name") => get("fontFamily", json!("Calibri")),
+        (FormatKind::Font, "size") => get("fontSize", json!(11.0)),
+        (FormatKind::Font, "underline") => map_token(
+            get("underlineType", json!("none")),
+            &[
+                ("none", "None"),
+                ("single", "Single"),
+                ("double", "Double"),
+                ("singleAccounting", "SingleAccountant"),
+                ("doubleAccounting", "DoubleAccountant"),
+            ],
+        )?,
+        (FormatKind::Font, "strikethrough") => get("strikethrough", json!(false)),
+        (FormatKind::Font, "subscript") => get("subscript", json!(false)),
+        (FormatKind::Font, "superscript") => get("superscript", json!(false)),
+        (FormatKind::Font, "tintAndShade") => get("fontColorTint", json!(0.0)),
+        (FormatKind::Fill, "color") => get("backgroundColor", Value::Null),
+        (FormatKind::Fill, "pattern") => map_token(
+            get("patternType", json!("none")),
+            &[
+                ("none", "None"),
+                ("solid", "Solid"),
+                ("mediumGray", "Gray50"),
+                ("darkGray", "Gray75"),
+                ("lightGray", "Gray25"),
+                ("darkHorizontal", "Horizontal"),
+                ("darkVertical", "Vertical"),
+                ("darkDown", "Down"),
+                ("darkUp", "Up"),
+                ("darkGrid", "Checker"),
+                ("darkTrellis", "SemiGray75"),
+                ("lightHorizontal", "LightHorizontal"),
+                ("lightVertical", "LightVertical"),
+                ("lightDown", "LightDown"),
+                ("lightUp", "LightUp"),
+                ("lightGrid", "Grid"),
+                ("lightTrellis", "CrissCross"),
+                ("gray125", "Gray16"),
+                ("gray0625", "Gray8"),
+            ],
+        )?,
+        (FormatKind::Fill, "patternColor") => get("patternForegroundColor", Value::Null),
+        (FormatKind::Fill, "patternTintAndShade") => get("patternForegroundColorTint", json!(0.0)),
+        (FormatKind::Fill, "tintAndShade") => get("backgroundColorTint", json!(0.0)),
+        (FormatKind::Protection, "locked") => get("locked", json!(true)),
+        (FormatKind::Protection, "formulaHidden") => get("hidden", json!(false)),
+        _ => return Err(unsupported(kind, property)),
+    };
+    Ok(value)
+}
+
+fn write_property(
+    kind: FormatKind,
+    property: &str,
+    value: &Value,
+) -> Result<(&'static str, Value), FormatError> {
+    if value.is_null() {
+        return Err(invalid(format!("{property} cannot be null")));
+    }
+    let mapped = match (kind, property) {
+        (FormatKind::Format, "horizontalAlignment") => (
+            "horizontalAlign",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("General", "general"),
+                    ("Left", "left"),
+                    ("Center", "center"),
+                    ("Right", "right"),
+                    ("Fill", "fill"),
+                    ("Justify", "justify"),
+                    ("CenterAcrossSelection", "centerContinuous"),
+                    ("Distributed", "distributed"),
+                ],
+            )?,
+        ),
+        (FormatKind::Format, "verticalAlignment") => (
+            "verticalAlign",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("Top", "top"),
+                    ("Center", "middle"),
+                    ("Bottom", "bottom"),
+                    ("Justify", "justify"),
+                    ("Distributed", "distributed"),
+                ],
+            )?,
+        ),
+        (FormatKind::Format, "wrapText") => ("wrapText", boolean(value, property)?),
+        (FormatKind::Format, "autoIndent") => ("autoIndent", boolean(value, property)?),
+        (FormatKind::Format, "indentLevel") => {
+            let number = integer(value, property)?;
+            if !(0..=250).contains(&number) {
+                return Err(invalid("indentLevel must be between 0 and 250"));
+            }
+            ("indent", json!(number))
+        }
+        (FormatKind::Format, "shrinkToFit") => ("shrinkToFit", boolean(value, property)?),
+        (FormatKind::Format, "textOrientation") => {
+            let number = integer(value, property)?;
+            if !((-90..=90).contains(&number) || number == 180) {
+                return Err(invalid("textOrientation must be -90 through 90, or 180"));
+            }
+            ("textRotation", json!(number))
+        }
+        (FormatKind::Format, "readingOrder") => (
+            "readingOrder",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("Context", "context"),
+                    ("LeftToRight", "ltr"),
+                    ("RightToLeft", "rtl"),
+                ],
+            )?,
+        ),
+        (FormatKind::Font, "bold") => ("bold", boolean(value, property)?),
+        (FormatKind::Font, "color") => ("fontColor", string(value, property)?),
+        (FormatKind::Font, "italic") => ("italic", boolean(value, property)?),
+        (FormatKind::Font, "name") => {
+            let name = value
+                .as_str()
+                .ok_or_else(|| invalid("name must be a string"))?;
+            if name.is_empty() || name.chars().count() > 31 {
+                return Err(invalid("name must contain 1 through 31 characters"));
+            }
+            ("fontFamily", json!(name))
+        }
+        (FormatKind::Font, "size") => {
+            let size = finite_number(value, property)?;
+            if !(1.0..=409.0).contains(&size) {
+                return Err(invalid("size must be between 1 and 409 points"));
+            }
+            ("fontSize", json!(size))
+        }
+        (FormatKind::Font, "underline") => (
+            "underlineType",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("None", "none"),
+                    ("Single", "single"),
+                    ("Double", "double"),
+                    ("SingleAccountant", "singleAccounting"),
+                    ("DoubleAccountant", "doubleAccounting"),
+                ],
+            )?,
+        ),
+        (FormatKind::Font, "strikethrough") => ("strikethrough", boolean(value, property)?),
+        (FormatKind::Font, "subscript") => ("subscript", boolean(value, property)?),
+        (FormatKind::Font, "superscript") => ("superscript", boolean(value, property)?),
+        (FormatKind::Font, "tintAndShade") => ("fontColorTint", bounded_tint(value, property)?),
+        (FormatKind::Fill, "color") => ("backgroundColor", string(value, property)?),
+        (FormatKind::Fill, "pattern") => (
+            "patternType",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("None", "none"),
+                    ("Solid", "solid"),
+                    ("Gray50", "mediumGray"),
+                    ("Gray75", "darkGray"),
+                    ("Gray25", "lightGray"),
+                    ("Horizontal", "darkHorizontal"),
+                    ("Vertical", "darkVertical"),
+                    ("Down", "darkDown"),
+                    ("Up", "darkUp"),
+                    ("Checker", "darkGrid"),
+                    ("SemiGray75", "darkTrellis"),
+                    ("LightHorizontal", "lightHorizontal"),
+                    ("LightVertical", "lightVertical"),
+                    ("LightDown", "lightDown"),
+                    ("LightUp", "lightUp"),
+                    ("Grid", "lightGrid"),
+                    ("CrissCross", "lightTrellis"),
+                    ("Gray16", "gray125"),
+                    ("Gray8", "gray0625"),
+                ],
+            )?,
+        ),
+        (FormatKind::Fill, "patternColor") => ("patternForegroundColor", string(value, property)?),
+        (FormatKind::Fill, "patternTintAndShade") => {
+            ("patternForegroundColorTint", bounded_tint(value, property)?)
+        }
+        (FormatKind::Fill, "tintAndShade") => {
+            ("backgroundColorTint", bounded_tint(value, property)?)
+        }
+        (FormatKind::Protection, "locked") => ("locked", boolean(value, property)?),
+        (FormatKind::Protection, "formulaHidden") => ("hidden", boolean(value, property)?),
+        _ => return Err(unsupported(kind, property)),
+    };
+    Ok(mapped)
+}
+
+fn map_token(value: Value, mappings: &[(&str, &str)]) -> Result<Value, FormatError> {
+    let token = value.as_str().ok_or_else(|| FormatError {
+        code: "GeneralException",
+        message: "The engine returned an invalid format token".to_string(),
+    })?;
+    mappings
+        .iter()
+        .find_map(|(internal, office)| (*internal == token).then(|| json!(office)))
+        .ok_or_else(|| FormatError {
+            code: "GeneralException",
+            message: format!("The engine returned unsupported format token '{token}'"),
+        })
+}
+
+fn enum_value(
+    value: &Value,
+    property: &str,
+    mappings: &[(&str, &str)],
+) -> Result<Value, FormatError> {
+    let token = value
+        .as_str()
+        .ok_or_else(|| invalid(format!("{property} must be a string enum value")))?;
+    mappings
+        .iter()
+        .find_map(|(office, internal)| (*office == token).then(|| json!(internal)))
+        .ok_or_else(|| invalid(format!("Unsupported {property} value '{token}'")))
+}
+
+fn boolean(value: &Value, property: &str) -> Result<Value, FormatError> {
+    value
+        .as_bool()
+        .map(Value::Bool)
+        .ok_or_else(|| invalid(format!("{property} must be a boolean")))
+}
+
+fn string(value: &Value, property: &str) -> Result<Value, FormatError> {
+    let string = value
+        .as_str()
+        .ok_or_else(|| invalid(format!("{property} must be a string")))?;
+    if string.is_empty() {
+        return Err(invalid(format!("{property} cannot be empty")));
+    }
+    Ok(json!(string))
+}
+
+fn finite_number(value: &Value, property: &str) -> Result<f64, FormatError> {
+    value
+        .as_f64()
+        .filter(|number| number.is_finite())
+        .ok_or_else(|| invalid(format!("{property} must be a finite number")))
+}
+
+fn integer(value: &Value, property: &str) -> Result<i64, FormatError> {
+    let number = finite_number(value, property)?;
+    if number.fract() != 0.0 || number < i64::MIN as f64 || number > i64::MAX as f64 {
+        return Err(invalid(format!("{property} must be an integer")));
+    }
+    Ok(number as i64)
+}
+
+fn bounded_tint(value: &Value, property: &str) -> Result<Value, FormatError> {
+    let tint = finite_number(value, property)?;
+    if !(-1.0..=1.0).contains(&tint) {
+        return Err(invalid(format!("{property} must be between -1 and 1")));
+    }
+    Ok(json!(tint))
+}
+
+fn unsupported(kind: FormatKind, property: &str) -> FormatError {
+    FormatError {
+        code: "InvalidArgument",
+        message: format!("Unsupported {:?} property '{property}'", kind),
+    }
+}
+
+fn invalid(message: impl Into<String>) -> FormatError {
+    FormatError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn engine(error: impl std::fmt::Display) -> FormatError {
+    FormatError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn encoding(error: impl std::fmt::Display) -> FormatError {
+    FormatError {
+        code: "GeneralException",
+        message: format!("format conversion failed: {error}"),
+    }
+}

--- a/compute/officejs/src/format_dimensions.js
+++ b/compute/officejs/src/format_dimensions.js
@@ -1,0 +1,82 @@
+(function (global) {
+  "use strict";
+
+  // RangeFormat's visual properties live in format.js.  Dimensions are kept
+  // in this extension so the same RangeFormat proxy can expose layout fields
+  // without turning the layout state into a cell-format field.  The host
+  // receives the ordinary generic set/load operations for scalar dimensions
+  // and a dedicated rangeFormatAutofit operation for the two methods.
+  var Excel = global.Excel;
+  var officeJs = global.__mogOfficeJs || {};
+  var prototype = Excel.RangeFormat && Excel.RangeFormat.prototype;
+
+  if (!prototype) return;
+
+  var DIMENSION_PROPERTIES = [
+    "columnWidth",
+    "rowHeight",
+    "useStandardHeight",
+    "useStandardWidth",
+  ];
+
+  function propertyNotLoaded(name) {
+    var error = new global.OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function defineDimension(name) {
+    if (Object.getOwnPropertyDescriptor(prototype, name)) return;
+    Object.defineProperty(prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        this["_" + name] = value;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: value,
+        });
+      },
+    });
+  }
+
+  DIMENSION_PROPERTIES.forEach(defineDimension);
+  if (typeof officeJs.addScalarProperties === "function") {
+    officeJs.addScalarProperties(prototype, DIMENSION_PROPERTIES);
+  } else {
+    prototype._additionalScalarProperties = DIMENSION_PROPERTIES.slice();
+  }
+
+  // format.js computes scalar members dynamically from both lists.  Keeping
+  // dimensions in the additional list therefore makes ordinary set() and
+  // toJSON() handle them exactly once, preserving the base setter's queue
+  // order and avoiding duplicate dimension operations.
+
+  function queueAutofit(format, axis) {
+    format.context._queue.push({
+      op: "rangeFormatAutofit",
+      id: format._id,
+      axis: axis,
+    });
+  }
+
+  prototype.autofitColumns = function () {
+    queueAutofit(this, "columns");
+  };
+
+  prototype.autofitRows = function () {
+    queueAutofit(this, "rows");
+  };
+})(globalThis);

--- a/compute/officejs/src/format_dimensions.rs
+++ b/compute/officejs/src/format_dimensions.rs
@@ -1,0 +1,725 @@
+//! Office.js `RangeFormat` layout properties.
+//!
+//! `CellFormat` deliberately contains visual cell properties only.  Row
+//! heights and column widths live in the sheet layout index, so this adapter
+//! translates the Office.js units at the boundary and delegates every change
+//! to the production `Sheet::layout()` facade.  A range such as `4:8` or
+//! `C:F` is retained as a tagged [`RangeAddress`]; it is never expanded to a
+//! worksheet-sized cell matrix.
+//!
+//! The host integration stores one [`FormatDimensionsRef`] alongside its
+//! ordinary format reference for a `RangeFormat` proxy.  Generic `load` and
+//! `set` operations route the four dimension properties here.  The JavaScript
+//! extension emits `rangeFormatAutofit { id, axis }` for `autofitRows()` and
+//! `autofitColumns()`; the host calls [`FormatDimensionsRef::autofit`].
+//!
+//! The pinned Office.js contract exposes both row height and column width in
+//! points.  The compute-api layout facade uses pixels for rendering reads and
+//! writes, while the persisted column representation is OOXML character
+//! width.  This adapter therefore converts Office points to the production
+//! pixel boundary; the engine's MDW/padding quantization remains authoritative
+//! for the resulting layout.  Standard-width resets use the typed canonical
+//! character-width methods so they do not drift through that pixel inverse.
+
+use std::collections::HashMap;
+
+use compute_api::{ComputeApiError, Sheet};
+use serde_json::{json, Map, Value};
+
+use crate::range_navigation::{parse_range_address, RangeAddress};
+
+const EXCEL_MAX_ROWS: u32 = 1_048_576;
+const MAX_ROW_HEIGHT_POINTS: f64 = 409.0;
+const SCREEN_DPI: f64 = 96.0;
+const POINTS_PER_INCH: f64 = 72.0;
+
+/// Errors returned by the layout/format projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FormatDimensionsError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+impl FormatDimensionsError {
+    fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            code: "InvalidArgument",
+            message: message.into(),
+        }
+    }
+
+    fn unsupported(message: impl Into<String>) -> Self {
+        // The embedded host uses InvalidArgument for a member that is part of
+        // the Microsoft surface but has no production representation.
+        Self::invalid(message)
+    }
+
+    fn engine(error: impl std::fmt::Display) -> Self {
+        Self {
+            code: "GeneralException",
+            message: error.to_string(),
+        }
+    }
+}
+
+impl From<ComputeApiError> for FormatDimensionsError {
+    fn from(error: ComputeApiError) -> Self {
+        match error {
+            ComputeApiError::InvalidAddress { .. }
+            | ComputeApiError::InvalidRange { .. }
+            | ComputeApiError::InvalidOperation(_)
+            | ComputeApiError::Compute(value_types::ComputeError::InvalidInput { .. }) => {
+                Self::invalid(error.to_string())
+            }
+            other => Self::engine(other),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DimensionAxis {
+    Rows,
+    Columns,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AutofitAxis {
+    Rows,
+    Columns,
+}
+
+impl AutofitAxis {
+    pub(crate) fn parse(value: &str) -> Result<Self, FormatDimensionsError> {
+        match value {
+            "rows" => Ok(Self::Rows),
+            "columns" => Ok(Self::Columns),
+            other => Err(FormatDimensionsError::invalid(format!(
+                "Unsupported RangeFormat autofit axis '{other}'"
+            ))),
+        }
+    }
+}
+
+/// A `RangeFormat` layout reference retaining the range's original shape.
+#[derive(Clone)]
+pub(crate) struct FormatDimensionsRef {
+    sheet: Sheet,
+    address: String,
+    range: RangeAddress,
+}
+
+impl FormatDimensionsRef {
+    /// Bind a layout reference to a canonical or sheet-qualified A1 range.
+    pub(crate) fn new(sheet: Sheet, address: String) -> Result<Self, FormatDimensionsError> {
+        // Use the Office.js range parser so full rows/columns remain tagged
+        // and a cross-sheet qualifier is rejected at the host boundary.
+        let range = parse_range_address(&sheet, &address).map_err(|error| {
+            FormatDimensionsError::invalid(format!("invalid range address: {}", error.message))
+        })?;
+        Ok(Self {
+            sheet,
+            address,
+            range,
+        })
+    }
+
+    pub(crate) fn address(&self) -> &str {
+        &self.address
+    }
+
+    pub(crate) fn range(&self) -> &RangeAddress {
+        &self.range
+    }
+
+    /// Load layout scalar properties into Office.js-shaped values.
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, FormatDimensionsError> {
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                "rowHeight" => json!(self.uniform_row_height()?),
+                "columnWidth" => self.uniform_column_width()?,
+                "useStandardHeight" => self.standard_height()?,
+                "useStandardWidth" => self.standard_width()?,
+                other => {
+                    return Err(FormatDimensionsError::unsupported(format!(
+                        "Unsupported RangeFormat layout property '{other}'"
+                    )));
+                }
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    /// Apply one queued dimension property.
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), FormatDimensionsError> {
+        match property {
+            "rowHeight" => self.set_row_height(value),
+            "columnWidth" => self.set_column_width(value),
+            // Microsoft documents these setters as intended only for `true`.
+            // `false` is deliberately a no-op and must not reset a custom
+            // dimension.
+            "useStandardHeight" => self.set_standard_height(value),
+            "useStandardWidth" => self.set_standard_width(value),
+            other => Err(FormatDimensionsError::unsupported(format!(
+                "Unsupported RangeFormat layout property '{other}'"
+            ))),
+        }
+    }
+
+    /// Compute and set best-fit dimensions for the selected range axis.
+    pub(crate) fn autofit(&self, axis: AutofitAxis) -> Result<(), FormatDimensionsError> {
+        match axis {
+            AutofitAxis::Rows => {
+                let (start, end) = self.axis_bounds(DimensionAxis::Rows)?;
+                self.ensure_rows_enumerable(start, end, "autofitRows")?;
+                let rows = (start..=end).collect::<Vec<_>>();
+                self.sheet
+                    .layout()
+                    .auto_fit_rows_and_set(rows)
+                    .map(|_| ())
+                    .map_err(FormatDimensionsError::from)
+            }
+            AutofitAxis::Columns => {
+                let (start, end) = self.axis_bounds(DimensionAxis::Columns)?;
+                // 16,384 column identities are a bounded layout axis and the
+                // production autofit primitive consumes that list directly.
+                // This never expands rows or cells.
+                let columns = (start..=end).collect::<Vec<_>>();
+                self.sheet
+                    .layout()
+                    .auto_fit_columns_and_set(columns)
+                    .map(|_| ())
+                    .map_err(FormatDimensionsError::from)
+            }
+        }
+    }
+
+    fn set_row_height(&self, value: &Value) -> Result<(), FormatDimensionsError> {
+        let points = finite_number(value, "rowHeight")?;
+        if !(0.0 < points && points <= MAX_ROW_HEIGHT_POINTS) {
+            return Err(FormatDimensionsError::invalid(format!(
+                "rowHeight must be greater than 0 and at most {MAX_ROW_HEIGHT_POINTS} points"
+            )));
+        }
+        let (start, end) = self.axis_bounds(DimensionAxis::Rows)?;
+        self.ensure_rows_enumerable(start, end, "rowHeight")?;
+        // SheetLayout speaks rendering pixels.  Office.js rowHeight speaks
+        // points.  The conversion is the engine's documented 96-DPI screen
+        // contract, not a font or content measurement.
+        let pixels = points_to_pixels(points);
+        for row in start..=end {
+            self.sheet
+                .layout()
+                .set_row_height(row, pixels)
+                .map_err(FormatDimensionsError::from)?;
+        }
+        Ok(())
+    }
+
+    fn set_column_width(&self, value: &Value) -> Result<(), FormatDimensionsError> {
+        let points = finite_number(value, "columnWidth")?;
+        if points <= 0.0 {
+            return Err(FormatDimensionsError::invalid(format!(
+                "columnWidth must be greater than 0 points"
+            )));
+        }
+        let pixels = points_to_pixels(points);
+        if !pixels.is_finite() {
+            return Err(FormatDimensionsError::invalid(
+                "columnWidth is outside the supported point range",
+            ));
+        }
+        let (start, end) = self.axis_bounds(DimensionAxis::Columns)?;
+        let columns = (start..=end)
+            .map(|column| (column, pixels))
+            .collect::<Vec<_>>();
+        // Office.js columnWidth is point-based. SheetLayout's pixel setter
+        // performs the production MDW/padding conversion into canonical
+        // character units; do not substitute an invented character heuristic.
+        self.sheet
+            .layout()
+            .set_col_widths(columns)
+            .map(|_| ())
+            .map_err(FormatDimensionsError::from)
+    }
+
+    fn set_standard_height(&self, value: &Value) -> Result<(), FormatDimensionsError> {
+        let use_standard = value
+            .as_bool()
+            .ok_or_else(|| FormatDimensionsError::invalid("useStandardHeight must be a boolean"))?;
+        if !use_standard {
+            return Ok(());
+        }
+        let default_pixels = self
+            .sheet
+            .layout()
+            .get_default_row_height()
+            .map_err(FormatDimensionsError::from)?;
+        let (start, end) = self.axis_bounds(DimensionAxis::Rows)?;
+        self.ensure_rows_enumerable(start, end, "useStandardHeight")?;
+        for row in start..=end {
+            self.sheet
+                .layout()
+                .set_row_height(row, default_pixels)
+                .map_err(FormatDimensionsError::from)?;
+        }
+        Ok(())
+    }
+
+    fn set_standard_width(&self, value: &Value) -> Result<(), FormatDimensionsError> {
+        let use_standard = value
+            .as_bool()
+            .ok_or_else(|| FormatDimensionsError::invalid("useStandardWidth must be a boolean"))?;
+        if !use_standard {
+            return Ok(());
+        }
+        let default_width = self
+            .sheet
+            .layout()
+            .get_default_col_width_chars()
+            .map_err(FormatDimensionsError::from)?;
+        let (start, end) = self.axis_bounds(DimensionAxis::Columns)?;
+        let columns = (start..=end)
+            .map(|column| (column, default_width))
+            .collect::<Vec<_>>();
+        self.sheet
+            .layout()
+            .set_col_widths_chars(columns)
+            .map(|_| ())
+            .map_err(FormatDimensionsError::from)
+    }
+
+    fn uniform_row_height(&self) -> Result<Option<f64>, FormatDimensionsError> {
+        let (start, end) = self.axis_bounds(DimensionAxis::Rows)?;
+        self.ensure_rows_enumerable(start, end, "rowHeight")?;
+        let mut values = (start..=end).map(|row| {
+            self.sheet
+                .layout()
+                .get_row_height(row)
+                .map(|pixels| pixels_to_points(pixels))
+                .map_err(FormatDimensionsError::from)
+        });
+        let Some(first) = values.next() else {
+            return Ok(None);
+        };
+        let first = first?;
+        for value in values {
+            if value? != first {
+                return Ok(None);
+            }
+        }
+        Ok(Some(first))
+    }
+
+    fn uniform_column_width(&self) -> Result<Value, FormatDimensionsError> {
+        let (start, end) = self.axis_bounds(DimensionAxis::Columns)?;
+        let mut values = (start..=end).map(|column| {
+            self.sheet
+                .layout()
+                .get_col_width(column)
+                .map(|pixels| pixels_to_points(pixels))
+                .map_err(FormatDimensionsError::from)
+        });
+        let Some(first) = values.next() else {
+            return Ok(Value::Null);
+        };
+        let first = first?;
+        for value in values {
+            if value? != first {
+                return Ok(Value::Null);
+            }
+        }
+        Ok(json!(first))
+    }
+
+    fn standard_height(&self) -> Result<Value, FormatDimensionsError> {
+        let default_pixels = self
+            .sheet
+            .layout()
+            .get_default_row_height()
+            .map_err(FormatDimensionsError::from)?;
+        let default_points = pixels_to_points(default_pixels);
+        let height = self.uniform_row_height()?;
+        Ok(match height {
+            Some(value) => json!(value == default_points),
+            None => Value::Null,
+        })
+    }
+
+    fn standard_width(&self) -> Result<Value, FormatDimensionsError> {
+        let default_pixels = self
+            .sheet
+            .layout()
+            .get_default_col_width()
+            .map_err(FormatDimensionsError::from)?;
+        let default_points = pixels_to_points(default_pixels);
+        let width = self.uniform_column_width()?;
+        Ok(match width {
+            Value::Number(value) => json!(value.as_f64() == Some(default_points)),
+            Value::Null => Value::Null,
+            _ => Value::Null,
+        })
+    }
+
+    fn axis_bounds(&self, axis: DimensionAxis) -> Result<(u32, u32), FormatDimensionsError> {
+        let (start_row, start_col, end_row, end_col) = self.range.bounds();
+        Ok(match axis {
+            DimensionAxis::Rows => (start_row, end_row),
+            DimensionAxis::Columns => (start_col, end_col),
+        })
+    }
+
+    fn ensure_rows_enumerable(
+        &self,
+        start: u32,
+        end: u32,
+        operation: &str,
+    ) -> Result<(), FormatDimensionsError> {
+        // A full column/worksheet selection has one million rows.  The
+        // production layout facade has per-row/autofit calls, so expanding
+        // this axis in the Office.js host would be both incorrect and an
+        // avoidable memory spike.  Keep the operation explicit until a true
+        // sparse row-range primitive exists.
+        if end - start + 1 >= EXCEL_MAX_ROWS {
+            return Err(FormatDimensionsError::unsupported(format!(
+                "RangeFormat.{operation} cannot enumerate the entire worksheet row axis"
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn points_to_pixels(points: f64) -> f64 {
+    points * SCREEN_DPI / POINTS_PER_INCH
+}
+
+fn pixels_to_points(pixels: f64) -> f64 {
+    pixels * POINTS_PER_INCH / SCREEN_DPI
+}
+
+/// A sparse row/column format target used by the host for full-axis ranges.
+///
+/// The normal `FormatRef` intentionally accepts bounded cell ranges only.  A
+/// full row or column can still carry a real format layer in the engine, and
+/// the row/column format facades apply it without creating one million cells.
+/// This helper covers mutations for the existing RangeFormat/RangeFont/
+/// RangeFill/FormatProtection scalar surface.  Bounded ranges continue to
+/// use `format.rs`, which owns their complete mixed-value projection.
+#[derive(Clone)]
+pub(crate) struct SparseFormatRef {
+    dimensions: FormatDimensionsRef,
+}
+
+impl SparseFormatRef {
+    pub(crate) fn new(sheet: Sheet, address: String) -> Result<Self, FormatDimensionsError> {
+        Ok(Self {
+            dimensions: FormatDimensionsRef::new(sheet, address)?,
+        })
+    }
+
+    pub(crate) fn is_axis_range(&self) -> bool {
+        self.dimensions.range().is_entire_row() || self.dimensions.range().is_entire_column()
+    }
+
+    /// Apply one visual format scalar to each selected sparse row/column.
+    ///
+    /// This is deliberately a patch operation.  Omitted format fields remain
+    /// untouched and `fill.clear` clears only fill fields.  The conversion is
+    /// kept here rather than routing through a finite max-row/max-column cell
+    /// rectangle.
+    pub(crate) fn set(
+        &self,
+        kind: &str,
+        property: &str,
+        value: &Value,
+    ) -> Result<(), FormatDimensionsError> {
+        let (format, clear_fields) = sparse_property_patch(kind, property, value)?;
+        // Type inference keeps the Office adapter on compute-api's public
+        // surface while still passing the production CellFormat type to the
+        // row/column format methods.
+        let format = serde_json::from_value(format).map_err(FormatDimensionsError::engine)?;
+        match self.dimensions.range() {
+            RangeAddress::Rows { start, end } => {
+                self.dimensions
+                    .ensure_rows_enumerable(*start, *end, "sparse format")?;
+                for row in *start..=*end {
+                    self.dimensions
+                        .sheet
+                        .formats()
+                        .patch_row_format(row, format.clone(), clear_fields.clone())
+                        .map_err(FormatDimensionsError::from)?;
+                }
+                Ok(())
+            }
+            RangeAddress::Columns { start, end } => {
+                for column in *start..=*end {
+                    self.dimensions
+                        .sheet
+                        .formats()
+                        .patch_col_format(*column, format.clone(), clear_fields.clone())
+                        .map_err(FormatDimensionsError::from)?;
+                }
+                Ok(())
+            }
+            RangeAddress::WholeSheet => Err(FormatDimensionsError::unsupported(
+                "Whole-worksheet format patches require a row or column range",
+            )),
+            RangeAddress::Cells { .. } => Err(FormatDimensionsError::unsupported(
+                "Sparse format patches require a full row or column range",
+            )),
+        }
+    }
+
+    pub(crate) fn dimensions(&self) -> &FormatDimensionsRef {
+        &self.dimensions
+    }
+}
+
+/// Convert one Office.js scalar to a sparse `CellFormat` patch.  The JSON
+/// boundary lets this adapter use compute-api's public typed methods without
+/// importing a private engine format type.
+fn sparse_property_patch(
+    kind: &str,
+    property: &str,
+    value: &Value,
+) -> Result<(Value, Vec<String>), FormatDimensionsError> {
+    if kind == "fill" && property == "clear" {
+        return Ok((
+            json!({}),
+            vec![
+                "backgroundColor".to_string(),
+                "backgroundColorTint".to_string(),
+                "patternType".to_string(),
+                "patternForegroundColor".to_string(),
+                "patternForegroundColorTint".to_string(),
+                "gradientFill".to_string(),
+            ],
+        ));
+    }
+    if value.is_null() {
+        return Err(FormatDimensionsError::invalid(format!(
+            "{property} cannot be null"
+        )));
+    }
+
+    let (field, value) = match (kind, property) {
+        ("format", "horizontalAlignment") => (
+            "horizontalAlign",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("General", "general"),
+                    ("Left", "left"),
+                    ("Center", "center"),
+                    ("Right", "right"),
+                    ("Fill", "fill"),
+                    ("Justify", "justify"),
+                    ("CenterAcrossSelection", "centerContinuous"),
+                    ("Distributed", "distributed"),
+                ],
+            )?,
+        ),
+        ("format", "verticalAlignment") => (
+            "verticalAlign",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("Top", "top"),
+                    ("Center", "middle"),
+                    ("Bottom", "bottom"),
+                    ("Justify", "justify"),
+                    ("Distributed", "distributed"),
+                ],
+            )?,
+        ),
+        ("format", "wrapText") => ("wrapText", boolean(value, property)?),
+        ("format", "autoIndent") => ("autoIndent", boolean(value, property)?),
+        ("format", "indentLevel") => {
+            let indent = integer(value, property)?;
+            if !(0..=250).contains(&indent) {
+                return Err(FormatDimensionsError::invalid(
+                    "indentLevel must be between 0 and 250",
+                ));
+            }
+            ("indent", json!(indent))
+        }
+        ("format", "shrinkToFit") => ("shrinkToFit", boolean(value, property)?),
+        ("format", "textOrientation") => {
+            let orientation = integer(value, property)?;
+            if !((-90..=90).contains(&orientation) || orientation == 180) {
+                return Err(FormatDimensionsError::invalid(
+                    "textOrientation must be -90 through 90, or 180",
+                ));
+            }
+            ("textRotation", json!(orientation))
+        }
+        ("format", "readingOrder") => (
+            "readingOrder",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("Context", "context"),
+                    ("LeftToRight", "ltr"),
+                    ("RightToLeft", "rtl"),
+                ],
+            )?,
+        ),
+        ("font", "bold") => ("bold", boolean(value, property)?),
+        ("font", "color") => ("fontColor", non_empty_string(value, property)?),
+        ("font", "italic") => ("italic", boolean(value, property)?),
+        ("font", "name") => {
+            let name = value
+                .as_str()
+                .ok_or_else(|| FormatDimensionsError::invalid("name must be a string"))?;
+            if name.is_empty() || name.chars().count() > 31 {
+                return Err(FormatDimensionsError::invalid(
+                    "name must contain 1 through 31 characters",
+                ));
+            }
+            ("fontFamily", json!(name))
+        }
+        ("font", "size") => {
+            let size = finite_number(value, property)?;
+            if !(1.0..=409.0).contains(&size) {
+                return Err(FormatDimensionsError::invalid(
+                    "size must be between 1 and 409 points",
+                ));
+            }
+            ("fontSize", json!(size))
+        }
+        ("font", "underline") => (
+            "underlineType",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("None", "none"),
+                    ("Single", "single"),
+                    ("Double", "double"),
+                    ("SingleAccountant", "singleAccounting"),
+                    ("DoubleAccountant", "doubleAccounting"),
+                ],
+            )?,
+        ),
+        ("font", "strikethrough") => ("strikethrough", boolean(value, property)?),
+        ("font", "subscript") => ("subscript", boolean(value, property)?),
+        ("font", "superscript") => ("superscript", boolean(value, property)?),
+        ("font", "tintAndShade") => ("fontColorTint", bounded_tint(value, property)?),
+        ("fill", "color") => ("backgroundColor", non_empty_string(value, property)?),
+        ("fill", "pattern") => (
+            "patternType",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("None", "none"),
+                    ("Solid", "solid"),
+                    ("Gray50", "mediumGray"),
+                    ("Gray75", "darkGray"),
+                    ("Gray25", "lightGray"),
+                    ("Horizontal", "darkHorizontal"),
+                    ("Vertical", "darkVertical"),
+                    ("Down", "darkDown"),
+                    ("Up", "darkUp"),
+                    ("Checker", "darkGrid"),
+                    ("SemiGray75", "darkTrellis"),
+                    ("LightHorizontal", "lightHorizontal"),
+                    ("LightVertical", "lightVertical"),
+                    ("LightDown", "lightDown"),
+                    ("LightUp", "lightUp"),
+                    ("Grid", "lightGrid"),
+                    ("CrissCross", "lightTrellis"),
+                    ("Gray16", "gray125"),
+                    ("Gray8", "gray0625"),
+                ],
+            )?,
+        ),
+        ("fill", "patternColor") => ("patternForegroundColor", non_empty_string(value, property)?),
+        ("fill", "patternTintAndShade") => {
+            ("patternForegroundColorTint", bounded_tint(value, property)?)
+        }
+        ("fill", "tintAndShade") => ("backgroundColorTint", bounded_tint(value, property)?),
+        ("protection", "locked") => ("locked", boolean(value, property)?),
+        ("protection", "formulaHidden") => ("hidden", boolean(value, property)?),
+        _ => {
+            return Err(FormatDimensionsError::unsupported(format!(
+                "Unsupported sparse {kind}.{property} property"
+            )));
+        }
+    };
+
+    let mut patch = Map::new();
+    patch.insert(field.to_string(), value);
+    Ok((Value::Object(patch), Vec::new()))
+}
+
+fn enum_value(
+    value: &Value,
+    property: &str,
+    mappings: &[(&str, &str)],
+) -> Result<Value, FormatDimensionsError> {
+    let token = value.as_str().ok_or_else(|| {
+        FormatDimensionsError::invalid(format!("{property} must be a string enum value"))
+    })?;
+    mappings
+        .iter()
+        .find_map(|(office, internal)| (*office == token).then(|| json!(internal)))
+        .ok_or_else(|| {
+            FormatDimensionsError::invalid(format!("Unsupported {property} value '{token}'"))
+        })
+}
+
+fn boolean(value: &Value, property: &str) -> Result<Value, FormatDimensionsError> {
+    value
+        .as_bool()
+        .map(Value::Bool)
+        .ok_or_else(|| FormatDimensionsError::invalid(format!("{property} must be a boolean")))
+}
+
+fn non_empty_string(value: &Value, property: &str) -> Result<Value, FormatDimensionsError> {
+    let value = value
+        .as_str()
+        .ok_or_else(|| FormatDimensionsError::invalid(format!("{property} must be a string")))?;
+    if value.is_empty() {
+        return Err(FormatDimensionsError::invalid(format!(
+            "{property} cannot be empty"
+        )));
+    }
+    Ok(json!(value))
+}
+
+fn finite_number(value: &Value, property: &str) -> Result<f64, FormatDimensionsError> {
+    value
+        .as_f64()
+        .filter(|number| number.is_finite())
+        .ok_or_else(|| {
+            FormatDimensionsError::invalid(format!("{property} must be a finite number"))
+        })
+}
+
+fn integer(value: &Value, property: &str) -> Result<i64, FormatDimensionsError> {
+    let number = finite_number(value, property)?;
+    if number.fract() != 0.0 || number < i64::MIN as f64 || number > i64::MAX as f64 {
+        return Err(FormatDimensionsError::invalid(format!(
+            "{property} must be an integer"
+        )));
+    }
+    Ok(number as i64)
+}
+
+fn bounded_tint(value: &Value, property: &str) -> Result<Value, FormatDimensionsError> {
+    let tint = finite_number(value, property)?;
+    if !(-1.0..=1.0).contains(&tint) {
+        return Err(FormatDimensionsError::invalid(format!(
+            "{property} must be between -1 and 1"
+        )));
+    }
+    Ok(json!(tint))
+}

--- a/compute/officejs/src/host.rs
+++ b/compute/officejs/src/host.rs
@@ -1,24 +1,392 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
-use compute_api::{CellAddress, Sheet, Workbook};
+use compute_api::{CellAddress, ComputeApiError, Sheet, Workbook, mutation::CellInput};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use value_types::CellValue;
+
+use crate::borders::{BorderCollectionRef, BorderError, BorderRef};
+use crate::dispatch::{
+    ExtensionBinding, ExtensionHandler, ExtensionRegistry, HostDispatchContext,
+};
+use crate::format::{FormatError, FormatRef};
+use crate::names::{self, NameError, NamedItemCollectionRef, NamedItemRef};
+use crate::range_content::{self, RangeContentError};
+use crate::range_navigation::{
+    RangeAddress, RangeNavigationError, navigate_range, parse_range_address,
+};
+use crate::sort_filter::{
+    AutoFilterApplyRequest, AutoFilterRef, RangeSortRequest, SortFilterError, apply_range_sort,
+};
+use crate::table_collections::{
+    self, TableCollectionError, TableCollectionKind, TableColumnRangeKind, TableColumnRef,
+    TableRowRef,
+};
+use crate::tables::{self, TableError, TableRangeKind, TableRef};
+use crate::validation::{ValidationError, ValidationRef};
+use crate::worksheets::{self, WorksheetError, WorksheetRef};
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "op")]
 enum Op {
     #[serde(rename = "getItem")]
     GetItem { id: String, name: String },
+    #[serde(rename = "getWorksheetCollection")]
+    GetWorksheetCollection { id: String },
+    #[serde(rename = "getActiveWorksheet")]
+    GetActiveWorksheet { id: String },
     #[serde(rename = "addWorksheet")]
     AddWorksheet { id: String, name: Option<String> },
+    #[serde(rename = "getNamedItemCollection")]
+    GetNamedItemCollection {
+        id: String,
+        #[serde(rename = "worksheetId")]
+        worksheet_id: Option<String>,
+    },
+    #[serde(rename = "nameAdd")]
+    NameAdd {
+        id: String,
+        #[serde(rename = "worksheetId")]
+        worksheet_id: Option<String>,
+        name: String,
+        comment: Option<String>,
+        #[serde(rename = "formulaLocal")]
+        formula_local: bool,
+        reference: Option<Value>,
+        #[serde(rename = "rangeId")]
+        range_id: Option<String>,
+    },
+    #[serde(rename = "nameGetCount")]
+    NameGetCount {
+        #[serde(rename = "resultId")]
+        result_id: String,
+        #[serde(rename = "worksheetId")]
+        worksheet_id: Option<String>,
+    },
+    #[serde(rename = "nameGetItem")]
+    NameGetItem {
+        id: String,
+        #[serde(rename = "worksheetId")]
+        worksheet_id: Option<String>,
+        name: String,
+        #[serde(rename = "orNullObject")]
+        or_null_object: bool,
+    },
+    #[serde(rename = "nameDelete")]
+    NameDelete { id: String },
+    #[serde(rename = "nameGetRange")]
+    NameGetRange {
+        id: String,
+        #[serde(rename = "nameId")]
+        name_id: String,
+        #[serde(rename = "orNullObject")]
+        or_null_object: bool,
+    },
+    #[serde(rename = "nameGetWorksheet")]
+    NameGetWorksheet {
+        id: String,
+        #[serde(rename = "nameId")]
+        name_id: String,
+        #[serde(rename = "orNullObject")]
+        or_null_object: bool,
+    },
+    #[serde(rename = "nameGetArrayValues")]
+    NameGetArrayValues {
+        id: String,
+        #[serde(rename = "nameId")]
+        name_id: String,
+    },
+    #[serde(rename = "worksheetGetItemOrNullObject")]
+    WorksheetGetItemOrNullObject { id: String, key: String },
+    #[serde(rename = "worksheetCollectionGetCount")]
+    WorksheetCollectionGetCount {
+        #[serde(rename = "collectionId")]
+        collection_id: String,
+        #[serde(rename = "resultId")]
+        result_id: String,
+        #[serde(rename = "visibleOnly")]
+        visible_only: bool,
+    },
+    #[serde(rename = "worksheetCollectionGetFirst")]
+    WorksheetCollectionGetFirst {
+        #[serde(rename = "collectionId")]
+        collection_id: String,
+        id: String,
+        #[serde(rename = "visibleOnly")]
+        visible_only: bool,
+        #[serde(rename = "orNull")]
+        or_null: bool,
+    },
+    #[serde(rename = "worksheetCollectionGetLast")]
+    WorksheetCollectionGetLast {
+        #[serde(rename = "collectionId")]
+        collection_id: String,
+        id: String,
+        #[serde(rename = "visibleOnly")]
+        visible_only: bool,
+        #[serde(rename = "orNull")]
+        or_null: bool,
+    },
+    #[serde(rename = "worksheetActivate")]
+    WorksheetActivate { id: String },
+    #[serde(rename = "worksheetDelete")]
+    WorksheetDelete { id: String },
+    #[serde(rename = "worksheetGetNext")]
+    WorksheetGetNext {
+        id: String,
+        #[serde(rename = "worksheetId")]
+        worksheet_id: String,
+        #[serde(rename = "visibleOnly")]
+        visible_only: bool,
+        #[serde(rename = "orNull")]
+        or_null: bool,
+    },
+    #[serde(rename = "worksheetGetPrevious")]
+    WorksheetGetPrevious {
+        id: String,
+        #[serde(rename = "worksheetId")]
+        worksheet_id: String,
+        #[serde(rename = "visibleOnly")]
+        visible_only: bool,
+        #[serde(rename = "orNull")]
+        or_null: bool,
+    },
     #[serde(rename = "getRange")]
     GetRange {
         id: String,
         #[serde(rename = "worksheetId")]
         worksheet_id: String,
-        address: String,
+        address: Option<String>,
+    },
+    #[serde(rename = "rangeNavigation")]
+    RangeNavigation {
+        id: String,
+        #[serde(rename = "rangeId")]
+        range_id: Option<String>,
+        #[serde(rename = "worksheetId")]
+        worksheet_id: Option<String>,
+        method: String,
+        #[serde(default)]
+        args: Vec<Value>,
+    },
+    #[serde(rename = "getRangeFormat")]
+    GetRangeFormat {
+        id: String,
+        #[serde(rename = "rangeId")]
+        range_id: String,
+        kind: String,
+    },
+    #[serde(rename = "getRangeBorderCollection")]
+    GetRangeBorderCollection {
+        id: String,
+        #[serde(rename = "rangeId")]
+        range_id: String,
+    },
+    #[serde(rename = "getRangeBorder")]
+    GetRangeBorder {
+        id: String,
+        #[serde(rename = "collectionId")]
+        collection_id: String,
+        index: String,
+    },
+    #[serde(rename = "getRangeDataValidation")]
+    GetRangeDataValidation {
+        id: String,
+        #[serde(rename = "rangeId")]
+        range_id: String,
+    },
+    #[serde(rename = "rangeClear")]
+    RangeClear {
+        id: String,
+        #[serde(rename = "applyTo")]
+        apply_to: String,
+    },
+    #[serde(rename = "rangeSort")]
+    RangeSort {
+        #[serde(rename = "rangeId")]
+        range_id: String,
+        fields: Value,
+        #[serde(rename = "matchCase")]
+        match_case: Option<bool>,
+        #[serde(rename = "hasHeaders")]
+        has_headers: Option<bool>,
+        orientation: Option<String>,
+        method: Option<String>,
+    },
+    #[serde(rename = "getAutoFilter")]
+    GetAutoFilter {
+        id: String,
+        #[serde(rename = "worksheetId")]
+        worksheet_id: String,
+    },
+    #[serde(rename = "autoFilterApply")]
+    AutoFilterApply {
+        id: String,
+        #[serde(rename = "worksheetId")]
+        worksheet_id: String,
+        address: Option<String>,
+        #[serde(rename = "rangeId")]
+        range_id: Option<String>,
+        #[serde(rename = "columnIndex")]
+        column_index: Option<i64>,
+        criteria: Option<Value>,
+    },
+    #[serde(rename = "autoFilterClearColumnCriteria")]
+    AutoFilterClearColumnCriteria {
+        id: String,
+        #[serde(rename = "columnIndex")]
+        column_index: i64,
+    },
+    #[serde(rename = "autoFilterClearCriteria")]
+    AutoFilterClearCriteria { id: String },
+    #[serde(rename = "autoFilterGetRange")]
+    AutoFilterGetRange {
+        id: String,
+        #[serde(rename = "autoFilterId")]
+        auto_filter_id: String,
+        #[serde(rename = "worksheetId")]
+        worksheet_id: String,
+        #[serde(rename = "nullObject")]
+        null_object: bool,
+    },
+    #[serde(rename = "autoFilterReapply")]
+    AutoFilterReapply { id: String },
+    #[serde(rename = "autoFilterRemove")]
+    AutoFilterRemove { id: String },
+    #[serde(rename = "tableAdd")]
+    TableAdd {
+        id: String,
+        #[serde(rename = "worksheetId")]
+        worksheet_id: Option<String>,
+        #[serde(rename = "hasHeaders")]
+        has_headers: bool,
+        address: Option<String>,
+        #[serde(rename = "rangeId")]
+        range_id: Option<String>,
+    },
+    #[serde(rename = "getTableCollection")]
+    GetTableCollection {
+        id: String,
+        #[serde(rename = "worksheetId")]
+        worksheet_id: Option<String>,
+    },
+    #[serde(rename = "tableGetItem")]
+    TableGetItem {
+        id: String,
+        #[serde(rename = "worksheetId")]
+        worksheet_id: Option<String>,
+        #[serde(rename = "collectionId")]
+        collection_id: Option<String>,
+        key: String,
+        #[serde(rename = "orNullObject", default)]
+        or_null_object: bool,
+        #[serde(rename = "byIndex", default)]
+        by_index: bool,
+    },
+    #[serde(rename = "tableGetRange")]
+    TableGetRange {
+        id: String,
+        #[serde(rename = "tableId")]
+        table_id: String,
+        kind: String,
+    },
+    #[serde(rename = "tableDelete")]
+    TableDelete { id: String },
+    #[serde(rename = "tableConvertToRange")]
+    TableConvertToRange {
+        id: String,
+        #[serde(rename = "tableId")]
+        table_id: String,
+    },
+    #[serde(rename = "tableResize")]
+    TableResize {
+        #[serde(rename = "tableId")]
+        table_id: String,
+        address: Option<String>,
+        #[serde(rename = "rangeId")]
+        range_id: Option<String>,
+    },
+    #[serde(rename = "tableCollectionGet")]
+    TableCollectionGet {
+        id: String,
+        #[serde(rename = "tableId")]
+        table_id: String,
+        kind: String,
+    },
+    #[serde(rename = "tableCollectionGetCount")]
+    TableCollectionGetCount {
+        #[serde(rename = "collectionId")]
+        collection_id: String,
+        #[serde(rename = "resultId")]
+        result_id: String,
+    },
+    #[serde(rename = "tableColumnGetItem")]
+    TableColumnGetItem {
+        id: String,
+        #[serde(rename = "tableId")]
+        table_id: String,
+        key: Value,
+        #[serde(rename = "orNullObject", default)]
+        or_null_object: bool,
+        #[serde(rename = "byIndex", default)]
+        by_index: bool,
+    },
+    #[serde(rename = "tableRowGetItem")]
+    TableRowGetItem {
+        id: String,
+        #[serde(rename = "tableId")]
+        table_id: String,
+        index: i64,
+    },
+    #[serde(rename = "tableColumnAdd")]
+    TableColumnAdd {
+        id: String,
+        #[serde(rename = "tableId")]
+        table_id: String,
+        index: Option<i64>,
+        values: Option<Value>,
+        name: Option<Value>,
+    },
+    #[serde(rename = "tableRowAdd")]
+    TableRowAdd {
+        id: String,
+        #[serde(rename = "tableId")]
+        table_id: String,
+        index: Option<i64>,
+        values: Option<Value>,
+        #[serde(rename = "alwaysInsert")]
+        always_insert: Option<bool>,
+    },
+    #[serde(rename = "tableColumnDelete")]
+    TableColumnDelete { id: String },
+    #[serde(rename = "tableRowDelete")]
+    TableRowDelete { id: String },
+    #[serde(rename = "tableRowDeleteMany")]
+    TableRowDeleteMany {
+        #[serde(rename = "tableId")]
+        table_id: String,
+        rows: Vec<Value>,
+    },
+    #[serde(rename = "tableRowDeleteAt")]
+    TableRowDeleteAt {
+        #[serde(rename = "tableId")]
+        table_id: String,
+        index: i64,
+        count: i64,
+    },
+    #[serde(rename = "tableColumnGetRange")]
+    TableColumnGetRange {
+        id: String,
+        #[serde(rename = "columnId")]
+        column_id: String,
+        kind: String,
+    },
+    #[serde(rename = "tableRowGetRange")]
+    TableRowGetRange {
+        id: String,
+        #[serde(rename = "rowId")]
+        row_id: String,
     },
     #[serde(rename = "set")]
     Set {
@@ -31,9 +399,9 @@ enum Op {
 }
 
 #[derive(Debug, Serialize)]
-struct BatchError {
-    code: &'static str,
-    message: String,
+pub(crate) struct BatchError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -42,28 +410,231 @@ struct BatchResult {
     error: Option<BatchError>,
     #[serde(default)]
     loaded: HashMap<String, HashMap<String, Value>>,
+    #[serde(default)]
+    results: HashMap<String, Value>,
 }
 
-struct RangeRef {
+#[derive(Clone)]
+pub(crate) struct RangeRef {
     sheet: Sheet,
-    address: String,
+    address: Option<String>,
+    is_null_object: bool,
+}
+
+impl RangeRef {
+    /// Construct a Range proxy produced by an extension-family operation.
+    ///
+    /// Core `getRange` operations still initialize this struct inline because
+    /// they own the request-path address validation.  Result-producing
+    /// families (for example search and used-range) need a narrow constructor
+    /// so they can bind a validated engine address without duplicating the
+    /// host's private fields.
+    pub(crate) fn new(sheet: Sheet, address: Option<String>, is_null_object: bool) -> Self {
+        Self {
+            sheet,
+            address,
+            is_null_object,
+        }
+    }
+
+    /// Return the underlying sheet for a family adapter that needs to reuse
+    /// the compute-api range primitives.
+    pub(crate) fn sheet(&self) -> Sheet {
+        self.sheet.clone()
+    }
+
+    /// Return the optional unqualified A1 address.  `None` represents the
+    /// whole worksheet or another unbounded range.
+    pub(crate) fn address(&self) -> Option<&str> {
+        self.address.as_deref()
+    }
+
+    pub(crate) fn is_null_object(&self) -> bool {
+        self.is_null_object
+    }
+}
+
+#[derive(Clone)]
+struct TableCollectionRef {
+    table: TableRef,
+    kind: TableCollectionKind,
 }
 
 pub(crate) struct Host {
     workbook: Workbook,
-    sheets: Mutex<HashMap<String, Sheet>>,
+    sheets: Mutex<HashMap<String, WorksheetRef>>,
+    worksheet_collections: Mutex<HashSet<String>>,
+    null_worksheets: Mutex<HashSet<String>>,
     ranges: Mutex<HashMap<String, RangeRef>>,
+    formats: Mutex<HashMap<String, FormatRef>>,
+    tables: Mutex<HashMap<String, TableRef>>,
+    null_tables: Mutex<HashSet<String>>,
+    table_collection_bindings: Mutex<HashMap<String, Option<Sheet>>>,
+    auto_filters: Mutex<HashMap<String, AutoFilterRef>>,
+    validations: Mutex<HashMap<String, ValidationRef>>,
+    border_collections: Mutex<HashMap<String, BorderCollectionRef>>,
+    borders: Mutex<HashMap<String, BorderRef>>,
+    table_collections: Mutex<HashMap<String, TableCollectionRef>>,
+    table_columns: Mutex<HashMap<String, TableColumnRef>>,
+    null_table_columns: Mutex<HashSet<String>>,
+    table_rows: Mutex<HashMap<String, TableRowRef>>,
+    name_collections: Mutex<HashMap<String, NamedItemCollectionRef>>,
+    names: Mutex<HashMap<String, NamedItemRef>>,
+    name_array_values: Mutex<HashMap<String, names::NamedItemArrayValuesRef>>,
+    extension_bindings: Mutex<HashMap<String, ExtensionBinding>>,
+    extensions: ExtensionRegistry,
     stdout: Mutex<String>,
+}
+
+struct ExtensionDispatch {
+    handled: bool,
+    delegated_load: Option<(String, Vec<String>)>,
 }
 
 impl Host {
     pub(crate) fn new(workbook: Workbook) -> Self {
+        Self::with_extensions(workbook, ExtensionRegistry::default())
+    }
+
+    /// Construct a host with a preassembled family registry.  Runtime setup
+    /// can use this when all family modules are known up front; callers may
+    /// also use [`Host::register_extension`] for incremental assembly before
+    /// the first sync.
+    pub(crate) fn with_extensions(
+        workbook: Workbook,
+        extensions: ExtensionRegistry,
+    ) -> Self {
         Self {
             workbook,
             sheets: Mutex::new(HashMap::new()),
+            worksheet_collections: Mutex::new(HashSet::new()),
+            null_worksheets: Mutex::new(HashSet::new()),
             ranges: Mutex::new(HashMap::new()),
+            formats: Mutex::new(HashMap::new()),
+            tables: Mutex::new(HashMap::new()),
+            null_tables: Mutex::new(HashSet::new()),
+            table_collection_bindings: Mutex::new(HashMap::new()),
+            auto_filters: Mutex::new(HashMap::new()),
+            validations: Mutex::new(HashMap::new()),
+            border_collections: Mutex::new(HashMap::new()),
+            borders: Mutex::new(HashMap::new()),
+            table_collections: Mutex::new(HashMap::new()),
+            table_columns: Mutex::new(HashMap::new()),
+            null_table_columns: Mutex::new(HashSet::new()),
+            table_rows: Mutex::new(HashMap::new()),
+            name_collections: Mutex::new(HashMap::new()),
+            names: Mutex::new(HashMap::new()),
+            name_array_values: Mutex::new(HashMap::new()),
+            extension_bindings: Mutex::new(HashMap::new()),
+            extensions,
             stdout: Mutex::new(String::new()),
         }
+    }
+
+    /// Register a family handler before evaluating a script.  Registration
+    /// is intentionally separate from the core `Op` enum so independent
+    /// object families can be added in their own modules.
+    pub(crate) fn register_extension<H>(&self, handler: H)
+    where
+        H: ExtensionHandler + 'static,
+    {
+        self.extensions.register(handler);
+    }
+
+    pub(crate) fn workbook(&self) -> Workbook {
+        self.workbook.clone()
+    }
+
+    pub(crate) fn lookup_worksheet(&self, id: &str) -> Result<WorksheetRef, BatchError> {
+        self.sheets
+            .lock()
+            .expect("sheets lock")
+            .get(id)
+            .cloned()
+            .ok_or_else(|| BatchError {
+                code: "InvalidObjectPath",
+                message: "The worksheet object is not available.".to_string(),
+            })
+    }
+
+    pub(crate) fn lookup_range(&self, id: &str) -> Result<RangeRef, BatchError> {
+        self.ranges
+            .lock()
+            .expect("ranges lock")
+            .get(id)
+            .cloned()
+            .ok_or_else(|| BatchError {
+                code: "InvalidObjectPath",
+                message: "The range object is not available.".to_string(),
+            })
+    }
+
+    pub(crate) fn lookup_format(&self, id: &str) -> Result<FormatRef, BatchError> {
+        self.formats
+            .lock()
+            .expect("formats lock")
+            .get(id)
+            .cloned()
+            .ok_or_else(|| BatchError {
+                code: "InvalidObjectPath",
+                message: "The RangeFormat object is not available.".to_string(),
+            })
+    }
+
+    pub(crate) fn bind_worksheet(&self, id: &str, worksheet: WorksheetRef) {
+        self.sheets
+            .lock()
+            .expect("sheets lock")
+            .insert(id.to_string(), worksheet);
+    }
+
+    pub(crate) fn bind_range(&self, id: &str, range: RangeRef) {
+        self.ranges
+            .lock()
+            .expect("ranges lock")
+            .insert(id.to_string(), range);
+    }
+
+    pub(crate) fn bind_extension_object(&self, id: &str, binding: ExtensionBinding) {
+        self.extension_bindings
+            .lock()
+            .expect("extension bindings lock")
+            .insert(id.to_string(), binding);
+    }
+
+    pub(crate) fn extension_binding(&self, id: &str) -> Option<ExtensionBinding> {
+        self.extension_bindings
+            .lock()
+            .expect("extension bindings lock")
+            .get(id)
+            .cloned()
+    }
+
+    fn dispatch_extension(
+        &self,
+        operation: &Value,
+        loaded: &mut HashMap<String, HashMap<String, Value>>,
+        results: &mut HashMap<String, Value>,
+    ) -> Result<ExtensionDispatch, BatchError> {
+        let mut context = HostDispatchContext::new(self, loaded, results);
+        let handled = self.extensions.dispatch(operation, &mut context)?;
+        Ok(ExtensionDispatch {
+            handled,
+            delegated_load: context.take_delegated_load(),
+        })
+    }
+
+    fn set_extension_property(
+        &self,
+        id: &str,
+        property: &str,
+        value: &Value,
+    ) -> Result<bool, BatchError> {
+        let Some(binding) = self.extension_binding(id) else {
+            return Ok(false);
+        };
+        binding.set(property, value)?;
+        Ok(true)
     }
 
     pub(crate) fn log(&self, line: &str) {
@@ -90,26 +661,84 @@ impl Host {
             Err(err) => serde_json::to_string(&BatchResult {
                 error: Some(err),
                 loaded: HashMap::new(),
+                results: HashMap::new(),
             })
             .expect("batch error encodes"),
         }
     }
 
     fn apply_ops(&self, raw: &str) -> Result<BatchResult, BatchError> {
-        let ops: Vec<Op> = serde_json::from_str(raw).map_err(|e| BatchError {
+        // Decode the outer batch as raw values so extension families can own
+        // additional operation names without editing the core `Op` enum.
+        // Known operations still take the exact typed path below.
+        let ops: Vec<Value> = serde_json::from_str(raw).map_err(|e| BatchError {
             code: "InvalidArgument",
             message: format!("invalid Office.js batch: {e}"),
         })?;
 
         let mut loaded = HashMap::new();
-        for op in ops {
+        let mut results = HashMap::new();
+        for raw_op in ops {
+            // Give extension handlers first refusal for both new operation
+            // names and property additions to existing core objects.  A
+            // handler can return `false` to preserve the core path below.
+            let dispatch = self.dispatch_extension(&raw_op, &mut loaded, &mut results)?;
+            let has_delegated_load = dispatch.delegated_load.is_some();
+            let raw_op = if let Some((target_id, properties)) = dispatch.delegated_load {
+                let operation_id = raw_op.get("id").and_then(Value::as_str).ok_or_else(|| {
+                    BatchError {
+                        code: "InvalidArgument",
+                        message: "A delegated load operation requires an id.".to_string(),
+                    }
+                })?;
+                if operation_id != target_id {
+                    return Err(BatchError {
+                        code: "InvalidArgument",
+                        message: "A delegated load handler changed the load target.".to_string(),
+                    });
+                }
+                let mut delegated = raw_op;
+                delegated["properties"] = Value::Array(
+                    properties.into_iter().map(Value::String).collect(),
+                );
+                delegated
+            } else {
+                raw_op
+            };
+            if dispatch.handled && !has_delegated_load {
+                continue;
+            }
+            let op = match serde_json::from_value::<Op>(raw_op.clone()) {
+                Ok(op) => op,
+                Err(error) => return Err(BatchError {
+                    code: "InvalidArgument",
+                    message: format!("invalid Office.js operation: {error}"),
+                }),
+            };
             match op {
                 Op::GetItem { id, name } => {
-                    let sheet = self.workbook.sheet_by_name(&name).map_err(|_| BatchError {
-                        code: "ItemNotFound",
-                        message: format!("The requested resource doesn't exist. Name: {name}"),
-                    })?;
-                    self.sheets.lock().expect("sheets lock").insert(id, sheet);
+                    let worksheet =
+                        worksheets::get_item(&self.workbook, &name).map_err(worksheet_error)?;
+                    self.sheets
+                        .lock()
+                        .expect("sheets lock")
+                        .insert(id.clone(), worksheet);
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::GetWorksheetCollection { id } => {
+                    self.worksheet_collections
+                        .lock()
+                        .expect("worksheet collections lock")
+                        .insert(id.clone());
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::GetActiveWorksheet { id } => {
+                    let worksheet = worksheets::active(&self.workbook).map_err(worksheet_error)?;
+                    self.sheets
+                        .lock()
+                        .expect("sheets lock")
+                        .insert(id.clone(), worksheet);
+                    mark_object(&mut loaded, &id, false);
                 }
                 Op::AddWorksheet { id, name } => {
                     let name = match name {
@@ -121,7 +750,262 @@ impl Host {
                         .create_sheet(&name)
                         .map_err(engine_error)?;
                     let sheet = self.workbook.sheet_by_name(&name).map_err(engine_error)?;
-                    self.sheets.lock().expect("sheets lock").insert(id, sheet);
+                    self.sheets
+                        .lock()
+                        .expect("sheets lock")
+                        .insert(id.clone(), WorksheetRef::new(self.workbook.clone(), sheet));
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::GetNamedItemCollection { id, worksheet_id } => {
+                    let collection = name_collection_for_scope(self, worksheet_id.as_deref())?;
+                    self.name_collections
+                        .lock()
+                        .expect("name collections lock")
+                        .insert(id.clone(), collection);
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::NameAdd {
+                    id,
+                    worksheet_id,
+                    name,
+                    comment,
+                    formula_local,
+                    reference,
+                    range_id,
+                } => {
+                    let collection = name_collection_for_scope(self, worksheet_id.as_deref())?;
+                    let item = match (reference, range_id) {
+                        (Some(reference), None) => collection
+                            .add(&name, &reference, formula_local, comment)
+                            .map_err(name_error)?,
+                        (None, Some(range_id)) => {
+                            let range = self
+                                .ranges
+                                .lock()
+                                .expect("ranges lock")
+                                .get(&range_id)
+                                .cloned()
+                                .ok_or_else(|| BatchError {
+                                    code: "InvalidObjectPath",
+                                    message: "The named-item Range object is not available."
+                                        .to_string(),
+                                })?;
+                            if range_has_unbounded_dimension(&range)? {
+                                return Err(BatchError {
+                                    code: "InvalidArgument",
+                                    message: "NamedItemCollection.add requires a bounded Range."
+                                        .to_string(),
+                                });
+                            }
+                            collection
+                                .add_range(
+                                    &name,
+                                    &range.sheet,
+                                    range.address.as_deref().expect("bounded address"),
+                                    comment,
+                                )
+                                .map_err(name_error)?
+                        }
+                        _ => {
+                            return Err(BatchError {
+                                code: "InvalidArgument",
+                                message: "NamedItemCollection.add requires exactly one reference or Range."
+                                    .to_string(),
+                            });
+                        }
+                    };
+                    self.names
+                        .lock()
+                        .expect("names lock")
+                        .insert(id.clone(), item);
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::NameGetCount {
+                    result_id,
+                    worksheet_id,
+                } => {
+                    let collection = name_collection_for_scope(self, worksheet_id.as_deref())?;
+                    results.insert(result_id, json!(collection.count().map_err(name_error)?));
+                }
+                Op::NameGetItem {
+                    id,
+                    worksheet_id,
+                    name,
+                    or_null_object,
+                } => {
+                    let collection = name_collection_for_scope(self, worksheet_id.as_deref())?;
+                    let item = if or_null_object {
+                        collection
+                            .get_item_or_null_object(&name)
+                            .map_err(name_error)?
+                    } else {
+                        collection.get_item(&name).map_err(name_error)?
+                    };
+                    let is_null = item.is_null_object();
+                    self.names
+                        .lock()
+                        .expect("names lock")
+                        .insert(id.clone(), item);
+                    mark_object(&mut loaded, &id, is_null);
+                }
+                Op::NameDelete { id } => {
+                    name_ref(&self.names, &id)?.delete().map_err(name_error)?;
+                }
+                Op::NameGetRange {
+                    id,
+                    name_id,
+                    or_null_object,
+                } => {
+                    let item = name_ref(&self.names, &name_id)?;
+                    let target = item.range().map_err(name_error)?;
+                    if target.is_none() && !or_null_object {
+                        return Err(BatchError {
+                            code: "InvalidReference",
+                            message: "The named item does not refer to a range.".to_string(),
+                        });
+                    }
+                    let (sheet, address, is_null_object) = match target {
+                        Some(target) => (target.sheet(), Some(target.address().to_string()), false),
+                        None => (
+                            self.workbook.sheet_by_index(0).map_err(engine_error)?,
+                            None,
+                            true,
+                        ),
+                    };
+                    self.ranges.lock().expect("ranges lock").insert(
+                        id.clone(),
+                        RangeRef {
+                            sheet,
+                            address,
+                            is_null_object,
+                        },
+                    );
+                    mark_object(&mut loaded, &id, is_null_object);
+                }
+                Op::NameGetWorksheet {
+                    id,
+                    name_id,
+                    or_null_object,
+                } => {
+                    let item = name_ref(&self.names, &name_id)?;
+                    let worksheet = item.worksheet().map_err(name_error)?;
+                    if worksheet.is_none() && !or_null_object {
+                        return Err(BatchError {
+                            code: "InvalidReference",
+                            message: "The named item does not have a worksheet scope."
+                                .to_string(),
+                        });
+                    }
+                    let worksheet = worksheet.map(|sheet| {
+                        WorksheetRef::new(self.workbook.clone(), sheet)
+                    });
+                    bind_nullable_worksheet(self, &mut loaded, id, worksheet, or_null_object);
+                }
+                Op::NameGetArrayValues { id, name_id } => {
+                    let item = name_ref(&self.names, &name_id)?;
+                    let values = item.array_values_ref();
+                    self.name_array_values
+                        .lock()
+                        .expect("named item array values lock")
+                        .insert(id.clone(), values);
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::WorksheetGetItemOrNullObject { id, key } => {
+                    let worksheet = worksheets::get_item_or_null(&self.workbook, &key)
+                        .map_err(worksheet_error)?;
+                    bind_nullable_worksheet(self, &mut loaded, id, worksheet, true);
+                }
+                Op::WorksheetCollectionGetCount {
+                    collection_id,
+                    result_id,
+                    visible_only,
+                } => {
+                    require_worksheet_collection(self, &collection_id)?;
+                    let count = worksheets::ordered(self.workbook.clone(), visible_only)
+                        .map_err(worksheet_error)?
+                        .len();
+                    results.insert(result_id, json!(count));
+                }
+                Op::WorksheetCollectionGetFirst {
+                    collection_id,
+                    id,
+                    visible_only,
+                    or_null,
+                } => {
+                    require_worksheet_collection(self, &collection_id)?;
+                    let worksheet = worksheets::ordered(self.workbook.clone(), visible_only)
+                        .map_err(worksheet_error)?
+                        .into_iter()
+                        .next();
+                    if worksheet.is_none() && !or_null {
+                        return Err(BatchError {
+                            code: "ItemNotFound",
+                            message: "The worksheet collection is empty.".to_string(),
+                        });
+                    }
+                    bind_nullable_worksheet(self, &mut loaded, id, worksheet, or_null);
+                }
+                Op::WorksheetCollectionGetLast {
+                    collection_id,
+                    id,
+                    visible_only,
+                    or_null,
+                } => {
+                    require_worksheet_collection(self, &collection_id)?;
+                    let worksheet = worksheets::ordered(self.workbook.clone(), visible_only)
+                        .map_err(worksheet_error)?;
+                    let worksheet = worksheet.into_iter().last();
+                    if worksheet.is_none() && !or_null {
+                        return Err(BatchError {
+                            code: "ItemNotFound",
+                            message: "The worksheet collection is empty.".to_string(),
+                        });
+                    }
+                    bind_nullable_worksheet(self, &mut loaded, id, worksheet, or_null);
+                }
+                Op::WorksheetActivate { id } => {
+                    worksheet_ref(&self.sheets, &id)?
+                        .activate()
+                        .map_err(worksheet_error)?;
+                }
+                Op::WorksheetDelete { id } => {
+                    worksheet_ref(&self.sheets, &id)?
+                        .delete()
+                        .map_err(worksheet_error)?;
+                }
+                Op::WorksheetGetNext {
+                    id,
+                    worksheet_id,
+                    visible_only,
+                    or_null,
+                } => {
+                    let worksheet = worksheet_ref(&self.sheets, &worksheet_id)?
+                        .next(visible_only)
+                        .map_err(worksheet_error)?;
+                    if worksheet.is_none() && !or_null {
+                        return Err(BatchError {
+                            code: "ItemNotFound",
+                            message: "There is no next worksheet.".to_string(),
+                        });
+                    }
+                    bind_nullable_worksheet(self, &mut loaded, id, worksheet, or_null);
+                }
+                Op::WorksheetGetPrevious {
+                    id,
+                    worksheet_id,
+                    visible_only,
+                    or_null,
+                } => {
+                    let worksheet = worksheet_ref(&self.sheets, &worksheet_id)?
+                        .previous(visible_only)
+                        .map_err(worksheet_error)?;
+                    if worksheet.is_none() && !or_null {
+                        return Err(BatchError {
+                            code: "ItemNotFound",
+                            message: "There is no previous worksheet.".to_string(),
+                        });
+                    }
+                    bind_nullable_worksheet(self, &mut loaded, id, worksheet, or_null);
                 }
                 Op::GetRange {
                     id,
@@ -137,78 +1021,1407 @@ impl Host {
                         .ok_or_else(|| BatchError {
                             code: "InvalidObjectPath",
                             message: "The worksheet object is not available.".to_string(),
-                        })?;
-                    // Validate the address now so sync fails in Office.js style.
-                    let _: (u32, u32, u32, u32) = compute_api::CellRange::from(address.as_str())
-                        .resolve()
-                        .map_err(|e| BatchError {
-                            code: "InvalidArgument",
-                            message: e.to_string(),
-                        })?;
-                    self.ranges
+                        })?
+                        .sheet();
+                    // An omitted address represents the whole worksheet. Its
+                    // cell-level properties are unbounded: reads return null
+                    // and writes are rejected. Validate bounded addresses now
+                    // so the failure occurs at context.sync().
+                    if let Some(address) = address.as_deref() {
+                        parse_range_address(&sheet, address).map_err(range_navigation_error)?;
+                    }
+                    self.ranges.lock().expect("ranges lock").insert(
+                        id.clone(),
+                        RangeRef {
+                            sheet,
+                            address,
+                            is_null_object: false,
+                        },
+                    );
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::RangeNavigation {
+                    id,
+                    range_id,
+                    worksheet_id,
+                    method,
+                    mut args,
+                } => {
+                    let (sheet, address) = match (range_id, worksheet_id) {
+                        (Some(range_id), None) => {
+                            let range = self
+                                .ranges
+                                .lock()
+                                .expect("ranges lock")
+                                .get(&range_id)
+                                .cloned()
+                                .ok_or_else(|| BatchError {
+                                    code: "InvalidObjectPath",
+                                    message: "The source range object is not available."
+                                        .to_string(),
+                                })?;
+                            parsed_range(&range)?;
+                            (range.sheet, range.address)
+                        }
+                        (None, Some(worksheet_id)) => {
+                            let sheet = self
+                                .sheets
+                                .lock()
+                                .expect("sheets lock")
+                                .get(&worksheet_id)
+                                .cloned()
+                                .ok_or_else(|| BatchError {
+                                    code: "InvalidObjectPath",
+                                    message: "The worksheet object is not available.".to_string(),
+                                })?
+                                .sheet();
+                            (sheet, None)
+                        }
+                        _ => {
+                            return Err(BatchError {
+                                code: "InvalidArgument",
+                                message: "Range navigation requires exactly one source Range or Worksheet."
+                                    .to_string(),
+                            });
+                        }
+                    };
+
+                    for argument in &mut args {
+                        let range_id = argument
+                            .as_object()
+                            .and_then(|object| object.get("rangeId"))
+                            .and_then(Value::as_str);
+                        let Some(range_id) = range_id else {
+                            continue;
+                        };
+                        let argument_range = self
+                            .ranges
+                            .lock()
+                            .expect("ranges lock")
+                            .get(range_id)
+                            .cloned()
+                            .ok_or_else(|| BatchError {
+                                code: "InvalidObjectPath",
+                                message: "The range argument object is not available.".to_string(),
+                            })?;
+                        if argument_range.sheet.id() != sheet.id() {
+                            return Err(BatchError {
+                                code: "InvalidArgument",
+                                message: "Range arguments must belong to the same worksheet."
+                                    .to_string(),
+                            });
+                        }
+                        let address = range_metadata(&argument_range)?.address;
+                        *argument = json!({ "address": address });
+                    }
+
+                    let result = navigate_range(sheet, address.as_deref(), &method, &args)
+                        .map_err(range_navigation_error)?;
+                    let address = if result.address.is_whole_sheet() {
+                        None
+                    } else {
+                        Some(result.address.to_a1())
+                    };
+                    self.ranges.lock().expect("ranges lock").insert(
+                        id.clone(),
+                        RangeRef {
+                            sheet: result.sheet,
+                            address,
+                            is_null_object: false,
+                        },
+                    );
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::GetRangeFormat { id, range_id, kind } => {
+                    let range = self
+                        .ranges
                         .lock()
                         .expect("ranges lock")
-                        .insert(id, RangeRef { sheet, address });
+                        .get(&range_id)
+                        .cloned()
+                        .ok_or_else(|| BatchError {
+                            code: "InvalidObjectPath",
+                            message: "The range object is not available.".to_string(),
+                        })?;
+                    if range_has_unbounded_dimension(&range)? {
+                        return Err(BatchError {
+                            code: "InvalidArgument",
+                            message: "Range formatting requires a bounded range.".to_string(),
+                        });
+                    }
+                    let address = range.address.ok_or_else(|| BatchError {
+                        code: "InvalidArgument",
+                        message: "Range formatting cannot be used on an unbounded worksheet range"
+                            .to_string(),
+                    })?;
+                    let format =
+                        FormatRef::new(range.sheet, address, &kind).map_err(format_error)?;
+                    self.formats
+                        .lock()
+                        .expect("formats lock")
+                        .insert(id.clone(), format);
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::GetRangeBorderCollection { id, range_id } => {
+                    let range = self
+                        .ranges
+                        .lock()
+                        .expect("ranges lock")
+                        .get(&range_id)
+                        .cloned()
+                        .ok_or_else(|| BatchError {
+                            code: "InvalidObjectPath",
+                            message: "The range object is not available.".to_string(),
+                        })?;
+                    if range_has_unbounded_dimension(&range)? {
+                        return Err(BatchError {
+                            code: "InvalidArgument",
+                            message: "RangeFormat.borders requires a bounded range.".to_string(),
+                        });
+                    }
+                    let address = range.address.ok_or_else(|| BatchError {
+                        code: "InvalidArgument",
+                        message: "RangeFormat.borders requires a bounded range.".to_string(),
+                    })?;
+                    let collection =
+                        BorderCollectionRef::new(range.sheet, address).map_err(border_error)?;
+                    self.border_collections
+                        .lock()
+                        .expect("border collections lock")
+                        .insert(id.clone(), collection);
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::GetRangeBorder {
+                    id,
+                    collection_id,
+                    index,
+                } => {
+                    let collection = self
+                        .border_collections
+                        .lock()
+                        .expect("border collections lock")
+                        .get(&collection_id)
+                        .cloned()
+                        .ok_or_else(|| BatchError {
+                            code: "InvalidObjectPath",
+                            message: "The border collection object is not available.".to_string(),
+                        })?;
+                    let border = collection.get_item(&index).map_err(border_error)?;
+                    self.borders
+                        .lock()
+                        .expect("borders lock")
+                        .insert(id.clone(), border);
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::GetRangeDataValidation { id, range_id } => {
+                    let range = self
+                        .ranges
+                        .lock()
+                        .expect("ranges lock")
+                        .get(&range_id)
+                        .cloned()
+                        .ok_or_else(|| BatchError {
+                            code: "InvalidObjectPath",
+                            message: "The range object is not available.".to_string(),
+                        })?;
+                    if range_has_unbounded_dimension(&range)? {
+                        return Err(BatchError {
+                            code: "InvalidArgument",
+                            message: "Range.dataValidation requires a bounded range.".to_string(),
+                        });
+                    }
+                    let address = range.address.ok_or_else(|| BatchError {
+                        code: "InvalidArgument",
+                        message: "Range.dataValidation requires a bounded range.".to_string(),
+                    })?;
+                    let validation =
+                        ValidationRef::new(range.sheet, address).map_err(validation_error)?;
+                    self.validations
+                        .lock()
+                        .expect("validations lock")
+                        .insert(id.clone(), validation);
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::RangeClear { id, apply_to } => {
+                    let range = self
+                        .ranges
+                        .lock()
+                        .expect("ranges lock")
+                        .get(&id)
+                        .cloned()
+                        .ok_or_else(|| BatchError {
+                            code: "InvalidObjectPath",
+                            message: "The range object is not available.".to_string(),
+                        })?;
+                    if range_has_unbounded_dimension(&range)? {
+                        return Err(BatchError {
+                            code: "InvalidArgument",
+                            message: "Range.clear requires a bounded range.".to_string(),
+                        });
+                    }
+                    let address = range.address.as_deref().ok_or_else(|| BatchError {
+                        code: "InvalidArgument",
+                        message: "Range.clear cannot be used on an unbounded worksheet range"
+                            .to_string(),
+                    })?;
+                    range_content::clear(&range.sheet, address, &apply_to)
+                        .map_err(range_content_error)?;
+                }
+                Op::RangeSort {
+                    range_id,
+                    fields,
+                    match_case,
+                    has_headers,
+                    orientation,
+                    method,
+                } => {
+                    let range = self
+                        .ranges
+                        .lock()
+                        .expect("ranges lock")
+                        .get(&range_id)
+                        .cloned()
+                        .ok_or_else(|| BatchError {
+                            code: "InvalidObjectPath",
+                            message: "The range object is not available.".to_string(),
+                        })?;
+                    if range_has_unbounded_dimension(&range)? {
+                        return Err(BatchError {
+                            code: "InvalidArgument",
+                            message: "Range.sort requires a bounded range.".to_string(),
+                        });
+                    }
+                    let address = range.address.as_deref().ok_or_else(|| BatchError {
+                        code: "InvalidArgument",
+                        message: "Range.sort cannot be used on an unbounded or null range."
+                            .to_string(),
+                    })?;
+                    apply_range_sort(
+                        &range.sheet,
+                        address,
+                        RangeSortRequest {
+                            fields,
+                            match_case,
+                            has_headers,
+                            orientation,
+                            method,
+                        },
+                    )
+                    .map_err(sort_filter_error)?;
+                }
+                Op::GetAutoFilter { id, worksheet_id } => {
+                    let sheet = self
+                        .sheets
+                        .lock()
+                        .expect("sheets lock")
+                        .get(&worksheet_id)
+                        .cloned()
+                        .ok_or_else(|| BatchError {
+                            code: "InvalidObjectPath",
+                            message: "The worksheet object is not available.".to_string(),
+                        })?
+                        .sheet();
+                    self.auto_filters
+                        .lock()
+                        .expect("auto filters lock")
+                        .insert(id.clone(), AutoFilterRef::new(sheet));
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::AutoFilterApply {
+                    id,
+                    worksheet_id,
+                    address,
+                    range_id,
+                    column_index,
+                    criteria,
+                } => {
+                    let sheet = self
+                        .sheets
+                        .lock()
+                        .expect("sheets lock")
+                        .get(&worksheet_id)
+                        .cloned()
+                        .ok_or_else(|| BatchError {
+                            code: "InvalidObjectPath",
+                            message: "The worksheet object is not available.".to_string(),
+                        })?
+                        .sheet();
+                    let address = match (address, range_id) {
+                        (Some(address), None) => address,
+                        (None, Some(range_id)) => {
+                            let range = self
+                                .ranges
+                                .lock()
+                                .expect("ranges lock")
+                                .get(&range_id)
+                                .cloned()
+                                .ok_or_else(|| BatchError {
+                                    code: "InvalidObjectPath",
+                                    message: "The AutoFilter range object is not available."
+                                        .to_string(),
+                                })?;
+                            if range.sheet.id() != sheet.id() {
+                                return Err(BatchError {
+                                    code: "InvalidArgument",
+                                    message: "AutoFilter Range must belong to its worksheet."
+                                        .to_string(),
+                                });
+                            }
+                            if range_has_unbounded_dimension(&range)? {
+                                return Err(BatchError {
+                                    code: "InvalidArgument",
+                                    message: "AutoFilter requires a bounded Range.".to_string(),
+                                });
+                            }
+                            range.address.ok_or_else(|| BatchError {
+                                code: "InvalidArgument",
+                                message: "AutoFilter requires a bounded Range.".to_string(),
+                            })?
+                        }
+                        _ => {
+                            return Err(BatchError {
+                                code: "InvalidArgument",
+                                message: "AutoFilter.apply requires exactly one address or Range."
+                                    .to_string(),
+                            });
+                        }
+                    };
+                    let mut auto_filter = self
+                        .auto_filters
+                        .lock()
+                        .expect("auto filters lock")
+                        .get(&id)
+                        .cloned()
+                        .unwrap_or_else(|| AutoFilterRef::new(sheet));
+                    auto_filter
+                        .apply(AutoFilterApplyRequest {
+                            range: address,
+                            column_index,
+                            criteria,
+                        })
+                        .map_err(sort_filter_error)?;
+                    self.auto_filters
+                        .lock()
+                        .expect("auto filters lock")
+                        .insert(id, auto_filter);
+                }
+                Op::AutoFilterClearColumnCriteria { id, column_index } => {
+                    let mut auto_filter = auto_filter_ref(&self.auto_filters, &id)?;
+                    auto_filter
+                        .clear_column_criteria(column_index)
+                        .map_err(sort_filter_error)?;
+                    self.auto_filters
+                        .lock()
+                        .expect("auto filters lock")
+                        .insert(id, auto_filter);
+                }
+                Op::AutoFilterClearCriteria { id } => {
+                    let mut auto_filter = auto_filter_ref(&self.auto_filters, &id)?;
+                    auto_filter.clear_criteria().map_err(sort_filter_error)?;
+                    self.auto_filters
+                        .lock()
+                        .expect("auto filters lock")
+                        .insert(id, auto_filter);
+                }
+                Op::AutoFilterGetRange {
+                    id,
+                    auto_filter_id,
+                    worksheet_id,
+                    null_object,
+                } => {
+                    let sheet = self
+                        .sheets
+                        .lock()
+                        .expect("sheets lock")
+                        .get(&worksheet_id)
+                        .cloned()
+                        .ok_or_else(|| BatchError {
+                            code: "InvalidObjectPath",
+                            message: "The worksheet object is not available.".to_string(),
+                        })?
+                        .sheet();
+                    let auto_filter = auto_filter_ref(&self.auto_filters, &auto_filter_id)?;
+                    let address = match auto_filter.range_address() {
+                        Ok(address) => Some(address),
+                        Err(error) if null_object && error.code == "ItemNotFound" => None,
+                        Err(error) => return Err(sort_filter_error(error)),
+                    };
+                    mark_object(&mut loaded, &id, address.is_none());
+                    self.ranges.lock().expect("ranges lock").insert(
+                        id,
+                        RangeRef {
+                            sheet,
+                            is_null_object: address.is_none(),
+                            address,
+                        },
+                    );
+                }
+                Op::AutoFilterReapply { id } => {
+                    let mut auto_filter = auto_filter_ref(&self.auto_filters, &id)?;
+                    auto_filter.reapply().map_err(sort_filter_error)?;
+                    self.auto_filters
+                        .lock()
+                        .expect("auto filters lock")
+                        .insert(id, auto_filter);
+                }
+                Op::AutoFilterRemove { id } => {
+                    let mut auto_filter = auto_filter_ref(&self.auto_filters, &id)?;
+                    auto_filter.remove().map_err(sort_filter_error)?;
+                    self.auto_filters
+                        .lock()
+                        .expect("auto filters lock")
+                        .insert(id, auto_filter);
+                }
+                Op::TableAdd {
+                    id,
+                    worksheet_id,
+                    has_headers,
+                    address,
+                    range_id,
+                } => {
+                    let range = range_id.as_ref().map(|range_id| {
+                        self.ranges
+                            .lock()
+                            .expect("ranges lock")
+                            .get(range_id)
+                            .cloned()
+                            .ok_or_else(|| BatchError {
+                                code: "InvalidObjectPath",
+                                message: "The Table.add Range object is not available.".to_string(),
+                            })
+                    });
+                    let range = range.transpose()?;
+                    let range_sheet = range.as_ref().map(|range| range.sheet.clone());
+                    let worksheet_scope = worksheet_id
+                        .as_ref()
+                        .map(|worksheet_id| {
+                            self.sheets
+                                .lock()
+                                .expect("sheets lock")
+                                .get(worksheet_id)
+                                .cloned()
+                                .ok_or_else(|| BatchError {
+                                    code: "InvalidObjectPath",
+                                    message: "The worksheet object is not available.".to_string(),
+                                })
+                        })
+                        .transpose()?;
+                    let address = match (address, range) {
+                        (Some(address), None) => {
+                            let sheet = tables::resolve_table_add_source(
+                                &self.workbook,
+                                worksheet_scope.map(|worksheet| worksheet.sheet()),
+                                range_sheet,
+                                &address,
+                            )
+                            .map_err(table_error)?;
+                            (sheet, address)
+                        }
+                        (None, Some(range)) => {
+                            if range_has_unbounded_dimension(&range)? {
+                                return Err(BatchError {
+                                    code: "InvalidArgument",
+                                    message: "Table.add requires a bounded Range.".to_string(),
+                                });
+                            }
+                            let address = range.address.ok_or_else(|| BatchError {
+                                code: "InvalidArgument",
+                                message: "Table.add requires a bounded Range.".to_string(),
+                            })?;
+                            let sheet = worksheet_scope
+                                .map(|worksheet| worksheet.sheet())
+                                .unwrap_or_else(|| range.sheet.clone());
+                            if sheet.id() != range.sheet.id() {
+                                return Err(BatchError {
+                                    code: "InvalidArgument",
+                                    message:
+                                        "Table.add Range must belong to its worksheet collection."
+                                            .to_string(),
+                                });
+                            }
+                            parse_range_address(&sheet, &address)
+                                .map_err(range_navigation_error)?;
+                            (sheet, address)
+                        }
+                        _ => {
+                            return Err(BatchError {
+                                code: "InvalidArgument",
+                                message: "Table.add requires exactly one address or Range."
+                                    .to_string(),
+                            });
+                        }
+                    };
+                    let table = TableRef::add(&self.workbook, address.0, &address.1, has_headers)
+                        .map_err(table_error)?;
+                    self.tables
+                        .lock()
+                        .expect("tables lock")
+                        .insert(id.clone(), table);
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::GetTableCollection { id, worksheet_id } => {
+                    let sheet = match worksheet_id {
+                        Some(worksheet_id) => Some(
+                            self.sheets
+                                .lock()
+                                .expect("sheets lock")
+                                .get(&worksheet_id)
+                                .cloned()
+                                .ok_or_else(|| BatchError {
+                                    code: "InvalidObjectPath",
+                                    message: "The worksheet object is not available."
+                                        .to_string(),
+                                })?
+                                .sheet(),
+                        ),
+                        None => None,
+                    };
+                    self.table_collection_bindings
+                        .lock()
+                        .expect("table collection bindings lock")
+                        .insert(id.clone(), sheet);
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::TableGetItem {
+                    id,
+                    worksheet_id,
+                    collection_id,
+                    key,
+                    or_null_object,
+                    by_index,
+                } => {
+                    let table = if let Some(collection_id) = collection_id {
+                        let scope = self
+                            .table_collection_bindings
+                            .lock()
+                            .expect("table collection bindings lock")
+                            .get(&collection_id)
+                            .cloned()
+                            .ok_or_else(|| BatchError {
+                                code: "InvalidObjectPath",
+                                message: "The TableCollection object is not available."
+                                    .to_string(),
+                            })?;
+                        match (scope, by_index) {
+                            (Some(sheet), false) => TableRef::get_item(sheet, &key),
+                            (Some(sheet), true) => key
+                                .parse::<i64>()
+                                .map_err(|_| table_error_invalid_index("table"))
+                                .and_then(|index| TableRef::get_item_at(sheet, index)),
+                            (None, false) => {
+                                TableRef::get_item_in_workbook(&self.workbook, &key)
+                            }
+                            (None, true) => key
+                                .parse::<i64>()
+                                .map_err(|_| table_error_invalid_index("table"))
+                                .and_then(|index| {
+                                    TableRef::get_item_at_in_workbook(&self.workbook, index)
+                                }),
+                        }
+                    } else {
+                        let worksheet_id = worksheet_id.ok_or_else(|| BatchError {
+                            code: "InvalidArgument",
+                            message: "Table.getItem requires a worksheet or collection scope."
+                                .to_string(),
+                        })?;
+                        let sheet = self
+                            .sheets
+                            .lock()
+                            .expect("sheets lock")
+                            .get(&worksheet_id)
+                            .cloned()
+                            .ok_or_else(|| BatchError {
+                                code: "InvalidObjectPath",
+                                message: "The worksheet object is not available.".to_string(),
+                            })?
+                            .sheet();
+                        if by_index {
+                            key.parse::<i64>()
+                                .map_err(|_| table_error_invalid_index("table"))
+                                .and_then(|index| TableRef::get_item_at(sheet, index))
+                        } else {
+                            TableRef::get_item(sheet, &key)
+                        }
+                    };
+                    match table {
+                        Ok(table) => {
+                            self.tables
+                                .lock()
+                                .expect("tables lock")
+                                .insert(id.clone(), table);
+                            self.null_tables
+                                .lock()
+                                .expect("null tables lock")
+                                .remove(&id);
+                            mark_object(&mut loaded, &id, false);
+                        }
+                        Err(error) if or_null_object && error.code == "ItemNotFound" => {
+                            self.null_tables
+                                .lock()
+                                .expect("null tables lock")
+                                .insert(id.clone());
+                            mark_object(&mut loaded, &id, true);
+                        }
+                        Err(error) => return Err(table_error(error)),
+                    }
+                }
+                Op::TableGetRange { id, table_id, kind } => {
+                    let table = self
+                        .tables
+                        .lock()
+                        .expect("tables lock")
+                        .get(&table_id)
+                        .cloned()
+                        .ok_or_else(|| BatchError {
+                            code: "InvalidObjectPath",
+                            message: "The table object is not available.".to_string(),
+                        })?;
+                    let kind = TableRangeKind::from_wire(&kind).map_err(table_error)?;
+                    let address = table.range_address(kind).map_err(table_error)?;
+                    self.ranges.lock().expect("ranges lock").insert(
+                        id.clone(),
+                        RangeRef {
+                            sheet: table.sheet(),
+                            address: Some(address),
+                            is_null_object: false,
+                        },
+                    );
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::TableDelete { id } => {
+                    let table = table_ref(&self.tables, &id)?;
+                    table.delete().map_err(table_error)?;
+                    self.tables
+                        .lock()
+                        .expect("tables lock")
+                        .remove(&id);
+                }
+                Op::TableConvertToRange { id, table_id } => {
+                    let table = table_ref(&self.tables, &table_id)?;
+                    let address = table.convert_to_range().map_err(table_error)?;
+                    self.ranges.lock().expect("ranges lock").insert(
+                        id.clone(),
+                        RangeRef {
+                            sheet: table.sheet(),
+                            address: Some(address),
+                            is_null_object: false,
+                        },
+                    );
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::TableResize {
+                    table_id,
+                    address,
+                    range_id,
+                } => {
+                    let table = table_ref(&self.tables, &table_id)?;
+                    let address = match (address, range_id) {
+                        (Some(address), None) => address,
+                        (None, Some(range_id)) => {
+                            let range = self.lookup_range(&range_id)?;
+                            if range_has_unbounded_dimension(&range)? {
+                                return Err(BatchError {
+                                    code: "InvalidArgument",
+                                    message: "Table.resize requires a bounded Range.".to_string(),
+                                });
+                            }
+                            range.address.ok_or_else(|| BatchError {
+                                code: "InvalidArgument",
+                                message: "Table.resize requires a bounded Range.".to_string(),
+                            })?
+                        }
+                        _ => {
+                            return Err(BatchError {
+                                code: "InvalidArgument",
+                                message: "Table.resize requires exactly one address or Range."
+                                    .to_string(),
+                            });
+                        }
+                    };
+                    table.resize(&address).map_err(table_error)?;
+                }
+                Op::TableCollectionGet { id, table_id, kind } => {
+                    let table = table_ref(&self.tables, &table_id)?;
+                    let kind =
+                        TableCollectionKind::from_wire(&kind).map_err(table_collection_error)?;
+                    self.table_collections
+                        .lock()
+                        .expect("table collections lock")
+                        .insert(id.clone(), TableCollectionRef { table, kind });
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::TableCollectionGetCount {
+                    collection_id,
+                    result_id,
+                } => {
+                    let collection = table_collection_ref(&self.table_collections, &collection_id)?;
+                    let mut projection = table_collections::load_collection(
+                        &collection.table,
+                        collection.kind,
+                        &["count".to_string()],
+                    )
+                    .map_err(table_collection_error)?;
+                    let count = projection.remove("count").ok_or_else(|| BatchError {
+                        code: "GeneralException",
+                        message: "The table collection did not return its count.".to_string(),
+                    })?;
+                    results.insert(result_id, count);
+                }
+                Op::TableColumnGetItem {
+                    id,
+                    table_id,
+                    key,
+                    or_null_object,
+                    by_index,
+                } => {
+                    let table = table_ref(&self.tables, &table_id)?;
+                    let column = if by_index {
+                        key.as_i64()
+                            .ok_or_else(|| BatchError {
+                                code: "InvalidArgument",
+                                message: "TableColumnCollection.getItemAt requires an integer."
+                                    .to_string(),
+                            })
+                            .and_then(|index| {
+                                table_collections::get_column_at(&table, index)
+                                    .map_err(table_collection_error)
+                            })
+                    } else {
+                        table_collections::get_column(&table, &key).map_err(table_collection_error)
+                    };
+                    match column {
+                        Ok(column) => {
+                            self.table_columns
+                                .lock()
+                                .expect("table columns lock")
+                                .insert(id.clone(), column);
+                            mark_object(&mut loaded, &id, false);
+                        }
+                        Err(error) if or_null_object && error.code == "ItemNotFound" => {
+                            self.null_table_columns
+                                .lock()
+                                .expect("null table columns lock")
+                                .insert(id.clone());
+                            mark_object(&mut loaded, &id, true);
+                        }
+                        Err(error) => return Err(error),
+                    }
+                }
+                Op::TableRowGetItem {
+                    id,
+                    table_id,
+                    index,
+                } => {
+                    let table = table_ref(&self.tables, &table_id)?;
+                    let row = table_collections::get_row_at(&table, index)
+                        .map_err(table_collection_error)?;
+                    self.table_rows
+                        .lock()
+                        .expect("table rows lock")
+                        .insert(id.clone(), row);
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::TableColumnAdd {
+                    id,
+                    table_id,
+                    index,
+                    values,
+                    name,
+                } => {
+                    let table = table_ref(&self.tables, &table_id)?;
+                    let column = table_collections::add_column(
+                        &table,
+                        index,
+                        values.as_ref(),
+                        name.as_ref(),
+                    )
+                    .map_err(table_collection_error)?;
+                    self.table_columns
+                        .lock()
+                        .expect("table columns lock")
+                        .insert(id.clone(), column);
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::TableRowAdd {
+                    id,
+                    table_id,
+                    index,
+                    values,
+                    always_insert,
+                } => {
+                    let table = table_ref(&self.tables, &table_id)?;
+                    let added =
+                        table_collections::add_rows(&table, index, values.as_ref(), always_insert)
+                            .map_err(table_collection_error)?;
+                    let added_index = added.row.index();
+                    self.table_rows
+                        .lock()
+                        .expect("table rows lock")
+                        .insert(id.clone(), added.row);
+                    mark_object(&mut loaded, &id, false);
+                    // `TableRowCollection.add` returns a live row proxy.  Its
+                    // positional selector is known only after the engine
+                    // applies the insertion (especially for append and
+                    // alwaysInsert:false), so hydrate the returned index in
+                    // the same sync response.
+                    loaded
+                        .entry(id)
+                        .or_default()
+                        .insert("index".to_string(), json!(added_index));
+                }
+                Op::TableColumnDelete { id } => {
+                    table_column_ref(&self.table_columns, &id)?
+                        .delete()
+                        .map_err(table_collection_error)?;
+                }
+                Op::TableRowDelete { id } => {
+                    table_row_ref(&self.table_rows, &id)?
+                        .delete()
+                        .map_err(table_collection_error)?;
+                }
+                Op::TableRowDeleteMany { table_id, rows } => {
+                    let table = table_ref(&self.tables, &table_id)?;
+                    let indices = rows
+                        .iter()
+                        .map(|value| {
+                            value
+                                .as_u64()
+                                .and_then(|index| u32::try_from(index).ok())
+                                .ok_or_else(|| BatchError {
+                                    code: "InvalidArgument",
+                                    message: "TableRowCollection.deleteRows requires row indices."
+                                        .to_string(),
+                                })
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    table_collections::delete_rows(&table, &indices)
+                        .map_err(table_collection_error)?;
+                }
+                Op::TableRowDeleteAt {
+                    table_id,
+                    index,
+                    count,
+                } => {
+                    let table = table_ref(&self.tables, &table_id)?;
+                    table_collections::delete_rows_at(&table, index, count)
+                        .map_err(table_collection_error)?;
+                }
+                Op::TableColumnGetRange {
+                    id,
+                    column_id,
+                    kind,
+                } => {
+                    let column = table_column_ref(&self.table_columns, &column_id)?;
+                    let kind =
+                        TableColumnRangeKind::from_wire(&kind).map_err(table_collection_error)?;
+                    let address = column.range_address(kind).map_err(table_collection_error)?;
+                    self.ranges.lock().expect("ranges lock").insert(
+                        id.clone(),
+                        RangeRef {
+                            sheet: column.sheet(),
+                            address: Some(address),
+                            is_null_object: false,
+                        },
+                    );
+                    mark_object(&mut loaded, &id, false);
+                }
+                Op::TableRowGetRange { id, row_id } => {
+                    let row = table_row_ref(&self.table_rows, &row_id)?;
+                    let address = row.range_address().map_err(table_collection_error)?;
+                    self.ranges.lock().expect("ranges lock").insert(
+                        id.clone(),
+                        RangeRef {
+                            sheet: row.sheet(),
+                            address: Some(address),
+                            is_null_object: false,
+                        },
+                    );
+                    mark_object(&mut loaded, &id, false);
                 }
                 Op::Set {
                     id,
                     property,
                     value,
                 } => {
-                    let ranges = self.ranges.lock().expect("ranges lock");
-                    let range = ranges.get(&id).ok_or_else(|| BatchError {
-                        code: "InvalidObjectPath",
-                        message: "The range object is not available.".to_string(),
-                    })?;
-                    let grid = json_to_write_grid(&value)?;
-                    match property.as_str() {
-                        "values" | "formulas" => {
-                            range
-                                .sheet
-                                .set_range(range.address.as_str(), &grid)
-                                .map_err(engine_error)?;
-                        }
-                        other => {
-                            return Err(BatchError {
-                                code: "InvalidArgument",
-                                message: format!("Unsupported Range property '{other}'"),
-                            });
-                        }
+                    if let Some(worksheet) =
+                        self.sheets.lock().expect("sheets lock").get(&id).cloned()
+                    {
+                        worksheet.set(&property, &value).map_err(worksheet_error)?;
+                        continue;
                     }
+                    if let Some(border) =
+                        self.borders.lock().expect("borders lock").get(&id).cloned()
+                    {
+                        border.apply_set(&property, &value).map_err(border_error)?;
+                        continue;
+                    }
+                    if let Some(collection) = self
+                        .border_collections
+                        .lock()
+                        .expect("border collections lock")
+                        .get(&id)
+                        .cloned()
+                    {
+                        collection.set(&property, &value).map_err(border_error)?;
+                        continue;
+                    }
+                    if let Some(column) = self
+                        .table_columns
+                        .lock()
+                        .expect("table columns lock")
+                        .get(&id)
+                        .cloned()
+                    {
+                        column
+                            .set(&property, &value)
+                            .map_err(table_collection_error)?;
+                        continue;
+                    }
+                    if let Some(row) = self
+                        .table_rows
+                        .lock()
+                        .expect("table rows lock")
+                        .get(&id)
+                        .cloned()
+                    {
+                        row.set(&property, &value).map_err(table_collection_error)?;
+                        continue;
+                    }
+                    if let Some(item) = self.names.lock().expect("names lock").get(&id).cloned() {
+                        item.set(&property, &value).map_err(name_error)?;
+                        continue;
+                    }
+                    if let Some(format) =
+                        self.formats.lock().expect("formats lock").get(&id).cloned()
+                    {
+                        format.set(&property, &value).map_err(format_error)?;
+                        continue;
+                    }
+                    if let Some(validation) = self
+                        .validations
+                        .lock()
+                        .expect("validations lock")
+                        .get(&id)
+                        .cloned()
+                    {
+                        validation
+                            .set(&property, &value)
+                            .map_err(validation_error)?;
+                        continue;
+                    }
+                    if let Some(table) = self.tables.lock().expect("tables lock").get(&id).cloned()
+                    {
+                        table.set(&property, &value).map_err(table_error)?;
+                        continue;
+                    }
+                    if self.set_extension_property(&id, &property, &value)? {
+                        continue;
+                    }
+                    let range = self
+                        .ranges
+                        .lock()
+                        .expect("ranges lock")
+                        .get(&id)
+                        .cloned()
+                        .ok_or_else(|| BatchError {
+                            code: "InvalidObjectPath",
+                            message: "The range object is not available.".to_string(),
+                        })?;
+                    if range_has_unbounded_dimension(&range)? {
+                        return Err(BatchError {
+                            code: "InvalidArgument",
+                            message: format!("Range.{property} requires a bounded range"),
+                        });
+                    }
+                    let address = range.address.as_deref().ok_or_else(|| BatchError {
+                        code: "InvalidArgument",
+                        message: format!(
+                            "Range.{property} cannot be set on an unbounded worksheet range"
+                        ),
+                    })?;
+                    if property == "numberFormat" {
+                        range_content::set(&range.sheet, address, &property, &value)
+                            .map_err(range_content_error)?;
+                        continue;
+                    }
+                    let write_property = WriteProperty::from_name(&property)?;
+                    let grid = json_to_write_grid(&value, write_property)?;
+                    range
+                        .sheet
+                        .set_range_typed(address, &grid)
+                        .map_err(write_error)?;
                 }
                 Op::Load { id, properties } => {
-                    let mut props = HashMap::new();
-                    if let Some(sheet) = self.sheets.lock().expect("sheets lock").get(&id) {
+                    let sheet = self.sheets.lock().expect("sheets lock").get(&id).cloned();
+                    let null_worksheet = self
+                        .null_worksheets
+                        .lock()
+                        .expect("null worksheets lock")
+                        .contains(&id);
+                    let worksheet_collection = self
+                        .worksheet_collections
+                        .lock()
+                        .expect("worksheet collections lock")
+                        .contains(&id);
+                    let range = self.ranges.lock().expect("ranges lock").get(&id).cloned();
+                    let format = self.formats.lock().expect("formats lock").get(&id).cloned();
+                    let table = self.tables.lock().expect("tables lock").get(&id).cloned();
+                    let null_table = self
+                        .null_tables
+                        .lock()
+                        .expect("null tables lock")
+                        .contains(&id);
+                    let table_collection_binding = self
+                        .table_collection_bindings
+                        .lock()
+                        .expect("table collection bindings lock")
+                        .get(&id)
+                        .cloned();
+                    let auto_filter = self
+                        .auto_filters
+                        .lock()
+                        .expect("auto filters lock")
+                        .get(&id)
+                        .cloned();
+                    let validation = self
+                        .validations
+                        .lock()
+                        .expect("validations lock")
+                        .get(&id)
+                        .cloned();
+                    let border_collection = self
+                        .border_collections
+                        .lock()
+                        .expect("border collections lock")
+                        .get(&id)
+                        .cloned();
+                    let border = self.borders.lock().expect("borders lock").get(&id).cloned();
+                    let table_collection = self
+                        .table_collections
+                        .lock()
+                        .expect("table collections lock")
+                        .get(&id)
+                        .cloned();
+                    let table_column = self
+                        .table_columns
+                        .lock()
+                        .expect("table columns lock")
+                        .get(&id)
+                        .cloned();
+                    let null_table_column = self
+                        .null_table_columns
+                        .lock()
+                        .expect("null table columns lock")
+                        .contains(&id);
+                    let table_row = self
+                        .table_rows
+                        .lock()
+                        .expect("table rows lock")
+                        .get(&id)
+                        .cloned();
+                    let name_collection = self
+                        .name_collections
+                        .lock()
+                        .expect("name collections lock")
+                        .get(&id)
+                        .cloned();
+                    let named_item = self.names.lock().expect("names lock").get(&id).cloned();
+                    let name_array_values = self
+                        .name_array_values
+                        .lock()
+                        .expect("named item array values lock")
+                        .get(&id)
+                        .cloned();
+                    let extension_binding = self.extension_binding(&id);
+                    if sheet.is_none()
+                        && !null_worksheet
+                        && !worksheet_collection
+                        && range.is_none()
+                        && format.is_none()
+                        && table.is_none()
+                        && !null_table
+                        && table_collection_binding.is_none()
+                        && auto_filter.is_none()
+                        && validation.is_none()
+                        && border_collection.is_none()
+                        && border.is_none()
+                        && table_collection.is_none()
+                        && table_column.is_none()
+                        && !null_table_column
+                        && table_row.is_none()
+                        && name_collection.is_none()
+                        && named_item.is_none()
+                        && name_array_values.is_none()
+                        && extension_binding.is_none()
+                    {
+                        return Err(BatchError {
+                            code: "InvalidObjectPath",
+                            message: "The object to load is not available.".to_string(),
+                        });
+                    }
+
+                    let props = loaded.entry(id).or_insert_with(HashMap::new);
+                    if let Some(sheet) = sheet {
+                        let mut worksheet_properties = Vec::new();
                         for property in &properties {
-                            if property == "name" {
-                                props.insert(
-                                    "name".to_string(),
-                                    Value::String(sheet.name().map_err(engine_error)?),
-                                );
+                            if property == "isNullObject" {
+                                props.insert(property.clone(), Value::Bool(false));
+                            } else {
+                                worksheet_properties.push(property.clone());
+                            }
+                        }
+                        props.extend(sheet.load(&worksheet_properties).map_err(worksheet_error)?);
+                    }
+                    if null_worksheet {
+                        for property in &properties {
+                            if property == "isNullObject" {
+                                props.insert(property.clone(), Value::Bool(true));
+                            } else {
+                                return Err(BatchError {
+                                    code: "InvalidObjectPath",
+                                    message: format!(
+                                        "Worksheet.{property} cannot be loaded from a null object"
+                                    ),
+                                });
                             }
                         }
                     }
-                    if let Some(range) = self.ranges.lock().expect("ranges lock").get(&id) {
+                    if worksheet_collection {
+                        let item_properties =
+                            collection_item_properties("WorksheetCollection", &properties)?;
+                        let items =
+                            worksheets::collection_items(&self.workbook, &item_properties, false)
+                                .map_err(worksheet_error)?;
+                        props.insert(
+                            "items".to_string(),
+                            serde_json::to_value(items).map_err(engine_error)?,
+                        );
+                    }
+                    if let Some(range) = range {
+                        if range.is_null_object {
+                            for property in &properties {
+                                if property == "isNullObject" {
+                                    props.insert(property.clone(), Value::Bool(true));
+                                } else {
+                                    return Err(BatchError {
+                                        code: "InvalidObjectPath",
+                                        message: format!(
+                                            "Range.{property} cannot be loaded from a null object"
+                                        ),
+                                    });
+                                }
+                            }
+                            continue;
+                        }
+                        let metadata = range_metadata(&range)?;
+                        let unbounded = range_has_unbounded_dimension(&range)?;
                         for property in &properties {
                             match property.as_str() {
+                                "isNullObject" => {
+                                    props.insert(property.clone(), Value::Bool(false));
+                                }
+                                "address" => {
+                                    props.insert(
+                                        "address".to_string(),
+                                        Value::String(metadata.address.clone()),
+                                    );
+                                }
+                                "rowIndex" => {
+                                    props.insert("rowIndex".to_string(), json!(metadata.row_index));
+                                }
+                                "columnIndex" => {
+                                    props.insert(
+                                        "columnIndex".to_string(),
+                                        json!(metadata.column_index),
+                                    );
+                                }
+                                "rowCount" => {
+                                    props.insert("rowCount".to_string(), json!(metadata.row_count));
+                                }
+                                "columnCount" => {
+                                    props.insert(
+                                        "columnCount".to_string(),
+                                        json!(metadata.column_count),
+                                    );
+                                }
+                                "cellCount" => {
+                                    props.insert(
+                                        "cellCount".to_string(),
+                                        json!(metadata.cell_count),
+                                    );
+                                }
                                 "values" => {
                                     props.insert(
                                         "values".to_string(),
-                                        range_values_json(&range.sheet, &range.address)?,
+                                        if unbounded {
+                                            Value::Null
+                                        } else {
+                                            range_values_json(
+                                                &range.sheet,
+                                                range.address.as_deref().expect("bounded address"),
+                                            )?
+                                        },
                                     );
                                 }
                                 "formulas" => {
                                     props.insert(
                                         "formulas".to_string(),
-                                        range_formulas_json(&range.sheet, &range.address)?,
+                                        if unbounded {
+                                            Value::Null
+                                        } else {
+                                            range_formulas_json(
+                                                &range.sheet,
+                                                range.address.as_deref().expect("bounded address"),
+                                            )?
+                                        },
                                     );
                                 }
-                                _ => {}
+                                "numberFormat" | "text" | "valueTypes" => {
+                                    props.extend(if unbounded {
+                                        HashMap::from([(property.clone(), Value::Null)])
+                                    } else {
+                                        range_content::load(
+                                            &range.sheet,
+                                            range.address.as_deref().expect("bounded address"),
+                                            std::slice::from_ref(property),
+                                        )
+                                        .map_err(range_content_error)?
+                                    });
+                                }
+                                other => return Err(unsupported_load_property("Range", other)),
                             }
                         }
                     }
-                    if !props.is_empty() {
-                        loaded.insert(id, props);
+                    if let Some(format) = format {
+                        props.extend(format.load(&properties).map_err(format_error)?);
+                    }
+                    if let Some(table) = table {
+                        props.extend(table.load(&properties).map_err(table_error)?);
+                    }
+                    if null_table {
+                        for property in &properties {
+                            if property == "isNullObject" {
+                                props.insert(property.clone(), Value::Bool(true));
+                            } else {
+                                return Err(BatchError {
+                                    code: "InvalidObjectPath",
+                                    message: format!(
+                                        "Table.{property} cannot be loaded from a null object"
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                    if let Some(scope) = table_collection_binding {
+                        let item_properties =
+                            table_collection_item_properties(&properties)?;
+                        let items = tables::collection_items(
+                            &self.workbook,
+                            scope.as_ref(),
+                            &item_properties,
+                        )
+                        .map_err(table_error)?;
+                        for property in &properties {
+                            match property.as_str() {
+                                "isNullObject" => {
+                                    props.insert(property.clone(), Value::Bool(false));
+                                }
+                                "count" => {
+                                    props.insert(property.clone(), json!(items.len()));
+                                }
+                                "items" => {
+                                    props.insert(
+                                        "items".to_string(),
+                                        serde_json::to_value(&items).map_err(engine_error)?,
+                                    );
+                                }
+                                p if p.starts_with("items/") => {
+                                    props.insert(
+                                        "items".to_string(),
+                                        serde_json::to_value(&items).map_err(engine_error)?,
+                                    );
+                                }
+                                other => {
+                                    return Err(unsupported_load_property(
+                                        "TableCollection",
+                                        other,
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                    if let Some(auto_filter) = auto_filter {
+                        let snapshot = auto_filter.snapshot().map_err(sort_filter_error)?;
+                        for property in &properties {
+                            let value = match property.as_str() {
+                                "criteria" => Value::Array(snapshot.criteria.clone()),
+                                "enabled" => Value::Bool(snapshot.enabled),
+                                "isDataFiltered" => Value::Bool(snapshot.is_data_filtered),
+                                other => {
+                                    return Err(unsupported_load_property("AutoFilter", other));
+                                }
+                            };
+                            props.insert(property.clone(), value);
+                        }
+                    }
+                    if let Some(validation) = validation {
+                        props.extend(validation.load(&properties).map_err(validation_error)?);
+                    }
+                    if let Some(collection) = border_collection {
+                        props.extend(collection.load(&properties).map_err(border_error)?);
+                    }
+                    if let Some(border) = border {
+                        props.extend(border.load(&properties).map_err(border_error)?);
+                    }
+                    if let Some(collection) = table_collection {
+                        props.extend(
+                            table_collections::load_collection(
+                                &collection.table,
+                                collection.kind,
+                                &properties,
+                            )
+                            .map_err(table_collection_error)?,
+                        );
+                    }
+                    if let Some(column) = table_column {
+                        props.extend(column.load(&properties).map_err(table_collection_error)?);
+                    }
+                    if null_table_column {
+                        for property in &properties {
+                            if property == "isNullObject" {
+                                props.insert(property.clone(), Value::Bool(true));
+                            } else {
+                                return Err(BatchError {
+                                    code: "InvalidObjectPath",
+                                    message: format!(
+                                        "TableColumn.{property} cannot be loaded from a null object"
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                    if let Some(row) = table_row {
+                        props.extend(row.load(&properties).map_err(table_collection_error)?);
+                    }
+                    if let Some(collection) = name_collection {
+                        let item_properties =
+                            collection_item_properties("NamedItemCollection", &properties)?;
+                        let items = collection
+                            .collection_items(&item_properties)
+                            .map_err(name_error)?;
+                        props.insert(
+                            "items".to_string(),
+                            serde_json::to_value(items).map_err(engine_error)?,
+                        );
+                    }
+                    if let Some(item) = named_item {
+                        props.extend(item.load(&properties).map_err(name_error)?);
+                    }
+                    if let Some(values) = name_array_values {
+                        props.extend(values.load(&properties).map_err(name_error)?);
+                    }
+                    if let Some(binding) = extension_binding {
+                        props.extend(binding.load(&properties)?);
                     }
                 }
             }
@@ -216,7 +2429,62 @@ impl Host {
         Ok(BatchResult {
             error: None,
             loaded,
+            results,
         })
+    }
+}
+
+struct RangeMetadata {
+    address: String,
+    row_index: u32,
+    column_index: u32,
+    row_count: u32,
+    column_count: u32,
+    cell_count: i64,
+}
+
+fn range_metadata(range: &RangeRef) -> Result<RangeMetadata, BatchError> {
+    let parsed = parsed_range(range)?;
+    let (start_row, start_col, _, _) = parsed.bounds();
+    let sheet_name = range.sheet.name().map_err(engine_error)?;
+    let address = format!("{}!{}", qualified_sheet_name(&sheet_name), parsed.to_a1());
+
+    Ok(RangeMetadata {
+        address,
+        row_index: start_row,
+        column_index: start_col,
+        row_count: parsed.row_count(),
+        column_count: parsed.column_count(),
+        cell_count: parsed.cell_count(),
+    })
+}
+
+fn parsed_range(range: &RangeRef) -> Result<RangeAddress, BatchError> {
+    if range.is_null_object {
+        return Err(BatchError {
+            code: "InvalidObjectPath",
+            message: "The range object is a null object.".to_string(),
+        });
+    }
+    match range.address.as_deref() {
+        Some(address) => parse_range_address(&range.sheet, address).map_err(range_navigation_error),
+        None => Ok(RangeAddress::WholeSheet),
+    }
+}
+
+fn range_has_unbounded_dimension(range: &RangeRef) -> Result<bool, BatchError> {
+    let parsed = parsed_range(range)?;
+    Ok(parsed.is_whole_sheet() || parsed.is_entire_row() || parsed.is_entire_column())
+}
+
+fn qualified_sheet_name(sheet_name: &str) -> String {
+    if sheet_name
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || character == '_')
+    {
+        sheet_name.to_string()
+    } else {
+        format!("'{}'", sheet_name.replace('\'', "''"))
     }
 }
 
@@ -244,7 +2512,339 @@ fn engine_error(err: impl std::fmt::Display) -> BatchError {
     }
 }
 
-fn json_to_write_grid(value: &Value) -> Result<Vec<Vec<String>>, BatchError> {
+fn format_error(err: FormatError) -> BatchError {
+    BatchError {
+        code: err.code,
+        message: err.message,
+    }
+}
+
+fn border_error(err: BorderError) -> BatchError {
+    BatchError {
+        code: err.code,
+        message: err.message,
+    }
+}
+
+fn name_error(err: NameError) -> BatchError {
+    BatchError {
+        code: err.code,
+        message: err.message,
+    }
+}
+
+fn name_collection_for_scope(
+    host: &Host,
+    worksheet_id: Option<&str>,
+) -> Result<NamedItemCollectionRef, BatchError> {
+    let scope = worksheet_id
+        .map(|id| worksheet_ref(&host.sheets, id).map(|worksheet| worksheet.stable_id()))
+        .transpose()?;
+    Ok(NamedItemCollectionRef::new(host.workbook.clone(), scope))
+}
+
+fn name_ref(
+    names: &Mutex<HashMap<String, NamedItemRef>>,
+    id: &str,
+) -> Result<NamedItemRef, BatchError> {
+    names
+        .lock()
+        .expect("names lock")
+        .get(id)
+        .cloned()
+        .ok_or_else(|| BatchError {
+            code: "InvalidObjectPath",
+            message: "The named item object is not available.".to_string(),
+        })
+}
+
+fn range_content_error(err: RangeContentError) -> BatchError {
+    BatchError {
+        code: err.code,
+        message: err.message,
+    }
+}
+
+fn range_navigation_error(err: RangeNavigationError) -> BatchError {
+    BatchError {
+        code: err.code,
+        message: err.message,
+    }
+}
+
+fn sort_filter_error(err: SortFilterError) -> BatchError {
+    BatchError {
+        code: err.code,
+        message: err.message,
+    }
+}
+
+fn validation_error(err: ValidationError) -> BatchError {
+    BatchError {
+        code: err.code,
+        message: err.message,
+    }
+}
+
+fn worksheet_error(err: WorksheetError) -> BatchError {
+    BatchError {
+        code: err.code,
+        message: err.message,
+    }
+}
+
+fn worksheet_ref(
+    worksheets: &Mutex<HashMap<String, WorksheetRef>>,
+    id: &str,
+) -> Result<WorksheetRef, BatchError> {
+    worksheets
+        .lock()
+        .expect("sheets lock")
+        .get(id)
+        .cloned()
+        .ok_or_else(|| BatchError {
+            code: "InvalidObjectPath",
+            message: "The worksheet object is not available.".to_string(),
+        })
+}
+
+fn require_worksheet_collection(host: &Host, id: &str) -> Result<(), BatchError> {
+    if host
+        .worksheet_collections
+        .lock()
+        .expect("worksheet collections lock")
+        .contains(id)
+    {
+        Ok(())
+    } else {
+        Err(BatchError {
+            code: "InvalidObjectPath",
+            message: "The worksheet collection object is not available.".to_string(),
+        })
+    }
+}
+
+fn bind_nullable_worksheet(
+    host: &Host,
+    loaded: &mut HashMap<String, HashMap<String, Value>>,
+    id: String,
+    worksheet: Option<WorksheetRef>,
+    _or_null: bool,
+) {
+    let is_null = worksheet.is_none();
+    if let Some(worksheet) = worksheet {
+        host.sheets
+            .lock()
+            .expect("sheets lock")
+            .insert(id.clone(), worksheet);
+    } else {
+        host.null_worksheets
+            .lock()
+            .expect("null worksheets lock")
+            .insert(id.clone());
+    }
+    mark_object(loaded, &id, is_null);
+}
+
+fn collection_item_properties(
+    object: &str,
+    properties: &[String],
+) -> Result<Vec<String>, BatchError> {
+    let mut result = Vec::new();
+    let mut defaults = false;
+    for property in properties {
+        if property == "items" {
+            defaults = true;
+        } else if let Some(item_property) = property.strip_prefix("items/") {
+            if item_property.is_empty() {
+                return Err(unsupported_load_property(object, property));
+            }
+            if !result.iter().any(|existing| existing == item_property) {
+                result.push(item_property.to_string());
+            }
+        } else if property == "isNullObject" {
+            continue;
+        } else {
+            return Err(unsupported_load_property(object, property));
+        }
+    }
+    if defaults { Ok(Vec::new()) } else { Ok(result) }
+}
+
+fn table_collection_item_properties(properties: &[String]) -> Result<Vec<String>, BatchError> {
+    let mut result = Vec::new();
+    let mut defaults = false;
+    for property in properties {
+        if property == "count" || property == "isNullObject" {
+            continue;
+        }
+        if property == "items" {
+            defaults = true;
+            continue;
+        }
+        if let Some(item_property) = property.strip_prefix("items/") {
+            if item_property.is_empty() {
+                return Err(unsupported_load_property("TableCollection", property));
+            }
+            if !result.iter().any(|existing| existing == item_property) {
+                result.push(item_property.to_string());
+            }
+            continue;
+        }
+        return Err(unsupported_load_property("TableCollection", property));
+    }
+    if defaults {
+        Ok(Vec::new())
+    } else {
+        Ok(result)
+    }
+}
+
+pub(crate) fn mark_object(
+    loaded: &mut HashMap<String, HashMap<String, Value>>,
+    id: &str,
+    is_null: bool,
+) {
+    loaded
+        .entry(id.to_string())
+        .or_default()
+        .insert("isNullObject".to_string(), Value::Bool(is_null));
+}
+
+fn auto_filter_ref(
+    auto_filters: &Mutex<HashMap<String, AutoFilterRef>>,
+    id: &str,
+) -> Result<AutoFilterRef, BatchError> {
+    auto_filters
+        .lock()
+        .expect("auto filters lock")
+        .get(id)
+        .cloned()
+        .ok_or_else(|| BatchError {
+            code: "InvalidObjectPath",
+            message: "The AutoFilter object is not available.".to_string(),
+        })
+}
+
+fn table_error(err: TableError) -> BatchError {
+    BatchError {
+        code: err.code,
+        message: err.message,
+    }
+}
+
+fn table_error_invalid_index(kind: &str) -> TableError {
+    TableError {
+        code: "InvalidArgument",
+        message: format!("TableCollection.getItemAt requires an integer {kind} index"),
+    }
+}
+
+fn table_collection_error(err: TableCollectionError) -> BatchError {
+    BatchError {
+        code: err.code,
+        message: err.message,
+    }
+}
+
+fn table_ref(tables: &Mutex<HashMap<String, TableRef>>, id: &str) -> Result<TableRef, BatchError> {
+    tables
+        .lock()
+        .expect("tables lock")
+        .get(id)
+        .cloned()
+        .ok_or_else(|| BatchError {
+            code: "InvalidObjectPath",
+            message: "The table object is not available.".to_string(),
+        })
+}
+
+fn table_collection_ref(
+    collections: &Mutex<HashMap<String, TableCollectionRef>>,
+    id: &str,
+) -> Result<TableCollectionRef, BatchError> {
+    collections
+        .lock()
+        .expect("table collections lock")
+        .get(id)
+        .cloned()
+        .ok_or_else(|| BatchError {
+            code: "InvalidObjectPath",
+            message: "The table collection object is not available.".to_string(),
+        })
+}
+
+fn table_column_ref(
+    columns: &Mutex<HashMap<String, TableColumnRef>>,
+    id: &str,
+) -> Result<TableColumnRef, BatchError> {
+    columns
+        .lock()
+        .expect("table columns lock")
+        .get(id)
+        .cloned()
+        .ok_or_else(|| BatchError {
+            code: "InvalidObjectPath",
+            message: "The table column object is not available.".to_string(),
+        })
+}
+
+fn table_row_ref(
+    rows: &Mutex<HashMap<String, TableRowRef>>,
+    id: &str,
+) -> Result<TableRowRef, BatchError> {
+    rows.lock()
+        .expect("table rows lock")
+        .get(id)
+        .cloned()
+        .ok_or_else(|| BatchError {
+            code: "InvalidObjectPath",
+            message: "The table row object is not available.".to_string(),
+        })
+}
+
+fn write_error(err: ComputeApiError) -> BatchError {
+    match err {
+        ComputeApiError::InvalidAddress { .. } | ComputeApiError::InvalidRange { .. } => {
+            BatchError {
+                code: "InvalidArgument",
+                message: err.to_string(),
+            }
+        }
+        other => engine_error(other),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum WriteProperty {
+    Values,
+    Formulas,
+}
+
+impl WriteProperty {
+    fn from_name(name: &str) -> Result<Self, BatchError> {
+        match name {
+            "values" => Ok(Self::Values),
+            "formulas" => Ok(Self::Formulas),
+            other => Err(BatchError {
+                code: "InvalidArgument",
+                message: format!("Unsupported Range property '{other}'"),
+            }),
+        }
+    }
+}
+
+fn unsupported_load_property(object: &str, property: &str) -> BatchError {
+    BatchError {
+        code: "InvalidArgument",
+        message: format!("Unsupported {object} load property '{property}'"),
+    }
+}
+
+fn json_to_write_grid(
+    value: &Value,
+    property: WriteProperty,
+) -> Result<Vec<Vec<Option<CellInput>>>, BatchError> {
     let rows = value.as_array().ok_or_else(|| BatchError {
         code: "InvalidArgument",
         message: "Range.values and Range.formulas require a 2-dimensional array".to_string(),
@@ -257,21 +2857,57 @@ fn json_to_write_grid(value: &Value) -> Result<Vec<Vec<String>>, BatchError> {
         })?;
         let mut out_row = Vec::with_capacity(cells.len());
         for cell in cells {
-            out_row.push(js_cell_to_write(cell));
+            out_row.push(js_cell_to_write(cell, property)?);
         }
         grid.push(out_row);
     }
     Ok(grid)
 }
 
-fn js_cell_to_write(value: &Value) -> String {
+fn js_cell_to_write(
+    value: &Value,
+    property: WriteProperty,
+) -> Result<Option<CellInput>, BatchError> {
     match value {
-        Value::Null => String::new(),
-        Value::Bool(true) => "TRUE".to_string(),
-        Value::Bool(false) => "FALSE".to_string(),
-        Value::Number(n) => n.to_string(),
-        Value::String(s) => s.clone(),
-        other => other.to_string(),
+        // Microsoft documents null entries in a 2-D property payload as
+        // preserve-cell sentinels. They must never become clear intents.
+        Value::Null => Ok(None),
+        Value::Bool(value) => Ok(Some(CellInput::Value {
+            value: CellValue::Boolean(*value),
+        })),
+        Value::Number(value) => value
+            .as_f64()
+            .map(CellValue::from)
+            .map(|value| Some(CellInput::Value { value }))
+            .ok_or_else(|| BatchError {
+                code: "InvalidArgument",
+                message: "Range values must contain finite JavaScript numbers".to_string(),
+            }),
+        Value::String(value) if value.is_empty() => Ok(Some(CellInput::Clear)),
+        Value::String(value) if has_formula_intent(value, property) => {
+            Ok(Some(CellInput::formula(value)))
+        }
+        Value::String(value) => Ok(Some(CellInput::Literal {
+            text: value.clone(),
+        })),
+        _ => Err(BatchError {
+            code: "InvalidArgument",
+            message: "Range values must contain only strings, numbers, booleans, or null"
+                .to_string(),
+        }),
+    }
+}
+
+fn has_formula_intent(value: &str, property: WriteProperty) -> bool {
+    match property {
+        // The Range.values contract explicitly says leading +, -, and = are
+        // interpreted as formulas.
+        WriteProperty::Values => {
+            value.starts_with('+') || value.starts_with('-') || value.starts_with('=')
+        }
+        // Range.formulas uses A1 formula strings. Non-formula strings are
+        // values and retain their JavaScript string type.
+        WriteProperty::Formulas => value.starts_with('='),
     }
 }
 
@@ -314,7 +2950,10 @@ fn range_formulas_json(sheet: &Sheet, address: &str) -> Result<Value, BatchError
 
 fn cell_to_js(value: CellValue) -> Value {
     match value {
-        CellValue::Null => Value::Null,
+        // Empty cells are represented as empty strings for bounded range
+        // values/formulas reads. Unbounded properties are handled separately
+        // and return null for the entire property.
+        CellValue::Null => Value::String(String::new()),
         CellValue::Boolean(b) => Value::Bool(b),
         CellValue::Number(_) => value.as_number().map(|n| json!(n)).unwrap_or(Value::Null),
         CellValue::Text(s) => Value::String(s.to_string()),

--- a/compute/officejs/src/host_objects.rs
+++ b/compute/officejs/src/host_objects.rs
@@ -1,0 +1,955 @@
+//! Production extension handlers for the Office.js object families.
+//!
+//! `host.rs` owns the request queue and the legacy object maps.  This module
+//! owns the operation-to-reference bridge for the newer object families.  A
+//! family reference remains in its implementation module; the adapters below
+//! only turn its family error into `BatchError` and bind the resulting proxy
+//! through `HostDispatchContext`.
+//!
+//! The dispatcher deliberately uses proxy IDs for operation fields and stores
+//! persisted IDs only inside the typed references.  Child operations first
+//! resolve a parent extension binding when possible, then fall back to an
+//! explicit worksheet plus persisted ID supplied by the JavaScript proxy.
+
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+
+use crate::application::ApplicationHandler;
+use crate::chart_core::{ChartCollectionRef, ChartError, ChartRef};
+use crate::chart_series::{ChartSeriesCollectionRef, ChartSeriesError, ChartSeriesRef};
+use crate::conditional_basic::{
+    ConditionalBorderSide, ConditionalChildKind, ConditionalFormatChildRef,
+    ConditionalFormatCollectionRef, ConditionalFormatError, ConditionalFormatRef,
+};
+use crate::dispatch::{ExtensionHandler, ExtensionObject, HostDispatchContext};
+use crate::host::BatchError;
+
+/// Register the family bridge with a host.  The host owner calls this once
+/// while constructing a `Host`, before any script batch is evaluated.
+pub(crate) fn register(host: &crate::host::Host) {
+    host.register_extension(HostObjectsHandler);
+    host.register_extension(ApplicationHandler);
+}
+
+/// The single registration point for the object-family operation names.  The
+/// implementation intentionally stays stateless; all state belongs to the
+/// bound typed references held by the host extension map.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct HostObjectsHandler;
+
+impl ExtensionHandler for HostObjectsHandler {
+    fn can_handle(&self, operation: &str) -> bool {
+        matches!(
+            operation,
+            // Charts and chart series.
+            "getChartCollection"
+                | "chartCollectionGetItem"
+                | "chartCollectionGetItemAt"
+                | "chartCollectionGetCount"
+                | "chartAdd"
+                | "chartGetItem"
+                | "chartGetItemAt"
+                | "chartDelete"
+                | "chartSetData"
+                | "chartSetPosition"
+                | "chartActivate"
+                | "getChartSeriesCollection"
+                | "chartSeriesCollectionGetItem"
+                | "chartSeriesCollectionGetCount"
+                | "chartSeriesCollectionAdd"
+                | "chartSeriesDelete"
+                | "chartSeriesGetDimensionDataSourceString"
+                | "chartSeriesGetDimensionDataSourceType"
+                | "chartSeriesGetDimensionValues"
+                | "chartSeriesSetDimensionSource"
+                // Conditional formats.
+                | "getConditionalFormatCollection"
+                | "conditionalFormatCollectionGetCount"
+                | "conditionalFormatCollectionGetItem"
+                | "conditionalFormatCollectionAdd"
+                | "conditionalFormatCollectionClearAll"
+                | "conditionalFormatChild"
+                | "conditionalFormatDelete"
+                | "conditionalFormatGetRange"
+                | "conditionalFormatSetRanges"
+                | "conditionalFormatChangeRule"
+        )
+    }
+
+    fn handle(
+        &self,
+        operation: &Value,
+        context: &mut HostDispatchContext<'_>,
+    ) -> Result<bool, BatchError> {
+        let op = required_string(operation, "op")?;
+        match op {
+            "getChartCollection"
+            | "chartCollectionGetItem"
+            | "chartCollectionGetItemAt"
+            | "chartCollectionGetCount"
+            | "chartAdd"
+            | "chartGetItem"
+            | "chartGetItemAt"
+            | "chartDelete"
+            | "chartSetData"
+            | "chartSetPosition"
+            | "chartActivate" => handle_chart_operation(operation, context),
+            "getChartSeriesCollection"
+            | "chartSeriesCollectionGetItem"
+            | "chartSeriesCollectionGetCount"
+            | "chartSeriesCollectionAdd"
+            | "chartSeriesDelete"
+            | "chartSeriesGetDimensionDataSourceString"
+            | "chartSeriesGetDimensionDataSourceType"
+            | "chartSeriesGetDimensionValues"
+            | "chartSeriesSetDimensionSource" => handle_chart_series_operation(operation, context),
+            "getConditionalFormatCollection"
+            | "conditionalFormatCollectionGetCount"
+            | "conditionalFormatCollectionGetItem"
+            | "conditionalFormatCollectionAdd"
+            | "conditionalFormatCollectionClearAll"
+            | "conditionalFormatChild"
+            | "conditionalFormatDelete"
+            | "conditionalFormatGetRange"
+            | "conditionalFormatSetRanges"
+            | "conditionalFormatChangeRule" => handle_conditional_operation(operation, context),
+            _ => Ok(false),
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// Shared extension object adapters
+// -------------------------------------------------------------------------
+
+struct ChartCollectionObject(ChartCollectionRef);
+struct ChartObject(ChartRef);
+struct ChartSeriesCollectionObject(ChartSeriesCollectionRef);
+struct ChartSeriesObject(ChartSeriesRef);
+struct ConditionalFormatCollectionObject(ConditionalFormatCollectionRef);
+struct ConditionalFormatObject(ConditionalFormatRef);
+struct ConditionalFormatChildObject(ConditionalFormatChildRef);
+
+impl ExtensionObject for ChartCollectionObject {
+    fn object_type(&self) -> &'static str {
+        "ChartCollection"
+    }
+
+    fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<std::collections::HashMap<String, Value>, BatchError> {
+        let (wants_items, item_properties) = collection_item_properties(properties)?;
+        let mut result = std::collections::HashMap::new();
+        for property in properties {
+            match property.as_str() {
+                "count" => {
+                    result.insert(
+                        "count".to_string(),
+                        json!(self.0.count().map_err(chart_error)?),
+                    );
+                }
+                "isNullObject" => {
+                    result.insert("isNullObject".to_string(), Value::Bool(false));
+                }
+                "items" => {}
+                item_path if item_path.starts_with("items/") => {}
+                other => return Err(invalid(format!("ChartCollection.{other} is unsupported"))),
+            }
+        }
+        if wants_items {
+            let descriptors = self
+                .0
+                .collection_items(&item_properties)
+                .map_err(chart_error)?;
+            result.insert(
+                "items".to_string(),
+                serde_json::to_value(descriptors).map_err(|error| BatchError {
+                    code: "GeneralException",
+                    message: format!("failed to encode chart collection items: {error}"),
+                })?,
+            );
+        }
+        Ok(result)
+    }
+
+    fn set(&self, property: &str, _value: &Value) -> Result<(), BatchError> {
+        Err(invalid(format!("ChartCollection.{property} is read-only")))
+    }
+}
+
+impl ExtensionObject for ChartObject {
+    fn object_type(&self) -> &'static str {
+        "Chart"
+    }
+
+    fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<std::collections::HashMap<String, Value>, BatchError> {
+        self.0.load(properties).map_err(chart_error)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        self.0.set(property, value).map_err(chart_error)
+    }
+}
+
+impl ExtensionObject for ChartSeriesCollectionObject {
+    fn object_type(&self) -> &'static str {
+        "ChartSeriesCollection"
+    }
+
+    fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<std::collections::HashMap<String, Value>, BatchError> {
+        self.0.load(properties).map_err(chart_series_error)
+    }
+
+    fn set(&self, property: &str, _value: &Value) -> Result<(), BatchError> {
+        Err(invalid(format!(
+            "ChartSeriesCollection.{property} is read-only"
+        )))
+    }
+}
+
+impl ExtensionObject for ChartSeriesObject {
+    fn object_type(&self) -> &'static str {
+        "ChartSeries"
+    }
+
+    fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<std::collections::HashMap<String, Value>, BatchError> {
+        self.0.load(properties).map_err(chart_series_error)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        self.0.set(property, value).map_err(chart_series_error)
+    }
+}
+
+impl ExtensionObject for ConditionalFormatCollectionObject {
+    fn object_type(&self) -> &'static str {
+        "ConditionalFormatCollection"
+    }
+
+    fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<std::collections::HashMap<String, Value>, BatchError> {
+        let (wants_items, item_properties) = collection_item_properties(properties)?;
+        let mut result = std::collections::HashMap::new();
+        for property in properties {
+            match property.as_str() {
+                "count" => {
+                    result.insert(
+                        "count".to_string(),
+                        json!(self.0.count().map_err(conditional_error)?),
+                    );
+                }
+                "isNullObject" | "items" => {}
+                other if other.starts_with("items/") => {}
+                other => {
+                    return Err(invalid(format!(
+                        "ConditionalFormatCollection.{other} is unsupported"
+                    )))
+                }
+            }
+        }
+        if wants_items {
+            let descriptors = self
+                .0
+                .collection_items(&item_properties)
+                .map_err(conditional_error)?;
+            result.insert(
+                "items".to_string(),
+                serde_json::to_value(descriptors).map_err(|error| BatchError {
+                    code: "GeneralException",
+                    message: format!("failed to encode conditional-format items: {error}"),
+                })?,
+            );
+        }
+        Ok(result)
+    }
+
+    fn set(&self, property: &str, _value: &Value) -> Result<(), BatchError> {
+        Err(invalid(format!(
+            "ConditionalFormatCollection.{property} is read-only"
+        )))
+    }
+}
+
+impl ExtensionObject for ConditionalFormatObject {
+    fn object_type(&self) -> &'static str {
+        "ConditionalFormat"
+    }
+
+    fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<std::collections::HashMap<String, Value>, BatchError> {
+        self.0.load(properties).map_err(conditional_error)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        self.0.set(property, value).map_err(conditional_error)
+    }
+}
+
+impl ExtensionObject for ConditionalFormatChildObject {
+    fn object_type(&self) -> &'static str {
+        "ConditionalFormatChild"
+    }
+
+    fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<std::collections::HashMap<String, Value>, BatchError> {
+        self.0.load(properties).map_err(conditional_error)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        self.0.set(property, value).map_err(conditional_error)
+    }
+}
+
+// -------------------------------------------------------------------------
+// Chart core/series operations
+// -------------------------------------------------------------------------
+
+fn handle_chart_operation(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+) -> Result<bool, BatchError> {
+    let op = required_string(operation, "op")?;
+    match op {
+        "getChartCollection" => {
+            let id = required_string(operation, "id")?;
+            let worksheet_id = required_string(operation, "worksheetId")?;
+            let worksheet = context.worksheet(worksheet_id)?;
+            context.bind_object(
+                id,
+                Arc::new(ChartCollectionObject(ChartCollectionRef::new(
+                    worksheet.sheet(),
+                ))),
+            );
+        }
+        "chartCollectionGetItem" | "chartCollectionGetItemAt" => {
+            let collection = chart_collection_from_operation(operation, context)?;
+            let by_index = op == "chartCollectionGetItemAt";
+            let or_null = operation
+                .get("orNullObject")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let chart = if by_index {
+                collection
+                    .get_item_at(required_i64(operation, "index")?)
+                    .map(Some)
+                    .map_err(chart_error)?
+            } else if or_null {
+                collection
+                    .get_item_or_null_object(required_string(operation, "name")?)
+                    .map_err(chart_error)?
+            } else {
+                collection
+                    .get_item(required_string(operation, "name")?)
+                    .map(Some)
+                    .map_err(chart_error)?
+            };
+            let id = required_string(operation, "id")?;
+            match chart {
+                Some(chart) => context.bind_object(id, Arc::new(ChartObject(chart))),
+                None if or_null => context.bind_null_object(id),
+                None => {
+                    return Err(invalid(
+                        "ChartCollection.getItem returned no chart without OrNullObject",
+                    ))
+                }
+            }
+        }
+        "chartCollectionGetCount" => {
+            let collection = chart_collection_from_operation(operation, context)?;
+            let result_id = required_string(operation, "resultId")?;
+            context.set_result(result_id, json!(collection.count().map_err(chart_error)?));
+        }
+        "chartAdd" => {
+            let id = required_string(operation, "id")?;
+            let collection = chart_collection_from_operation(operation, context)?;
+            let range = range_from_operation(operation, context, "rangeId", "sourceData")?;
+            let chart = collection
+                .add(
+                    required_string(operation, "type")?,
+                    range.address().ok_or_else(|| {
+                        invalid("ChartCollection.add requires a bounded source Range")
+                    })?,
+                    operation.get("seriesBy").and_then(Value::as_str),
+                )
+                .map_err(chart_error)?;
+            context.bind_object(id, Arc::new(ChartObject(chart)));
+        }
+        "chartGetItem" | "chartGetItemAt" => {
+            // The collection lookup operation is the only supported path for
+            // ChartCollection.getItem. Keep this branch for older proxies that
+            // send the operation name directly with a worksheet/chart scope.
+            let collection = chart_collection_from_operation(operation, context)?;
+            let id = required_string(operation, "id")?;
+            let or_null = operation
+                .get("orNullObject")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let chart = if op == "chartGetItemAt" {
+                collection
+                    .get_item_at(required_i64(operation, "index")?)
+                    .map(Some)
+                    .map_err(chart_error)?
+            } else if or_null {
+                collection
+                    .get_item_or_null_object(required_string(operation, "name")?)
+                    .map_err(chart_error)?
+            } else {
+                collection
+                    .get_item(required_string(operation, "name")?)
+                    .map(Some)
+                    .map_err(chart_error)?
+            };
+            match chart {
+                Some(chart) => context.bind_object(id, Arc::new(ChartObject(chart))),
+                None if or_null => context.bind_null_object(id),
+                None => return Err(invalid("Chart lookup returned no chart")),
+            }
+        }
+        "chartDelete" => {
+            let chart = chart_from_operation(operation, context)?;
+            chart.delete().map_err(chart_error)?;
+        }
+        "chartSetData" => {
+            let chart = chart_from_operation(operation, context)?;
+            let range = range_from_operation(operation, context, "rangeId", "sourceData")?;
+            chart
+                .set_data(
+                    range
+                        .address()
+                        .ok_or_else(|| invalid("Chart.setData requires a bounded source Range"))?,
+                    operation.get("seriesBy").and_then(Value::as_str),
+                )
+                .map_err(chart_error)?;
+        }
+        "chartSetPosition" => {
+            let chart = chart_from_operation(operation, context)?;
+            let start = address_from_operation(operation, context, "startRangeId", "startAddress")?;
+            let end =
+                optional_address_from_operation(operation, context, "endRangeId", "endAddress")?;
+            chart
+                .set_position(&start, end.as_deref())
+                .map_err(chart_error)?;
+        }
+        "chartActivate" => {
+            return Err(unsupported(
+                "Chart.activate requires an interactive Excel window",
+            ));
+        }
+        _ => return Ok(false),
+    }
+    Ok(true)
+}
+
+fn handle_chart_series_operation(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+) -> Result<bool, BatchError> {
+    let op = required_string(operation, "op")?;
+    match op {
+        "getChartSeriesCollection" => {
+            let id = required_string(operation, "id")?;
+            let chart = chart_from_operation(operation, context)?;
+            let collection = ChartSeriesCollectionRef::new(context.workbook(), chart);
+            context.bind_object(id, Arc::new(ChartSeriesCollectionObject(collection)));
+        }
+        "chartSeriesCollectionGetItem" => {
+            let collection = chart_series_collection_from_operation(operation, context)?;
+            let item = collection
+                .get_item_at(required_i64(operation, "index")?)
+                .map_err(chart_series_error)?;
+            context.bind_object(
+                required_string(operation, "id")?,
+                Arc::new(ChartSeriesObject(item)),
+            );
+        }
+        "chartSeriesCollectionGetCount" => {
+            let collection = chart_series_collection_from_operation(operation, context)?;
+            context.set_result(
+                required_string(operation, "resultId")?,
+                json!(collection.count().map_err(chart_series_error)?),
+            );
+        }
+        "chartSeriesCollectionAdd" => {
+            let collection = chart_series_collection_from_operation(operation, context)?;
+            let name = operation.get("name").and_then(Value::as_str);
+            let index = operation.get("index").and_then(Value::as_i64);
+            let item = collection.add(name, index).map_err(chart_series_error)?;
+            context.bind_object(
+                required_string(operation, "id")?,
+                Arc::new(ChartSeriesObject(item)),
+            );
+        }
+        "chartSeriesDelete" => {
+            let item = chart_series_from_operation(operation, context)?;
+            item.delete().map_err(chart_series_error)?;
+        }
+        "chartSeriesGetDimensionDataSourceString"
+        | "chartSeriesGetDimensionDataSourceType"
+        | "chartSeriesGetDimensionValues" => {
+            let item = chart_series_from_operation(operation, context)?;
+            let dimension = required_string(operation, "dimension")?;
+            let value = match op {
+                "chartSeriesGetDimensionDataSourceString" => Value::String(
+                    item.get_dimension_data_source_string(dimension)
+                        .map_err(chart_series_error)?,
+                ),
+                "chartSeriesGetDimensionDataSourceType" => Value::String(
+                    item.get_dimension_data_source_type(dimension)
+                        .map_err(chart_series_error)?,
+                ),
+                _ => json!(item
+                    .get_dimension_values(dimension)
+                    .map_err(chart_series_error)?),
+            };
+            context.set_result(required_string(operation, "resultId")?, value);
+        }
+        "chartSeriesSetDimensionSource" => {
+            let item = chart_series_from_operation(operation, context)?;
+            let range = range_from_operation(operation, context, "rangeId", "address")?;
+            item.set_dimension_source(
+                required_string(operation, "dimension")?,
+                &range.sheet(),
+                range.address().ok_or_else(|| {
+                    invalid("ChartSeries dimension source requires a bounded Range")
+                })?,
+            )
+            .map_err(chart_series_error)?;
+        }
+        _ => return Ok(false),
+    }
+    Ok(true)
+}
+
+fn chart_collection_from_operation(
+    operation: &Value,
+    context: &HostDispatchContext<'_>,
+) -> Result<ChartCollectionRef, BatchError> {
+    if let Some(collection_id) = operation.get("collectionId").and_then(Value::as_str) {
+        if let Ok(collection) = context.extension_object::<ChartCollectionObject>(collection_id) {
+            return Ok(collection.0.clone());
+        }
+    }
+    let worksheet_id = required_string(operation, "worksheetId")?;
+    Ok(ChartCollectionRef::new(
+        context.worksheet(worksheet_id)?.sheet(),
+    ))
+}
+
+fn chart_from_operation(
+    operation: &Value,
+    context: &HostDispatchContext<'_>,
+) -> Result<ChartRef, BatchError> {
+    for field in ["chartId", "parentId", "chartObjectId"] {
+        if let Some(id) = operation.get(field).and_then(Value::as_str) {
+            if let Ok(chart) = context.extension_object::<ChartObject>(id) {
+                return Ok(chart.0.clone());
+            }
+        }
+    }
+    let worksheet_id = required_string(operation, "worksheetId")?;
+    let chart_id = required_string(operation, "chartId")?;
+    Ok(ChartRef::new(
+        context.worksheet(worksheet_id)?.sheet(),
+        chart_id,
+    ))
+}
+
+fn chart_series_collection_from_operation(
+    operation: &Value,
+    context: &HostDispatchContext<'_>,
+) -> Result<ChartSeriesCollectionRef, BatchError> {
+    if let Some(collection_id) = operation.get("collectionId").and_then(Value::as_str) {
+        if let Ok(collection) =
+            context.extension_object::<ChartSeriesCollectionObject>(collection_id)
+        {
+            return Ok(collection.0.clone());
+        }
+    }
+    Ok(ChartSeriesCollectionRef::new(
+        context.workbook(),
+        chart_from_operation(operation, context)?,
+    ))
+}
+
+fn chart_series_from_operation(
+    operation: &Value,
+    context: &HostDispatchContext<'_>,
+) -> Result<ChartSeriesRef, BatchError> {
+    if let Some(id) = operation.get("id").and_then(Value::as_str) {
+        if let Ok(item) = context.extension_object::<ChartSeriesObject>(id) {
+            return Ok(item.0.clone());
+        }
+    }
+    let collection = chart_series_collection_from_operation(operation, context)?;
+    collection
+        .get_item_at(required_i64(operation, "index")?)
+        .map_err(chart_series_error)
+}
+
+// -------------------------------------------------------------------------
+// Conditional-format operations
+// -------------------------------------------------------------------------
+
+fn handle_conditional_operation(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+) -> Result<bool, BatchError> {
+    let op = required_string(operation, "op")?;
+    match op {
+        "getConditionalFormatCollection" => {
+            let range = context.range(required_string(operation, "rangeId")?)?;
+            let address = range
+                .address()
+                .ok_or_else(|| invalid("ConditionalFormatCollection requires a bounded Range"))?;
+            let collection = ConditionalFormatCollectionRef::new(range.sheet(), address)
+                .map_err(conditional_error)?;
+            context.bind_object(
+                required_string(operation, "id")?,
+                Arc::new(ConditionalFormatCollectionObject(collection)),
+            );
+        }
+        "conditionalFormatCollectionGetCount" => {
+            let collection = conditional_collection_from_operation(operation, context)?;
+            context.set_result(
+                required_string(operation, "resultId")?,
+                json!(collection.count().map_err(conditional_error)?),
+            );
+        }
+        "conditionalFormatCollectionGetItem" => {
+            let collection = conditional_collection_from_operation(operation, context)?;
+            let item = collection
+                .get_item(
+                    required_string(operation, "key")?,
+                    operation
+                        .get("byIndex")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false),
+                    operation
+                        .get("orNullObject")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false),
+                )
+                .map_err(conditional_error)?;
+            let id = required_string(operation, "id")?;
+            if item.is_null_object() {
+                context.bind_null_object(id);
+            } else {
+                context.bind_object(id, Arc::new(ConditionalFormatObject(item)));
+            }
+        }
+        "conditionalFormatCollectionAdd" => {
+            let collection = conditional_collection_from_operation(operation, context)?;
+            let item = collection
+                .add(required_string(operation, "type")?)
+                .map_err(conditional_error)?;
+            context.bind_object(
+                required_string(operation, "id")?,
+                Arc::new(ConditionalFormatObject(item)),
+            );
+        }
+        "conditionalFormatCollectionClearAll" => {
+            conditional_collection_from_operation(operation, context)?
+                .clear_all()
+                .map_err(conditional_error)?;
+        }
+        "conditionalFormatChild" => {
+            let parent_id = required_string(operation, "parentId")?;
+            let parent = context.extension_object::<ConditionalFormatObject>(parent_id)?;
+            let kind = ConditionalChildKind::from_wire(required_string(operation, "kind")?)
+                .map_err(conditional_error)?;
+            let side =
+                ConditionalBorderSide::from_wire(operation.get("side").and_then(Value::as_str))
+                    .map_err(conditional_error)?;
+            let child = parent
+                .0
+                .child(
+                    kind,
+                    side,
+                    operation
+                        .get("orNullObject")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false),
+                )
+                .map_err(conditional_error)?;
+            let id = required_string(operation, "id")?;
+            if child.is_null_object() {
+                context.bind_null_object(id);
+            } else {
+                context.bind_object(id, Arc::new(ConditionalFormatChildObject(child)));
+            }
+        }
+        "conditionalFormatDelete" => {
+            conditional_from_operation(operation, context)?
+                .delete()
+                .map_err(conditional_error)?;
+        }
+        "conditionalFormatGetRange" => {
+            // The common dispatcher owns RangeRef construction.  The current
+            // context deliberately exposes only rebinding of an existing
+            // RangeRef, so this operation is kept explicit until the host
+            // owner adds its address-to-Range binding hook.
+            return Err(unsupported(
+                "ConditionalFormat.getRange requires the host Range binding hook",
+            ));
+        }
+        "conditionalFormatSetRanges" => {
+            let ranges = conditional_ranges_from_operation(operation, context)?;
+            conditional_from_operation(operation, context)?
+                .set_ranges(ranges)
+                .map_err(conditional_error)?;
+        }
+        "conditionalFormatChangeRule" => {
+            conditional_from_operation(operation, context)?
+                .change_rule(required_string(operation, "type")?, operation.get("rule"))
+                .map_err(conditional_error)?;
+        }
+        _ => return Ok(false),
+    }
+    Ok(true)
+}
+
+fn conditional_collection_from_operation(
+    operation: &Value,
+    context: &HostDispatchContext<'_>,
+) -> Result<ConditionalFormatCollectionRef, BatchError> {
+    let id = operation
+        .get("collectionId")
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid("Conditional-format operation requires collectionId"))?;
+    Ok(context
+        .extension_object::<ConditionalFormatCollectionObject>(id)?
+        .0
+        .clone())
+}
+
+fn conditional_from_operation(
+    operation: &Value,
+    context: &HostDispatchContext<'_>,
+) -> Result<ConditionalFormatRef, BatchError> {
+    let id = required_string(operation, "id")?;
+    if let Ok(item) = context.extension_object::<ConditionalFormatObject>(id) {
+        return Ok(item.0.clone());
+    }
+    let sheet = context
+        .worksheet(required_string(operation, "worksheetId")?)?
+        .sheet();
+    Ok(ConditionalFormatRef::new(
+        sheet,
+        required_string(operation, "formatId")?,
+    ))
+}
+
+fn conditional_ranges_from_operation(
+    operation: &Value,
+    context: &HostDispatchContext<'_>,
+) -> Result<Vec<compute_api::CFCellRange>, BatchError> {
+    let values = operation
+        .get("ranges")
+        .and_then(Value::as_array)
+        .ok_or_else(|| invalid("ConditionalFormat.setRanges requires a ranges array"))?;
+    if values.is_empty() {
+        return Err(invalid("ConditionalFormat.setRanges requires at least one range"));
+    }
+    values
+        .iter()
+        .map(|value| {
+            let object = value
+                .as_object()
+                .ok_or_else(|| invalid("ConditionalFormat.setRanges range must be an object"))?;
+            if let Some(range_id) = object.get("rangeId").and_then(Value::as_str) {
+                let range = context.range(range_id)?;
+                if range.is_null_object() {
+                    return Err(invalid("ConditionalFormat.setRanges cannot use a null Range"));
+                }
+                let address = range.address().ok_or_else(|| {
+                    invalid("ConditionalFormat.setRanges requires bounded Range objects")
+                })?;
+                return cf_cell_range(&range.sheet(), address);
+            }
+            let address = object
+                .get("address")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    invalid("ConditionalFormat.setRanges range requires rangeId or address")
+                })?;
+            let sheet_id = operation
+                .get("worksheetId")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    invalid("ConditionalFormat.setRanges address requires worksheetId")
+                })?;
+            let sheet = context.worksheet(sheet_id)?.sheet();
+            cf_cell_range(&sheet, address)
+        })
+        .collect()
+}
+
+fn cf_cell_range(
+    sheet: &compute_api::Sheet,
+    address: &str,
+) -> Result<compute_api::CFCellRange, BatchError> {
+    let parsed = crate::range_navigation::parse_range_address(sheet, address).map_err(|error| {
+        BatchError {
+            code: error.code,
+            message: error.message,
+        }
+    })?;
+    let (start_row, start_col, end_row, end_col) = match parsed {
+        crate::range_navigation::RangeAddress::Cells {
+            start_row,
+            start_column,
+            end_row,
+            end_column,
+        } => (start_row, start_column, end_row, end_column),
+        _ => return Err(invalid("ConditionalFormat.setRanges requires bounded ranges")),
+    };
+    Ok(compute_api::CFCellRange::new(
+        start_row,
+        start_col,
+        end_row,
+        end_col,
+    ))
+}
+
+// -------------------------------------------------------------------------
+// Wire helpers and error conversion
+// -------------------------------------------------------------------------
+
+fn collection_item_properties(properties: &[String]) -> Result<(bool, Vec<String>), BatchError> {
+    let mut wants_items = false;
+    let mut item_properties = Vec::new();
+    for property in properties {
+        if property == "items" {
+            wants_items = true;
+        } else if let Some(item_property) = property.strip_prefix("items/") {
+            if item_property.is_empty() || item_property.contains('/') {
+                return Err(invalid(format!(
+                    "Invalid collection item property '{property}'"
+                )));
+            }
+            wants_items = true;
+            if !item_properties
+                .iter()
+                .any(|existing| existing == item_property)
+            {
+                item_properties.push(item_property.to_string());
+            }
+        }
+    }
+    Ok((wants_items, item_properties))
+}
+
+fn range_from_operation(
+    operation: &Value,
+    context: &HostDispatchContext<'_>,
+    id_field: &str,
+    address_field: &str,
+) -> Result<crate::host::RangeRef, BatchError> {
+    if let Some(id) = operation.get(id_field).and_then(Value::as_str) {
+        return context.range(id);
+    }
+    let _ = address_field;
+    Err(invalid(format!("Operation requires {id_field}")))
+}
+
+fn address_from_operation(
+    operation: &Value,
+    context: &HostDispatchContext<'_>,
+    range_field: &str,
+    address_field: &str,
+) -> Result<String, BatchError> {
+    if let Some(id) = operation.get(range_field).and_then(Value::as_str) {
+        let range = context.range(id)?;
+        return range
+            .address()
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| invalid(format!("Operation {range_field} requires a bounded Range")));
+    }
+    required_string(operation, address_field).map(ToOwned::to_owned)
+}
+
+fn optional_address_from_operation(
+    operation: &Value,
+    context: &HostDispatchContext<'_>,
+    range_field: &str,
+    address_field: &str,
+) -> Result<Option<String>, BatchError> {
+    if let Some(id) = operation.get(range_field).and_then(Value::as_str) {
+        let range = context.range(id)?;
+        return range
+            .address()
+            .map(|address| Some(address.to_string()))
+            .ok_or_else(|| invalid(format!("Operation {range_field} requires a bounded Range")));
+    }
+    Ok(operation
+        .get(address_field)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned))
+}
+
+fn required_string<'a>(value: &'a Value, field: &str) -> Result<&'a str, BatchError> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| invalid(format!("Operation requires a non-empty {field}")))
+}
+
+fn required_i64(value: &Value, field: &str) -> Result<i64, BatchError> {
+    value
+        .get(field)
+        .and_then(Value::as_i64)
+        .ok_or_else(|| invalid(format!("Operation requires integer {field}")))
+}
+
+fn invalid(message: impl Into<String>) -> BatchError {
+    BatchError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn unsupported(message: impl Into<String>) -> BatchError {
+    BatchError {
+        code: "ApiNotFound",
+        message: message.into(),
+    }
+}
+
+fn chart_error(error: ChartError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn chart_series_error(error: ChartSeriesError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn conditional_error(error: ConditionalFormatError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}

--- a/compute/officejs/src/hyperlinks.js
+++ b/compute/officejs/src/hyperlinks.js
@@ -1,0 +1,165 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs;
+
+  function richApiError(code, message) {
+    var error = new OfficeExtension.Error({
+      code: code,
+      message: message,
+    });
+    error.name = "RichApi.Error";
+    error.code = code;
+    return error;
+  }
+
+  function propertyNotLoaded(name) {
+    return richApiError(
+      "PropertyNotLoaded",
+      "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context."
+    );
+  }
+
+  function invalidArgument(message) {
+    return richApiError("InvalidArgument", message);
+  }
+
+  function isPlainObject(value) {
+    if (value === null || typeof value !== "object") return false;
+    var prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  }
+
+  var fields = [
+    "address",
+    "documentReference",
+    "screenTip",
+    "textToDisplay",
+  ];
+
+  // RangeHyperlink is a plain value object, rather than a child ClientObject.
+  // Keep only declared fields on the wire and reject accidental dialect fields
+  // instead of silently dropping caller intent.
+  function normalizeHyperlink(value) {
+    if (!isPlainObject(value)) {
+      throw invalidArgument("Range.hyperlink must be a plain object");
+    }
+
+    var normalized = {};
+    Object.keys(value).forEach(function (name) {
+      if (fields.indexOf(name) < 0) {
+        throw invalidArgument(
+          "Unsupported Range.hyperlink property '" + name + "'"
+        );
+      }
+
+      // JSON.stringify omits undefined properties. Treating undefined as an
+      // omitted optional member gives the same behavior before a sync while
+      // retaining strict string typing for values that reach the host.
+      if (value[name] === undefined) return;
+      if (typeof value[name] !== "string") {
+        throw invalidArgument("Range.hyperlink." + name + " must be a string");
+      }
+      normalized[name] = value[name];
+    });
+    return normalized;
+  }
+
+  function copyWithoutHyperlink(source, isClientObject) {
+    var result = {};
+    Object.keys(source).forEach(function (name) {
+      if (name === "hyperlink") return;
+      // range_content.js treats a ClientObject source specially: writable
+      // fields are copied while read-only scalar metadata is ignored. Once we
+      // materialize toJSON in this wrapper, retain that distinction explicitly.
+      if (
+        isClientObject &&
+        ["values", "formulas", "numberFormat", "format"].indexOf(name) < 0
+      ) {
+        return;
+      }
+      result[name] = source[name];
+    });
+    return result;
+  }
+
+  function sourceProperties(source) {
+    if (source instanceof ClientObject) {
+      return source.toJSON();
+    }
+    if (source === null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+    return source;
+  }
+
+  if (officeJs && typeof officeJs.addScalarProperties === "function") {
+    officeJs.addScalarProperties(Excel.Range.prototype, ["hyperlink"]);
+  } else {
+    var scalar = Excel.Range.prototype._additionalScalarProperties || [];
+    if (scalar.indexOf("hyperlink") < 0) scalar.push("hyperlink");
+    Excel.Range.prototype._additionalScalarProperties = scalar;
+  }
+
+  Object.defineProperty(Excel.Range.prototype, "hyperlink", {
+    configurable: true,
+    enumerable: true,
+    get: function () {
+      if (!this._loaded.hyperlink) throw propertyNotLoaded("hyperlink");
+      return this._hyperlink;
+    },
+    set: function (value) {
+      var normalized = normalizeHyperlink(value);
+      this._hyperlink = normalized;
+      this._loaded.hyperlink = true;
+      this.context._queue.push({
+        op: "set",
+        id: this._id,
+        property: "hyperlink",
+        value: normalized,
+      });
+    },
+  });
+
+  // range_content.js owns the general Range.set implementation. Extend it
+  // here after that projection is installed, retaining its UpdateOptions and
+  // format/value handling while making hyperlink a writable Range scalar.
+  var previousSet = Excel.Range.prototype.set;
+  Excel.Range.prototype.set = function (source, options) {
+    var isClientObject = source instanceof ClientObject;
+    if (
+      isClientObject &&
+      Object.getPrototypeOf(this) !== Object.getPrototypeOf(source)
+    ) {
+      throw invalidArgument("The object passed to set must have the same type.");
+    }
+    var properties = sourceProperties(source);
+    var hasHyperlink = Object.prototype.hasOwnProperty.call(
+      properties,
+      "hyperlink"
+    );
+    var normalized = hasHyperlink
+      ? normalizeHyperlink(properties.hyperlink)
+      : null;
+
+    if (typeof previousSet === "function") {
+      var remaining = hasHyperlink
+        ? copyWithoutHyperlink(properties, isClientObject)
+        : source;
+      if (remaining instanceof ClientObject || Object.keys(remaining).length > 0) {
+        previousSet.call(this, remaining, options);
+      }
+    }
+    // Validate the hyperlink before this point, so a malformed value cannot
+    // leave a queued hyperlink operation behind when another Range.set field
+    // is rejected. Queue it after the existing Range.set work has validated.
+    if (hasHyperlink) {
+      this.hyperlink = normalized;
+    }
+  };
+})(globalThis);

--- a/compute/officejs/src/hyperlinks.rs
+++ b/compute/officejs/src/hyperlinks.rs
@@ -1,0 +1,245 @@
+//! Office.js `Range.hyperlink` translation.
+//!
+//! A RangeHyperlink is a compound scalar in Office.js.  The adapter keeps the
+//! wire value deliberately small (`address`, `documentReference`, `screenTip`,
+//! and `textToDisplay`) and delegates persistence to the sheet hyperlink
+//! facade.  It never keeps a second hyperlink map in the Office.js host.
+
+use std::collections::HashMap;
+
+use compute_api::{CellRange, ComputeApiError, Sheet};
+use serde_json::{Map, Value, json};
+
+use crate::range_navigation::{RangeNavigationError, parse_range_address};
+
+/// Error returned by the Office.js hyperlink projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HyperlinkError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RangeHyperlinkInput {
+    address: Option<String>,
+    document_reference: Option<String>,
+    screen_tip: Option<String>,
+    text_to_display: Option<String>,
+}
+
+/// Load the RangeHyperlink represented by the first hyperlink in `address`.
+///
+/// Excel exposes one compound value for a Range.  When a range contains more
+/// than one hyperlink, the top-left hyperlink is the deterministic projection;
+/// this also matches the `textToDisplay` declaration, which names the top-left
+/// cell in the range.  An unlinked range is represented by an empty object,
+/// because `Range.hyperlink` itself is a non-null `RangeHyperlink` value.
+pub(crate) fn load(sheet: &Sheet, address: &str) -> Result<HashMap<String, Value>, HyperlinkError> {
+    let bounds = resolve_bounded(sheet, address)?;
+    let links = sheet.hyperlinks().get_all_hyperlinks().map_err(engine)?;
+
+    let selected = links
+        .into_iter()
+        .filter_map(|link| {
+            let (row, col) = hyperlink_anchor_top_left(&link.cell_ref)?;
+            (row >= bounds.0 && row <= bounds.2 && col >= bounds.1 && col <= bounds.3)
+                .then_some((row, col, link))
+        })
+        .min_by_key(|(row, col, _)| (*row, *col))
+        .map(|(_, _, link)| link);
+
+    let value = selected
+        .map(range_hyperlink_value)
+        .unwrap_or_else(|| Value::Object(Map::new()));
+    Ok(HashMap::from([(String::from("hyperlink"), value)]))
+}
+
+/// Return the top-left coordinate for either a cell or a range hyperlink.
+/// Imported XLSX can preserve a single `<hyperlink ref="A1:B2">` on the
+/// top-left cell map, so parsing only `CellAddress` would make that durable
+/// hyperlink invisible to Range.hyperlink reads.
+fn hyperlink_anchor_top_left(cell_ref: &str) -> Option<(u32, u32)> {
+    let reference = cell_ref
+        .rsplit_once('!')
+        .map(|(_, reference)| reference)
+        .unwrap_or(cell_ref);
+    let (row, col, _, _) = CellRange::from(reference).resolve().ok()?;
+    Some((row, col))
+}
+
+/// Set a Range.hyperlink value on the top-left cell of the bounded range.
+///
+/// The typed sheet facade receives all four Office.js members, including
+/// empty-but-explicit display/tooltip strings.  If neither target member is
+/// present, the operation is interpreted as clearing the hyperlink in the
+/// range; this gives the optional RangeHyperlink shape a useful clear form and
+/// remains content/format preserving.
+pub(crate) fn set(sheet: &Sheet, address: &str, value: &Value) -> Result<(), HyperlinkError> {
+    let bounds = resolve_bounded(sheet, address)?;
+    let input = parse_input(value)?;
+    let (row, col) = (bounds.0, bounds.1);
+
+    if input.address.is_none() && input.document_reference.is_none() {
+        return sheet
+            .clear_with_mode(CellRange::Bounds(row, col, row, col), "hyperlinks")
+            .map(|_| ())
+            .map_err(engine);
+    }
+
+    sheet
+        .hyperlinks()
+        .set_hyperlink_with_metadata(
+            row,
+            col,
+            input.address.as_deref(),
+            input.document_reference.as_deref(),
+            input.text_to_display.as_deref(),
+            input.screen_tip.as_deref(),
+        )
+        .map(|_| ())
+        .map_err(engine)
+}
+
+/// Clear hyperlinks for a Range.clear operation.
+///
+/// `RemoveHyperlinks` has the documented Excel behavior of clearing both
+/// hyperlinks and direct cell formatting while preserving values, conditional
+/// formats, and data validation.  The compute-api format clear is scoped to
+/// direct cell formats, so it composes with the hyperlink clear without
+/// touching those other features.
+pub(crate) fn clear(sheet: &Sheet, address: &str, apply_to: &str) -> Result<(), HyperlinkError> {
+    let bounds = resolve_bounded(sheet, address)?;
+    let range = CellRange::Bounds(bounds.0, bounds.1, bounds.2, bounds.3);
+    match apply_to {
+        "Hyperlinks" | "hyperlinks" => sheet
+            .clear_with_mode(range, "hyperlinks")
+            .map(|_| ())
+            .map_err(engine),
+        "RemoveHyperlinks" | "removeHyperlinks" => {
+            sheet
+                .clear_with_mode(range.clone(), "hyperlinks")
+                .map_err(engine)?;
+            sheet
+                .clear_with_mode(range, "formats")
+                .map(|_| ())
+                .map_err(engine)
+        }
+        other => Err(invalid(format!(
+            "Unsupported Range hyperlink clear mode '{other}'"
+        ))),
+    }
+}
+
+fn resolve_bounded(sheet: &Sheet, address: &str) -> Result<(u32, u32, u32, u32), HyperlinkError> {
+    let parsed = parse_range_address(sheet, address).map_err(navigation)?;
+    if parsed.is_whole_sheet() || parsed.is_entire_row() || parsed.is_entire_column() {
+        return Err(invalid(
+            "Range.hyperlink requires a bounded cell range".to_string(),
+        ));
+    }
+    Ok(parsed.bounds())
+}
+
+fn parse_input(value: &Value) -> Result<RangeHyperlinkInput, HyperlinkError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid("Range.hyperlink must be a plain object".to_string()))?;
+
+    for key in object.keys() {
+        if !matches!(
+            key.as_str(),
+            "address" | "documentReference" | "screenTip" | "textToDisplay"
+        ) {
+            return Err(invalid(format!(
+                "Unsupported Range.hyperlink property '{key}'"
+            )));
+        }
+    }
+
+    let read_string = |name: &str| -> Result<Option<String>, HyperlinkError> {
+        match object.get(name) {
+            None => Ok(None),
+            Some(Value::String(value)) => Ok(Some(value.clone())),
+            Some(_) => Err(invalid(format!("Range.hyperlink.{name} must be a string"))),
+        }
+    };
+
+    let address = read_string("address")?;
+    let document_reference = read_string("documentReference")?;
+    let screen_tip = read_string("screenTip")?;
+    let text_to_display = read_string("textToDisplay")?;
+
+    if address.as_deref().is_some_and(|value| value.is_empty())
+        && document_reference
+            .as_deref()
+            .is_none_or(|value| value.is_empty())
+    {
+        return Err(invalid(
+            "Range.hyperlink requires a non-empty address or documentReference".to_string(),
+        ));
+    }
+    if document_reference
+        .as_deref()
+        .is_some_and(|value| value.is_empty())
+        && address.as_deref().is_none_or(|value| value.is_empty())
+    {
+        return Err(invalid(
+            "Range.hyperlink requires a non-empty address or documentReference".to_string(),
+        ));
+    }
+
+    Ok(RangeHyperlinkInput {
+        address,
+        document_reference,
+        screen_tip,
+        text_to_display,
+    })
+}
+
+fn range_hyperlink_value(link: impl serde::Serialize) -> Value {
+    let source = serde_json::to_value(link).unwrap_or(Value::Null);
+    let mut result = Map::new();
+    if let Some(address) = source.get("target").and_then(Value::as_str) {
+        result.insert("address".to_string(), json!(address));
+    }
+    if let Some(document_reference) = source.get("location").and_then(Value::as_str) {
+        result.insert("documentReference".to_string(), json!(document_reference));
+    }
+    if let Some(screen_tip) = source.get("tooltip").and_then(Value::as_str) {
+        result.insert("screenTip".to_string(), json!(screen_tip));
+    }
+    if let Some(text_to_display) = source.get("display").and_then(Value::as_str) {
+        result.insert("textToDisplay".to_string(), json!(text_to_display));
+    }
+    Value::Object(result)
+}
+
+fn navigation(error: RangeNavigationError) -> HyperlinkError {
+    HyperlinkError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn engine(error: ComputeApiError) -> HyperlinkError {
+    let code = match &error {
+        ComputeApiError::InvalidAddress { .. } | ComputeApiError::InvalidRange { .. } => {
+            "InvalidArgument"
+        }
+        ComputeApiError::Compute(value_types::ComputeError::InvalidInput { .. }) => {
+            "InvalidArgument"
+        }
+        _ => "GeneralException",
+    };
+    HyperlinkError {
+        code,
+        message: error.to_string(),
+    }
+}
+
+fn invalid(message: impl Into<String>) -> HyperlinkError {
+    HyperlinkError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}

--- a/compute/officejs/src/lib.rs
+++ b/compute/officejs/src/lib.rs
@@ -4,9 +4,31 @@
 //! `Excel.run` / `RequestContext` / `load` / `context.sync`, not a custom
 //! workbook wrapper.
 
+mod borders;
+mod chart_core;
+mod chart_series;
+mod dispatch;
 mod error;
+mod format;
+mod format_dimensions;
 mod host;
+mod hyperlinks;
+mod names;
+mod protection;
+mod range_areas;
+mod range_content;
+mod range_copy;
+mod range_fill;
+mod range_metadata;
+mod range_navigation;
+mod range_search;
+mod range_structure;
 mod runtime;
+mod sort_filter;
+mod table_collections;
+mod tables;
+mod validation;
+mod worksheets;
 
 pub use error::OfficeJsError;
 pub use runtime::{ScriptOutput, run_office_js, run_office_js_with_workbook};

--- a/compute/officejs/src/named_styles.js
+++ b/compute/officejs/src/named_styles.js
@@ -1,0 +1,413 @@
+(function (global) {
+  "use strict";
+
+  // Excel.Style is a named cell-style object.  The range formatting classes
+  // already own the font/fill/protection/border proxy implementations; this
+  // module only supplies the named-style object paths and retargets those
+  // existing proxies to style-backed host operations.
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var hooks = global.__mogOfficeJs || {};
+
+  var STYLE_SCALARS = [
+    "autoIndent",
+    "builtIn",
+    "formulaHidden",
+    "horizontalAlignment",
+    "includeAlignment",
+    "includeBorder",
+    "includeFont",
+    "includeNumber",
+    "includePatterns",
+    "includeProtection",
+    "indentLevel",
+    "locked",
+    "name",
+    "numberFormat",
+    "numberFormatLocal",
+    "readingOrder",
+    "shrinkToFit",
+    "textOrientation",
+    "verticalAlignment",
+    "wrapText",
+  ];
+  var STYLE_READONLY = ["builtIn", "name"];
+  var STYLE_NAVIGATION = ["borders", "fill", "font"];
+  var STYLE_ITEM_SCALARS = STYLE_SCALARS.slice();
+  var BORDER_KEYS = [
+    "EdgeTop",
+    "EdgeBottom",
+    "EdgeLeft",
+    "EdgeRight",
+    "InsideVertical",
+    "InsideHorizontal",
+    "DiagonalDown",
+    "DiagonalUp",
+  ];
+
+  function error(code, message) {
+    var result = new OfficeExtension.Error({ code: code, message: message });
+    result.name = "RichApi.Error";
+    result.code = code;
+    return result;
+  }
+
+  function propertyNotLoaded(name) {
+    return error(
+      "PropertyNotLoaded",
+      "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context."
+    );
+  }
+
+  function invalidArgument(message) {
+    return error("InvalidArgument", message);
+  }
+
+  function requireString(value, property) {
+    if (typeof value !== "string" || value.length === 0) {
+      throw invalidArgument(property + " must be a non-empty string");
+    }
+    return value;
+  }
+
+  function replaceQueuedRangeOperation(context, id, replacement) {
+    var queue = context._queue;
+    var operation = queue[queue.length - 1];
+    if (!operation || operation.id !== id) {
+      throw new Error("named style child did not queue its expected binding operation");
+    }
+    queue[queue.length - 1] = replacement;
+  }
+
+  function styleFormatChild(style, Constructor, kind) {
+    // RangeFont/RangeFill/FormatProtection are the established formatting
+    // proxies.  Their constructor queues getRangeFormat against a target with
+    // an _id; replacing that one operation keeps the proxy class and its
+    // set/load/toJSON semantics while selecting a named-style backend.
+    var child = new Constructor(style.context, { _id: style._id });
+    replaceQueuedRangeOperation(style.context, child._id, {
+      op: "getStyleFormat",
+      id: child._id,
+      styleId: style._id,
+      kind: kind,
+    });
+    child._styleId = style._id;
+    return child;
+  }
+
+  function styleBorderCollection(style) {
+    var collection = new Excel.RangeBorderCollection(style.context, { _id: style._id });
+    replaceQueuedRangeOperation(style.context, collection._id, {
+      op: "getStyleBorderCollection",
+      id: collection._id,
+      styleId: style._id,
+    });
+    collection._styleId = style._id;
+    collection._style = style;
+    return collection;
+  }
+
+  function setStyleBorders(collection, source, options) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+    var properties = source instanceof ClientObject ? source.toJSON() : source;
+    if (properties.tintAndShade !== undefined) {
+      collection.tintAndShade = properties.tintAndShade;
+    }
+    if (properties.items !== undefined) {
+      if (!Array.isArray(properties.items)) {
+        throw invalidArgument("Style.borders.items must be an array");
+      }
+      properties.items.forEach(function (item) {
+        if (!item || typeof item !== "object") {
+          throw invalidArgument("Style.borders.items entries must be objects");
+        }
+        var side = item.sideIndex;
+        requireString(side, "Style.borders item sideIndex");
+        collection.getItem(side).set(item, options);
+      });
+    }
+    return collection;
+  }
+
+  function styleScalarDescriptor(name, writable) {
+    Object.defineProperty(Style.prototype, name, {
+      configurable: true,
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: writable
+        ? function (value) {
+            this["_" + name] = value;
+            this._loaded[name] = true;
+            this.context._queue.push({
+              op: "set",
+              id: this._id,
+              property: name,
+              value: value,
+            });
+          }
+        : undefined,
+    });
+  }
+
+  function styleToJSON() {
+    var data = {};
+    STYLE_SCALARS.forEach(function (name) {
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }, this);
+
+    if (this._font) data.font = this._font.toJSON();
+    if (this._fill) data.fill = this._fill.toJSON();
+    if (this._borders && this._borders._loaded.items) {
+      // StyleData.borders is an array of RangeBorderData, while the live
+      // RangeBorderCollection data wrapper contains an `items` member.
+      data.borders = this._borders.toJSON().items || [];
+    }
+    return data;
+  }
+
+  function setProperties(source, options) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+
+    var isClientObject = source instanceof ClientObject;
+    var properties = source;
+    if (isClientObject) {
+      if (Object.getPrototypeOf(this) !== Object.getPrototypeOf(source)) {
+        throw invalidArgument("The object passed to set must have the same type.");
+      }
+      properties = source.toJSON();
+    }
+
+    STYLE_SCALARS.forEach(function (name) {
+      if (!Object.prototype.hasOwnProperty.call(properties, name) || properties[name] === undefined) {
+        return;
+      }
+      if (STYLE_READONLY.indexOf(name) >= 0) {
+        if (!options || options.throwOnReadOnly !== false) {
+          throw invalidArgument("The property '" + name + "' is read-only.");
+        }
+        return;
+      }
+      this[name] = properties[name];
+    }, this);
+
+    STYLE_NAVIGATION.forEach(function (name) {
+      if (!Object.prototype.hasOwnProperty.call(properties, name) || properties[name] === undefined) {
+        return;
+      }
+      var child = isClientObject ? source[name] : properties[name];
+      if (name === "borders") setStyleBorders(this[name], child, options);
+      else this[name].set(child, options);
+    }, this);
+  }
+
+  function Style(context, collection) {
+    ClientObject.call(this, context);
+    this._collection = collection || null;
+    this._scalarProperties = STYLE_SCALARS.slice();
+    this._navigationProperties = STYLE_NAVIGATION.slice();
+  }
+  Style.prototype = Object.create(ClientObject.prototype);
+  Style.prototype.constructor = Style;
+  Style.prototype.set = setProperties;
+  Style.prototype.toJSON = styleToJSON;
+  Style.prototype.delete = function () {
+    this.context._queue.push({ op: "styleDelete", id: this._id });
+  };
+
+  STYLE_SCALARS.forEach(function (name) {
+    styleScalarDescriptor(name, STYLE_READONLY.indexOf(name) < 0);
+  });
+
+  Object.defineProperty(Style.prototype, "font", {
+    configurable: true,
+    get: function () {
+      if (!this._font) this._font = styleFormatChild(this, Excel.RangeFont, "font");
+      return this._font;
+    },
+  });
+  Object.defineProperty(Style.prototype, "fill", {
+    configurable: true,
+    get: function () {
+      if (!this._fill) this._fill = styleFormatChild(this, Excel.RangeFill, "fill");
+      return this._fill;
+    },
+  });
+  Object.defineProperty(Style.prototype, "borders", {
+    configurable: true,
+    get: function () {
+      if (!this._borders) this._borders = styleBorderCollection(this);
+      return this._borders;
+    },
+  });
+
+  function collectionToJSON() {
+    if (!this._loaded.items) return {};
+    return {
+      items: (this._items || []).map(function (item) {
+        return item.toJSON();
+      }),
+    };
+  }
+
+  function StyleCollection(context) {
+    ClientObject.call(this, context);
+    this._scalarProperties = ["items"];
+    this.context._queue.push({ op: "getStyleCollection", id: this._id });
+    if (typeof hooks.configureCollection === "function") {
+      hooks.configureCollection(this, function (key) {
+        return this.getItem(String(key));
+      });
+    }
+  }
+  StyleCollection.prototype = Object.create(ClientObject.prototype);
+  StyleCollection.prototype.constructor = StyleCollection;
+  StyleCollection.prototype.add = function (name) {
+    requireString(name, "StyleCollection.add name");
+    this.context._queue.push({
+      op: "styleAdd",
+      collectionId: this._id,
+      name: name,
+    });
+  };
+  StyleCollection.prototype.getCount = function () {
+    var result = hooks.createClientResult(this.context);
+    this.context._queue.push({ op: "styleGetCount", resultId: result._id });
+    return result;
+  };
+  StyleCollection.prototype.getItem = function (name) {
+    requireString(name, "StyleCollection.getItem name");
+    var style = new Style(this.context, this);
+    this.context._queue.push({
+      op: "styleGetItem",
+      id: style._id,
+      collectionId: this._id,
+      name: name,
+      orNullObject: false,
+    });
+    return style;
+  };
+  StyleCollection.prototype.getItemAt = function (index) {
+    if (typeof index !== "number" || !isFinite(index) || Math.floor(index) !== index) {
+      throw invalidArgument("StyleCollection.getItemAt requires an integer index");
+    }
+    var style = new Style(this.context, this);
+    this.context._queue.push({
+      op: "styleGetItemAt",
+      id: style._id,
+      collectionId: this._id,
+      index: index,
+    });
+    return style;
+  };
+  StyleCollection.prototype.getItemOrNullObject = function (name) {
+    requireString(name, "StyleCollection.getItemOrNullObject name");
+    var style = new Style(this.context, this);
+    this.context._queue.push({
+      op: "styleGetItem",
+      id: style._id,
+      collectionId: this._id,
+      name: name,
+      orNullObject: true,
+    });
+    return style;
+  };
+  StyleCollection.prototype.toJSON = collectionToJSON;
+
+  // A style border collection needs a style-specific binding for collection
+  // members.  The normal RangeBorderCollection implementation remains the
+  // source of validation, caching, scalar descriptors, and toJSON behavior.
+  var rangeBorderGetItem = Excel.RangeBorderCollection.prototype.getItem;
+  Excel.RangeBorderCollection.prototype.getItem = function (index) {
+    if (!this._styleId) return rangeBorderGetItem.call(this, index);
+    if (typeof index !== "string" || BORDER_KEYS.indexOf(index) < 0) {
+      throw invalidArgument("Unsupported BorderIndex value '" + index + "'");
+    }
+    if (this._itemsByKey[index]) return this._itemsByKey[index];
+    var border = new Excel.RangeBorder(this.context, this, index);
+    replaceQueuedRangeOperation(this.context, border._id, {
+      op: "getStyleBorder",
+      id: border._id,
+      collectionId: this._id,
+      styleId: this._styleId,
+      index: index,
+    });
+    border._styleId = this._styleId;
+    this._itemsByKey[index] = border;
+    return border;
+  };
+
+  // The generated RangeBorderCollection has no explicit `set` method in the
+  // pinned class declaration, but Style.set accepts RangeBorderCollection
+  // update data with an `items` array.  Add this only to style-backed
+  // collections; ordinary range collections keep their existing surface.
+  var rangeBorderCollectionSet = Excel.RangeBorderCollection.prototype.set;
+  Excel.RangeBorderCollection.prototype.set = function (source, options) {
+    if (!this._styleId) {
+      if (typeof rangeBorderCollectionSet === "function") {
+        return rangeBorderCollectionSet.call(this, source, options);
+      }
+      throw invalidArgument("RangeBorderCollection.set is unavailable");
+    }
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+    var properties = source instanceof ClientObject ? source.toJSON() : source;
+    if (properties.tintAndShade !== undefined) this.tintAndShade = properties.tintAndShade;
+    if (properties.items !== undefined) {
+      if (!Array.isArray(properties.items)) {
+        throw invalidArgument("RangeBorderCollection.items must be an array");
+      }
+      properties.items.forEach(function (item) {
+        if (!item || typeof item !== "object") {
+          throw invalidArgument("RangeBorderCollection.items entries must be objects");
+        }
+        var side = item.sideIndex;
+        requireString(side, "RangeBorderCollection item sideIndex");
+        this.getItem(side).set(item, options);
+      }, this);
+    }
+    return this;
+  };
+
+  Object.defineProperty(Excel.Workbook.prototype, "styles", {
+    configurable: true,
+    get: function () {
+      if (!this._styles) this._styles = new StyleCollection(this.context);
+      return this._styles;
+    },
+  });
+
+  Object.defineProperty(Excel.Range.prototype, "style", {
+    configurable: true,
+    get: function () {
+      if (!this._loaded.style) throw propertyNotLoaded("style");
+      return this._style;
+    },
+    set: function (value) {
+      requireString(value, "Range.style");
+      this._style = value;
+      this._loaded.style = true;
+      this.context._queue.push({
+        op: "set",
+        id: this._id,
+        property: "style",
+        value: value,
+      });
+    },
+  });
+  if (typeof hooks.addScalarProperties === "function") {
+    hooks.addScalarProperties(Excel.Range.prototype, ["style"]);
+  }
+
+  Excel.Style = Style;
+  Excel.StyleCollection = StyleCollection;
+})(globalThis);

--- a/compute/officejs/src/named_styles.rs
+++ b/compute/officejs/src/named_styles.rs
@@ -1,0 +1,1510 @@
+//! Office.js named cell styles.
+//!
+//! The JavaScript side exposes the pinned Workbook.styles, StyleCollection,
+//! and Style surface. This module owns the host extension operations and
+//! delegates all reads and mutations to the production WorkbookStyles facade.
+//! Style application copies the persisted CellFormat into the target range,
+//! matching Excel's value semantics: changing a style later does not mutate
+//! cells that already received it.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use compute_api::{CellRange, CellStyleDef, ComputeApiError, Workbook};
+use domain_types::CellFormat;
+use serde_json::{Map, Value, json};
+
+use crate::dispatch::{ExtensionHandler, ExtensionObject, HostDispatchContext};
+use crate::host::{BatchError, RangeRef};
+
+const STYLE_SCALARS: &[&str] = &[
+    "autoIndent",
+    "builtIn",
+    "formulaHidden",
+    "horizontalAlignment",
+    "includeAlignment",
+    "includeBorder",
+    "includeFont",
+    "includeNumber",
+    "includePatterns",
+    "includeProtection",
+    "indentLevel",
+    "locked",
+    "name",
+    "numberFormat",
+    "numberFormatLocal",
+    "readingOrder",
+    "shrinkToFit",
+    "textOrientation",
+    "verticalAlignment",
+    "wrapText",
+];
+
+const STYLE_INCLUDE_PROPERTIES: &[&str] = &[
+    "includeAlignment",
+    "includeBorder",
+    "includeFont",
+    "includeNumber",
+    "includePatterns",
+    "includeProtection",
+];
+
+const STYLE_METADATA_KEY: &str = "mog.officejs.style.includeFlags";
+
+const BORDER_KEYS: &[&str] = &[
+    "EdgeTop",
+    "EdgeBottom",
+    "EdgeLeft",
+    "EdgeRight",
+    "InsideVertical",
+    "InsideHorizontal",
+    "DiagonalDown",
+    "DiagonalUp",
+];
+
+static NEXT_STYLE_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Host-facing translation failure. Keeping the Rich API code at this
+/// boundary prevents compute-api errors from leaking into the Office router.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StyleError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+impl StyleError {
+    fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            code: "InvalidArgument",
+            message: message.into(),
+        }
+    }
+
+    fn not_found(message: impl Into<String>) -> Self {
+        Self {
+            code: "ItemNotFound",
+            message: message.into(),
+        }
+    }
+
+    fn read_only(property: &str) -> Self {
+        Self::invalid(format!("Style.{property} is read-only"))
+    }
+
+    fn unsupported(message: impl Into<String>) -> Self {
+        Self {
+            code: "InvalidArgument",
+            message: message.into(),
+        }
+    }
+
+    fn engine(error: impl std::fmt::Display) -> Self {
+        Self {
+            code: "GeneralException",
+            message: error.to_string(),
+        }
+    }
+}
+
+fn style_error(error: StyleError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn api_error(error: ComputeApiError) -> StyleError {
+    StyleError::engine(error)
+}
+
+fn encoding(error: impl std::fmt::Display) -> StyleError {
+    StyleError::engine(format!("style format conversion failed: {error}"))
+}
+
+fn style_id() -> String {
+    // CellStyleDef documents a UUID-shaped stable ID. The engine only needs
+    // an opaque map key, so a process-unique UUID-shaped value keeps this
+    // adapter independent of an additional random-ID dependency while still
+    // satisfying the persisted ID contract.
+    let value = NEXT_STYLE_ID.fetch_add(1, Ordering::Relaxed);
+    format!("00000000-0000-0000-0000-{value:012x}")
+}
+
+fn all_styles(workbook: &Workbook) -> Result<Vec<CellStyleDef>, StyleError> {
+    workbook
+        .styles()
+        .get_all_custom_cell_styles()
+        .map_err(api_error)
+}
+
+fn style_by_id(workbook: &Workbook, id: &str) -> Result<CellStyleDef, StyleError> {
+    all_styles(workbook)?
+        .into_iter()
+        .find(|style| style.id == id)
+        .ok_or_else(|| StyleError::not_found(format!("Style '{id}' was not found")))
+}
+
+fn style_by_name(workbook: &Workbook, name: &str) -> Result<Option<CellStyleDef>, StyleError> {
+    Ok(all_styles(workbook)?
+        .into_iter()
+        .find(|style| style.name.eq_ignore_ascii_case(name)))
+}
+
+fn style_from_name(workbook: &Workbook, name: &str) -> Result<CellStyleDef, StyleError> {
+    style_by_name(workbook, name)?
+        .ok_or_else(|| StyleError::not_found(format!("Style '{name}' was not found")))
+}
+
+fn ensure_custom(style: &CellStyleDef) -> Result<(), StyleError> {
+    if style.built_in {
+        Err(StyleError::unsupported(
+            "Built-in styles cannot be changed or deleted",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn metadata_flags(format: &CellFormat) -> Map<String, Value> {
+    format
+        .extensions
+        .as_ref()
+        .and_then(|extensions| extensions.get(STYLE_METADATA_KEY))
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn include_flag(format: &CellFormat, property: &str) -> Value {
+    metadata_flags(format)
+        .get(property)
+        .cloned()
+        .unwrap_or_else(|| json!(true))
+}
+
+fn set_include_flag(
+    format: &mut CellFormat,
+    property: &str,
+    value: &Value,
+) -> Result<(), StyleError> {
+    let value = value
+        .as_bool()
+        .ok_or_else(|| StyleError::invalid(format!("{property} must be a boolean")))?;
+    let extensions = format.extensions.get_or_insert_with(Default::default);
+    let flags = extensions
+        .entry(STYLE_METADATA_KEY.to_string())
+        .or_insert_with(|| json!({}));
+    let flags = flags
+        .as_object_mut()
+        .ok_or_else(|| encoding("style include metadata is not an object"))?;
+    flags.insert(property.to_string(), json!(value));
+    Ok(())
+}
+
+/// Remove adapter-only include metadata before a style is copied into cells.
+fn format_for_application(mut format: CellFormat) -> CellFormat {
+    if let Some(extensions) = format.extensions.as_mut() {
+        extensions.remove(STYLE_METADATA_KEY);
+        if extensions.is_empty() {
+            format.extensions = None;
+        }
+    }
+    format
+}
+
+fn format_value(format: &CellFormat) -> Result<Value, StyleError> {
+    serde_json::to_value(format).map_err(encoding)
+}
+
+fn format_from_value(value: Value) -> Result<CellFormat, StyleError> {
+    serde_json::from_value(value).map_err(encoding)
+}
+
+fn format_field(format: &Value, field: &str, default: Value) -> Value {
+    format
+        .as_object()
+        .and_then(|format| format.get(field))
+        .filter(|value| !value.is_null())
+        .cloned()
+        .unwrap_or(default)
+}
+
+fn map_internal_token(
+    value: Value,
+    property: &str,
+    mappings: &[(&str, &str)],
+) -> Result<Value, StyleError> {
+    let token = value
+        .as_str()
+        .ok_or_else(|| StyleError::engine(format!("The engine returned an invalid {property}")))?;
+    mappings
+        .iter()
+        .find_map(|(internal, office)| (*internal == token).then(|| json!(office)))
+        .ok_or_else(|| {
+            StyleError::engine(format!("The engine returned unsupported {property} '{token}'"))
+        })
+}
+
+fn enum_value(
+    value: &Value,
+    property: &str,
+    mappings: &[(&str, &str)],
+) -> Result<Value, StyleError> {
+    let token = value
+        .as_str()
+        .ok_or_else(|| StyleError::invalid(format!("{property} must be a string enum value")))?;
+    mappings
+        .iter()
+        .find_map(|(office, internal)| (*office == token).then(|| json!(internal)))
+        .ok_or_else(|| StyleError::invalid(format!("Unsupported {property} value '{token}'")))
+}
+
+fn bool_value(value: &Value, property: &str) -> Result<Value, StyleError> {
+    value
+        .as_bool()
+        .map(Value::Bool)
+        .ok_or_else(|| StyleError::invalid(format!("{property} must be a boolean")))
+}
+
+fn string_value(value: &Value, property: &str, allow_empty: bool) -> Result<Value, StyleError> {
+    let value = value
+        .as_str()
+        .ok_or_else(|| StyleError::invalid(format!("{property} must be a string")))?;
+    if !allow_empty && value.is_empty() {
+        return Err(StyleError::invalid(format!("{property} cannot be empty")));
+    }
+    Ok(json!(value))
+}
+
+fn finite_number(value: &Value, property: &str) -> Result<f64, StyleError> {
+    value
+        .as_f64()
+        .filter(|value| value.is_finite())
+        .ok_or_else(|| StyleError::invalid(format!("{property} must be a finite number")))
+}
+
+fn integer(value: &Value, property: &str) -> Result<i64, StyleError> {
+    let value = finite_number(value, property)?;
+    if value.fract() != 0.0 || value < i64::MIN as f64 || value > i64::MAX as f64 {
+        return Err(StyleError::invalid(format!("{property} must be an integer")));
+    }
+    Ok(value as i64)
+}
+
+fn tint(value: &Value, property: &str) -> Result<Value, StyleError> {
+    let value = finite_number(value, property)?;
+    if !(-1.0..=1.0).contains(&value) {
+        return Err(StyleError::invalid(format!("{property} must be between -1 and 1")));
+    }
+    Ok(json!(value))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StyleFormatKind {
+    Format,
+    Font,
+    Fill,
+    Protection,
+}
+
+fn read_format_property(
+    kind: StyleFormatKind,
+    property: &str,
+    format: &Value,
+) -> Result<Value, StyleError> {
+    let value = match (kind, property) {
+        (StyleFormatKind::Format, "horizontalAlignment") => map_internal_token(
+            format_field(format, "horizontalAlign", json!("general")),
+            property,
+            &[
+                ("general", "General"),
+                ("left", "Left"),
+                ("center", "Center"),
+                ("right", "Right"),
+                ("fill", "Fill"),
+                ("justify", "Justify"),
+                ("centerContinuous", "CenterAcrossSelection"),
+                ("distributed", "Distributed"),
+            ],
+        )?,
+        (StyleFormatKind::Format, "verticalAlignment") => map_internal_token(
+            format_field(format, "verticalAlign", json!("bottom")),
+            property,
+            &[
+                ("top", "Top"),
+                ("middle", "Center"),
+                ("bottom", "Bottom"),
+                ("justify", "Justify"),
+                ("distributed", "Distributed"),
+            ],
+        )?,
+        (StyleFormatKind::Format, "wrapText") => {
+            format_field(format, "wrapText", json!(false))
+        }
+        (StyleFormatKind::Format, "autoIndent") => {
+            format_field(format, "autoIndent", json!(false))
+        }
+        (StyleFormatKind::Format, "indentLevel") => format_field(format, "indent", json!(0)),
+        (StyleFormatKind::Format, "shrinkToFit") => {
+            format_field(format, "shrinkToFit", json!(false))
+        }
+        (StyleFormatKind::Format, "textOrientation") => {
+            format_field(format, "textRotation", json!(0))
+        }
+        (StyleFormatKind::Format, "readingOrder") => map_internal_token(
+            format_field(format, "readingOrder", json!("context")),
+            property,
+            &[
+                ("context", "Context"),
+                ("ltr", "LeftToRight"),
+                ("rtl", "RightToLeft"),
+            ],
+        )?,
+        (StyleFormatKind::Font, "bold") => format_field(format, "bold", json!(false)),
+        (StyleFormatKind::Font, "color") => {
+            format_field(format, "fontColor", json!("#000000"))
+        }
+        (StyleFormatKind::Font, "italic") => format_field(format, "italic", json!(false)),
+        (StyleFormatKind::Font, "name") => {
+            format_field(format, "fontFamily", json!("Calibri"))
+        }
+        (StyleFormatKind::Font, "size") => format_field(format, "fontSize", json!(11.0)),
+        (StyleFormatKind::Font, "underline") => map_internal_token(
+            format_field(format, "underlineType", json!("none")),
+            property,
+            &[
+                ("none", "None"),
+                ("single", "Single"),
+                ("double", "Double"),
+                ("singleAccounting", "SingleAccountant"),
+                ("doubleAccounting", "DoubleAccountant"),
+            ],
+        )?,
+        (StyleFormatKind::Font, "strikethrough") => {
+            format_field(format, "strikethrough", json!(false))
+        }
+        (StyleFormatKind::Font, "subscript") => {
+            format_field(format, "subscript", json!(false))
+        }
+        (StyleFormatKind::Font, "superscript") => {
+            format_field(format, "superscript", json!(false))
+        }
+        (StyleFormatKind::Font, "tintAndShade") => {
+            format_field(format, "fontColorTint", json!(0.0))
+        }
+        (StyleFormatKind::Fill, "color") => {
+            format_field(format, "backgroundColor", Value::Null)
+        }
+        (StyleFormatKind::Fill, "pattern") => map_internal_token(
+            format_field(format, "patternType", json!("none")),
+            property,
+            &[
+                ("none", "None"),
+                ("solid", "Solid"),
+                ("mediumGray", "Gray50"),
+                ("darkGray", "Gray75"),
+                ("lightGray", "Gray25"),
+                ("darkHorizontal", "Horizontal"),
+                ("darkVertical", "Vertical"),
+                ("darkDown", "Down"),
+                ("darkUp", "Up"),
+                ("darkGrid", "Checker"),
+                ("darkTrellis", "SemiGray75"),
+                ("lightHorizontal", "LightHorizontal"),
+                ("lightVertical", "LightVertical"),
+                ("lightDown", "LightDown"),
+                ("lightUp", "LightUp"),
+                ("lightGrid", "Grid"),
+                ("lightTrellis", "CrissCross"),
+                ("gray125", "Gray16"),
+                ("gray0625", "Gray8"),
+            ],
+        )?,
+        (StyleFormatKind::Fill, "patternColor") => {
+            format_field(format, "patternForegroundColor", Value::Null)
+        }
+        (StyleFormatKind::Fill, "patternTintAndShade") => {
+            format_field(format, "patternForegroundColorTint", json!(0.0))
+        }
+        (StyleFormatKind::Fill, "tintAndShade") => {
+            format_field(format, "backgroundColorTint", json!(0.0))
+        }
+        (StyleFormatKind::Protection, "locked") => {
+            format_field(format, "locked", json!(true))
+        }
+        (StyleFormatKind::Protection, "formulaHidden") => {
+            format_field(format, "hidden", json!(false))
+        }
+        _ => {
+            return Err(StyleError::unsupported(format!(
+                "Unsupported {kind:?} property '{property}'"
+            )))
+        }
+    };
+    Ok(value)
+}
+
+fn write_format_property(
+    kind: StyleFormatKind,
+    property: &str,
+    value: &Value,
+) -> Result<(&'static str, Value), StyleError> {
+    if value.is_null() {
+        return Err(StyleError::invalid(format!("{property} cannot be null")));
+    }
+    let mapped = match (kind, property) {
+        (StyleFormatKind::Format, "horizontalAlignment") => (
+            "horizontalAlign",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("General", "general"),
+                    ("Left", "left"),
+                    ("Center", "center"),
+                    ("Right", "right"),
+                    ("Fill", "fill"),
+                    ("Justify", "justify"),
+                    ("CenterAcrossSelection", "centerContinuous"),
+                    ("Distributed", "distributed"),
+                ],
+            )?,
+        ),
+        (StyleFormatKind::Format, "verticalAlignment") => (
+            "verticalAlign",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("Top", "top"),
+                    ("Center", "middle"),
+                    ("Bottom", "bottom"),
+                    ("Justify", "justify"),
+                    ("Distributed", "distributed"),
+                ],
+            )?,
+        ),
+        (StyleFormatKind::Format, "wrapText") => ("wrapText", bool_value(value, property)?),
+        (StyleFormatKind::Format, "autoIndent") => ("autoIndent", bool_value(value, property)?),
+        (StyleFormatKind::Format, "indentLevel") => {
+            let value = integer(value, property)?;
+            if !(0..=250).contains(&value) {
+                return Err(StyleError::invalid("indentLevel must be between 0 and 250"));
+            }
+            ("indent", json!(value))
+        }
+        (StyleFormatKind::Format, "shrinkToFit") => {
+            ("shrinkToFit", bool_value(value, property)?)
+        }
+        (StyleFormatKind::Format, "textOrientation") => {
+            let value = integer(value, property)?;
+            if !((-90..=90).contains(&value) || value == 180) {
+                return Err(StyleError::invalid(
+                    "textOrientation must be -90 through 90, or 180",
+                ));
+            }
+            ("textRotation", json!(value))
+        }
+        (StyleFormatKind::Format, "readingOrder") => (
+            "readingOrder",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("Context", "context"),
+                    ("LeftToRight", "ltr"),
+                    ("RightToLeft", "rtl"),
+                ],
+            )?,
+        ),
+        (StyleFormatKind::Font, "bold") => ("bold", bool_value(value, property)?),
+        (StyleFormatKind::Font, "color") => {
+            ("fontColor", string_value(value, property, false)?)
+        }
+        (StyleFormatKind::Font, "italic") => ("italic", bool_value(value, property)?),
+        (StyleFormatKind::Font, "name") => {
+            let value = value
+                .as_str()
+                .filter(|value| !value.is_empty() && value.chars().count() <= 31)
+                .ok_or_else(|| StyleError::invalid("name must contain 1 through 31 characters"))?;
+            ("fontFamily", json!(value))
+        }
+        (StyleFormatKind::Font, "size") => {
+            let value = finite_number(value, property)?;
+            if !(1.0..=409.0).contains(&value) {
+                return Err(StyleError::invalid("size must be between 1 and 409 points"));
+            }
+            ("fontSize", json!(value))
+        }
+        (StyleFormatKind::Font, "underline") => (
+            "underlineType",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("None", "none"),
+                    ("Single", "single"),
+                    ("Double", "double"),
+                    ("SingleAccountant", "singleAccounting"),
+                    ("DoubleAccountant", "doubleAccounting"),
+                ],
+            )?,
+        ),
+        (StyleFormatKind::Font, "strikethrough") => {
+            ("strikethrough", bool_value(value, property)?)
+        }
+        (StyleFormatKind::Font, "subscript") => ("subscript", bool_value(value, property)?),
+        (StyleFormatKind::Font, "superscript") => {
+            ("superscript", bool_value(value, property)?)
+        }
+        (StyleFormatKind::Font, "tintAndShade") => {
+            ("fontColorTint", tint(value, property)?)
+        }
+        (StyleFormatKind::Fill, "color") => {
+            ("backgroundColor", string_value(value, property, false)?)
+        }
+        (StyleFormatKind::Fill, "pattern") => (
+            "patternType",
+            enum_value(
+                value,
+                property,
+                &[
+                    ("None", "none"),
+                    ("Solid", "solid"),
+                    ("Gray50", "mediumGray"),
+                    ("Gray75", "darkGray"),
+                    ("Gray25", "lightGray"),
+                    ("Horizontal", "darkHorizontal"),
+                    ("Vertical", "darkVertical"),
+                    ("Down", "darkDown"),
+                    ("Up", "darkUp"),
+                    ("Checker", "darkGrid"),
+                    ("SemiGray75", "darkTrellis"),
+                    ("LightHorizontal", "lightHorizontal"),
+                    ("LightVertical", "lightVertical"),
+                    ("LightDown", "lightDown"),
+                    ("LightUp", "lightUp"),
+                    ("Grid", "lightGrid"),
+                    ("CrissCross", "lightTrellis"),
+                    ("Gray16", "gray125"),
+                    ("Gray8", "gray0625"),
+                ],
+            )?,
+        ),
+        (StyleFormatKind::Fill, "patternColor") => (
+            "patternForegroundColor",
+            string_value(value, property, false)?,
+        ),
+        (StyleFormatKind::Fill, "patternTintAndShade") => {
+            ("patternForegroundColorTint", tint(value, property)?)
+        }
+        (StyleFormatKind::Fill, "tintAndShade") => {
+            ("backgroundColorTint", tint(value, property)?)
+        }
+        (StyleFormatKind::Protection, "locked") => {
+            ("locked", bool_value(value, property)?)
+        }
+        (StyleFormatKind::Protection, "formulaHidden") => {
+            ("hidden", bool_value(value, property)?)
+        }
+        _ => {
+            return Err(StyleError::unsupported(format!(
+                "Unsupported {kind:?} property '{property}'"
+            )))
+        }
+    };
+    Ok(mapped)
+}
+
+fn style_scalar(format: &CellFormat, property: &str) -> Result<Value, StyleError> {
+    let encoded = format_value(format)?;
+    match property {
+        "builtIn" | "name" => Err(StyleError::unsupported(format!(
+            "{property} is not a CellFormat property"
+        ))),
+        property if STYLE_INCLUDE_PROPERTIES.contains(&property) => {
+            Ok(include_flag(format, property))
+        }
+        "formulaHidden" => {
+            read_format_property(StyleFormatKind::Protection, "formulaHidden", &encoded)
+        }
+        "locked" => read_format_property(StyleFormatKind::Protection, "locked", &encoded),
+        "numberFormat" | "numberFormatLocal" => {
+            Ok(format_field(&encoded, "numberFormat", json!("General")))
+        }
+        property => read_format_property(StyleFormatKind::Format, property, &encoded),
+    }
+}
+
+fn set_style_scalar(
+    format: &mut CellFormat,
+    property: &str,
+    value: &Value,
+) -> Result<(), StyleError> {
+    if STYLE_INCLUDE_PROPERTIES.contains(&property) {
+        return set_include_flag(format, property, value);
+    }
+    let kind = match property {
+        "formulaHidden" | "locked" => StyleFormatKind::Protection,
+        "numberFormat" | "numberFormatLocal" => {
+            let value = string_value(value, property, true)?;
+            let mut encoded = format_value(format)?;
+            encoded
+                .as_object_mut()
+                .expect("CellFormat serializes as object")
+                .insert("numberFormat".to_string(), value);
+            *format = format_from_value(encoded)?;
+            return Ok(());
+        }
+        _ => StyleFormatKind::Format,
+    };
+    let (field, value) = write_format_property(kind, property, value)?;
+    let mut encoded = format_value(format)?;
+    encoded
+        .as_object_mut()
+        .expect("CellFormat serializes as object")
+        .insert(field.to_string(), value);
+    *format = format_from_value(encoded)?;
+    Ok(())
+}
+
+fn update_style(
+    workbook: &Workbook,
+    current: CellStyleDef,
+    format: CellFormat,
+) -> Result<(), StyleError> {
+    ensure_custom(&current)?;
+    let updated = CellStyleDef { format, ..current };
+    workbook
+        .styles()
+        .update_custom_cell_style(&updated.id, updated)
+        .map(|_| ())
+        .map_err(api_error)
+}
+
+fn update_style_format(
+    workbook: &Workbook,
+    id: &str,
+    mutate: impl FnOnce(&mut CellFormat) -> Result<(), StyleError>,
+) -> Result<(), StyleError> {
+    let style = style_by_id(workbook, id)?;
+    ensure_custom(&style)?;
+    let mut format = style.format;
+    mutate(&mut format)?;
+    update_style(workbook, style, format)
+}
+
+// ---------------------------------------------------------------------------
+// Style collection and style objects
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub(crate) struct StyleCollectionRef {
+    workbook: Workbook,
+}
+
+impl StyleCollectionRef {
+    fn new(workbook: Workbook) -> Self {
+        Self { workbook }
+    }
+
+    fn add(&self, name: &str) -> Result<(), StyleError> {
+        if name.is_empty() {
+            return Err(StyleError::invalid("StyleCollection.add name cannot be empty"));
+        }
+        if style_by_name(&self.workbook, name)?.is_some() {
+            return Err(StyleError::invalid(format!("Style '{name}' already exists")));
+        }
+        self.workbook
+            .styles()
+            .create_custom_cell_style(CellStyleDef {
+                id: style_id(),
+                name: name.to_string(),
+                category: None,
+                format: CellFormat::default(),
+                built_in: false,
+            })
+            .map(|_| ())
+            .map_err(api_error)
+    }
+
+    fn get_or_null(&self, name: &str) -> Result<Option<StyleRef>, StyleError> {
+        Ok(style_by_name(&self.workbook, name)?
+            .map(|style| StyleRef::new(self.workbook.clone(), style.id)))
+    }
+
+    fn get_at(&self, index: usize) -> Result<StyleRef, StyleError> {
+        let styles = all_styles(&self.workbook)?;
+        styles
+            .get(index)
+            .map(|style| StyleRef::new(self.workbook.clone(), style.id.clone()))
+            .ok_or_else(|| StyleError::not_found(format!("Style index {index} is out of range")))
+    }
+
+    fn count(&self) -> Result<usize, StyleError> {
+        all_styles(&self.workbook).map(|styles| styles.len())
+    }
+
+    fn items(&self, properties: &[String]) -> Result<Vec<Value>, StyleError> {
+        let requested = normalize_item_properties(properties)?;
+        all_styles(&self.workbook)?
+            .into_iter()
+            .map(|style| {
+                let item = StyleRef::new(self.workbook.clone(), style.id.clone());
+                let values = item.load(&requested)?;
+                Ok(json!({ "key": style.name, "properties": values }))
+            })
+            .collect()
+    }
+}
+
+impl ExtensionObject for StyleCollectionRef {
+    fn object_type(&self) -> &'static str {
+        "StyleCollection"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        let mut result = HashMap::new();
+        let mut load_items = false;
+        let mut item_properties = Vec::new();
+        let mut all_item_properties = false;
+        for property in properties {
+            match property.as_str() {
+                "isNullObject" => {}
+                "items" | "items/$all" | "$all" => {
+                    load_items = true;
+                    all_item_properties = true;
+                }
+                property if property.starts_with("items/") => {
+                    load_items = true;
+                    let property = &property["items/".len()..];
+                    if property == "$all" {
+                        all_item_properties = true;
+                    } else if STYLE_SCALARS.contains(&property) {
+                        item_properties.push(property.to_string());
+                    } else {
+                        return Err(style_error(StyleError::unsupported(format!(
+                            "Unsupported StyleCollection item load property '{property}'"
+                        ))));
+                    }
+                }
+                other => {
+                    return Err(style_error(StyleError::unsupported(format!(
+                        "Unsupported StyleCollection load property '{other}'"
+                    ))));
+                }
+            }
+        }
+        if load_items {
+            if all_item_properties || item_properties.is_empty() {
+                item_properties = STYLE_SCALARS
+                    .iter()
+                    .map(|property| (*property).to_string())
+                    .collect();
+            }
+            result.insert(
+                "items".to_string(),
+                Value::Array(self.items(&item_properties).map_err(style_error)?),
+            );
+        }
+        Ok(result)
+    }
+
+    fn set(&self, property: &str, _value: &Value) -> Result<(), BatchError> {
+        Err(style_error(StyleError::unsupported(format!(
+            "StyleCollection.{property} is read-only or unsupported"
+        ))))
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct StyleRef {
+    workbook: Workbook,
+    id: String,
+}
+
+impl StyleRef {
+    fn new(workbook: Workbook, id: String) -> Self {
+        Self { workbook, id }
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, StyleError> {
+        let style = style_by_id(&self.workbook, &self.id)?;
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                "isNullObject" => continue,
+                "name" => json!(style.name),
+                "builtIn" => json!(style.built_in),
+                property => style_scalar(&style.format, property)?,
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), StyleError> {
+        if matches!(property, "name" | "builtIn") {
+            return Err(StyleError::read_only(property));
+        }
+        update_style_format(&self.workbook, &self.id, |format| {
+            set_style_scalar(format, property, value)
+        })
+    }
+
+    fn delete(&self) -> Result<(), StyleError> {
+        let style = style_by_id(&self.workbook, &self.id)?;
+        ensure_custom(&style)?;
+        self.workbook
+            .styles()
+            .delete_custom_cell_style(&self.id)
+            .map(|_| ())
+            .map_err(api_error)
+    }
+}
+
+impl ExtensionObject for StyleRef {
+    fn object_type(&self) -> &'static str {
+        "Style"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        self.load(properties).map_err(style_error)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        self.set(property, value).map_err(style_error)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct StyleFormatRef {
+    workbook: Workbook,
+    style_id: String,
+    kind: StyleFormatKind,
+}
+
+impl StyleFormatRef {
+    fn new(workbook: Workbook, style_id: String, kind: StyleFormatKind) -> Self {
+        Self {
+            workbook,
+            style_id,
+            kind,
+        }
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, StyleError> {
+        let style = style_by_id(&self.workbook, &self.style_id)?;
+        let format = format_value(&style.format)?;
+        properties
+            .iter()
+            .filter(|property| property.as_str() != "isNullObject")
+            .map(|property| {
+                Ok((
+                    property.clone(),
+                    read_format_property(self.kind, property, &format)?,
+                ))
+            })
+            .collect()
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), StyleError> {
+        update_style_format(&self.workbook, &self.style_id, |format| {
+            let (field, value) = write_format_property(self.kind, property, value)?;
+            let mut encoded = format_value(format)?;
+            encoded
+                .as_object_mut()
+                .expect("CellFormat serializes as object")
+                .insert(field.to_string(), value);
+            *format = format_from_value(encoded)?;
+            Ok(())
+        })
+    }
+}
+
+impl ExtensionObject for StyleFormatRef {
+    fn object_type(&self) -> &'static str {
+        match self.kind {
+            StyleFormatKind::Font => "RangeFont",
+            StyleFormatKind::Fill => "RangeFill",
+            StyleFormatKind::Protection => "FormatProtection",
+            StyleFormatKind::Format => "RangeFormat",
+        }
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        self.load(properties).map_err(style_error)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        self.set(property, value).map_err(style_error)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Style borders
+// ---------------------------------------------------------------------------
+
+fn border_field(index: &str) -> Result<(&'static str, Option<&'static str>), StyleError> {
+    match index {
+        "EdgeTop" => Ok(("top", None)),
+        "EdgeBottom" => Ok(("bottom", None)),
+        "EdgeLeft" => Ok(("left", None)),
+        "EdgeRight" => Ok(("right", None)),
+        "InsideVertical" => Ok(("vertical", None)),
+        "InsideHorizontal" => Ok(("horizontal", None)),
+        "DiagonalDown" => Ok(("diagonal", Some("diagonalDown"))),
+        "DiagonalUp" => Ok(("diagonal", Some("diagonalUp"))),
+        other => Err(StyleError::invalid(format!(
+            "Unsupported BorderIndex value '{other}'"
+        ))),
+    }
+}
+
+fn office_style_weight(token: &str) -> Result<(&'static str, &'static str), StyleError> {
+    match token {
+        "none" => Ok(("None", "Thin")),
+        "thin" => Ok(("Continuous", "Thin")),
+        "medium" => Ok(("Continuous", "Medium")),
+        "thick" => Ok(("Continuous", "Thick")),
+        "hair" => Ok(("Continuous", "Hairline")),
+        "dashed" => Ok(("Dash", "Thin")),
+        "mediumDashed" => Ok(("Dash", "Medium")),
+        "dotted" => Ok(("Dot", "Thin")),
+        "dashDot" => Ok(("DashDot", "Thin")),
+        "mediumDashDot" => Ok(("DashDot", "Medium")),
+        "dashDotDot" => Ok(("DashDotDot", "Thin")),
+        "mediumDashDotDot" => Ok(("DashDotDot", "Medium")),
+        "double" => Ok(("Double", "Thin")),
+        "slantDashDot" => Ok(("SlantDashDot", "Thin")),
+        other => Err(StyleError::engine(format!(
+            "The engine returned unsupported border style token '{other}'"
+        ))),
+    }
+}
+
+fn internal_style_for_pair(style: &str, weight: &str) -> Result<&'static str, StyleError> {
+    match (style, weight) {
+        ("None", _) => Ok("none"),
+        ("Continuous", "Hairline") => Ok("hair"),
+        ("Continuous", "Thin") => Ok("thin"),
+        ("Continuous", "Medium") => Ok("medium"),
+        ("Continuous", "Thick") => Ok("thick"),
+        ("Dash", "Thin") => Ok("dashed"),
+        ("Dash", "Medium") => Ok("mediumDashed"),
+        ("DashDot", "Thin") => Ok("dashDot"),
+        ("DashDot", "Medium") => Ok("mediumDashDot"),
+        ("DashDotDot", "Thin") => Ok("dashDotDot"),
+        ("DashDotDot", "Medium") => Ok("mediumDashDotDot"),
+        ("Dot", "Thin") => Ok("dotted"),
+        ("Double", "Thin") => Ok("double"),
+        ("SlantDashDot", "Thin") => Ok("slantDashDot"),
+        _ => Err(StyleError::unsupported(format!(
+            "BorderLineStyle '{style}' with BorderWeight '{weight}' has no lossless engine representation"
+        ))),
+    }
+}
+
+fn side_object<'a>(encoded: &'a Value, field: &str) -> Option<&'a Map<String, Value>> {
+    encoded
+        .get("borders")
+        .and_then(Value::as_object)
+        .and_then(|borders| borders.get(field))
+        .and_then(Value::as_object)
+}
+
+fn border_value(encoded: &Value, index: &str, property: &str) -> Result<Value, StyleError> {
+    let (field, diagonal_flag) = border_field(index)?;
+    let enabled = diagonal_flag
+        .map(|flag| {
+            encoded
+                .get("borders")
+                .and_then(Value::as_object)
+                .and_then(|borders| borders.get(flag))
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        })
+        .unwrap_or(true);
+    let side = if enabled { side_object(encoded, field) } else { None };
+    match property {
+        "sideIndex" => Ok(json!(index)),
+        "color" => Ok(side
+            .and_then(|side| side.get("color"))
+            .cloned()
+            .unwrap_or(Value::Null)),
+        "tintAndShade" => Ok(side
+            .and_then(|side| side.get("colorTint"))
+            .cloned()
+            .unwrap_or_else(|| json!(0.0))),
+        "style" => {
+            let token = side
+                .and_then(|side| side.get("style"))
+                .and_then(Value::as_str)
+                .unwrap_or("none");
+            office_style_weight(token).map(|(style, _)| json!(style))
+        }
+        "weight" => {
+            let token = side
+                .and_then(|side| side.get("style"))
+                .and_then(Value::as_str)
+                .unwrap_or("none");
+            office_style_weight(token).map(|(_, weight)| json!(weight))
+        }
+        other => Err(StyleError::unsupported(format!(
+            "Unsupported RangeBorder property '{other}'"
+        ))),
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct StyleBorderCollectionRef {
+    workbook: Workbook,
+    style_id: String,
+}
+
+impl StyleBorderCollectionRef {
+    fn new(workbook: Workbook, style_id: String) -> Self {
+        Self { workbook, style_id }
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, StyleError> {
+        let style = style_by_id(&self.workbook, &self.style_id)?;
+        let encoded = format_value(&style.format)?;
+        let mut item_properties = Vec::new();
+        let mut load_items = false;
+        let mut all_items = false;
+        let mut result = HashMap::new();
+        for property in properties {
+            match property.as_str() {
+                "isNullObject" => {}
+                "count" => {
+                    result.insert("count".to_string(), json!(BORDER_KEYS.len()));
+                }
+                "tintAndShade" => {
+                    let values = BORDER_KEYS
+                        .iter()
+                        .map(|index| border_value(&encoded, index, "tintAndShade"))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    result.insert("tintAndShade".to_string(), aggregate(values));
+                }
+                "items" | "items/$all" | "$all" => {
+                    load_items = true;
+                    all_items = true;
+                }
+                property if property.starts_with("items/") => {
+                    load_items = true;
+                    let property = &property["items/".len()..];
+                    if property == "$all" {
+                        all_items = true;
+                    } else if ["color", "sideIndex", "style", "tintAndShade", "weight"]
+                        .contains(&property)
+                    {
+                        item_properties.push(property.to_string());
+                    } else {
+                        return Err(StyleError::unsupported(format!(
+                            "Unsupported RangeBorderCollection item property '{property}'"
+                        )));
+                    }
+                }
+                other => {
+                    return Err(StyleError::unsupported(format!(
+                        "Unsupported RangeBorderCollection property '{other}'"
+                    )));
+                }
+            }
+        }
+        if load_items {
+            if all_items || item_properties.is_empty() {
+                item_properties = ["color", "sideIndex", "style", "tintAndShade", "weight"]
+                    .iter()
+                    .map(|property| (*property).to_string())
+                    .collect();
+            }
+            let items = BORDER_KEYS
+                .iter()
+                .map(|index| {
+                    let properties = item_properties
+                        .iter()
+                        .map(|property| {
+                            Ok((
+                                property.clone(),
+                                border_value(&encoded, index, property)?,
+                            ))
+                        })
+                        .collect::<Result<Map<String, Value>, StyleError>>()?;
+                    Ok(json!({ "key": *index, "properties": properties }))
+                })
+                .collect::<Result<Vec<_>, StyleError>>()?;
+            result.insert("items".to_string(), Value::Array(items));
+        }
+        Ok(result)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), StyleError> {
+        if property != "tintAndShade" {
+            return Err(StyleError::unsupported(format!(
+                "RangeBorderCollection.{property} is read-only or unsupported"
+            )));
+        }
+        let value = tint(value, property)?;
+        update_style_format(&self.workbook, &self.style_id, |format| {
+            let mut encoded = format_value(format)?;
+            let borders = encoded
+                .as_object_mut()
+                .expect("CellFormat serializes as object")
+                .entry("borders")
+                .or_insert_with(|| json!({}));
+            let borders = borders
+                .as_object_mut()
+                .ok_or_else(|| encoding("style borders is not an object"))?;
+            for index in BORDER_KEYS {
+                let (field, _) = border_field(index)?;
+                let side = borders.entry(field.to_string()).or_insert_with(|| json!({}));
+                if let Some(side) = side.as_object_mut() {
+                    side.insert("colorTint".to_string(), value.clone());
+                }
+            }
+            *format = format_from_value(encoded)?;
+            Ok(())
+        })
+    }
+}
+
+impl ExtensionObject for StyleBorderCollectionRef {
+    fn object_type(&self) -> &'static str {
+        "RangeBorderCollection"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        self.load(properties).map_err(style_error)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        self.set(property, value).map_err(style_error)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct StyleBorderRef {
+    workbook: Workbook,
+    style_id: String,
+    index: String,
+}
+
+impl StyleBorderRef {
+    fn new(workbook: Workbook, style_id: String, index: String) -> Result<Self, StyleError> {
+        border_field(&index)?;
+        Ok(Self {
+            workbook,
+            style_id,
+            index,
+        })
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, StyleError> {
+        let style = style_by_id(&self.workbook, &self.style_id)?;
+        let encoded = format_value(&style.format)?;
+        properties
+            .iter()
+            .filter(|property| property.as_str() != "isNullObject")
+            .map(|property| {
+                Ok((
+                    property.clone(),
+                    border_value(&encoded, &self.index, property)?,
+                ))
+            })
+            .collect()
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), StyleError> {
+        let index = self.index.clone();
+        update_style_format(&self.workbook, &self.style_id, |format| {
+            let (field, diagonal_flag) = border_field(&index)?;
+            let mut encoded = format_value(format)?;
+            let borders = encoded
+                .as_object_mut()
+                .expect("CellFormat serializes as object")
+                .entry("borders")
+                .or_insert_with(|| json!({}));
+            let borders = borders
+                .as_object_mut()
+                .ok_or_else(|| encoding("style borders is not an object"))?;
+            let side = borders.entry(field.to_string()).or_insert_with(|| json!({}));
+            let side = side
+                .as_object_mut()
+                .ok_or_else(|| encoding("style border side is not an object"))?;
+            match property {
+                "sideIndex" => return Err(StyleError::read_only("sideIndex")),
+                "color" => {
+                    side.insert("color".to_string(), string_value(value, property, false)?);
+                }
+                "tintAndShade" => {
+                    side.insert("colorTint".to_string(), tint(value, property)?);
+                }
+                "style" => {
+                    let style = value.as_str().ok_or_else(|| {
+                        StyleError::invalid("style must be a string enum value")
+                    })?;
+                    let weight = side
+                        .get("style")
+                        .and_then(Value::as_str)
+                        .map(office_style_weight)
+                        .transpose()?
+                        .map(|(_, weight)| weight)
+                        .unwrap_or("Thin");
+                    side.insert(
+                        "style".to_string(),
+                        json!(internal_style_for_pair(style, weight)?),
+                    );
+                    if let Some(flag) = diagonal_flag {
+                        borders.insert(flag.to_string(), json!(style != "None"));
+                    }
+                }
+                "weight" => {
+                    let weight = value.as_str().ok_or_else(|| {
+                        StyleError::invalid("weight must be a string enum value")
+                    })?;
+                    let style = side
+                        .get("style")
+                        .and_then(Value::as_str)
+                        .map(office_style_weight)
+                        .transpose()?
+                        .map(|(style, _)| style)
+                        .ok_or_else(|| {
+                            StyleError::unsupported(
+                                "RangeBorder.weight cannot create a border when style is None",
+                            )
+                        })?;
+                    side.insert(
+                        "style".to_string(),
+                        json!(internal_style_for_pair(style, weight)?),
+                    );
+                }
+                other => {
+                    return Err(StyleError::unsupported(format!(
+                        "Unsupported RangeBorder property '{other}'"
+                    )))
+                }
+            }
+            *format = format_from_value(encoded)?;
+            Ok(())
+        })
+    }
+}
+
+impl ExtensionObject for StyleBorderRef {
+    fn object_type(&self) -> &'static str {
+        "RangeBorder"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        self.load(properties).map_err(style_error)
+    }
+
+    fn set(&self, property: &str, value: &Value) -> Result<(), BatchError> {
+        self.set(property, value).map_err(style_error)
+    }
+}
+
+fn aggregate(values: Vec<Value>) -> Value {
+    let Some(first) = values.first() else {
+        return Value::Null;
+    };
+    if values.iter().all(|value| value == first) {
+        first.clone()
+    } else {
+        Value::Null
+    }
+}
+
+fn normalize_item_properties(properties: &[String]) -> Result<Vec<String>, StyleError> {
+    if properties.is_empty() {
+        return Ok(STYLE_SCALARS
+            .iter()
+            .map(|property| (*property).to_string())
+            .collect());
+    }
+    let mut normalized = Vec::new();
+    for property in properties {
+        if property == "isNullObject" {
+            continue;
+        }
+        if STYLE_SCALARS.contains(&property.as_str()) {
+            if !normalized.contains(property) {
+                normalized.push(property.clone());
+            }
+        } else {
+            return Err(StyleError::unsupported(format!(
+                "Unsupported Style item property '{property}'"
+            )));
+        }
+    }
+    Ok(normalized)
+}
+
+// ---------------------------------------------------------------------------
+// Extension operation handler
+// ---------------------------------------------------------------------------
+
+/// Handler installed by the Office.js runtime owner. The central host keeps
+/// generic load/set routing and object maps; this handler only owns custom
+/// named-style operations and binds the typed objects those operations create.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct NamedStylesHandler;
+
+impl NamedStylesHandler {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+fn operation_string<'a>(operation: &'a Value, field: &str) -> Result<&'a str, BatchError> {
+    operation
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| BatchError {
+            code: "InvalidArgument",
+            message: format!("style operation requires a string '{field}'"),
+        })
+}
+
+impl ExtensionHandler for NamedStylesHandler {
+    fn can_handle(&self, operation: &str) -> bool {
+        matches!(
+            operation,
+            "getStyleCollection"
+                | "styleAdd"
+                | "styleGetCount"
+                | "styleGetItem"
+                | "styleGetItemAt"
+                | "styleDelete"
+                | "getStyleFormat"
+                | "getStyleBorderCollection"
+                | "getStyleBorder"
+        )
+    }
+
+    fn handle(
+        &self,
+        operation: &Value,
+        context: &mut HostDispatchContext<'_>,
+    ) -> Result<bool, BatchError> {
+        let name = operation
+            .get("op")
+            .and_then(Value::as_str)
+            .ok_or_else(|| BatchError {
+                code: "InvalidArgument",
+                message: "style operation is missing op".to_string(),
+            })?;
+        let workbook = context.workbook();
+        match name {
+            "getStyleCollection" => {
+                let id = operation_string(operation, "id")?;
+                context.bind_object(id, Arc::new(StyleCollectionRef::new(workbook)));
+            }
+            "styleAdd" => {
+                let collection_id = operation_string(operation, "collectionId")?;
+                let collection = context.extension_object::<StyleCollectionRef>(collection_id)?;
+                collection
+                    .add(operation_string(operation, "name")?)
+                    .map_err(style_error)?;
+            }
+            "styleGetCount" => {
+                let result_id = operation_string(operation, "resultId")?;
+                let collection = operation
+                    .get("collectionId")
+                    .and_then(Value::as_str)
+                    .map(|id| context.extension_object::<StyleCollectionRef>(id))
+                    .transpose()?
+                    .unwrap_or_else(|| Arc::new(StyleCollectionRef::new(workbook.clone())));
+                context.set_result(result_id, json!(collection.count().map_err(style_error)?));
+            }
+            "styleGetItem" => {
+                let id = operation_string(operation, "id")?;
+                let name = operation_string(operation, "name")?;
+                let or_null = operation
+                    .get("orNullObject")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let collection = operation
+                    .get("collectionId")
+                    .and_then(Value::as_str)
+                    .map(|id| context.extension_object::<StyleCollectionRef>(id))
+                    .transpose()?
+                    .unwrap_or_else(|| Arc::new(StyleCollectionRef::new(workbook.clone())));
+                match collection.get_or_null(name).map_err(style_error)? {
+                    Some(style) => context.bind_object(id, Arc::new(style)),
+                    None if or_null => context.bind_null_object(id),
+                    None => {
+                        return Err(style_error(StyleError::not_found(format!(
+                            "Style '{name}' was not found"
+                        ))))
+                    }
+                }
+            }
+            "styleGetItemAt" => {
+                let id = operation_string(operation, "id")?;
+                let index = operation
+                    .get("index")
+                    .and_then(Value::as_i64)
+                    .filter(|index| *index >= 0)
+                    .ok_or_else(|| BatchError {
+                        code: "InvalidArgument",
+                        message: "StyleCollection.getItemAt requires a non-negative integer index"
+                            .to_string(),
+                    })? as usize;
+                let collection = operation
+                    .get("collectionId")
+                    .and_then(Value::as_str)
+                    .map(|id| context.extension_object::<StyleCollectionRef>(id))
+                    .transpose()?
+                    .unwrap_or_else(|| Arc::new(StyleCollectionRef::new(workbook.clone())));
+                context.bind_object(id, Arc::new(collection.get_at(index).map_err(style_error)?));
+            }
+            "styleDelete" => {
+                let id = operation_string(operation, "id")?;
+                let style = context.extension_object::<StyleRef>(id)?;
+                style.delete().map_err(style_error)?;
+            }
+            "getStyleFormat" => {
+                let id = operation_string(operation, "id")?;
+                let style_id = operation_string(operation, "styleId")?;
+                let kind = match operation_string(operation, "kind")? {
+                    "font" => StyleFormatKind::Font,
+                    "fill" => StyleFormatKind::Fill,
+                    "protection" => StyleFormatKind::Protection,
+                    "format" => StyleFormatKind::Format,
+                    other => {
+                        return Err(style_error(StyleError::unsupported(format!(
+                            "Unsupported style format kind '{other}'"
+                        ))))
+                    }
+                };
+                context.bind_object(
+                    id,
+                    Arc::new(StyleFormatRef::new(workbook, style_id.to_string(), kind)),
+                );
+            }
+            "getStyleBorderCollection" => {
+                let id = operation_string(operation, "id")?;
+                let style_id = operation_string(operation, "styleId")?;
+                context.bind_object(
+                    id,
+                    Arc::new(StyleBorderCollectionRef::new(workbook, style_id.to_string())),
+                );
+            }
+            "getStyleBorder" => {
+                let id = operation_string(operation, "id")?;
+                let style_id = operation_string(operation, "styleId")?;
+                let index = operation_string(operation, "index")?;
+                let border =
+                    StyleBorderRef::new(workbook, style_id.to_string(), index.to_string())
+                        .map_err(style_error)?;
+                context.bind_object(id, Arc::new(border));
+            }
+            _ => return Ok(false),
+        }
+        Ok(true)
+    }
+}

--- a/compute/officejs/src/names.js
+++ b/compute/officejs/src/names.js
@@ -1,0 +1,357 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var configureCollection = global.__mogOfficeJs.configureCollection;
+
+  function propertyNotLoaded(name) {
+    var error = new global.OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function invalidRequestContext() {
+    return new global.OfficeExtension.Error({
+      code: "InvalidRequestContext",
+      message: "The object belongs to a different request context.",
+    });
+  }
+
+  function requirePropertyObject(source) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+  }
+
+  function stringArgument(value, property) {
+    if (typeof value !== "string") {
+      throw new global.OfficeExtension.Error({
+        code: "InvalidArgument",
+        message: property + " must be a string",
+      });
+    }
+    return value;
+  }
+
+  function collectionOptions(collection) {
+    return {
+      worksheetId: collection._worksheet ? collection._worksheet._id : null,
+    };
+  }
+
+  function NamedItemCollection(context, worksheet) {
+    ClientObject.call(this, context);
+    this._worksheet = worksheet || null;
+    // Register the collection binding before any generic load/count request
+    // reaches the host. The host needs the worksheet scope to resolve names.
+    this.context._queue.push({
+      op: "getNamedItemCollection",
+      id: this._id,
+      worksheetId: this._worksheet ? this._worksheet._id : null,
+    });
+    // `items` is hydrated through the shared collection descriptor hook. The
+    // host returns `{ key, properties }` descriptors; the factory below calls
+    // this collection's normal getItem path for each key.
+    this._scalarProperties = ["items"];
+    configureCollection(this, function (key) {
+      return this.getItem(key);
+    });
+  }
+  NamedItemCollection.prototype = Object.create(ClientObject.prototype);
+  NamedItemCollection.prototype.constructor = NamedItemCollection;
+
+  NamedItemCollection.prototype.add = function (name, reference, comment) {
+    var itemName = stringArgument(name, "NamedItemCollection.add name");
+    var operation = {
+      op: "nameAdd",
+      id: null,
+      worksheetId: this._worksheet ? this._worksheet._id : null,
+      name: itemName,
+      comment: comment === undefined ? null : stringArgument(comment, "comment"),
+      formulaLocal: false,
+      reference: null,
+      rangeId: null,
+    };
+
+    if (reference instanceof Excel.Range) {
+      if (reference.context !== this.context) throw invalidRequestContext();
+      operation.rangeId = reference._id;
+    } else if (typeof reference === "string") {
+      operation.reference = reference;
+    } else {
+      throw new global.OfficeExtension.Error({
+        code: "InvalidArgument",
+        message: "NamedItemCollection.add reference must be a Range or string",
+      });
+    }
+
+    var item = new NamedItem(this.context, this);
+    operation.id = item._id;
+    this.context._queue.push(operation);
+    return item;
+  };
+
+  NamedItemCollection.prototype.addFormulaLocal = function (name, formula, comment) {
+    var itemName = stringArgument(name, "NamedItemCollection.addFormulaLocal name");
+    var formulaText = stringArgument(formula, "formula");
+    var item = new NamedItem(this.context, this);
+    this.context._queue.push({
+      op: "nameAdd",
+      id: item._id,
+      worksheetId: this._worksheet ? this._worksheet._id : null,
+      name: itemName,
+      comment: comment === undefined ? null : stringArgument(comment, "comment"),
+      formulaLocal: true,
+      reference: formulaText,
+      rangeId: null,
+    });
+    return item;
+  };
+
+  NamedItemCollection.prototype.getCount = function () {
+    var result = global.__mogOfficeJs.createClientResult(this.context);
+    var options = collectionOptions(this);
+    this.context._queue.push({
+      op: "nameGetCount",
+      resultId: result._id,
+      worksheetId: options.worksheetId,
+    });
+    return result;
+  };
+
+  NamedItemCollection.prototype.getItem = function (name) {
+    var itemName = stringArgument(name, "NamedItemCollection.getItem name");
+    var item = new NamedItem(this.context, this);
+    var options = collectionOptions(this);
+    this.context._queue.push({
+      op: "nameGetItem",
+      id: item._id,
+      worksheetId: options.worksheetId,
+      name: itemName,
+      orNullObject: false,
+    });
+    return item;
+  };
+
+  NamedItemCollection.prototype.getItemOrNullObject = function (name) {
+    var itemName = stringArgument(name, "NamedItemCollection.getItemOrNullObject name");
+    var item = new NamedItem(this.context, this);
+    var options = collectionOptions(this);
+    this.context._queue.push({
+      op: "nameGetItem",
+      id: item._id,
+      worksheetId: options.worksheetId,
+      name: itemName,
+      orNullObject: true,
+    });
+    return item;
+  };
+
+  NamedItemCollection.prototype.toJSON = function () {
+    if (!this._loaded.items) return {};
+    return { items: this.items.map(function (item) { return item.toJSON(); }) };
+  };
+
+  function NamedItem(context, collection) {
+    ClientObject.call(this, context);
+    this._collection = collection;
+    this._scalarProperties = [
+      "comment",
+      "formula",
+      "name",
+      "scope",
+      "type",
+      "value",
+      "visible",
+    ];
+    this._navigationProperties = [
+      "arrayValues",
+      "worksheet",
+      "worksheetOrNullObject",
+    ];
+  }
+  NamedItem.prototype = Object.create(ClientObject.prototype);
+  NamedItem.prototype.constructor = NamedItem;
+
+  ["name", "scope", "type", "value"].forEach(function (name) {
+    Object.defineProperty(NamedItem.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      configurable: true,
+    });
+  });
+
+  ["comment", "formula", "visible"].forEach(function (name) {
+    Object.defineProperty(NamedItem.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        this["_" + name] = value;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: value,
+        });
+      },
+      configurable: true,
+    });
+  });
+
+  // `isNullObject` is supplied by the shared ClientObject implementation.
+  // Keep the named item scalar list limited to the Office NamedItem fields;
+  // null-object hydration is a transport detail and is never serialized as a
+  // made-up NamedItem property.
+
+  NamedItem.prototype.set = function (source) {
+    requirePropertyObject(source);
+    ["comment", "formula", "visible"].forEach(function (name) {
+      if (source instanceof ClientObject) {
+        if (source._loaded[name]) this[name] = source[name];
+      } else if (Object.prototype.hasOwnProperty.call(source, name)) {
+        this[name] = source[name];
+      }
+    }, this);
+  };
+
+  NamedItem.prototype.delete = function () {
+    this.context._queue.push({ op: "nameDelete", id: this._id });
+  };
+
+  function namedRange(item, orNullObject) {
+    // The host binds the resulting range by the NamedItem proxy ID. The range
+    // constructor only needs a context here; its worksheet is resolved by the
+    // host from the name definition itself.
+    var range = new Excel.Range(item.context, null, null);
+    item.context._queue.push({
+      op: "nameGetRange",
+      id: range._id,
+      nameId: item._id,
+      orNullObject: orNullObject,
+    });
+    return range;
+  }
+
+  NamedItem.prototype.getRange = function () {
+    return namedRange(this, false);
+  };
+
+  NamedItem.prototype.getRangeOrNullObject = function () {
+    return namedRange(this, true);
+  };
+
+  function namedWorksheet(item, orNullObject) {
+    var worksheet = new Excel.Worksheet(item.context, null);
+    item.context._queue.push({
+      op: "nameGetWorksheet",
+      id: worksheet._id,
+      nameId: item._id,
+      orNullObject: orNullObject === true,
+    });
+    return worksheet;
+  }
+
+  Object.defineProperty(NamedItem.prototype, "worksheet", {
+    get: function () {
+      if (!this._worksheet) this._worksheet = namedWorksheet(this, false);
+      return this._worksheet;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(NamedItem.prototype, "worksheetOrNullObject", {
+    get: function () {
+      if (!this._worksheetOrNullObject) {
+        this._worksheetOrNullObject = namedWorksheet(this, true);
+      }
+      return this._worksheetOrNullObject;
+    },
+    configurable: true,
+  });
+
+  function NamedItemArrayValues(context, item) {
+    ClientObject.call(this, context);
+    this._item = item;
+    this._scalarProperties = ["types", "values"];
+    context._queue.push({
+      op: "nameGetArrayValues",
+      id: this._id,
+      nameId: item._id,
+    });
+  }
+  NamedItemArrayValues.prototype = Object.create(ClientObject.prototype);
+  NamedItemArrayValues.prototype.constructor = NamedItemArrayValues;
+
+  ["types", "values"].forEach(function (name) {
+    Object.defineProperty(NamedItemArrayValues.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      configurable: true,
+    });
+  });
+
+  NamedItemArrayValues.prototype.toJSON = function () {
+    var data = {};
+    this._scalarProperties.forEach(function (name) {
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }, this);
+    return data;
+  };
+
+  Object.defineProperty(NamedItem.prototype, "arrayValues", {
+    get: function () {
+      if (!this._arrayValues) {
+        this._arrayValues = new NamedItemArrayValues(this.context, this);
+      }
+      return this._arrayValues;
+    },
+    configurable: true,
+  });
+
+  NamedItem.prototype.toJSON = function () {
+    var data = {};
+    this._scalarProperties.forEach(function (name) {
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }, this);
+    if (this._arrayValues && (this._arrayValues._loaded.types || this._arrayValues._loaded.values)) {
+      data.arrayValues = this._arrayValues.toJSON();
+    }
+    return data;
+  };
+
+  Object.defineProperty(Excel.Workbook.prototype, "names", {
+    get: function () {
+      if (!this._names) this._names = new NamedItemCollection(this.context, null);
+      return this._names;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(Excel.Worksheet.prototype, "names", {
+    get: function () {
+      if (!this._names) this._names = new NamedItemCollection(this.context, this);
+      return this._names;
+    },
+    configurable: true,
+  });
+
+  Excel.NamedItemCollection = NamedItemCollection;
+  Excel.NamedItem = NamedItem;
+  Excel.NamedItemArrayValues = NamedItemArrayValues;
+})(globalThis);

--- a/compute/officejs/src/names.rs
+++ b/compute/officejs/src/names.rs
@@ -1,0 +1,1000 @@
+//! Office.js named-item data helpers.
+//! The Office.js host owns proxy lifetime and batching. This module projects
+//! persisted `DefinedName` records to scalar properties; it resolves a real
+//! `Range` only from explicit A1, never guessing unresolved identifiers.
+//!
+//! Host routing for collection CRUD, range/worksheet navigation, array values,
+//! and generic load is defined by operations emitted from `names.js`.
+use compute_api::{CellRange, DefinedNameInput, MutationResult, NamedRangeUpdate, Sheet, Workbook};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use value_types::{CellError, CellValue};
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NameRecord {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) refers_to: String,
+    #[serde(default)]
+    pub(crate) raw_refers_to: Option<String>,
+    #[serde(default)]
+    pub(crate) scope: Option<String>,
+    #[serde(default)]
+    pub(crate) comment: Option<String>,
+    #[serde(default)]
+    pub(crate) custom_menu: Option<String>,
+    #[serde(default)]
+    pub(crate) description: Option<String>,
+    #[serde(default)]
+    pub(crate) help: Option<String>,
+    #[serde(default)]
+    pub(crate) status_bar: Option<String>,
+    #[serde(default = "default_true")]
+    pub(crate) visible: bool,
+    #[serde(default)]
+    pub(crate) xlm: bool,
+    #[serde(default)]
+    pub(crate) function: bool,
+    #[serde(default)]
+    pub(crate) vb_procedure: bool,
+    #[serde(default)]
+    pub(crate) publish_to_server: bool,
+    #[serde(default)]
+    pub(crate) workbook_parameter: bool,
+    #[serde(default)]
+    pub(crate) xml_space_preserve: bool,
+    #[serde(default)]
+    pub(crate) order: Option<u32>,
+    #[serde(default)]
+    pub(crate) linked_range_id: Option<Value>,
+}
+impl NameRecord {
+    pub(crate) fn from_value(value: Value) -> Result<Self, NameError> {
+        serde_json::from_value(value).map_err(encoding)
+    }
+    pub(crate) fn from_serializable<T: Serialize>(value: &T) -> Result<Self, NameError> {
+        Self::from_value(serde_json::to_value(value).map_err(encoding)?)
+    }
+}
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NameCollectionItem {
+    pub(crate) key: String,
+    pub(crate) properties: HashMap<String, Value>,
+}
+const DEFAULT_NAMED_ITEM_PROPERTIES: &[&str] = &[
+    "comment", "formula", "name", "scope", "type", "value", "visible",
+];
+#[derive(Clone)]
+pub(crate) struct NameRange {
+    sheet: Sheet,
+    address: String,
+}
+impl NameRange {
+    pub(crate) fn sheet(&self) -> Sheet {
+        self.sheet.clone()
+    }
+    pub(crate) fn address(&self) -> &str {
+        &self.address
+    }
+    pub(crate) fn display_address(&self) -> Result<String, NameError> {
+        let sheet_name = self.sheet.name().map_err(engine)?;
+        Ok(format!(
+            "{}!{}",
+            qualified_sheet_name(&sheet_name),
+            self.address
+        ))
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NameError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+#[derive(Clone)]
+pub(crate) struct NamedItemCollectionRef {
+    workbook: Workbook,
+    scope: Option<String>,
+}
+impl NamedItemCollectionRef {
+    pub(crate) fn new(workbook: Workbook, scope: Option<String>) -> Self {
+        Self { workbook, scope }
+    }
+    pub(crate) fn add(
+        &self,
+        name: &str,
+        reference: &Value,
+        formula_local: bool,
+        comment: Option<String>,
+    ) -> Result<NamedItemRef, NameError> {
+        let formula = normalize_reference(reference, formula_local)?;
+        self.create(name, formula, comment)
+    }
+    pub(crate) fn add_range(
+        &self,
+        name: &str,
+        sheet: &Sheet,
+        address: &str,
+        comment: Option<String>,
+    ) -> Result<NamedItemRef, NameError> {
+        let formula = formula_for_range(sheet, address)?;
+        self.create(name, formula, comment)
+    }
+    pub(crate) fn get_item(&self, name: &str) -> Result<NamedItemRef, NameError> {
+        if name.trim().is_empty() {
+            return Err(invalid("NamedItemCollection.getItem name cannot be empty"));
+        }
+        let record = self
+            .workbook
+            .names()
+            .get_named_range_by_name(name, self.scope.clone())
+            .map_err(compute_error)?
+            .map(|record| NameRecord::from_serializable(&record))
+            .transpose()?;
+        let Some(record) = record else {
+            return Err(item_not_found(name));
+        };
+        Ok(NamedItemRef::new(self.workbook.clone(), record.id, false))
+    }
+    pub(crate) fn get_item_or_null_object(&self, name: &str) -> Result<NamedItemRef, NameError> {
+        if name.trim().is_empty() {
+            return Err(invalid(
+                "NamedItemCollection.getItemOrNullObject name cannot be empty",
+            ));
+        }
+        let record = self
+            .workbook
+            .names()
+            .get_named_range_by_name(name, self.scope.clone())
+            .map_err(compute_error)?
+            .map(|record| NameRecord::from_serializable(&record))
+            .transpose()?;
+        Ok(match record {
+            Some(record) => NamedItemRef::new(self.workbook.clone(), record.id, false),
+            None => NamedItemRef::null(self.workbook.clone()),
+        })
+    }
+    pub(crate) fn count(&self) -> Result<usize, NameError> {
+        self.workbook
+            .names()
+            .get_named_ranges_by_scope(self.scope.clone())
+            .map(|records| records.len())
+            .map_err(compute_error)
+    }
+    pub(crate) fn collection_items(
+        &self,
+        properties: &[String],
+    ) -> Result<Vec<NameCollectionItem>, NameError> {
+        if properties.is_empty() {
+            self.items(DEFAULT_NAMED_ITEM_PROPERTIES)
+        } else {
+            self.items(properties)
+        }
+    }
+    fn items<P: AsRef<str>>(&self, properties: &[P]) -> Result<Vec<NameCollectionItem>, NameError> {
+        let records = self
+            .workbook
+            .names()
+            .get_named_ranges_by_scope(self.scope.clone())
+            .map_err(compute_error)?;
+        let records = records
+            .iter()
+            .map(NameRecord::from_serializable)
+            .collect::<Result<Vec<_>, _>>()?;
+        collection_items(&self.workbook, &records, properties)
+    }
+    fn create(
+        &self,
+        name: &str,
+        formula: String,
+        comment: Option<String>,
+    ) -> Result<NamedItemRef, NameError> {
+        if name.trim().is_empty() {
+            return Err(invalid("Named item name cannot be empty"));
+        }
+        let result = self
+            .workbook
+            .names()
+            .create_named_range(DefinedNameInput {
+                name: name.to_string(),
+                refers_to: formula,
+                scope: self.scope.clone(),
+                comment,
+            })
+            .map_err(compute_error)?;
+        let record = mutation_record(result)?;
+        Ok(NamedItemRef::new(self.workbook.clone(), record.id, false))
+    }
+}
+#[derive(Clone)]
+pub(crate) struct NamedItemRef {
+    workbook: Workbook,
+    id: String,
+    null_object: bool,
+}
+impl NamedItemRef {
+    fn new(workbook: Workbook, id: String, null_object: bool) -> Self {
+        Self {
+            workbook,
+            id,
+            null_object,
+        }
+    }
+    fn null(workbook: Workbook) -> Self {
+        Self::new(workbook, String::new(), true)
+    }
+    pub(crate) fn is_null_object(&self) -> bool {
+        self.null_object
+    }
+    pub(crate) fn resolve(&self) -> Result<Option<NameRecord>, NameError> {
+        if self.null_object {
+            return Ok(None);
+        }
+        let record = self
+            .workbook
+            .names()
+            .get_named_range_by_id(&self.id)
+            .map_err(compute_error)?;
+        record
+            .map(|record| NameRecord::from_serializable(&record))
+            .transpose()
+    }
+    pub(crate) fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, NameError> {
+        // A null-object probe is valid without a persisted record. Keep this
+        // transport property separate from NamedItemData while allowing
+        // callers to load it alongside ordinary scalar fields.
+        let mut result = HashMap::new();
+        if properties.iter().any(|property| property == "isNullObject") {
+            result.insert("isNullObject".to_string(), Value::Bool(self.null_object));
+        }
+        let properties = properties
+            .iter()
+            .filter(|property| property.as_str() != "isNullObject")
+            .cloned()
+            .collect::<Vec<_>>();
+        if properties.is_empty() || self.null_object {
+            return Ok(result);
+        }
+        let record = self.resolve()?.ok_or_else(|| item_not_found(&self.id))?;
+        result.extend(name_properties(&self.workbook, &record, &properties)?);
+        Ok(result)
+    }
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), NameError> {
+        let _record = self.resolve()?.ok_or_else(|| item_not_found(&self.id))?;
+        let updates = match property {
+            "comment" => NamedRangeUpdate {
+                comment: Some(Some(
+                    value
+                        .as_str()
+                        .ok_or_else(|| invalid("NamedItem.comment must be a string"))?
+                        .to_string(),
+                )),
+                ..Default::default()
+            },
+            "formula" => {
+                let formula = value
+                    .as_str()
+                    .filter(|value| !value.trim().is_empty())
+                    .ok_or_else(|| invalid("NamedItem.formula must be a non-empty string"))?;
+                NamedRangeUpdate {
+                    refers_to: Some(ensure_formula_prefix(formula.trim())),
+                    ..Default::default()
+                }
+            }
+            "visible" => NamedRangeUpdate {
+                visible: Some(
+                    value
+                        .as_bool()
+                        .ok_or_else(|| invalid("NamedItem.visible must be a boolean"))?,
+                ),
+                ..Default::default()
+            },
+            other => {
+                return Err(unsupported(format!(
+                    "NamedItem.{other} is read-only or unsupported"
+                )));
+            }
+        };
+        self.workbook
+            .names()
+            .update_named_range(&self.id, updates)
+            .map_err(compute_error)?;
+        Ok(())
+    }
+    pub(crate) fn delete(&self) -> Result<(), NameError> {
+        if self.null_object {
+            return Ok(());
+        }
+        self.workbook
+            .names()
+            .remove_named_range_by_id(&self.id)
+            .map_err(compute_error)?;
+        Ok(())
+    }
+    pub(crate) fn worksheet(&self) -> Result<Option<Sheet>, NameError> {
+        let Some(record) = self.resolve()? else {
+            return if self.null_object {
+                Ok(None)
+            } else {
+                Err(item_not_found(&self.id))
+            };
+        };
+        record
+            .scope
+            .as_deref()
+            .map(|scope| {
+                find_sheet_by_id(&self.workbook, scope).ok_or_else(|| item_not_found(scope))
+            })
+            .transpose()
+    }
+    pub(crate) fn array_values_ref(&self) -> NamedItemArrayValuesRef {
+        NamedItemArrayValuesRef::new(self.clone())
+    }
+    pub(crate) fn range(&self) -> Result<Option<NameRange>, NameError> {
+        let Some(record) = self.resolve()? else {
+            if !self.null_object {
+                return Err(item_not_found(&self.id));
+            }
+            return Ok(None);
+        };
+        resolve_name_range(&self.workbook, &record)
+    }
+}
+#[derive(Clone)]
+pub(crate) struct NamedItemArrayValuesRef(NamedItemRef);
+impl NamedItemArrayValuesRef {
+    pub(crate) fn new(item: NamedItemRef) -> Self {
+        Self(item)
+    }
+    pub(crate) fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, NameError> {
+        let wants_values = properties.is_empty() || properties.iter().any(|p| p == "values");
+        let wants_types = properties.is_empty() || properties.iter().any(|p| p == "types");
+        if properties.iter().any(|p| p != "values" && p != "types") {
+            return Err(unsupported(
+                "NamedItemArrayValues only exposes values and types".into(),
+            ));
+        }
+        let cells = if let Some(range) = self.0.range()? {
+            range
+                .sheet()
+                .get_range_values_2d(range.address())
+                .map_err(compute_error)?
+        } else {
+            let record = self
+                .0
+                .resolve()?
+                .ok_or_else(|| item_not_found(&self.0.id))?;
+            let ClassifiedName::Scalar(value, value_type) =
+                classify_name(&self.0.workbook, &record)?
+            else {
+                return Err(unsupported(
+                    "NamedItem.arrayValues is unavailable for an array or unsupported formula"
+                        .to_string(),
+                ));
+            };
+            let mut result = HashMap::new();
+            if wants_values {
+                result.insert("values".to_string(), json!([[value]]));
+            }
+            if wants_types {
+                result.insert("types".to_string(), json!([[value_type]]));
+            }
+            return Ok(result);
+        };
+        let mut result = HashMap::new();
+        if wants_values {
+            result.insert("values".to_string(), array_grid(&cells, array_value)?);
+        }
+        if wants_types {
+            result.insert(
+                "types".to_string(),
+                array_grid(&cells, |cell| {
+                    Ok(Value::String(array_type(cell).to_string()))
+                })?,
+            );
+        }
+        Ok(result)
+    }
+}
+fn array_grid<F>(cells: &[Vec<CellValue>], mut map: F) -> Result<Value, NameError>
+where
+    F: FnMut(&CellValue) -> Result<Value, NameError>,
+{
+    Ok(Value::Array(
+        cells
+            .iter()
+            .map(|row| row.iter().map(&mut map).collect::<Result<Vec<_>, _>>())
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .map(Value::Array)
+            .collect(),
+    ))
+}
+fn array_value(value: &CellValue) -> Result<Value, NameError> {
+    match value {
+        CellValue::Null => Ok(Value::String(String::new())),
+        CellValue::Number(number) => Ok(json!(number.get())),
+        CellValue::Text(text) => Ok(Value::String(text.to_string())),
+        CellValue::Boolean(value) => Ok(Value::Bool(*value)),
+        CellValue::Error(error, _) => Ok(Value::String(error.to_string())),
+        CellValue::Control(control) => Ok(Value::Bool(control.value)),
+        CellValue::Array(_) | CellValue::Image(_) => Err(unsupported(
+            "NamedItemArrayValues contains a rich cell value unsupported by this slice".to_string(),
+        )),
+    }
+}
+fn array_type(value: &CellValue) -> &'static str {
+    match value {
+        CellValue::Null => "Empty",
+        CellValue::Number(number) => {
+            if number.get().fract() == 0.0 {
+                "Integer"
+            } else {
+                "Double"
+            }
+        }
+        CellValue::Text(_) => "String",
+        CellValue::Boolean(_) | CellValue::Control(_) => "Boolean",
+        CellValue::Error(_, _) => "Error",
+        CellValue::Array(_) | CellValue::Image(_) => "RichValue",
+    }
+}
+fn mutation_record(result: MutationResult) -> Result<NameRecord, NameError> {
+    let data = result.data.ok_or_else(|| NameError {
+        code: "GeneralException",
+        message: "The compute engine did not return the created named item.".to_string(),
+    })?;
+    NameRecord::from_value(data)
+}
+pub(crate) fn normalize_reference(value: &Value, formula_local: bool) -> Result<String, NameError> {
+    match value {
+        Value::String(text) => {
+            let text = text.trim();
+            if text.is_empty() {
+                return Err(invalid("Named item formula cannot be empty"));
+            }
+            if formula_local
+                || text.starts_with('=')
+                || text.contains('!')
+                || CellRange::from(text).resolve().is_ok()
+            {
+                Ok(ensure_formula_prefix(text))
+            } else {
+                Ok(format!("=\"{}\"", text.replace('"', "\"\"")))
+            }
+        }
+        Value::Number(number) => {
+            let number = number
+                .as_f64()
+                .ok_or_else(|| invalid("Named item numeric references must be finite numbers"))?;
+            if !number.is_finite() {
+                return Err(invalid(
+                    "Named item numeric references must be finite numbers",
+                ));
+            }
+            Ok(format!("={number}"))
+        }
+        Value::Bool(value) => Ok(if *value {
+            "=TRUE".to_string()
+        } else {
+            "=FALSE".to_string()
+        }),
+        _ => Err(invalid(
+            "Named item references must be a Range, string, number, or boolean",
+        )),
+    }
+}
+pub(crate) fn formula_for_range(sheet: &Sheet, address: &str) -> Result<String, NameError> {
+    let (start_row, start_col, end_row, end_col) = CellRange::from(address)
+        .resolve()
+        .map_err(|error| invalid(error.to_string()))?;
+    if start_row > end_row || start_col > end_col {
+        return Err(invalid(format!("Invalid named range address '{address}'")));
+    }
+    let sheet_name = sheet.name().map_err(engine)?;
+    let start = absolute_cell(start_row, start_col);
+    let end = absolute_cell(end_row, end_col);
+    let range = if start == end {
+        start
+    } else {
+        format!("{start}:{end}")
+    };
+    Ok(format!("={}!{range}", qualified_sheet_name(&sheet_name)))
+}
+pub(crate) fn name_properties<P: AsRef<str>>(
+    workbook: &Workbook,
+    record: &NameRecord,
+    properties: &[P],
+) -> Result<HashMap<String, Value>, NameError> {
+    if properties.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let classified = classify_name(workbook, record)?;
+    let mut result = HashMap::new();
+    for property in properties {
+        let property = property.as_ref();
+        let value = match property {
+            "name" => Value::String(record.name.clone()),
+            "formula" => Value::String(formula_for_record(workbook, record)?.ok_or_else(|| {
+                unsupported(
+                    "NamedItem.formula is unavailable because the engine only has an opaque identity formula"
+                        .to_string(),
+                )
+            })?),
+            "scope" => Value::String(
+                if record.scope.is_some() {
+                    "Worksheet"
+                } else {
+                    "Workbook"
+                }
+                .to_string(),
+            ),
+            "visible" => Value::Bool(record.visible),
+            "comment" => Value::String(record.comment.clone().unwrap_or_default()),
+            "type" => Value::String(classified.office_type().ok_or_else(|| {
+                unsupported(format!(
+                    "NamedItem.type is unavailable for formula '{}'",
+                    formula_for_error(record)
+                ))
+            })?),
+            "value" => classified.office_value().ok_or_else(|| {
+                unsupported(format!(
+                    "NamedItem.value is unavailable for formula '{}'",
+                    formula_for_error(record)
+                ))
+            })?,
+            other => return Err(unsupported(format!("NamedItem.{other} is not supported"))),
+        };
+        result.insert(property.to_string(), value);
+    }
+    Ok(result)
+}
+pub(crate) fn collection_items<P: AsRef<str>>(
+    workbook: &Workbook,
+    records: &[NameRecord],
+    properties: &[P],
+) -> Result<Vec<NameCollectionItem>, NameError> {
+    records
+        .iter()
+        .map(|record| {
+            Ok(NameCollectionItem {
+                // Names are case-insensitive selectors in Office.js and are
+                // stable across property changes. The host can still resolve
+                // this key by the persisted ID if it keeps an ID map.
+                key: record.name.clone(),
+                properties: name_properties(workbook, record, properties)?,
+            })
+        })
+        .collect()
+}
+pub(crate) fn resolve_name_range(
+    workbook: &Workbook,
+    record: &NameRecord,
+) -> Result<Option<NameRange>, NameError> {
+    let Some(formula) = formula_for_record(workbook, record)? else {
+        return Ok(None);
+    };
+    let body = formula.strip_prefix('=').unwrap_or(&formula).trim();
+    let (sheet_token, address) = match split_sheet_reference(body) {
+        Some((sheet, address)) => (Some(sheet), address),
+        None => (None, body),
+    };
+
+    let bounds = match CellRange::from(address.trim()).resolve() {
+        Ok(bounds) if bounds.0 <= bounds.2 && bounds.1 <= bounds.3 => bounds,
+        _ => return Ok(None),
+    };
+
+    let sheet = if let Some(token) = sheet_token {
+        let sheet_name = unquote_sheet_name(token)?;
+        find_sheet_by_name(workbook, &sheet_name)
+    } else if let Some(scope) = record.scope.as_deref() {
+        find_sheet_by_id(workbook, scope)
+    } else {
+        workbook.sheet_by_index(0).ok()
+    };
+
+    let Some(sheet) = sheet else {
+        return Ok(None);
+    };
+    let address = canonical_address(bounds);
+    Ok(Some(NameRange { sheet, address }))
+}
+
+fn classify_name(workbook: &Workbook, record: &NameRecord) -> Result<ClassifiedName, NameError> {
+    if let Some(range) = resolve_name_range(workbook, record)? {
+        return Ok(ClassifiedName::Range(range));
+    }
+
+    let Some(formula) = formula_for_record(workbook, record)? else {
+        return Ok(ClassifiedName::Unsupported);
+    };
+    let body = formula.strip_prefix('=').unwrap_or(&formula).trim();
+    if body.eq_ignore_ascii_case("TRUE") {
+        return Ok(ClassifiedName::Scalar(json!(true), "Boolean"));
+    }
+    if body.eq_ignore_ascii_case("FALSE") {
+        return Ok(ClassifiedName::Scalar(json!(false), "Boolean"));
+    }
+    if let Some(string) = parse_excel_string(body) {
+        return Ok(ClassifiedName::Scalar(Value::String(string), "String"));
+    }
+    if let Ok(number) = body.parse::<f64>()
+        && number.is_finite()
+    {
+        let numeric_type = if is_integer_literal(body) {
+            "Integer"
+        } else {
+            "Double"
+        };
+        return Ok(ClassifiedName::Scalar(json!(number), numeric_type));
+    }
+    if let Some(error) = CellError::parse_error_str(body) {
+        return Ok(ClassifiedName::Scalar(
+            Value::String(error.to_string()),
+            "Error",
+        ));
+    }
+    // Delegate formula parsing/evaluation to the production engine.
+    let sheet = evaluation_sheet(workbook, record).ok_or_else(|| {
+        unsupported(format!(
+            "NamedItem formula '{}' has no worksheet evaluation context",
+            formula_for_error(record)
+        ))
+    })?;
+    let value = workbook
+        .names()
+        .evaluate_expression(sheet.id(), &formula)
+        .map_err(compute_error)?;
+    classified_from_cell_value(value)
+}
+
+enum ClassifiedName {
+    Range(NameRange),
+    Scalar(Value, &'static str),
+    Unsupported,
+}
+
+impl ClassifiedName {
+    fn office_type(&self) -> Option<String> {
+        match self {
+            Self::Range(_) => Some("Range".to_string()),
+            Self::Scalar(_, kind) => Some((*kind).to_string()),
+            Self::Unsupported => None,
+        }
+    }
+
+    fn office_value(&self) -> Option<Value> {
+        match self {
+            Self::Range(range) => range.display_address().ok().map(Value::String),
+            Self::Scalar(value, _) => Some(value.clone()),
+            Self::Unsupported => None,
+        }
+    }
+}
+
+fn classified_from_cell_value(value: CellValue) -> Result<ClassifiedName, NameError> {
+    let (office_value, office_type) = match value {
+        CellValue::Null => (Value::String(String::new()), "String"),
+        CellValue::Number(number) => {
+            let number = number.get();
+            (json!(number), if number.fract() == 0.0 { "Integer" } else { "Double" })
+        }
+        CellValue::Text(text) => (Value::String(text.to_string()), "String"),
+        CellValue::Boolean(value) => (Value::Bool(value), "Boolean"),
+        CellValue::Error(error, _) => (Value::String(error.to_string()), "Error"),
+        // The current expression query reduces arrays to their top-left value.
+        CellValue::Array(_) => return Err(unsupported("NamedItem formula evaluated to an array; array results need the full evaluator query".to_string())),
+        CellValue::Control(control) => (Value::Bool(control.value), "Boolean"),
+        CellValue::Image(_) => return Err(unsupported("NamedItem formula evaluated to an image value, which this Office.js slice does not expose".to_string())),
+    };
+    Ok(ClassifiedName::Scalar(office_value, office_type))
+}
+
+fn evaluation_sheet(workbook: &Workbook, record: &NameRecord) -> Option<Sheet> {
+    record
+        .scope
+        .as_deref()
+        .and_then(|scope| find_sheet_by_id(workbook, scope))
+        .or_else(|| workbook.sheet_by_index(0).ok())
+}
+
+fn formula_for_record(
+    workbook: &Workbook,
+    record: &NameRecord,
+) -> Result<Option<String>, NameError> {
+    if let Some(formula) = record_formula(record) {
+        return Ok(Some(formula));
+    }
+    workbook
+        .names()
+        .get_named_range_formula_by_id(&record.id)
+        .map_err(compute_error)
+        .map(|formula| formula.map(|formula| ensure_formula_prefix(formula.trim())))
+}
+
+fn record_formula(record: &NameRecord) -> Option<String> {
+    let source = record
+        .raw_refers_to
+        .as_deref()
+        .unwrap_or(record.refers_to.as_str())
+        .trim();
+    if record.raw_refers_to.is_none()
+        && serde_json::from_str::<Value>(source)
+            .ok()
+            .is_some_and(|value| value.is_object())
+    {
+        return None;
+    }
+    Some(ensure_formula_prefix(source))
+}
+
+fn formula_for_error(record: &NameRecord) -> String {
+    record_formula(record).unwrap_or_else(|| "<opaque IdentityFormula>".to_string())
+}
+
+fn ensure_formula_prefix(source: &str) -> String {
+    if source.starts_with('=') {
+        source.to_string()
+    } else {
+        format!("={source}")
+    }
+}
+
+fn parse_excel_string(body: &str) -> Option<String> {
+    let mut chars = body.chars();
+    if chars.next()? != '"' || !body.ends_with('"') {
+        return None;
+    }
+    let inner = &body[1..body.len() - 1];
+    let mut result = String::with_capacity(inner.len());
+    let mut chars = inner.chars();
+    while let Some(character) = chars.next() {
+        if character == '"' {
+            if chars.next() != Some('"') {
+                return None;
+            }
+            result.push('"');
+        } else {
+            result.push(character);
+        }
+    }
+    Some(result)
+}
+
+fn is_integer_literal(body: &str) -> bool {
+    !body.contains(['.', 'e', 'E'])
+}
+
+fn split_sheet_reference(body: &str) -> Option<(&str, &str)> {
+    let mut quoted = false;
+    let mut index = 0;
+    for (offset, character) in body.char_indices() {
+        if character == '\'' {
+            quoted = !quoted;
+        } else if character == '!' && !quoted {
+            index = offset;
+            break;
+        }
+    }
+    (index > 0).then(|| (&body[..index], &body[index + 1..]))
+}
+
+fn unquote_sheet_name(token: &str) -> Result<String, NameError> {
+    let token = token.trim();
+    if token.starts_with('\'') {
+        if !token.ends_with('\'') || token.len() < 2 {
+            return Err(invalid(format!("Invalid worksheet reference '{token}'")));
+        }
+        let inner = &token[1..token.len() - 1];
+        Ok(inner.replace("''", "'"))
+    } else if token.contains('\'') {
+        Err(invalid(format!("Invalid worksheet reference '{token}'")))
+    } else {
+        Ok(token.to_string())
+    }
+}
+
+fn find_sheet_by_name(workbook: &Workbook, name: &str) -> Option<Sheet> {
+    let count = workbook.sheet_count().ok()?;
+    for index in 0..count {
+        let sheet = workbook.sheet_by_index(index).ok()?;
+        if sheet.name().ok()?.eq_ignore_ascii_case(name) {
+            return Some(sheet);
+        }
+    }
+    None
+}
+
+fn find_sheet_by_id(workbook: &Workbook, id: &str) -> Option<Sheet> {
+    let count = workbook.sheet_count().ok()?;
+    for index in 0..count {
+        let sheet = workbook.sheet_by_index(index).ok()?;
+        if sheet.id().to_uuid_string().eq_ignore_ascii_case(id) {
+            return Some(sheet);
+        }
+    }
+    None
+}
+
+fn canonical_address(bounds: (u32, u32, u32, u32)) -> String {
+    let (start_row, start_col, end_row, end_col) = bounds;
+    let start = cell_address(start_row, start_col);
+    let end = cell_address(end_row, end_col);
+    if start == end {
+        start
+    } else {
+        format!("{start}:{end}")
+    }
+}
+
+fn absolute_cell(row: u32, col: u32) -> String {
+    format!("${}${}", column_name(col), row + 1)
+}
+
+fn cell_address(row: u32, col: u32) -> String {
+    format!("{}{}", column_name(col), row + 1)
+}
+
+fn qualified_sheet_name(name: &str) -> String {
+    if name
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || character == '_')
+    {
+        name.to_string()
+    } else {
+        format!("'{}'", name.replace('\'', "''"))
+    }
+}
+
+fn column_name(mut column: u32) -> String {
+    let mut reversed = Vec::new();
+    loop {
+        reversed.push((b'A' + (column % 26) as u8) as char);
+        column /= 26;
+        if column == 0 {
+            break;
+        }
+        column -= 1;
+    }
+    reversed.into_iter().rev().collect()
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn item_not_found(key: &str) -> NameError {
+    NameError {
+        code: "ItemNotFound",
+        message: format!("The requested named item doesn't exist. Name or ID: {key}"),
+    }
+}
+
+fn compute_error(error: compute_api::ComputeApiError) -> NameError {
+    let code = match &error {
+        compute_api::ComputeApiError::InvalidAddress { .. }
+        | compute_api::ComputeApiError::InvalidRange { .. }
+        | compute_api::ComputeApiError::InvalidOperation(_) => "InvalidArgument",
+        compute_api::ComputeApiError::SheetNotFound { .. } => "ItemNotFound",
+        compute_api::ComputeApiError::Compute(value_types::ComputeError::Eval { message })
+            if message.to_ascii_lowercase().contains("not found") =>
+        {
+            "ItemNotFound"
+        }
+        compute_api::ComputeApiError::Compute(value_types::ComputeError::Eval { .. }) => {
+            "InvalidArgument"
+        }
+        compute_api::ComputeApiError::Compute(value_types::ComputeError::Parse { .. }) => {
+            "InvalidArgument"
+        }
+        _ => "GeneralException",
+    };
+    NameError {
+        code,
+        message: error.to_string(),
+    }
+}
+
+fn unsupported(message: String) -> NameError {
+    NameError {
+        code: "InvalidArgument",
+        message,
+    }
+}
+
+fn invalid(message: impl Into<String>) -> NameError {
+    NameError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn engine(error: impl std::fmt::Display) -> NameError {
+    NameError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn encoding(error: serde_json::Error) -> NameError {
+    NameError {
+        code: "GeneralException",
+        message: format!("Failed to encode named item value: {error}"),
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primitive_references_are_formula_normalized() {
+        assert_eq!(normalize_reference(&json!(42), false).unwrap(), "=42");
+        assert_eq!(normalize_reference(&json!(true), false).unwrap(), "=TRUE");
+        assert_eq!(
+            normalize_reference(&json!("hello"), false).unwrap(),
+            "=\"hello\""
+        );
+        assert_eq!(
+            normalize_reference(&json!("=SUM(A1:A2)"), false).unwrap(),
+            "=SUM(A1:A2)"
+        );
+    }
+
+    #[test]
+    fn unresolved_names_are_not_ranges() {
+        let workbook = Workbook::blank().unwrap().0;
+        let record = NameRecord {
+            id: "id".to_string(),
+            name: "Alias".to_string(),
+            refers_to: "=OtherName".to_string(),
+            raw_refers_to: None,
+            scope: None,
+            comment: None,
+            visible: true,
+            ..Default::default()
+        };
+        assert!(resolve_name_range(&workbook, &record).unwrap().is_none());
+    }
+
+    #[test]
+    fn explicit_range_uses_a1_canonical_address() {
+        let workbook = Workbook::blank().unwrap().0;
+        let record = NameRecord {
+            id: "id".to_string(),
+            name: "Area".to_string(),
+            refers_to: "=Sheet1!$b$2:$D$3".to_string(),
+            raw_refers_to: None,
+            scope: None,
+            comment: None,
+            visible: true,
+            ..Default::default()
+        };
+        let range = resolve_name_range(&workbook, &record).unwrap().unwrap();
+        assert_eq!(range.address(), "B2:D3");
+        assert_eq!(range.display_address().unwrap(), "Sheet1!B2:D3");
+    }
+
+    #[test]
+    fn production_defined_name_fields_use_camel_case_and_keep_identity_opaque() {
+        let record = NameRecord::from_value(json!({
+            "id": "id",
+            "name": "Sales",
+            "refersTo": "{\"template\":\"A1\",\"refs\":[]}",
+            "rawRefersTo": null,
+            "scope": "sheet-id",
+            "comment": "note",
+            "customMenu": "menu",
+            "statusBar": "status",
+            "visible": false,
+            "linkedRangeId": "range-id"
+        }))
+        .unwrap();
+
+        assert_eq!(record.custom_menu.as_deref(), Some("menu"));
+        assert_eq!(record.status_bar.as_deref(), Some("status"));
+        assert_eq!(record.linked_range_id, Some(json!("range-id")));
+        assert!(record_formula(&record).is_none());
+    }
+}

--- a/compute/officejs/src/pivot_core.js
+++ b/compute/officejs/src/pivot_core.js
@@ -1,0 +1,630 @@
+(function (global) {
+  "use strict";
+
+  // PivotTable is deliberately a thin Office.js proxy.  The persisted ID and
+  // configuration live in compute-api; this file only creates request-context
+  // objects and queues operations for the host dispatcher.  In particular,
+  // refresh and delete are host operations so they use the engine's real
+  // pivot materializer and never maintain a second JavaScript result cache.
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs || {};
+
+  function propertyNotLoaded(name) {
+    var error = new OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function invalidArgument(message) {
+    var error = new OfficeExtension.Error({
+      code: "InvalidArgument",
+      message: message,
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidArgument";
+    return error;
+  }
+
+  function invalidRequestContext() {
+    var error = new OfficeExtension.Error({
+      code: "InvalidRequestContext",
+      message: "The object belongs to a different request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidRequestContext";
+    return error;
+  }
+
+  function newClientResult(context) {
+    if (typeof officeJs.createClientResult === "function") {
+      return officeJs.createClientResult(context);
+    }
+    return new OfficeExtension.ClientResult(context);
+  }
+
+  function nonEmptyString(value, property) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw invalidArgument(property + " must be a non-empty string");
+    }
+    return value;
+  }
+
+  function requirePropertyObject(source) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+  }
+
+  function assertSameContext(object, context, property) {
+    if (object instanceof ClientObject) {
+      if (object.context !== context) throw invalidRequestContext();
+      return object;
+    }
+    throw invalidArgument(property + " must be a Range, string, or Table");
+  }
+
+  function isRange(value) {
+    return typeof Excel.Range === "function" && value instanceof Excel.Range;
+  }
+
+  function isTable(value) {
+    return typeof Excel.Table === "function" && value instanceof Excel.Table;
+  }
+
+  function sourceArgument(value, context) {
+    if (isRange(value)) {
+      assertSameContext(value, context, "PivotTableCollection.add source");
+      return { rangeId: value._id };
+    }
+    if (isTable(value)) {
+      assertSameContext(value, context, "PivotTableCollection.add source");
+      return { tableId: value._id };
+    }
+    if (typeof value === "string" && value.trim().length > 0) {
+      return { address: value };
+    }
+    throw invalidArgument(
+      "PivotTableCollection.add source must be a Range, string, or Table"
+    );
+  }
+
+  function destinationArgument(value, context) {
+    if (isRange(value)) {
+      assertSameContext(value, context, "PivotTableCollection.add destination");
+      return { rangeId: value._id };
+    }
+    if (typeof value === "string" && value.trim().length > 0) {
+      return { address: value };
+    }
+    throw invalidArgument(
+      "PivotTableCollection.add destination must be a Range or range address"
+    );
+  }
+
+  function scopeFields(collection, operation) {
+    operation.collectionId = collection._id;
+    if (collection._worksheet) operation.worksheetId = collection._worksheet._id;
+    return operation;
+  }
+
+  function persistedPivotKey(pivot) {
+    if (!pivot) return null;
+    // `_idValue` is populated from a loaded persisted id.  `_key` is retained
+    // for a getItem proxy before the host binding has completed.  The host
+    // receives `pivotObjectId` as well, so newly-created proxies remain valid
+    // even while their persisted ID is not known to JavaScript.
+    if (typeof pivot._idValue === "string" && pivot._idValue.length > 0) {
+      return pivot._idValue;
+    }
+    if (typeof pivot._pivotId === "string" && pivot._pivotId.length > 0) {
+      return pivot._pivotId;
+    }
+    if (typeof pivot._key === "string" && pivot._key.length > 0) {
+      return pivot._key;
+    }
+    return null;
+  }
+
+  function queuePivotBinding(pivot, collection, key, orNullObject) {
+    var operation = {
+      op: "pivotTableGetItem",
+      id: pivot._id,
+      key: String(key),
+      orNullObject: orNullObject === true,
+    };
+    scopeFields(collection, operation);
+    pivot.context._queue.push(operation);
+    return pivot;
+  }
+
+  function PivotTableCollection(context, worksheet, workbook) {
+    ClientObject.call(this, context);
+    this._worksheet = worksheet || null;
+    this._workbook = workbook || null;
+    this._scalarProperties = ["items"];
+    this._navigationProperties = ["items"];
+    this._itemCache = Object.create(null);
+
+    // Binding is queued at construction time.  This preserves operation order
+    // when a worksheet itself was obtained in the same Excel.run batch.
+    context._queue.push({
+      op: "getPivotTableCollection",
+      id: this._id,
+      worksheetId: this._worksheet ? this._worksheet._id : null,
+    });
+
+    if (typeof officeJs.configureCollection === "function") {
+      officeJs.configureCollection(this, function (key) {
+        return this.getItem(String(key));
+      });
+    } else {
+      // Kept for conformance harnesses that evaluate this family without the
+      // shared bootstrap.  Production uses configureCollection above.
+      var collection = this;
+      this._hydrateItems = function (descriptors) {
+        if (!Array.isArray(descriptors)) {
+          throw new OfficeExtension.Error({
+            code: "GeneralException",
+            message: "The host returned an invalid collection result.",
+          });
+        }
+        return descriptors.map(function (descriptor) {
+          if (!descriptor || typeof descriptor !== "object" || !("key" in descriptor)) {
+            throw new OfficeExtension.Error({
+              code: "GeneralException",
+              message: "The host returned an invalid collection item descriptor.",
+            });
+          }
+          var item = collection.getItem(String(descriptor.key));
+          var properties = descriptor.properties || {};
+          Object.keys(properties).forEach(function (name) {
+            if (typeof officeJs.hydrateProperty === "function") {
+              officeJs.hydrateProperty(item, name, properties[name]);
+            } else {
+              item._loaded[name] = true;
+              item[name === "id" ? "_idValue" : "_" + name] = properties[name];
+            }
+          });
+          return item;
+        });
+      };
+    }
+  }
+  PivotTableCollection.prototype = Object.create(ClientObject.prototype);
+  PivotTableCollection.prototype.constructor = PivotTableCollection;
+
+  Object.defineProperty(PivotTableCollection.prototype, "items", {
+    get: function () {
+      if (!this._loaded.items) throw propertyNotLoaded("items");
+      return this._items || [];
+    },
+    configurable: true,
+  });
+
+  PivotTableCollection.prototype._newPivot = function (key) {
+    var pivot = new PivotTable(this.context, this._worksheet, this, key);
+    pivot._key = key == null ? null : String(key);
+    pivot._pivotId = pivot._key;
+    return pivot;
+  };
+
+  PivotTableCollection.prototype.add = function (name, source, destination) {
+    name = nonEmptyString(name, "PivotTableCollection.add name");
+    var sourceFields = sourceArgument(source, this.context);
+    var destinationFields = destinationArgument(destination, this.context);
+    var pivot = this._newPivot(null);
+    var operation = {
+      op: "pivotTableAdd",
+      id: pivot._id,
+      name: name,
+    };
+    scopeFields(this, operation);
+    if (Object.prototype.hasOwnProperty.call(sourceFields, "rangeId")) {
+      operation.sourceRangeId = sourceFields.rangeId;
+    } else if (Object.prototype.hasOwnProperty.call(sourceFields, "tableId")) {
+      operation.sourceTableId = sourceFields.tableId;
+    } else {
+      operation.sourceAddress = sourceFields.address;
+    }
+    if (Object.prototype.hasOwnProperty.call(destinationFields, "rangeId")) {
+      operation.destinationRangeId = destinationFields.rangeId;
+    } else {
+      operation.destinationAddress = destinationFields.address;
+    }
+    this.context._queue.push(operation);
+    return pivot;
+  };
+
+  PivotTableCollection.prototype.getItem = function (key) {
+    key = nonEmptyString(key, "PivotTableCollection.getItem name");
+    var cacheKey = "item:" + key.toLowerCase();
+    var pivot = this._itemCache[cacheKey];
+    if (!pivot) {
+      pivot = this._newPivot(key);
+      this._itemCache[cacheKey] = pivot;
+      queuePivotBinding(pivot, this, key, false);
+    }
+    return pivot;
+  };
+
+  PivotTableCollection.prototype.getItemOrNullObject = function (key) {
+    key = nonEmptyString(key, "PivotTableCollection.getItemOrNullObject name");
+    var cacheKey = "null:" + key.toLowerCase();
+    var pivot = this._itemCache[cacheKey];
+    if (!pivot) {
+      pivot = this._newPivot(key);
+      this._itemCache[cacheKey] = pivot;
+      queuePivotBinding(pivot, this, key, true);
+    }
+    return pivot;
+  };
+
+  PivotTableCollection.prototype.getCount = function () {
+    var result = newClientResult(this.context);
+    var operation = {
+      op: "pivotTableCollectionGetCount",
+      resultId: result._id,
+    };
+    scopeFields(this, operation);
+    this.context._queue.push(operation);
+    return result;
+  };
+
+  PivotTableCollection.prototype.refreshAll = function () {
+    var operation = { op: "pivotTableCollectionRefreshAll" };
+    scopeFields(this, operation);
+    this.context._queue.push(operation);
+  };
+
+  PivotTableCollection.prototype.load = function (props) {
+    // The constructor binds the collection.  Keeping load as a thin wrapper
+    // ensures collection loads use the shared path's item descriptor handling.
+    return ClientObject.prototype.load.call(this, props);
+  };
+
+  PivotTableCollection.prototype.toJSON = function () {
+    if (!this._loaded.items) return {};
+    return {
+      items: this.items.map(function (item) {
+        return item && typeof item.toJSON === "function" ? item.toJSON() : item;
+      }),
+    };
+  };
+
+  function PivotTable(context, worksheet, collection, key) {
+    ClientObject.call(this, context);
+    this._worksheet = worksheet || null;
+    this._collection = collection || null;
+    this._key = key == null ? null : String(key);
+    this._pivotId = this._key;
+    this._scalarProperties = [
+      "allowMultipleFiltersPerField",
+      "enableDataValueEditing",
+      "id",
+      "name",
+      "refreshOnOpen",
+      "useCustomSortLists",
+    ];
+    this._navigationProperties = [
+      "columnHierarchies",
+      "dataHierarchies",
+      "filterHierarchies",
+      "hierarchies",
+      "layout",
+      "rowHierarchies",
+      "worksheet",
+    ];
+  }
+  PivotTable.prototype = Object.create(ClientObject.prototype);
+  PivotTable.prototype.constructor = PivotTable;
+
+  Object.defineProperty(PivotTable.prototype, "id", {
+    get: function () {
+      if (!this._loaded.id) throw propertyNotLoaded("id");
+      return this._idValue;
+    },
+    configurable: true,
+  });
+
+  [
+    "allowMultipleFiltersPerField",
+    "enableDataValueEditing",
+    "name",
+    "refreshOnOpen",
+    "useCustomSortLists",
+  ].forEach(function (name) {
+    Object.defineProperty(PivotTable.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        if (name === "name") {
+          value = nonEmptyString(value, "PivotTable.name");
+        } else if (typeof value !== "boolean") {
+          throw invalidArgument("PivotTable." + name + " must be a boolean");
+        }
+        this["_" + name] = value;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: value,
+        });
+      },
+      configurable: true,
+    });
+  });
+
+  PivotTable.prototype.set = function (source, options) {
+    requirePropertyObject(source);
+    var properties = source;
+    if (source instanceof ClientObject) {
+      if (!(source instanceof PivotTable)) {
+        throw invalidArgument("The object passed to set must be a PivotTable");
+      }
+      properties = source.toJSON();
+    }
+    var names = [
+      "allowMultipleFiltersPerField",
+      "enableDataValueEditing",
+      "name",
+      "refreshOnOpen",
+      "useCustomSortLists",
+    ];
+    names.forEach(function (name) {
+      if (Object.prototype.hasOwnProperty.call(properties, name) && properties[name] !== undefined) {
+        this[name] = properties[name];
+      }
+    }, this);
+
+    // `id` is the only read-only scalar in this core update shape.  Match the
+    // Office.js update option while still making accidental writes visible.
+    if (
+      Object.prototype.hasOwnProperty.call(properties, "id") &&
+      properties.id !== undefined &&
+      !(options && options.throwOnReadOnly === false)
+    ) {
+      throw invalidArgument("PivotTable.id is read-only");
+    }
+  };
+
+  PivotTable.prototype.delete = function () {
+    this.context._queue.push({ op: "pivotTableDelete", id: this._id });
+  };
+
+  PivotTable.prototype.refresh = function () {
+    this.context._queue.push({ op: "pivotTableRefresh", id: this._id });
+  };
+
+  PivotTable.prototype.getDataSourceString = function () {
+    var result = newClientResult(this.context);
+    this.context._queue.push({
+      op: "pivotTableGetDataSourceString",
+      id: this._id,
+      resultId: result._id,
+    });
+    return result;
+  };
+
+  PivotTable.prototype.getDataSourceType = function () {
+    var result = newClientResult(this.context);
+    this.context._queue.push({
+      op: "pivotTableGetDataSourceType",
+      id: this._id,
+      resultId: result._id,
+    });
+    return result;
+  };
+
+  Object.defineProperty(PivotTable.prototype, "layout", {
+    get: function () {
+      if (!this._layout) this._layout = new PivotLayout(this.context, this);
+      return this._layout;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(PivotTable.prototype, "worksheet", {
+    get: function () {
+      if (this._worksheet) return this._worksheet;
+      if (!this._worksheetResult) {
+        this._worksheetResult = new Excel.Worksheet(this.context, null);
+        this.context._queue.push({
+          op: "pivotTableGetWorksheet",
+          id: this._worksheetResult._id,
+          pivotId: this._id,
+          pivotObjectId: this._id,
+        });
+      }
+      return this._worksheetResult;
+    },
+    configurable: true,
+  });
+
+  PivotTable.prototype.toJSON = function () {
+    var data = {};
+    this._scalarProperties.forEach(function (name) {
+      if (!this._loaded[name]) return;
+      data[name] = name === "id" ? this._idValue : this["_" + name];
+    }, this);
+    return data;
+  };
+
+  function PivotLayout(context, pivot) {
+    ClientObject.call(this, context);
+    this._pivot = pivot || null;
+    this._scalarProperties = [
+      "altTextDescription",
+      "altTextTitle",
+      "autoFormat",
+      "emptyCellText",
+      "enableFieldList",
+      "fillEmptyCells",
+      "layoutType",
+      "preserveFormatting",
+      "showColumnGrandTotals",
+      "showFieldHeaders",
+      "showRowGrandTotals",
+      "subtotalLocation",
+    ];
+    // Layout is a separately bound ClientObject so generic load/set can use
+    // the same extension binding table as PivotTable and hierarchy objects.
+    context._queue.push({
+      op: "pivotGetLayout",
+      id: this._id,
+      pivotId: pivot ? pivot._id : null,
+      pivotObjectId: pivot ? pivot._id : null,
+    });
+  }
+  PivotLayout.prototype = Object.create(ClientObject.prototype);
+  PivotLayout.prototype.constructor = PivotLayout;
+
+  [
+    "altTextDescription",
+    "altTextTitle",
+    "autoFormat",
+    "emptyCellText",
+    "enableFieldList",
+    "fillEmptyCells",
+    "layoutType",
+    "preserveFormatting",
+    "showColumnGrandTotals",
+    "showFieldHeaders",
+    "showRowGrandTotals",
+    "subtotalLocation",
+  ].forEach(function (name) {
+    Object.defineProperty(PivotLayout.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        this["_" + name] = value;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: value,
+        });
+      },
+      configurable: true,
+    });
+  });
+
+  PivotLayout.prototype.set = function (source) {
+    requirePropertyObject(source);
+    var properties = source instanceof ClientObject ? source.toJSON() : source;
+    [
+      "altTextDescription",
+      "altTextTitle",
+      "autoFormat",
+      "emptyCellText",
+      "enableFieldList",
+      "fillEmptyCells",
+      "layoutType",
+      "preserveFormatting",
+      "showColumnGrandTotals",
+      "showFieldHeaders",
+      "showRowGrandTotals",
+      "subtotalLocation",
+    ].forEach(function (name) {
+      if (Object.prototype.hasOwnProperty.call(properties, name) && properties[name] !== undefined) {
+        this[name] = properties[name];
+      }
+    }, this);
+  };
+
+  PivotLayout.prototype._range = function (kind) {
+    var worksheet = this._pivot && this._pivot._worksheet ? this._pivot._worksheet : null;
+    var range = new Excel.Range(this.context, worksheet, null);
+    this.context._queue.push({
+      op: "pivotLayoutGetRange",
+      id: range._id,
+      layoutId: this._id,
+      pivotId: this._pivot ? this._pivot._id : null,
+      pivotObjectId: this._pivot ? this._pivot._id : null,
+      kind: kind,
+    });
+    return range;
+  };
+
+  PivotLayout.prototype.getRange = function () {
+    return this._range("full");
+  };
+
+  PivotLayout.prototype.getRowLabelRange = function () {
+    return this._range("rowLabel");
+  };
+
+  PivotLayout.prototype.getColumnLabelRange = function () {
+    return this._range("columnLabel");
+  };
+
+  PivotLayout.prototype.getDataBodyRange = function () {
+    return this._range("dataBody");
+  };
+
+  PivotLayout.prototype.getFilterAxisRange = function () {
+    return this._range("filterAxis");
+  };
+
+  PivotLayout.prototype.toJSON = function () {
+    var data = {};
+    this._scalarProperties.forEach(function (name) {
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }, this);
+    return data;
+  };
+
+  function worksheetPivotTables(worksheet) {
+    if (!worksheet._pivotTables) {
+      worksheet._pivotTables = new PivotTableCollection(worksheet.context, worksheet, null);
+    }
+    return worksheet._pivotTables;
+  }
+
+  function workbookPivotTables(workbook) {
+    if (!workbook._pivotTables) {
+      workbook._pivotTables = new PivotTableCollection(workbook.context, null, workbook);
+    }
+    return workbook._pivotTables;
+  }
+
+  Object.defineProperty(Excel.Worksheet.prototype, "pivotTables", {
+    get: function () {
+      return worksheetPivotTables(this);
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(Excel.Workbook.prototype, "pivotTables", {
+    get: function () {
+      return workbookPivotTables(this);
+    },
+    configurable: true,
+  });
+
+  Excel.PivotTableCollection = PivotTableCollection;
+  Excel.PivotTable = PivotTable;
+  Excel.PivotLayout = PivotLayout;
+
+  // The hierarchy family is loaded after this module in the production
+  // runtime.  Its installer is intentionally optional so either module order
+  // remains valid for isolated conformance tests.
+  if (officeJs && typeof officeJs.installPivotHierarchyProperties === "function") {
+    officeJs.installPivotHierarchyProperties();
+  }
+})(globalThis);

--- a/compute/officejs/src/pivot_core.rs
+++ b/compute/officejs/src/pivot_core.rs
@@ -1,0 +1,1227 @@
+//! Office.js PivotTable collection and core object adapters.
+//!
+//! This module owns the wire translation for PivotTable lifecycle operations
+//! and delegates persistence, computation, refresh, and deletion to
+//! compute-api/the production compute engine. It never keeps a second workbook
+//! map or copies calculated values into host state.
+//
+// Wire operations consumed by the host integrator:
+//
+// * getPivotTableCollection { id, worksheetId }
+// * pivotTableAdd { id, collectionId, worksheetId?, name,
+//   sourceRangeId?|sourceTableId?|sourceAddress?, destinationRangeId?
+//   |destinationAddress? }
+// * pivotTableGetItem { id, collectionId, worksheetId?, key, orNullObject }
+// * pivotTableCollectionGetCount { collectionId, worksheetId?, resultId }
+// * pivotTableCollectionRefreshAll { collectionId, worksheetId? }
+// * pivotTableDelete { id }, pivotTableRefresh { id }
+// * pivotTableGetDataSourceString { id, resultId }
+// * pivotTableGetDataSourceType { id, resultId }
+// * pivotGetLayout { id, pivotId, pivotObjectId }
+// * pivotLayoutGetRange { id, layoutId, pivotId, pivotObjectId, kind }
+// * pivotTableGetWorksheet { id, pivotId, pivotObjectId }
+//
+// A host handler should bind PivotRef for PivotTable objects, PivotLayoutRef
+// for layout objects, and a real RangeRef for layout range operations.
+// Hierarchy objects use the PivotRef config, update_config, worksheet, and
+// stable_id methods.
+
+use std::collections::HashMap;
+
+use compute_api::pure::{self, PivotTableConfig, PivotTableResult};
+use compute_api::{CellRange, ComputeApiError, Sheet, Workbook};
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use crate::range_navigation::{parse_range_address, RangeAddress, RangeNavigationError};
+use crate::tables::{TableError, TableRangeKind, TableRef};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PivotError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+impl PivotError {
+    pub(crate) fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+impl From<ComputeApiError> for PivotError {
+    fn from(error: ComputeApiError) -> Self {
+        let code = match error {
+            ComputeApiError::InvalidAddress { .. }
+            | ComputeApiError::InvalidRange { .. }
+            | ComputeApiError::InvalidOperation(_) => "InvalidArgument",
+            ComputeApiError::SheetNotFound { .. } => "ItemNotFound",
+            ComputeApiError::CellError(_) => "InvalidArgument",
+            ComputeApiError::EngineShutdown
+            | ComputeApiError::ThreadSpawn(_)
+            | ComputeApiError::Compute(_) => "GeneralException",
+        };
+        Self::new(code, error.to_string())
+    }
+}
+
+impl From<RangeNavigationError> for PivotError {
+    fn from(error: RangeNavigationError) -> Self {
+        Self::new(error.code, error.message)
+    }
+}
+
+impl From<TableError> for PivotError {
+    fn from(error: TableError) -> Self {
+        Self::new(error.code, error.message)
+    }
+}
+
+fn invalid(message: impl Into<String>) -> PivotError {
+    PivotError::new("InvalidArgument", message)
+}
+
+fn item_not_found(key: impl Into<String>) -> PivotError {
+    PivotError::new(
+        "ItemNotFound",
+        format!("PivotTable '{}' was not found", key.into()),
+    )
+}
+
+fn unsupported(owner: &str, property: &str) -> PivotError {
+    PivotError::new(
+        "UnsupportedOperation",
+        format!("{owner}.{property} is unsupported by this Office.js host"),
+    )
+}
+
+fn encoding(error: impl std::fmt::Display) -> PivotError {
+    PivotError::new(
+        "GeneralException",
+        format!("Failed to encode PivotTable state: {error}"),
+    )
+}
+
+const DEFAULT_PIVOT_PROPERTIES: &[&str] = &[
+    "allowMultipleFiltersPerField",
+    "enableDataValueEditing",
+    "id",
+    "name",
+    "refreshOnOpen",
+    "useCustomSortLists",
+];
+
+const DEFAULT_LAYOUT_PROPERTIES: &[&str] = &[
+    "altTextDescription",
+    "altTextTitle",
+    "autoFormat",
+    "emptyCellText",
+    "enableFieldList",
+    "fillEmptyCells",
+    "layoutType",
+    "preserveFormatting",
+    "showColumnGrandTotals",
+    "showFieldHeaders",
+    "showRowGrandTotals",
+    "subtotalLocation",
+];
+
+#[derive(Clone)]
+pub(crate) enum PivotSource {
+    Range { sheet: Sheet, address: String },
+    Table(TableRef),
+}
+
+impl PivotSource {
+    pub(crate) fn range(sheet: Sheet, address: impl Into<String>) -> Self {
+        Self::Range {
+            sheet,
+            address: address.into(),
+        }
+    }
+
+    pub(crate) fn table(table: TableRef) -> Self {
+        Self::Table(table)
+    }
+
+    fn resolve(&self) -> Result<(Sheet, String), PivotError> {
+        match self {
+            Self::Range { sheet, address } => {
+                let parsed = bounded_range(sheet, address, "PivotTableCollection.add source")?;
+                Ok((sheet.clone(), parsed.to_a1()))
+            }
+            Self::Table(table) => {
+                let address = table.range_address(TableRangeKind::Full)?;
+                Ok((table.sheet(), address))
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PivotDestination {
+    pub(crate) sheet: Sheet,
+    pub(crate) address: String,
+}
+
+impl PivotDestination {
+    pub(crate) fn new(sheet: Sheet, address: impl Into<String>) -> Self {
+        Self {
+            sheet,
+            address: address.into(),
+        }
+    }
+
+    fn anchor(&self) -> Result<(u32, u32), PivotError> {
+        let parsed = bounded_range(
+            &self.sheet,
+            &self.address,
+            "PivotTableCollection.add destination",
+        )?;
+        let (row, col, _, _) = parsed.bounds();
+        Ok((row, col))
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PivotRange {
+    sheet: Sheet,
+    address: String,
+}
+
+impl PivotRange {
+    pub(crate) fn new(sheet: Sheet, address: impl Into<String>) -> Self {
+        Self {
+            sheet,
+            address: address.into(),
+        }
+    }
+
+    pub(crate) fn sheet(&self) -> Sheet {
+        self.sheet.clone()
+    }
+
+    pub(crate) fn address(&self) -> &str {
+        &self.address
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct PivotTableCollectionItem {
+    pub(crate) key: String,
+    pub(crate) worksheet_id: String,
+    pub(crate) properties: HashMap<String, Value>,
+}
+
+#[derive(Clone)]
+pub(crate) struct PivotTableCollectionRef {
+    workbook: Workbook,
+    worksheet: Option<Sheet>,
+}
+
+impl PivotTableCollectionRef {
+    pub(crate) fn new(workbook: Workbook, worksheet: Option<Sheet>) -> Self {
+        Self {
+            workbook,
+            worksheet,
+        }
+    }
+
+    pub(crate) fn workbook(&self) -> Workbook {
+        self.workbook.clone()
+    }
+
+    pub(crate) fn worksheet(&self) -> Option<Sheet> {
+        self.worksheet.clone()
+    }
+
+    pub(crate) fn source_from_string(&self, source: &str) -> Result<PivotSource, PivotError> {
+        let (sheet, address) = resolve_qualified_range(
+            &self.workbook,
+            self.worksheet.as_ref(),
+            source,
+            "PivotTableCollection.add source",
+        )?;
+        Ok(PivotSource::range(sheet, address))
+    }
+
+    pub(crate) fn destination_from_string(
+        &self,
+        destination: &str,
+    ) -> Result<PivotDestination, PivotError> {
+        let (sheet, address) = resolve_qualified_range(
+            &self.workbook,
+            self.worksheet.as_ref(),
+            destination,
+            "PivotTableCollection.add destination",
+        )?;
+        Ok(PivotDestination::new(sheet, address))
+    }
+
+    pub(crate) fn get_count(&self) -> Result<usize, PivotError> {
+        Ok(self.records()?.len())
+    }
+
+    pub(crate) fn get_item(&self, key: &str) -> Result<PivotRef, PivotError> {
+        required_name(key, "PivotTableCollection.getItem")?;
+        let (_, config) = self
+            .records()?
+            .into_iter()
+            .find(|(_, config)| {
+                config.id.eq_ignore_ascii_case(key) || config.name.eq_ignore_ascii_case(key)
+            })
+            .ok_or_else(|| item_not_found(key))?;
+        let worksheet = self.output_sheet(&config)?;
+        Ok(PivotRef::new(
+            self.workbook.clone(),
+            worksheet,
+            config.id,
+            false,
+        ))
+    }
+
+    pub(crate) fn get_item_or_null_object(
+        &self,
+        key: &str,
+    ) -> Result<Option<PivotRef>, PivotError> {
+        required_name(key, "PivotTableCollection.getItemOrNullObject")?;
+        match self.get_item(key) {
+            Ok(pivot) => Ok(Some(pivot)),
+            Err(error) if error.code == "ItemNotFound" => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub(crate) fn add(
+        &self,
+        name: &str,
+        source: PivotSource,
+        destination: PivotDestination,
+    ) -> Result<PivotRef, PivotError> {
+        required_name(name, "PivotTableCollection.add name")?;
+        if self
+            .records()?
+            .iter()
+            .any(|(_, config)| config.name.eq_ignore_ascii_case(name))
+        {
+            return Err(invalid(format!(
+                "A PivotTable named '{name}' already exists in this collection"
+            )));
+        }
+
+        let (source_sheet, source_address) = source.resolve()?;
+        let (destination_row, destination_col) = destination.anchor()?;
+        let source_range = bounded_range(
+            &source_sheet,
+            &source_address,
+            "PivotTableCollection.add source",
+        )?;
+        let (start_row, start_col, end_row, end_col) = source_range.bounds();
+        let data = source_sheet
+            .get_range_values_2d(CellRange::Bounds(start_row, start_col, end_row, end_col))
+            .map_err(PivotError::from)?;
+        let fields = pure::detect_fields(data);
+        let fields = serde_json::to_value(fields).map_err(encoding)?;
+
+        let source_sheet_name = source_sheet.name().map_err(PivotError::from)?;
+        let destination_sheet_name = destination.sheet.name().map_err(PivotError::from)?;
+        let config_value = json!({
+            "schemaVersion": 2,
+            "id": "",
+            "name": name,
+            "sourceSheetId": source_sheet.id().to_uuid_string(),
+            "sourceSheetName": source_sheet_name,
+            "sourceRange": {
+                "startRow": start_row,
+                "startCol": start_col,
+                "endRow": end_row,
+                "endCol": end_col,
+            },
+            "outputSheetId": destination.sheet.id().to_uuid_string(),
+            "outputSheetName": destination_sheet_name,
+            "outputLocation": { "row": destination_row, "col": destination_col },
+            "fields": fields,
+            "placements": [],
+            "filters": [],
+        });
+
+        let config = destination
+            .sheet
+            .pivots()
+            .create_config(&config_value)
+            .map_err(PivotError::from)?;
+        Ok(PivotRef::new(
+            self.workbook.clone(),
+            destination.sheet,
+            config.id,
+            false,
+        ))
+    }
+
+    pub(crate) fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, PivotError> {
+        let (wants_items, item_properties) = collection_query(properties)?;
+        let mut result = HashMap::new();
+        if wants_items {
+            let items = self.collection_items(&item_properties)?;
+            result.insert(
+                "items".to_string(),
+                serde_json::to_value(items).map_err(encoding)?,
+            );
+        }
+        if properties.iter().any(|property| property == "isNullObject") {
+            result.insert("isNullObject".to_string(), Value::Bool(false));
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn collection_items(
+        &self,
+        properties: &[String],
+    ) -> Result<Vec<PivotTableCollectionItem>, PivotError> {
+        let properties = if properties.is_empty() {
+            DEFAULT_PIVOT_PROPERTIES
+                .iter()
+                .map(|property| (*property).to_string())
+                .collect::<Vec<_>>()
+        } else {
+            properties.to_vec()
+        };
+        self.records()?
+            .into_iter()
+            .map(|(_, config)| {
+                let worksheet = self.output_sheet(&config)?;
+                let pivot = PivotRef::new(
+                    self.workbook.clone(),
+                    worksheet.clone(),
+                    config.id.clone(),
+                    false,
+                );
+                Ok(PivotTableCollectionItem {
+                    key: config.id,
+                    worksheet_id: worksheet.id().to_uuid_string(),
+                    properties: pivot.load(&properties)?,
+                })
+            })
+            .collect()
+    }
+
+    pub(crate) fn refresh_all(&self) -> Result<(), PivotError> {
+        for (_, config) in self.records()? {
+            let worksheet = self.output_sheet(&config)?;
+            let pivot = PivotRef::new(self.workbook.clone(), worksheet, config.id, false);
+            pivot.refresh()?;
+        }
+        Ok(())
+    }
+
+    fn records(&self) -> Result<Vec<(Sheet, PivotTableConfig)>, PivotError> {
+        let mut result = Vec::new();
+        if let Some(sheet) = &self.worksheet {
+            result.extend(
+                sheet
+                    .pivots()
+                    .get_all()
+                    .map_err(PivotError::from)?
+                    .into_iter()
+                    .map(|config| (sheet.clone(), config)),
+            );
+        } else {
+            for name in self.workbook.sheet_names().map_err(PivotError::from)? {
+                let sheet = self
+                    .workbook
+                    .sheet_by_name(&name)
+                    .map_err(PivotError::from)?;
+                result.extend(
+                    sheet
+                        .pivots()
+                        .get_all()
+                        .map_err(PivotError::from)?
+                        .into_iter()
+                        .map(|config| (sheet.clone(), config)),
+                );
+            }
+        }
+        result.sort_by(|(left_sheet, left), (right_sheet, right)| {
+            left_sheet
+                .id()
+                .to_uuid_string()
+                .cmp(&right_sheet.id().to_uuid_string())
+                .then_with(|| left.output_location.row.cmp(&right.output_location.row))
+                .then_with(|| left.output_location.col.cmp(&right.output_location.col))
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        Ok(result)
+    }
+
+    fn output_sheet(&self, config: &PivotTableConfig) -> Result<Sheet, PivotError> {
+        resolve_config_sheet(&self.workbook, config)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PivotRef {
+    workbook: Workbook,
+    worksheet: Sheet,
+    stable_id: String,
+    null_object: bool,
+}
+
+impl PivotRef {
+    pub(crate) fn new(
+        workbook: Workbook,
+        worksheet: Sheet,
+        stable_id: impl Into<String>,
+        null_object: bool,
+    ) -> Self {
+        Self {
+            workbook,
+            worksheet,
+            stable_id: stable_id.into(),
+            null_object,
+        }
+    }
+
+    pub(crate) fn null(workbook: Workbook, worksheet: Sheet) -> Self {
+        Self::new(workbook, worksheet, "", true)
+    }
+
+    pub(crate) fn stable_id(&self) -> &str {
+        &self.stable_id
+    }
+
+    pub(crate) fn worksheet(&self) -> Sheet {
+        self.worksheet.clone()
+    }
+
+    pub(crate) fn workbook(&self) -> Workbook {
+        self.workbook.clone()
+    }
+
+    pub(crate) fn is_null_object(&self) -> bool {
+        self.null_object
+    }
+
+    pub(crate) fn config(&self) -> Result<PivotTableConfig, PivotError> {
+        if self.null_object {
+            return Err(PivotError::new(
+                "InvalidObjectPath",
+                "PivotTable is a null object",
+            ));
+        }
+        if let Some(config) = self
+            .worksheet
+            .pivots()
+            .get(&self.stable_id)
+            .map_err(PivotError::from)?
+        {
+            return Ok(config);
+        }
+        for name in self.workbook.sheet_names().map_err(PivotError::from)? {
+            let sheet = self
+                .workbook
+                .sheet_by_name(&name)
+                .map_err(PivotError::from)?;
+            if let Some(config) = sheet
+                .pivots()
+                .get(&self.stable_id)
+                .map_err(PivotError::from)?
+            {
+                return Ok(config);
+            }
+        }
+        Err(item_not_found(&self.stable_id))
+    }
+
+    pub(crate) fn refresh_binding(&self) -> Result<Self, PivotError> {
+        let config = self.config()?;
+        Ok(Self::new(
+            self.workbook.clone(),
+            resolve_config_sheet(&self.workbook, &config)?,
+            self.stable_id.clone(),
+            false,
+        ))
+    }
+
+    pub(crate) fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, PivotError> {
+        let config = self.config()?;
+        let properties = if properties.is_empty() {
+            DEFAULT_PIVOT_PROPERTIES
+                .iter()
+                .map(|property| (*property).to_string())
+                .collect::<Vec<_>>()
+        } else {
+            properties.to_vec()
+        };
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                "isNullObject" => Value::Bool(false),
+                "id" => Value::String(config.id.clone()),
+                "name" => Value::String(config.name.clone()),
+                "allowMultipleFiltersPerField" => {
+                    json!(config.allow_multiple_filters_per_field.unwrap_or(false))
+                }
+                "enableDataValueEditing" => Value::Bool(false),
+                "refreshOnOpen" => Value::Bool(refresh_on_open(&config)),
+                "useCustomSortLists" => Value::Bool(false),
+                navigation if is_navigation_property(navigation) => {
+                    return Err(unsupported("PivotTable", navigation));
+                }
+                other => return Err(unsupported("PivotTable", other)),
+            };
+            result.insert(property, value);
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn update_config(
+        &self,
+        config: PivotTableConfig,
+    ) -> Result<PivotTableConfig, PivotError> {
+        let current = self.config()?;
+        let updated = self
+            .output_sheet_for(&current)?
+            .pivots()
+            .update(&self.stable_id, config)
+            .map_err(PivotError::from)?
+            .extract_data::<Option<PivotTableConfig>>()
+            .flatten()
+            .ok_or_else(|| item_not_found(&self.stable_id))?;
+        Ok(updated)
+    }
+
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), PivotError> {
+        let mut config = self.config()?;
+        match property {
+            "name" => config.name = required_value_string(value, "PivotTable.name")?.to_string(),
+            "allowMultipleFiltersPerField" => {
+                config.allow_multiple_filters_per_field = Some(required_bool(
+                    value,
+                    "PivotTable.allowMultipleFiltersPerField",
+                )?);
+            }
+            "refreshOnOpen" => {
+                let refresh = required_bool(value, "PivotTable.refreshOnOpen")?;
+                let mut object = serde_json::to_value(&config).map_err(encoding)?;
+                ensure_object(&mut object, "dataOptions");
+                object["dataOptions"]["refreshOnOpen"] = Value::Bool(refresh);
+                config = serde_json::from_value(object).map_err(encoding)?;
+            }
+            "id" => return Err(invalid("PivotTable.id is read-only")),
+            "enableDataValueEditing" | "useCustomSortLists" => {
+                return Err(unsupported("PivotTable", property));
+            }
+            other => return Err(unsupported("PivotTable", other)),
+        }
+        self.update_config(config)?;
+        Ok(())
+    }
+
+    pub(crate) fn delete(&self) -> Result<(), PivotError> {
+        let config = self.config()?;
+        self.output_sheet_for(&config)?
+            .pivots()
+            .delete(&self.stable_id)
+            .map_err(PivotError::from)?;
+        Ok(())
+    }
+
+    pub(crate) fn refresh(&self) -> Result<(), PivotError> {
+        let config = self.config()?;
+        self.output_sheet_for(&config)?
+            .pivots()
+            .refresh(&self.stable_id, None)
+            .map_err(PivotError::from)?;
+        Ok(())
+    }
+
+    pub(crate) fn data_source_string(&self) -> Result<String, PivotError> {
+        let config = self.config()?;
+        let source_sheet = source_sheet_for(&self.workbook, &config)?;
+        let sheet_name = source_sheet.name().map_err(PivotError::from)?;
+        Ok(format!(
+            "{}!{}",
+            qualified_sheet_name(&sheet_name),
+            range_to_a1(&config.source_range)
+        ))
+    }
+
+    pub(crate) fn data_source_type(&self) -> Result<&'static str, PivotError> {
+        let config = self.config()?;
+        let source_sheet = source_sheet_for(&self.workbook, &config)?;
+        let tables = self.workbook.get_all_tables().map_err(PivotError::from)?;
+        for entry in tables {
+            let Some(table_sheet) = resolve_sheet_id(&self.workbook, &entry.sheet_id)? else {
+                continue;
+            };
+            if table_sheet.id() == source_sheet.id() && entry.table.range == config.source_range {
+                return Ok("LocalTable");
+            }
+        }
+        Ok("LocalRange")
+    }
+
+    pub(crate) fn layout_range(
+        &self,
+        kind: PivotLayoutRangeKind,
+    ) -> Result<PivotRange, PivotError> {
+        let config = self.config()?;
+        let sheet = self.output_sheet_for(&config)?;
+        let result = sheet
+            .pivots()
+            .materialize(&self.stable_id, None)
+            .map_err(PivotError::from)?;
+        let bounds = result.rendered_bounds;
+        let anchor = config.output_location;
+        let (start_row, start_col, end_row, end_col) =
+            layout_bounds(kind, anchor.row, anchor.col, &bounds, &result)?;
+        Ok(PivotRange::new(
+            sheet,
+            a1_range(start_row, start_col, end_row, end_col)?,
+        ))
+    }
+
+    pub(crate) fn layout(&self) -> PivotLayoutRef {
+        PivotLayoutRef::new(self.clone())
+    }
+
+    fn output_sheet_for(&self, config: &PivotTableConfig) -> Result<Sheet, PivotError> {
+        resolve_config_sheet(&self.workbook, config)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PivotLayoutRangeKind {
+    Full,
+    RowLabel,
+    ColumnLabel,
+    DataBody,
+    FilterAxis,
+}
+
+impl PivotLayoutRangeKind {
+    pub(crate) fn from_wire(value: &str) -> Result<Self, PivotError> {
+        match value {
+            "full" => Ok(Self::Full),
+            "rowLabel" => Ok(Self::RowLabel),
+            "columnLabel" => Ok(Self::ColumnLabel),
+            "dataBody" => Ok(Self::DataBody),
+            "filterAxis" => Ok(Self::FilterAxis),
+            other => Err(invalid(format!(
+                "Unsupported PivotLayout range kind '{other}'"
+            ))),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PivotLayoutRef {
+    pivot: PivotRef,
+}
+
+impl PivotLayoutRef {
+    pub(crate) fn new(pivot: PivotRef) -> Self {
+        Self { pivot }
+    }
+
+    pub(crate) fn pivot(&self) -> PivotRef {
+        self.pivot.clone()
+    }
+
+    pub(crate) fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, PivotError> {
+        let config = self.pivot.config()?;
+        let properties = if properties.is_empty() {
+            DEFAULT_LAYOUT_PROPERTIES
+                .iter()
+                .map(|property| (*property).to_string())
+                .collect::<Vec<_>>()
+        } else {
+            properties.to_vec()
+        };
+        let object = serde_json::to_value(&config).map_err(encoding)?;
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                "isNullObject" => Value::Bool(false),
+                "altTextDescription" | "altTextTitle" => Value::String(String::new()),
+                "autoFormat" => Value::Bool(config.auto_format.unwrap_or(true)),
+                "emptyCellText" => object
+                    .pointer("/dataOptions/emptyValue")
+                    .cloned()
+                    .unwrap_or_else(|| Value::String(String::new())),
+                "enableFieldList" => Value::Bool(true),
+                "fillEmptyCells" => Value::Bool(false),
+                "layoutType" => layout_type_value(&config),
+                "preserveFormatting" => Value::Bool(config.preserve_formatting.unwrap_or(true)),
+                "showColumnGrandTotals" => json!(config
+                    .layout
+                    .as_ref()
+                    .and_then(|layout| layout.show_column_grand_totals)
+                    .unwrap_or(true)),
+                "showFieldHeaders" => {
+                    let layout = config.layout.as_ref();
+                    let row = layout
+                        .and_then(|layout| layout.show_row_headers)
+                        .unwrap_or(true);
+                    let column = layout
+                        .and_then(|layout| layout.show_column_headers)
+                        .unwrap_or(true);
+                    Value::Bool(row || column)
+                }
+                "showRowGrandTotals" => json!(config
+                    .layout
+                    .as_ref()
+                    .and_then(|layout| layout.show_row_grand_totals)
+                    .unwrap_or(true)),
+                "subtotalLocation" => subtotal_location_value(&config),
+                other => return Err(unsupported("PivotLayout", other)),
+            };
+            result.insert(property, value);
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), PivotError> {
+        let mut object = serde_json::to_value(self.pivot.config()?).map_err(encoding)?;
+        match property {
+            "autoFormat" => {
+                object["autoFormat"] = Value::Bool(required_bool(value, "PivotLayout.autoFormat")?);
+            }
+            "preserveFormatting" => {
+                object["preserveFormatting"] =
+                    Value::Bool(required_bool(value, "PivotLayout.preserveFormatting")?);
+            }
+            "showRowGrandTotals" | "showColumnGrandTotals" => {
+                let value = required_bool(value, &format!("PivotLayout.{property}"))?;
+                ensure_object(&mut object, "layout");
+                object["layout"][property] = Value::Bool(value);
+            }
+            "showFieldHeaders" => {
+                let value = required_bool(value, "PivotLayout.showFieldHeaders")?;
+                ensure_object(&mut object, "layout");
+                object["layout"]["showRowHeaders"] = Value::Bool(value);
+                object["layout"]["showColumnHeaders"] = Value::Bool(value);
+            }
+            "layoutType" => {
+                let layout = required_value_string(value, "PivotLayout.layoutType")?;
+                ensure_object(&mut object, "layout");
+                object["layout"]["layoutForm"] = Value::String(layout_form(layout)?.to_string());
+            }
+            "subtotalLocation" => {
+                let location = required_value_string(value, "PivotLayout.subtotalLocation")?;
+                ensure_object(&mut object, "layout");
+                object["layout"]["subtotalLocation"] =
+                    Value::String(subtotal_form(location)?.to_string());
+            }
+            "emptyCellText" => {
+                let value = required_value_string(value, "PivotLayout.emptyCellText")?;
+                ensure_object(&mut object, "dataOptions");
+                object["dataOptions"]["emptyValue"] = Value::String(value.to_string());
+            }
+            "altTextDescription" | "altTextTitle" | "enableFieldList" | "fillEmptyCells" => {
+                return Err(unsupported("PivotLayout", property));
+            }
+            other => return Err(unsupported("PivotLayout", other)),
+        }
+        let config = serde_json::from_value(object).map_err(encoding)?;
+        self.pivot.update_config(config)?;
+        Ok(())
+    }
+
+    pub(crate) fn range(&self, kind: PivotLayoutRangeKind) -> Result<PivotRange, PivotError> {
+        self.pivot.layout_range(kind)
+    }
+
+    pub(crate) fn set_method(&self, method: &str, value: &Value) -> Result<(), PivotError> {
+        match method {
+            "displayBlankLineAfterEachItem" => {
+                let value = required_bool(value, "PivotLayout.displayBlankLineAfterEachItem")?;
+                let mut object = serde_json::to_value(self.pivot.config()?).map_err(encoding)?;
+                ensure_object(&mut object, "layout");
+                object["layout"]["insertBlankRowAfterItem"] = Value::Bool(value);
+                let config = serde_json::from_value(object).map_err(encoding)?;
+                self.pivot.update_config(config)?;
+                Ok(())
+            }
+            "repeatAllItemLabels" => {
+                let value = required_bool(value, "PivotLayout.repeatAllItemLabels")?;
+                let mut object = serde_json::to_value(self.pivot.config()?).map_err(encoding)?;
+                ensure_object(&mut object, "layout");
+                object["layout"]["repeatRowLabels"] = Value::Bool(value);
+                let config = serde_json::from_value(object).map_err(encoding)?;
+                self.pivot.update_config(config)?;
+                Ok(())
+            }
+            other => Err(unsupported("PivotLayout", other)),
+        }
+    }
+}
+
+fn is_navigation_property(property: &str) -> bool {
+    matches!(
+        property,
+        "columnHierarchies"
+            | "dataHierarchies"
+            | "filterHierarchies"
+            | "hierarchies"
+            | "layout"
+            | "rowHierarchies"
+            | "worksheet"
+    )
+}
+
+fn required_name<'a>(value: &'a str, owner: &str) -> Result<&'a str, PivotError> {
+    if value.trim().is_empty() {
+        Err(invalid(format!("{owner} name must be a non-empty string")))
+    } else {
+        Ok(value)
+    }
+}
+
+fn required_value_string<'a>(value: &'a Value, property: &str) -> Result<&'a str, PivotError> {
+    let value = value
+        .as_str()
+        .ok_or_else(|| invalid(format!("{property} must be a string")))?;
+    if value.trim().is_empty() {
+        return Err(invalid(format!("{property} must be a non-empty string")));
+    }
+    Ok(value)
+}
+
+fn required_bool(value: &Value, property: &str) -> Result<bool, PivotError> {
+    value
+        .as_bool()
+        .ok_or_else(|| invalid(format!("{property} must be a boolean")))
+}
+
+fn ensure_object(value: &mut Value, key: &str) {
+    if !value.get(key).is_some_and(Value::is_object) {
+        value[key] = json!({});
+    }
+}
+
+fn bounded_range(
+    sheet: &Sheet,
+    address: &str,
+    operation: &str,
+) -> Result<RangeAddress, PivotError> {
+    let parsed = parse_range_address(sheet, address)?;
+    if parsed.is_whole_sheet() || parsed.is_entire_row() || parsed.is_entire_column() {
+        return Err(invalid(format!(
+            "{operation} requires a bounded range: '{address}'"
+        )));
+    }
+    Ok(parsed)
+}
+
+fn resolve_qualified_range(
+    workbook: &Workbook,
+    scope: Option<&Sheet>,
+    raw: &str,
+    operation: &str,
+) -> Result<(Sheet, String), PivotError> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err(invalid(format!(
+            "{operation} must be a non-empty range address"
+        )));
+    }
+    let (sheet_name, address) = split_sheet_qualifier(raw)?;
+    let sheet = match sheet_name {
+        Some(name) => find_sheet_case_insensitive(workbook, &name)?,
+        None => scope
+            .cloned()
+            .or_else(|| workbook.sheet_by_index(0).ok())
+            .ok_or_else(|| PivotError::new("ItemNotFound", "The workbook has no worksheet"))?,
+    };
+    let address = bounded_range(&sheet, &address, operation)?.to_a1();
+    Ok((sheet, address))
+}
+
+fn split_sheet_qualifier(raw: &str) -> Result<(Option<String>, String), PivotError> {
+    let Some(index) = raw.rfind('!') else {
+        return Ok((None, raw.to_string()));
+    };
+    let sheet = raw[..index].trim();
+    let address = raw[index + 1..].trim();
+    if sheet.is_empty() || address.is_empty() {
+        return Err(invalid(format!("Invalid qualified range address '{raw}'")));
+    }
+    let sheet = if sheet.starts_with('\'') && sheet.ends_with('\'') && sheet.len() >= 2 {
+        sheet[1..sheet.len() - 1].replace("''", "'")
+    } else {
+        sheet.to_string()
+    };
+    Ok((Some(sheet), address.to_string()))
+}
+
+fn find_sheet_case_insensitive(workbook: &Workbook, name: &str) -> Result<Sheet, PivotError> {
+    let names = workbook.sheet_names().map_err(PivotError::from)?;
+    let actual = names
+        .into_iter()
+        .find(|candidate| candidate.eq_ignore_ascii_case(name))
+        .ok_or_else(|| {
+            PivotError::new("ItemNotFound", format!("Worksheet '{name}' was not found"))
+        })?;
+    workbook.sheet_by_name(&actual).map_err(PivotError::from)
+}
+
+fn resolve_config_sheet(
+    workbook: &Workbook,
+    config: &PivotTableConfig,
+) -> Result<Sheet, PivotError> {
+    if let Some(id) = config.output_sheet_id.as_deref() {
+        if let Some(sheet) = resolve_sheet_id(workbook, id)? {
+            return Ok(sheet);
+        }
+    }
+    find_sheet_case_insensitive(workbook, &config.output_sheet_name)
+}
+
+fn source_sheet_for(workbook: &Workbook, config: &PivotTableConfig) -> Result<Sheet, PivotError> {
+    if let Some(id) = config.source_sheet_id.as_deref() {
+        if let Some(sheet) = resolve_sheet_id(workbook, id)? {
+            return Ok(sheet);
+        }
+    }
+    find_sheet_case_insensitive(workbook, &config.source_sheet_name)
+}
+
+fn resolve_sheet_id(workbook: &Workbook, id: &str) -> Result<Option<Sheet>, PivotError> {
+    if let Ok(sheet_id) = cell_types::SheetId::from_uuid_str(id) {
+        return Ok(workbook.sheet(&sheet_id).ok());
+    }
+    for name in workbook.sheet_names().map_err(PivotError::from)? {
+        let sheet = workbook.sheet_by_name(&name).map_err(PivotError::from)?;
+        if sheet.id().to_uuid_string().eq_ignore_ascii_case(id) {
+            return Ok(Some(sheet));
+        }
+    }
+    Ok(None)
+}
+
+fn collection_query(properties: &[String]) -> Result<(bool, Vec<String>), PivotError> {
+    let mut wants_items = false;
+    let mut item_properties = Vec::new();
+    for property in properties {
+        match property.as_str() {
+            "items" => wants_items = true,
+            "isNullObject" => {}
+            property if property.starts_with("items/") => {
+                let child = property.trim_start_matches("items/");
+                if child.is_empty() {
+                    return Err(unsupported("PivotTableCollection", property));
+                }
+                wants_items = true;
+                if !item_properties.iter().any(|item| item == child) {
+                    item_properties.push(child.to_string());
+                }
+            }
+            other => return Err(unsupported("PivotTableCollection", other)),
+        }
+    }
+    Ok((wants_items, item_properties))
+}
+
+fn refresh_on_open(config: &PivotTableConfig) -> bool {
+    config
+        .data_options
+        .as_ref()
+        .and_then(|options| options.refresh_on_open)
+        .unwrap_or(false)
+}
+
+fn layout_type_value(config: &PivotTableConfig) -> Value {
+    let value = config
+        .layout
+        .as_ref()
+        .and_then(|layout| layout.layout_form.as_ref())
+        .and_then(|form| serde_json::to_value(form).ok())
+        .and_then(|value| value.as_str().map(ToString::to_string))
+        .map(|value| match value.as_str() {
+            "compact" => "Compact".to_string(),
+            "tabular" => "Tabular".to_string(),
+            "outline" => "Outline".to_string(),
+            _ => "Compact".to_string(),
+        })
+        .unwrap_or_else(|| "Compact".to_string());
+    Value::String(value)
+}
+
+fn subtotal_location_value(config: &PivotTableConfig) -> Value {
+    let value = config
+        .layout
+        .as_ref()
+        .and_then(|layout| layout.subtotal_location.as_ref())
+        .and_then(|location| serde_json::to_value(location).ok())
+        .and_then(|value| value.as_str().map(ToString::to_string))
+        .map(|value| match value.as_str() {
+            "top" => "AtTop".to_string(),
+            "bottom" => "AtBottom".to_string(),
+            _ => "AtBottom".to_string(),
+        })
+        .unwrap_or_else(|| "AtBottom".to_string());
+    Value::String(value)
+}
+
+fn layout_form(value: &str) -> Result<&'static str, PivotError> {
+    match value.to_ascii_lowercase().as_str() {
+        "compact" => Ok("compact"),
+        "tabular" => Ok("tabular"),
+        "outline" => Ok("outline"),
+        other => Err(invalid(format!(
+            "PivotLayout.layoutType '{other}' is invalid"
+        ))),
+    }
+}
+
+fn subtotal_form(value: &str) -> Result<&'static str, PivotError> {
+    match value {
+        "AtTop" | "top" => Ok("top"),
+        "AtBottom" | "bottom" => Ok("bottom"),
+        "Off" | "off" => Err(unsupported("PivotLayout", "subtotalLocation")),
+        other => Err(invalid(format!(
+            "PivotLayout.subtotalLocation '{other}' is invalid"
+        ))),
+    }
+}
+
+fn layout_bounds(
+    kind: PivotLayoutRangeKind,
+    anchor_row: u32,
+    anchor_col: u32,
+    bounds: &domain_types::domain::pivot::PivotRenderedBounds,
+    result: &PivotTableResult,
+) -> Result<(u32, u32, u32, u32), PivotError> {
+    if bounds.total_rows == 0 || bounds.total_cols == 0 {
+        return Err(item_not_found("empty PivotTable"));
+    }
+    let full_end_row = checked_end(anchor_row, bounds.total_rows)?;
+    let full_end_col = checked_end(anchor_col, bounds.total_cols)?;
+    match kind {
+        PivotLayoutRangeKind::Full => Ok((anchor_row, anchor_col, full_end_row, full_end_col)),
+        PivotLayoutRangeKind::ColumnLabel => {
+            if bounds.first_data_row == 0 {
+                return Err(item_not_found("PivotTable column labels"));
+            }
+            Ok((
+                anchor_row,
+                anchor_col,
+                checked_end(anchor_row, bounds.first_data_row)?,
+                full_end_col,
+            ))
+        }
+        PivotLayoutRangeKind::RowLabel => {
+            if bounds.first_data_col == 0 {
+                return Err(item_not_found("PivotTable row labels"));
+            }
+            Ok((
+                anchor_row
+                    .checked_add(bounds.first_data_row)
+                    .ok_or_else(|| invalid("PivotTable row range exceeds worksheet limits"))?,
+                anchor_col,
+                full_end_row,
+                checked_end(anchor_col, bounds.first_data_col)?,
+            ))
+        }
+        PivotLayoutRangeKind::DataBody => {
+            if bounds.num_data_cols == 0 {
+                return Err(item_not_found("PivotTable data body"));
+            }
+            let row_grand_total = u32::from(result.grand_totals.row.is_some());
+            let body_rows = bounds
+                .total_rows
+                .checked_sub(bounds.first_data_row)
+                .and_then(|rows| rows.checked_sub(row_grand_total))
+                .ok_or_else(|| item_not_found("PivotTable data body"))?;
+            if body_rows == 0 {
+                return Err(item_not_found("PivotTable data body"));
+            }
+            let start_row = anchor_row
+                .checked_add(bounds.first_data_row)
+                .ok_or_else(|| invalid("PivotTable data range exceeds worksheet limits"))?;
+            let start_col = anchor_col
+                .checked_add(bounds.first_data_col)
+                .ok_or_else(|| invalid("PivotTable data range exceeds worksheet limits"))?;
+            Ok((
+                start_row,
+                start_col,
+                checked_end(start_row, body_rows)?,
+                checked_end(start_col, bounds.num_data_cols)?,
+            ))
+        }
+        PivotLayoutRangeKind::FilterAxis => Err(item_not_found("PivotTable filter axis")),
+    }
+}
+
+fn checked_end(start: u32, length: u32) -> Result<u32, PivotError> {
+    if length == 0 {
+        return Err(item_not_found("empty PivotTable range"));
+    }
+    start
+        .checked_add(length - 1)
+        .ok_or_else(|| invalid("PivotTable range exceeds worksheet limits"))
+}
+
+fn a1_range(
+    start_row: u32,
+    start_col: u32,
+    end_row: u32,
+    end_col: u32,
+) -> Result<String, PivotError> {
+    if start_row > end_row || start_col > end_col {
+        return Err(invalid("PivotTable range is empty"));
+    }
+    let start = format!("{}{}", column_name(start_col)?, start_row + 1);
+    let end = format!("{}{}", column_name(end_col)?, end_row + 1);
+    if start == end {
+        Ok(start)
+    } else {
+        Ok(format!("{start}:{end}"))
+    }
+}
+
+fn range_to_a1(range: &domain_types::domain::pivot::CellRange) -> String {
+    format!(
+        "{}{}:{}{}",
+        column_name_unchecked(range.start_col),
+        range.start_row + 1,
+        column_name_unchecked(range.end_col),
+        range.end_row + 1
+    )
+}
+
+fn column_name(column: u32) -> Result<String, PivotError> {
+    if column >= 16_384 {
+        return Err(invalid(
+            "PivotTable range exceeds the worksheet column limit",
+        ));
+    }
+    Ok(column_name_unchecked(column))
+}
+
+fn column_name_unchecked(mut column: u32) -> String {
+    let mut reversed = Vec::new();
+    loop {
+        reversed.push((b'A' + (column % 26) as u8) as char);
+        column /= 26;
+        if column == 0 {
+            break;
+        }
+        column -= 1;
+    }
+    reversed.into_iter().rev().collect()
+}
+
+fn qualified_sheet_name(name: &str) -> String {
+    if name
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || character == '_')
+    {
+        name.to_string()
+    } else {
+        format!("'{}'", name.replace('\'', "''"))
+    }
+}

--- a/compute/officejs/src/pivot_hierarchies.js
+++ b/compute/officejs/src/pivot_hierarchies.js
@@ -1,0 +1,656 @@
+(function (global) {
+  "use strict";
+
+  // This module contains the Office.js proxy layer for the four PivotTable
+  // hierarchy collections.  The host owns the persisted pivot config; these
+  // objects only keep request-context identity and queue the corresponding
+  // operation.  The `pivotId` in each operation is the persisted pivot ID,
+  // while `id` remains the request-context proxy ID.
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs || {};
+  var configureCollection = officeJs.configureCollection;
+
+  function propertyNotLoaded(name) {
+    var error = new OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function invalidArgument(message) {
+    var error = new OfficeExtension.Error({
+      code: "InvalidArgument",
+      message: message,
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidArgument";
+    return error;
+  }
+
+  function invalidRequestContext() {
+    var error = new OfficeExtension.Error({
+      code: "InvalidRequestContext",
+      message: "The object belongs to a different request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidRequestContext";
+    return error;
+  }
+
+  function requirePropertyObject(source) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+  }
+
+  function stringArgument(value, property) {
+    if (typeof value !== "string") throw invalidArgument(property + " must be a string");
+    return value;
+  }
+
+  function integerArgument(value, property) {
+    if (typeof value !== "number" || !isFinite(value) || Math.floor(value) !== value) {
+      throw invalidArgument(property + " must be an integer");
+    }
+    if (value < 0) throw invalidArgument(property + " must be non-negative");
+    return value;
+  }
+
+  function enumArgument(value, property, values) {
+    stringArgument(value, property);
+    if (values.indexOf(value) < 0) {
+      throw invalidArgument(property + " has an invalid value");
+    }
+    return value;
+  }
+
+  var AGGREGATION_FUNCTIONS = [
+    "Unknown",
+    "Automatic",
+    "Sum",
+    "Count",
+    "Average",
+    "Max",
+    "Min",
+    "Product",
+    "CountNumbers",
+    "StandardDeviation",
+    "StandardDeviationP",
+    "Variance",
+    "VarianceP",
+  ];
+
+  var SHOW_AS_CALCULATIONS = [
+    "Unknown",
+    "None",
+    "PercentOfGrandTotal",
+    "PercentOfRowTotal",
+    "PercentOfColumnTotal",
+    "PercentOfParentRowTotal",
+    "PercentOfParentColumnTotal",
+    "PercentOfParentTotal",
+    "PercentOf",
+    "RunningTotal",
+    "PercentRunningTotal",
+    "DifferenceFrom",
+    "PercentDifferenceFrom",
+    "RankAscending",
+    "RankDecending",
+    "Index",
+  ];
+
+  function validateScalar(name, value) {
+    switch (name) {
+      case "name":
+      case "numberFormat":
+        return stringArgument(value, "PivotHierarchy." + name);
+      case "position":
+        return integerArgument(value, "PivotHierarchy.position");
+      case "enableMultipleFilterItems":
+        if (typeof value !== "boolean") {
+          throw invalidArgument("PivotHierarchy.enableMultipleFilterItems must be a boolean");
+        }
+        return value;
+      case "summarizeBy":
+        return enumArgument(value, "DataPivotHierarchy.summarizeBy", AGGREGATION_FUNCTIONS);
+      case "showAs":
+        if (value == null || typeof value !== "object" || Array.isArray(value)) {
+          throw invalidArgument("DataPivotHierarchy.showAs must be an object");
+        }
+        if (!Object.prototype.hasOwnProperty.call(value, "calculation")) {
+          throw invalidArgument("DataPivotHierarchy.showAs.calculation is required");
+        }
+        enumArgument(value.calculation, "DataPivotHierarchy.showAs.calculation", SHOW_AS_CALCULATIONS);
+        return value;
+      default:
+        return value;
+    }
+  }
+
+  // PivotTable implementations can expose the persisted ID under any of
+  // these private fields while they are being constructed.  Keeping this
+  // lookup in one place lets the proxy preserve the proxy/persisted ID split.
+  function persistedPivotId(pivot) {
+    if (!pivot) return "";
+    if (pivot._pivotRef) {
+      var refId = persistedPivotId(pivot._pivotRef);
+      if (refId) return refId;
+    }
+    // A PivotTable obtained by name starts with `_pivotId`/`_key` equal to
+    // that display name.  Once its binding has loaded, `_idValue` is the
+    // engine's stable persisted identity and must win over those hints;
+    // otherwise a hierarchy collection would look up the name as an ID and
+    // every `hierarchies` item would report ItemNotFound.
+    var candidates = [
+      pivot._idValue,
+      pivot._pivotId,
+      pivot._pivotKey,
+      pivot._key,
+      pivot._nameHint,
+    ];
+    for (var i = 0; i < candidates.length; i++) {
+      if (typeof candidates[i] === "string" && candidates[i].length > 0) {
+        return candidates[i];
+      }
+    }
+    // A pivot created by the core adapter is always bound before one of its
+    // hierarchy collections is accessed.  This fallback preserves a useful
+    // object-path error for an unbound proxy instead of throwing in JavaScript.
+    return pivot._id;
+  }
+
+  function hierarchyKey(hierarchy) {
+    if (!hierarchy) return "";
+    var candidates = [
+      hierarchy._key,
+      hierarchy._pivotHierarchyId,
+      hierarchy._idValue,
+    ];
+    for (var i = 0; i < candidates.length; i++) {
+      if (typeof candidates[i] === "string" && candidates[i].length > 0) {
+        return candidates[i];
+      }
+    }
+    return hierarchy._id;
+  }
+
+  function samePivot(left, right) {
+    if (!left || !right) return false;
+    if (left === right) return true;
+    return persistedPivotId(left) === persistedPivotId(right);
+  }
+
+  function collectionItemCacheKey(key, nullObject) {
+    return (nullObject ? "null:" : "item:") + String(key).toLowerCase();
+  }
+
+  function itemConstructorFor(kind) {
+    switch (kind) {
+      case "all": return Excel.PivotHierarchy;
+      case "row":
+      case "column": return Excel.RowColumnPivotHierarchy;
+      case "data": return Excel.DataPivotHierarchy;
+      case "filter": return Excel.FilterPivotHierarchy;
+      default: throw invalidArgument("Unsupported PivotHierarchy collection kind");
+    }
+  }
+
+  function itemTypeFor(kind) {
+    switch (kind) {
+      case "all": return Excel.PivotHierarchy;
+      case "row":
+      case "column": return Excel.RowColumnPivotHierarchy;
+      case "data": return Excel.DataPivotHierarchy;
+      case "filter": return Excel.FilterPivotHierarchy;
+      default: return null;
+    }
+  }
+
+  function PivotHierarchyCollectionBase(context, pivot, kind) {
+    ClientObject.call(this, context);
+    this._pivot = pivot || null;
+    this._pivotId = persistedPivotId(pivot);
+    this._kind = kind;
+    this._scalarProperties = ["items", "count"];
+    this._navigationProperties = ["items"];
+    this._itemCache = Object.create(null);
+
+    // The pivot core adapter resolves `pivotId` against its persisted config.
+    // `pivotObjectId` is retained as a path hint for hosts that bind the
+    // collection through the already registered PivotTable proxy.
+    context._queue.push({
+      op: "pivotGetHierarchyCollection",
+      id: this._id,
+      pivotId: this._pivotId,
+      pivotObjectId: pivot ? pivot._id : null,
+      kind: kind,
+    });
+
+    if (typeof configureCollection === "function") {
+      configureCollection(this, function (key) {
+        // Descriptor hydration happens after the host finishes the current
+        // sync.  Queue the ordinary item binding for the next sync so an item
+        // obtained from `collection.items` can be mutated just like one from
+        // an explicit getItem call.
+        return this._getItem(key, true, false);
+      });
+    } else {
+      // The shipped bootstrap provides configureCollection.  This fallback
+      // keeps this module independently evaluable by the conformance harness.
+      var collection = this;
+      this._hydrateItems = function (descriptors) {
+        if (!Array.isArray(descriptors)) {
+          throw new OfficeExtension.Error({
+            code: "GeneralException",
+            message: "The host returned an invalid collection result.",
+          });
+        }
+        return descriptors.map(function (descriptor) {
+          if (!descriptor || typeof descriptor !== "object" || !("key" in descriptor)) {
+            throw new OfficeExtension.Error({
+              code: "GeneralException",
+              message: "The host returned an invalid collection item descriptor.",
+            });
+          }
+          var item = collection._getItem(descriptor.key, true, false);
+          var properties = descriptor.properties || {};
+          Object.keys(properties).forEach(function (name) {
+            if (typeof officeJs.hydrateProperty === "function") {
+              officeJs.hydrateProperty(item, name, properties[name]);
+            } else {
+              item._loaded[name] = true;
+              item[name === "id" ? "_idValue" : "_" + name] = properties[name];
+            }
+          });
+          return item;
+        });
+      };
+      Object.defineProperty(this, "items", {
+        get: function () {
+          if (!this._loaded.items) throw propertyNotLoaded("items");
+          return this._items || [];
+        },
+        configurable: true,
+      });
+    }
+  }
+  PivotHierarchyCollectionBase.prototype = Object.create(ClientObject.prototype);
+  PivotHierarchyCollectionBase.prototype.constructor = PivotHierarchyCollectionBase;
+
+  Object.defineProperty(PivotHierarchyCollectionBase.prototype, "count", {
+    get: function () {
+      if (!this._loaded.count) throw propertyNotLoaded("count");
+      return this._count;
+    },
+    configurable: true,
+  });
+
+  PivotHierarchyCollectionBase.prototype._newItem = function (key) {
+    var Constructor = itemConstructorFor(this._kind);
+    return new Constructor(this.context, this._pivot, key, false, this);
+  };
+
+  PivotHierarchyCollectionBase.prototype._getItem = function (key, bind, orNullObject) {
+    key = String(key);
+    var cacheKey = collectionItemCacheKey(key, orNullObject === true);
+    var item = this._itemCache[cacheKey];
+    if (!item) {
+      item = this._newItem(key);
+      item._key = key;
+      item._collection = this;
+      this._itemCache[cacheKey] = item;
+    }
+    if (bind === true) {
+      this.context._queue.push({
+        op: "pivotHierarchyGetItem",
+        id: item._id,
+        collectionId: this._id,
+        pivotId: this._pivotId,
+        pivotObjectId: this._pivot ? this._pivot._id : null,
+        kind: this._kind,
+        key: key,
+        orNullObject: orNullObject === true,
+      });
+    }
+    return item;
+  };
+
+  PivotHierarchyCollectionBase.prototype.getItem = function (key) {
+    stringArgument(key, "PivotHierarchyCollection.getItem name");
+    return this._getItem(key, true, false);
+  };
+
+  PivotHierarchyCollectionBase.prototype.getItemOrNullObject = function (key) {
+    stringArgument(key, "PivotHierarchyCollection.getItemOrNullObject name");
+    return this._getItem(key, true, true);
+  };
+
+  PivotHierarchyCollectionBase.prototype.getCount = function () {
+    var result = typeof officeJs.createClientResult === "function"
+      ? officeJs.createClientResult(this.context)
+      : new OfficeExtension.ClientResult(this.context);
+    this.context._queue.push({
+      op: "pivotHierarchyCollectionGetCount",
+      collectionId: this._id,
+      resultId: result._id,
+    });
+    return result;
+  };
+
+  PivotHierarchyCollectionBase.prototype.toJSON = function () {
+    if (!this._loaded.items) return {};
+    return {
+      items: this.items.map(function (item) {
+        return item && typeof item.toJSON === "function" ? item.toJSON() : item;
+      }),
+    };
+  };
+
+  function defineCollectionCtor(name, parent) {
+    var Constructor = function (context, pivot, explicitKind) {
+      PivotHierarchyCollectionBase.call(this, context, pivot, explicitKind || name);
+    };
+    Constructor.prototype = Object.create(parent.prototype);
+    Constructor.prototype.constructor = Constructor;
+    return Constructor;
+  }
+
+  function addHierarchy(collection, pivotHierarchy) {
+    if (
+      !(pivotHierarchy instanceof Excel.PivotHierarchy) ||
+      pivotHierarchy.constructor !== Excel.PivotHierarchy
+    ) {
+      throw invalidArgument("PivotHierarchyCollection.add requires a PivotHierarchy");
+    }
+    if (pivotHierarchy.context !== collection.context) throw invalidRequestContext();
+    if (!samePivot(collection._pivot, pivotHierarchy._pivot)) {
+      throw invalidArgument("The PivotHierarchy belongs to a different PivotTable");
+    }
+
+    var key = hierarchyKey(pivotHierarchy);
+    var item = collection._newItem(key);
+    item._key = key;
+    item._collection = collection;
+    collection.context._queue.push({
+      op: "pivotHierarchyAdd",
+      id: item._id,
+      collectionId: collection._id,
+      pivotId: collection._pivotId,
+      pivotObjectId: collection._pivot ? collection._pivot._id : null,
+      hierarchyObjectId: pivotHierarchy._id,
+      hierarchyId: key,
+      kind: collection._kind,
+    });
+    return item;
+  }
+
+  function removeHierarchy(collection, hierarchy) {
+    var Expected = itemTypeFor(collection._kind);
+    if (!(hierarchy instanceof Expected)) {
+      throw invalidArgument("PivotHierarchyCollection.remove requires an item from this collection");
+    }
+    if (hierarchy.context !== collection.context) throw invalidRequestContext();
+    if (!samePivot(collection._pivot, hierarchy._pivot)) {
+      throw invalidArgument("The PivotHierarchy belongs to a different PivotTable");
+    }
+    collection.context._queue.push({
+      op: "pivotHierarchyRemove",
+      id: hierarchy._id,
+      collectionId: collection._id,
+      pivotId: collection._pivotId,
+      pivotObjectId: collection._pivot ? collection._pivot._id : null,
+      hierarchyId: hierarchyKey(hierarchy),
+      kind: collection._kind,
+    });
+  }
+
+  function PivotHierarchy(context, pivot, key, bind, collection) {
+    ClientObject.call(this, context);
+    this._pivot = pivot || null;
+    this._collection = collection || null;
+    this._key = key == null ? null : String(key);
+    this._scalarProperties = ["id", "name"];
+    if (bind === true && collection) collection._getItem(this._key, true, false);
+  }
+  PivotHierarchy.prototype = Object.create(ClientObject.prototype);
+  PivotHierarchy.prototype.constructor = PivotHierarchy;
+
+  function RowColumnPivotHierarchy(context, pivot, key, bind, collection) {
+    PivotHierarchy.call(this, context, pivot, key, bind, collection);
+    this._scalarProperties = ["id", "name", "position"];
+  }
+  RowColumnPivotHierarchy.prototype = Object.create(PivotHierarchy.prototype);
+  RowColumnPivotHierarchy.prototype.constructor = RowColumnPivotHierarchy;
+
+  function FilterPivotHierarchy(context, pivot, key, bind, collection) {
+    PivotHierarchy.call(this, context, pivot, key, bind, collection);
+    this._scalarProperties = ["enableMultipleFilterItems", "id", "name", "position"];
+  }
+  FilterPivotHierarchy.prototype = Object.create(PivotHierarchy.prototype);
+  FilterPivotHierarchy.prototype.constructor = FilterPivotHierarchy;
+
+  function DataPivotHierarchy(context, pivot, key, bind, collection) {
+    PivotHierarchy.call(this, context, pivot, key, bind, collection);
+    this._scalarProperties = [
+      "field",
+      "id",
+      "name",
+      "numberFormat",
+      "position",
+      "showAs",
+      "summarizeBy",
+    ];
+  }
+  DataPivotHierarchy.prototype = Object.create(PivotHierarchy.prototype);
+  DataPivotHierarchy.prototype.constructor = DataPivotHierarchy;
+
+  function defineReadWriteScalars(Constructor, names) {
+    names.forEach(function (name) {
+      Object.defineProperty(Constructor.prototype, name, {
+        get: function () {
+          if (!this._loaded[name]) throw propertyNotLoaded(name);
+          return this["_" + name];
+        },
+        set: function (value) {
+          value = validateScalar(name, value);
+          this["_" + name] = value;
+          this._loaded[name] = true;
+          this.context._queue.push({
+            op: "set",
+            id: this._id,
+            property: name,
+            value: value,
+          });
+        },
+        configurable: true,
+      });
+    });
+  }
+
+  function defineReadOnlyScalar(Constructor, name) {
+    Object.defineProperty(Constructor.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return name === "id" ? this._idValue : this["_" + name];
+      },
+      configurable: true,
+    });
+  }
+
+  defineReadOnlyScalar(PivotHierarchy, "id");
+  defineReadWriteScalars(PivotHierarchy, ["name"]);
+
+  defineReadOnlyScalar(RowColumnPivotHierarchy, "id");
+  defineReadWriteScalars(RowColumnPivotHierarchy, ["name", "position"]);
+
+  defineReadOnlyScalar(FilterPivotHierarchy, "id");
+  defineReadWriteScalars(FilterPivotHierarchy, ["enableMultipleFilterItems", "name", "position"]);
+
+  defineReadOnlyScalar(DataPivotHierarchy, "id");
+  defineReadWriteScalars(DataPivotHierarchy, [
+    "name",
+    "numberFormat",
+    "position",
+    "showAs",
+    "summarizeBy",
+  ]);
+
+  // The compute pivot model exposes a data hierarchy's source field as the
+  // compact `{ id, name }` descriptor returned by the host.  Keep it a
+  // readonly, load-gated property here; a later PivotField family can replace
+  // the descriptor with a richer proxy without changing this data hierarchy
+  // contract.
+  Object.defineProperty(DataPivotHierarchy.prototype, "field", {
+    get: function () {
+      if (!this._loaded.field) throw propertyNotLoaded("field");
+      return this._field;
+    },
+    configurable: true,
+  });
+
+  function setProperties(source, options, names) {
+    requirePropertyObject(source);
+    var properties = source;
+    if (source instanceof ClientObject) {
+      if (Object.getPrototypeOf(this) !== Object.getPrototypeOf(source)) {
+        throw invalidArgument("The object passed to set must have the same type.");
+      }
+      properties = source.toJSON();
+    }
+    if (
+      Object.prototype.hasOwnProperty.call(properties, "id") &&
+      properties.id !== undefined &&
+      !(options && options.throwOnReadOnly === false)
+    ) {
+      throw invalidArgument("PivotHierarchy.id is read-only");
+    }
+    names.forEach(function (name) {
+      if (Object.prototype.hasOwnProperty.call(properties, name) && properties[name] !== undefined) {
+        this[name] = properties[name];
+      }
+    }, this);
+  }
+
+  PivotHierarchy.prototype.set = function (source, options) {
+    setProperties.call(this, source, options, ["name"]);
+  };
+  RowColumnPivotHierarchy.prototype.set = function (source, options) {
+    setProperties.call(this, source, options, ["name", "position"]);
+  };
+  FilterPivotHierarchy.prototype.set = function (source, options) {
+    setProperties.call(this, source, options, ["enableMultipleFilterItems", "name", "position"]);
+  };
+  DataPivotHierarchy.prototype.set = function (source, options) {
+    setProperties.call(this, source, options, [
+      "name",
+      "numberFormat",
+      "position",
+      "showAs",
+      "summarizeBy",
+    ]);
+  };
+
+  function setToDefault() {
+    this.context._queue.push({
+      op: "pivotHierarchySetToDefault",
+      id: this._id,
+      pivotId: persistedPivotId(this._pivot),
+      hierarchyId: hierarchyKey(this),
+    });
+  }
+  RowColumnPivotHierarchy.prototype.setToDefault = setToDefault;
+  FilterPivotHierarchy.prototype.setToDefault = setToDefault;
+  DataPivotHierarchy.prototype.setToDefault = setToDefault;
+
+  function toJSON() {
+    var data = {};
+    (this._scalarProperties || []).forEach(function (name) {
+      if (this._loaded[name]) {
+        data[name] = name === "id" ? this._idValue : this["_" + name];
+      }
+    }, this);
+    return data;
+  }
+  PivotHierarchy.prototype.toJSON = toJSON;
+  RowColumnPivotHierarchy.prototype.toJSON = toJSON;
+  FilterPivotHierarchy.prototype.toJSON = toJSON;
+  DataPivotHierarchy.prototype.toJSON = toJSON;
+
+  var PivotHierarchyCollection = defineCollectionCtor("all", PivotHierarchyCollectionBase);
+  var RowColumnPivotHierarchyCollection = defineCollectionCtor("row", PivotHierarchyCollectionBase);
+  var DataPivotHierarchyCollection = defineCollectionCtor("data", PivotHierarchyCollectionBase);
+  var FilterPivotHierarchyCollection = defineCollectionCtor("filter", PivotHierarchyCollectionBase);
+
+  [
+    [RowColumnPivotHierarchyCollection, "row"],
+    [RowColumnPivotHierarchyCollection, "column"],
+    [DataPivotHierarchyCollection, "data"],
+    [FilterPivotHierarchyCollection, "filter"],
+  ].forEach(function (entry) {
+    entry[0].prototype.add = function (pivotHierarchy) {
+      return addHierarchy(this, pivotHierarchy);
+    };
+    entry[0].prototype.remove = function (hierarchy) {
+      removeHierarchy(this, hierarchy);
+    };
+  });
+
+  function installPivotTableProperties() {
+    if (!Excel.PivotTable || !Excel.PivotTable.prototype) return;
+    var properties = [
+      ["hierarchies", PivotHierarchyCollection],
+      ["rowHierarchies", RowColumnPivotHierarchyCollection],
+      ["columnHierarchies", RowColumnPivotHierarchyCollection],
+      ["dataHierarchies", DataPivotHierarchyCollection],
+      ["filterHierarchies", FilterPivotHierarchyCollection],
+    ];
+    properties.forEach(function (entry) {
+      var name = entry[0];
+      var Constructor = entry[1];
+      var descriptor = Object.getOwnPropertyDescriptor(Excel.PivotTable.prototype, name);
+      if (descriptor && descriptor.configurable === false) return;
+      Object.defineProperty(Excel.PivotTable.prototype, name, {
+        get: function () {
+          if (!this._hierarchyCollections) {
+            Object.defineProperty(this, "_hierarchyCollections", {
+              value: Object.create(null),
+              writable: true,
+              configurable: true,
+            });
+          }
+          if (!this._hierarchyCollections[name]) {
+            var kind = name === "columnHierarchies" ? "column" : undefined;
+            this._hierarchyCollections[name] = new Constructor(this.context, this, kind);
+          }
+          return this._hierarchyCollections[name];
+        },
+        configurable: true,
+      });
+    });
+  }
+
+  // Pivot core is loaded immediately before this module in production. Keep a
+  // hook for a host that loads modules in the opposite order.
+  if (global.__mogOfficeJs) {
+    global.__mogOfficeJs.installPivotHierarchyProperties = installPivotTableProperties;
+  }
+  installPivotTableProperties();
+
+  Excel.PivotHierarchyCollection = PivotHierarchyCollection;
+  Excel.PivotHierarchy = PivotHierarchy;
+  Excel.RowColumnPivotHierarchyCollection = RowColumnPivotHierarchyCollection;
+  Excel.RowColumnPivotHierarchy = RowColumnPivotHierarchy;
+  Excel.FilterPivotHierarchyCollection = FilterPivotHierarchyCollection;
+  Excel.FilterPivotHierarchy = FilterPivotHierarchy;
+  Excel.DataPivotHierarchyCollection = DataPivotHierarchyCollection;
+  Excel.DataPivotHierarchy = DataPivotHierarchy;
+})(globalThis);

--- a/compute/officejs/src/pivot_hierarchies.rs
+++ b/compute/officejs/src/pivot_hierarchies.rs
@@ -1,0 +1,978 @@
+//! Office.js PivotTable hierarchy collections.
+//!
+//! The Office.js layer represents a PivotTable field in five related views:
+//! `hierarchies` contains every source field and the four area collections
+//! contain the placements currently on the row, column, data, or filter axis.
+//! This module owns the wire translation for those views.  The host adapter
+//! keeps the persisted PivotTable config in the engine and calls these helpers
+//! for each load/set/add/remove operation.
+//!
+//! A hierarchy collection item descriptor uses a stable placement ID (or the
+//! source field ID for the all-fields collection) as `key`.  The descriptor
+//! key is separate from the Office.js proxy ID allocated by `bootstrap.js`.
+//! Reads always receive the current config, so a fresh `load` observes a
+//! rename, move, aggregation change, or number-format change made by an
+//! earlier request batch.
+//!
+//! The JavaScript proxy emits `pivotGetHierarchyCollection` and
+//! `pivotHierarchyGetItem` to bind objects, `pivotHierarchyCollectionGetCount`
+//! for deferred counts, and `pivotHierarchyAdd`, `pivotHierarchyRemove`, and
+//! `pivotHierarchySetToDefault` for mutations.  Generic `load` and `set`
+//! operations then call the helpers below through the extension binding.
+
+use std::collections::HashMap;
+
+use domain_types::domain::analytics::AggregateFunction;
+use domain_types::domain::pivot::{
+    PivotField, PivotFieldArea, PivotFieldPlacementFlat, PivotTableConfig, ShowValuesAs,
+    ShowValuesAsBaseItem, ShowValuesAsConfig,
+};
+use serde_json::{json, Value};
+use value_types::CellValue;
+
+/// Errors returned by the hierarchy translation layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PivotHierarchyError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+fn invalid(message: impl Into<String>) -> PivotHierarchyError {
+    PivotHierarchyError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn item_not_found(key: &str, kind: PivotHierarchyKind) -> PivotHierarchyError {
+    PivotHierarchyError {
+        code: "ItemNotFound",
+        message: format!("No {kind} PivotHierarchy named '{key}' exists"),
+    }
+}
+
+fn unsupported(property: &str, owner: &str) -> PivotHierarchyError {
+    PivotHierarchyError {
+        code: "UnsupportedOperation",
+        message: format!("{owner}.{property} is unsupported"),
+    }
+}
+
+/// The wire selector used by the five PivotTable hierarchy collections.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PivotHierarchyKind {
+    /// `PivotTable.hierarchies` — all fields available from the source.
+    All,
+    /// `PivotTable.rowHierarchies`.
+    Row,
+    /// `PivotTable.columnHierarchies`.
+    Column,
+    /// `PivotTable.dataHierarchies`.
+    Data,
+    /// `PivotTable.filterHierarchies`.
+    Filter,
+}
+
+impl PivotHierarchyKind {
+    /// Parse the compact selector emitted by `pivot_hierarchies.js`.
+    pub(crate) fn from_wire(value: &str) -> Result<Self, PivotHierarchyError> {
+        match value {
+            "all" => Ok(Self::All),
+            "row" => Ok(Self::Row),
+            "column" => Ok(Self::Column),
+            "data" => Ok(Self::Data),
+            "filter" => Ok(Self::Filter),
+            _ => Err(invalid(format!(
+                "Unsupported PivotHierarchy collection kind '{value}'"
+            ))),
+        }
+    }
+
+    fn area(self) -> Option<PivotFieldArea> {
+        match self {
+            Self::All => None,
+            Self::Row => Some(PivotFieldArea::Row),
+            Self::Column => Some(PivotFieldArea::Column),
+            Self::Data => Some(PivotFieldArea::Value),
+            Self::Filter => Some(PivotFieldArea::Filter),
+        }
+    }
+
+    fn owner(self) -> &'static str {
+        match self {
+            Self::All => "PivotHierarchy",
+            Self::Row | Self::Column => "RowColumnPivotHierarchy",
+            Self::Data => "DataPivotHierarchy",
+            Self::Filter => "FilterPivotHierarchy",
+        }
+    }
+}
+
+impl std::fmt::Display for PivotHierarchyKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::All => "PivotHierarchy",
+            Self::Row => "row hierarchy",
+            Self::Column => "column hierarchy",
+            Self::Data => "data hierarchy",
+            Self::Filter => "filter hierarchy",
+        })
+    }
+}
+
+/// One `{key, properties}` descriptor consumed by the shared collection hook.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct PivotHierarchyCollectionItem {
+    pub(crate) key: String,
+    pub(crate) properties: HashMap<String, Value>,
+}
+
+/// A resolved hierarchy identity.  The aggregate `hierarchies` collection is
+/// backed by `PivotTableConfig.fields`, while an axis collection is backed by
+/// one of the flat placement records.  Keeping these as distinct variants is
+/// deliberate: treating every item as a placement makes the all-fields path
+/// resolve to `None` and turns every lookup into `ItemNotFound`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum PivotHierarchyItemRef<'a> {
+    Field(&'a PivotField),
+    Placement(&'a PivotFieldPlacementFlat),
+}
+
+/// Return collection items for a current pivot config.
+pub(crate) fn collection_items(
+    config: &PivotTableConfig,
+    kind: PivotHierarchyKind,
+    properties: &[String],
+) -> Result<Vec<PivotHierarchyCollectionItem>, PivotHierarchyError> {
+    let mut result = Vec::new();
+    match kind {
+        PivotHierarchyKind::All => {
+            for field in &config.fields {
+                result.push(PivotHierarchyCollectionItem {
+                    key: field.id.to_string(),
+                    properties: hierarchy_properties(
+                        config,
+                        kind,
+                        &field.id.to_string(),
+                        properties,
+                    )?,
+                });
+            }
+        }
+        PivotHierarchyKind::Row
+        | PivotHierarchyKind::Column
+        | PivotHierarchyKind::Data
+        | PivotHierarchyKind::Filter => {
+            let placements = placements_for_area(config, kind);
+            for placement in placements {
+                result.push(PivotHierarchyCollectionItem {
+                    key: placement_key(placement),
+                    properties: hierarchy_properties(
+                        config,
+                        kind,
+                        &placement_key(placement),
+                        properties,
+                    )?,
+                });
+            }
+        }
+    }
+    Ok(result)
+}
+
+/// Load collection-level properties.  Collection items are requested through
+/// `items` or `items/<property>` paths and are returned as descriptors.
+pub(crate) fn load_collection(
+    config: &PivotTableConfig,
+    kind: PivotHierarchyKind,
+    properties: &[String],
+) -> Result<HashMap<String, Value>, PivotHierarchyError> {
+    let mut result = HashMap::new();
+    let mut item_properties = Vec::new();
+    let mut wants_items = false;
+    for property in properties {
+        if property == "items" {
+            wants_items = true;
+        } else if let Some(item_property) = property.strip_prefix("items/") {
+            if item_property.is_empty() {
+                return Err(unsupported(property, kind.owner()));
+            }
+            wants_items = true;
+            if !item_properties
+                .iter()
+                .any(|existing| existing == item_property)
+            {
+                item_properties.push(item_property.to_string());
+            }
+        } else if property == "isNullObject" {
+            result.insert(property.clone(), Value::Bool(false));
+        } else if property == "count" {
+            result.insert(property.clone(), json!(count(config, kind)));
+        } else {
+            return Err(unsupported(property, kind.owner()));
+        }
+    }
+    if wants_items {
+        result.insert(
+            "items".to_string(),
+            serde_json::to_value(collection_items(config, kind, &item_properties)?).map_err(
+                |error| PivotHierarchyError {
+                    code: "GeneralException",
+                    message: format!("failed to encode PivotHierarchy items: {error}"),
+                },
+            )?,
+        );
+    }
+    Ok(result)
+}
+
+/// Return the collection count without materializing item properties.
+pub(crate) fn count(config: &PivotTableConfig, kind: PivotHierarchyKind) -> usize {
+    match kind {
+        PivotHierarchyKind::All => config.fields.len(),
+        PivotHierarchyKind::Row
+        | PivotHierarchyKind::Column
+        | PivotHierarchyKind::Data
+        | PivotHierarchyKind::Filter => placements_for_area(config, kind).len(),
+    }
+}
+
+/// Resolve one collection item by its Office.js name or ID and return the
+/// requested scalar properties.  Name matching is case-insensitive, as it is
+/// for the Excel collection `getItem` methods.
+pub(crate) fn load_item(
+    config: &PivotTableConfig,
+    kind: PivotHierarchyKind,
+    key: &str,
+    properties: &[String],
+) -> Result<HashMap<String, Value>, PivotHierarchyError> {
+    let _ = resolve_item(config, kind, key)?;
+    hierarchy_properties(config, kind, key, properties)
+}
+
+/// Resolve whether a collection lookup has a matching item.
+pub(crate) fn contains_item(
+    config: &PivotTableConfig,
+    kind: PivotHierarchyKind,
+    key: &str,
+) -> bool {
+    resolve_item(config, kind, key).is_ok()
+}
+
+/// Apply one writable Office.js hierarchy property to a persisted config.
+///
+/// The caller is responsible for persisting the returned config through the
+/// PivotRef/engine update operation.  This function performs strict type and
+/// enum conversion, and therefore keeps the host adapter free of ad-hoc JSON
+/// translation.
+pub(crate) fn apply_set(
+    config: &mut PivotTableConfig,
+    kind: PivotHierarchyKind,
+    key: &str,
+    property: &str,
+    value: &Value,
+) -> Result<(), PivotHierarchyError> {
+    if kind == PivotHierarchyKind::All {
+        if property != "name" {
+            return Err(unsupported(property, kind.owner()));
+        }
+        let name = value
+            .as_str()
+            .ok_or_else(|| invalid("PivotHierarchy.name must be a string"))?;
+        let field = resolve_field_mut(config, key)?;
+        field.name = name.to_string();
+        return Ok(());
+    }
+
+    let placement_index = resolve_placement_index(config, kind, key)?;
+    match property {
+        "name" => {
+            let name = value
+                .as_str()
+                .ok_or_else(|| invalid(format!("{}.name must be a string", kind.owner())))?;
+            config.placements[placement_index].display_name = Some(name.to_string());
+        }
+        "position" => {
+            let position = value
+                .as_u64()
+                .and_then(|value| usize::try_from(value).ok())
+                .ok_or_else(|| {
+                    invalid(format!(
+                        "{}.position must be a non-negative integer",
+                        kind.owner()
+                    ))
+                })?;
+            let area = kind.area().expect("non-all hierarchy has an area");
+            // Reordering through the config primitive gives equal-position
+            // writes deterministic Office ordering: a hierarchy assigned an
+            // existing position is inserted after the item already there.
+            if !config.reorder_placement(placement_index, area, position) {
+                return Err(item_not_found(key, kind));
+            }
+        }
+        "enableMultipleFilterItems" if kind == PivotHierarchyKind::Filter => {
+            let enabled = value.as_bool().ok_or_else(|| {
+                invalid("FilterPivotHierarchy.enableMultipleFilterItems must be a boolean")
+            })?;
+            config.allow_multiple_filters_per_field = Some(enabled);
+        }
+        "numberFormat" if kind == PivotHierarchyKind::Data => {
+            let format = value
+                .as_str()
+                .ok_or_else(|| invalid("DataPivotHierarchy.numberFormat must be a string"))?;
+            config.placements[placement_index].number_format = Some(format.to_string());
+        }
+        "summarizeBy" if kind == PivotHierarchyKind::Data => {
+            let text = value
+                .as_str()
+                .ok_or_else(|| invalid("DataPivotHierarchy.summarizeBy must be a string"))?;
+            config.placements[placement_index].aggregate_function =
+                Some(aggregate_from_office(text)?);
+        }
+        "showAs" if kind == PivotHierarchyKind::Data => {
+            config.placements[placement_index].show_values_as = Some(show_as_from_office(value)?);
+        }
+        _ => return Err(unsupported(property, kind.owner())),
+    }
+    Ok(())
+}
+
+/// Reset an axis/filter/data hierarchy's optional placement state to Excel's
+/// default.  The all-fields collection has no `setToDefault` member.
+pub(crate) fn set_to_default(
+    config: &mut PivotTableConfig,
+    kind: PivotHierarchyKind,
+    key: &str,
+) -> Result<(), PivotHierarchyError> {
+    if kind == PivotHierarchyKind::All {
+        return Err(unsupported("setToDefault", kind.owner()));
+    }
+    let index = resolve_placement_index(config, kind, key)?;
+    let field_id = config.placements[index].field_id.clone();
+    let placement = &mut config.placements[index];
+    placement.display_name = None;
+    match kind {
+        PivotHierarchyKind::Row | PivotHierarchyKind::Column => {
+            placement.aggregate_function = None;
+            placement.number_format = None;
+            placement.show_values_as = None;
+            placement.sort_order = None;
+            placement.custom_sort_list = None;
+            placement.sort_by_value = None;
+            placement.date_grouping = None;
+            placement.number_grouping = None;
+            placement.show_subtotals = None;
+        }
+        PivotHierarchyKind::Data => {
+            placement.aggregate_function = Some(AggregateFunction::Sum);
+            placement.number_format = None;
+            placement.show_values_as = None;
+        }
+        PivotHierarchyKind::Filter => {}
+        PivotHierarchyKind::All => unreachable!(),
+    }
+    // The public pivot reset operation clears the field's filter alongside
+    // placement-specific options.  Keep that behavior for every hierarchy
+    // view so a reset cannot leave stale filtering in the materialized matrix.
+    config.filters.retain(|filter| filter.field_id != field_id);
+    Ok(())
+}
+
+/// Add a source hierarchy to one of the four mutable axis collections.
+/// Existing placements of the same field in another area are removed, as
+/// required by the Office.js `add(PivotHierarchy)` contract.
+pub(crate) fn add(
+    config: &mut PivotTableConfig,
+    kind: PivotHierarchyKind,
+    source_key: &str,
+) -> Result<String, PivotHierarchyError> {
+    let area = kind
+        .area()
+        .ok_or_else(|| invalid("PivotHierarchyCollection.add is unavailable on hierarchies"))?;
+    let field = resolve_field(config, source_key)?.clone();
+    let field_id = field.id.to_string();
+
+    // Excel moves an existing hierarchy between row, column, and filter
+    // collections.  Value placements are independent: a source field may be
+    // present on an axis and in the data area at the same time (for example,
+    // Region as row labels and Count of Region as a value).  Preserve value
+    // placements while moving among the three structural axes.
+    if let Some(existing) = config
+        .placements
+        .iter()
+        .find(|placement| placement.field_id == field.id && placement.area == area)
+    {
+        return Ok(placement_key(existing));
+    }
+    if area != PivotFieldArea::Value {
+        config.placements.retain(|placement| {
+            !(placement.field_id == field.id
+                && placement.area != area
+                && placement.area != PivotFieldArea::Value)
+        });
+    }
+
+    let position = config
+        .placements
+        .iter()
+        .filter(|placement| placement.area == area)
+        .count();
+    let placement_id = new_placement_id(config, kind, &field_id);
+    config.placements.push(PivotFieldPlacementFlat {
+        placement_id: placement_id.clone().into(),
+        field_id: field.id,
+        calculated_field_id: None,
+        area,
+        position,
+        aggregate_function: (kind == PivotHierarchyKind::Data).then_some(AggregateFunction::Sum),
+        sort_order: None,
+        custom_sort_list: None,
+        sort_by_value: None,
+        date_grouping: None,
+        number_grouping: None,
+        show_subtotals: None,
+        display_name: None,
+        number_format: None,
+        show_values_as: None,
+    });
+    reindex_area(config, area);
+    Ok(placement_id)
+}
+
+/// Remove a hierarchy placement from its current area.
+pub(crate) fn remove(
+    config: &mut PivotTableConfig,
+    kind: PivotHierarchyKind,
+    key: &str,
+) -> Result<(), PivotHierarchyError> {
+    let area = kind
+        .area()
+        .ok_or_else(|| invalid("PivotHierarchyCollection.remove is unavailable on hierarchies"))?;
+    let index = resolve_placement_index(config, kind, key)?;
+    config.placements.remove(index);
+    reindex_area(config, area);
+    Ok(())
+}
+
+fn placements_for_area(
+    config: &PivotTableConfig,
+    kind: PivotHierarchyKind,
+) -> Vec<&PivotFieldPlacementFlat> {
+    let Some(area) = kind.area() else {
+        return Vec::new();
+    };
+    let mut placements: Vec<_> = config
+        .placements
+        .iter()
+        .filter(|placement| placement.area == area)
+        .collect();
+    placements.sort_by_key(|placement| placement.position);
+    placements
+}
+
+/// Resolve a hierarchy against the current config.
+///
+/// This is intentionally public within the Office.js crate so the extension
+/// host can bind a hierarchy object using the same source-field lookup as
+/// collection loads.  In particular, `All` resolves from `config.fields`; it
+/// does not have a placement and must never be represented by `None`.
+pub(crate) fn resolve_item<'a>(
+    config: &'a PivotTableConfig,
+    kind: PivotHierarchyKind,
+    key: &str,
+) -> Result<PivotHierarchyItemRef<'a>, PivotHierarchyError> {
+    if kind == PivotHierarchyKind::All {
+        resolve_field(config, key).map(PivotHierarchyItemRef::Field)
+    } else {
+        resolve_placement(config, kind, key).map(PivotHierarchyItemRef::Placement)
+    }
+}
+
+/// Resolve the source field represented by a hierarchy item.
+///
+/// Axis placements carry only `field_id`, so the helper performs the second
+/// lookup for those views.  The all-fields view already resolves to its field
+/// directly and therefore succeeds even though it has no placement record.
+pub(crate) fn hierarchy_field<'a>(
+    config: &'a PivotTableConfig,
+    kind: PivotHierarchyKind,
+    key: &str,
+) -> Result<&'a PivotField, PivotHierarchyError> {
+    match resolve_item(config, kind, key)? {
+        PivotHierarchyItemRef::Field(field) => Ok(field),
+        PivotHierarchyItemRef::Placement(placement) => config
+            .get_field(placement.field_id.as_str())
+            .ok_or_else(|| item_not_found(key, kind)),
+    }
+}
+
+fn resolve_placement_index(
+    config: &PivotTableConfig,
+    kind: PivotHierarchyKind,
+    key: &str,
+) -> Result<usize, PivotHierarchyError> {
+    let area = kind
+        .area()
+        .ok_or_else(|| invalid("The all-fields hierarchy has no placement"))?;
+    config
+        .placements
+        .iter()
+        .position(|placement| placement.area == area && placement_matches(config, placement, key))
+        .ok_or_else(|| item_not_found(key, kind))
+}
+
+fn resolve_field<'a>(
+    config: &'a PivotTableConfig,
+    key: &str,
+) -> Result<&'a PivotField, PivotHierarchyError> {
+    config
+        .fields
+        .iter()
+        .find(|field| field_matches(field, key))
+        .ok_or_else(|| item_not_found(key, PivotHierarchyKind::All))
+}
+
+fn resolve_field_mut<'a>(
+    config: &'a mut PivotTableConfig,
+    key: &str,
+) -> Result<&'a mut PivotField, PivotHierarchyError> {
+    config
+        .fields
+        .iter_mut()
+        .find(|field| field_matches(field, key))
+        .ok_or_else(|| item_not_found(key, PivotHierarchyKind::All))
+}
+
+fn field_matches(field: &PivotField, key: &str) -> bool {
+    field.id.as_str().eq_ignore_ascii_case(key) || field.name.eq_ignore_ascii_case(key)
+}
+
+fn placement_matches(
+    config: &PivotTableConfig,
+    placement: &PivotFieldPlacementFlat,
+    key: &str,
+) -> bool {
+    placement.placement_id.as_str().eq_ignore_ascii_case(key)
+        || placement.field_id.as_str().eq_ignore_ascii_case(key)
+        || config
+            .get_field(placement.field_id.as_str())
+            .is_some_and(|field| field.name.eq_ignore_ascii_case(key))
+        || placement
+            .display_name
+            .as_deref()
+            .is_some_and(|name| name.eq_ignore_ascii_case(key))
+        // Data hierarchies expose Excel's generated "Sum of <field>" style
+        // name when no display override is stored.  Include that name in
+        // lookup so `getItem(data.name)` remains valid after a fresh read.
+        || (placement.area == PivotFieldArea::Value
+            && config.get_field(placement.field_id.as_str()).is_some_and(|field| {
+                let aggregate = placement
+                    .aggregate_function
+                    .unwrap_or(AggregateFunction::Sum);
+                format!("{} of {}", aggregate_label(aggregate), field.name)
+                    .eq_ignore_ascii_case(key)
+            }))
+}
+
+fn hierarchy_properties(
+    config: &PivotTableConfig,
+    kind: PivotHierarchyKind,
+    key: &str,
+    properties: &[String],
+) -> Result<HashMap<String, Value>, PivotHierarchyError> {
+    let mut result = HashMap::new();
+    let resolved = resolve_item(config, kind, key)?;
+    let (field, placement) = match resolved {
+        // `hierarchies` resolves directly to a source field.  It has no
+        // placement, but the field itself is a valid item and supplies id and
+        // name for all collection/object reads.
+        PivotHierarchyItemRef::Field(field) => (Some(field), None),
+        PivotHierarchyItemRef::Placement(placement) => (
+            config.get_field(placement.field_id.as_str()),
+            Some(placement),
+        ),
+    };
+
+    let default_properties: &[&str] = match kind {
+        PivotHierarchyKind::All => &["id", "name"],
+        PivotHierarchyKind::Row | PivotHierarchyKind::Column => &["id", "name", "position"],
+        PivotHierarchyKind::Filter => &["enableMultipleFilterItems", "id", "name", "position"],
+        PivotHierarchyKind::Data => &[
+            "field",
+            "id",
+            "name",
+            "numberFormat",
+            "position",
+            "showAs",
+            "summarizeBy",
+        ],
+    };
+    let properties: Vec<String> = if properties.is_empty() {
+        default_properties
+            .iter()
+            .map(|property| (*property).to_string())
+            .collect()
+    } else {
+        properties.to_vec()
+    };
+    for property in &properties {
+        match property.as_str() {
+            "isNullObject" => {
+                result.insert(property.clone(), Value::Bool(false));
+            }
+            "id" => {
+                let id = placement
+                    .as_ref()
+                    .map(|placement| placement.field_id.to_string())
+                    .or_else(|| field.map(|field| field.id.to_string()))
+                    .ok_or_else(|| item_not_found(key, kind))?;
+                result.insert(property.clone(), Value::String(id));
+            }
+            "name" => {
+                let name = display_name(config, kind, key)?;
+                result.insert(property.clone(), Value::String(name));
+            }
+            "position" if kind != PivotHierarchyKind::All => {
+                result.insert(
+                    property.clone(),
+                    json!(placement.as_ref().expect("placement loaded").position),
+                );
+            }
+            "enableMultipleFilterItems" if kind == PivotHierarchyKind::Filter => {
+                result.insert(
+                    property.clone(),
+                    json!(config.allow_multiple_filters_per_field.unwrap_or(false)),
+                );
+            }
+            "numberFormat" if kind == PivotHierarchyKind::Data => {
+                result.insert(
+                    property.clone(),
+                    Value::String(
+                        placement
+                            .as_ref()
+                            .expect("placement loaded")
+                            .number_format
+                            .clone()
+                            .unwrap_or_else(|| "General".to_string()),
+                    ),
+                );
+            }
+            "summarizeBy" if kind == PivotHierarchyKind::Data => {
+                let aggregate = placement
+                    .as_ref()
+                    .expect("placement loaded")
+                    .aggregate_function
+                    .unwrap_or(AggregateFunction::Sum);
+                result.insert(
+                    property.clone(),
+                    Value::String(aggregate_to_office(aggregate)),
+                );
+            }
+            "showAs" if kind == PivotHierarchyKind::Data => {
+                let show_as = placement
+                    .as_ref()
+                    .expect("placement loaded")
+                    .show_values_as
+                    .as_ref()
+                    .map(show_as_to_office)
+                    .unwrap_or_else(|| json!({"calculation": "None"}));
+                result.insert(property.clone(), show_as);
+            }
+            "field" if kind == PivotHierarchyKind::Data => {
+                let field = field.ok_or_else(|| item_not_found(key, kind))?;
+                result.insert(
+                    property.clone(),
+                    json!({"id": field.id, "name": field.name}),
+                );
+            }
+            other => return Err(unsupported(other, kind.owner())),
+        }
+    }
+    Ok(result)
+}
+
+fn resolve_placement<'a>(
+    config: &'a PivotTableConfig,
+    kind: PivotHierarchyKind,
+    key: &str,
+) -> Result<&'a PivotFieldPlacementFlat, PivotHierarchyError> {
+    let area = kind
+        .area()
+        .ok_or_else(|| invalid("The all-fields hierarchy has no placement"))?;
+    config
+        .placements
+        .iter()
+        .filter(|placement| placement.area == area)
+        .find(|placement| placement_matches(config, placement, key))
+        .ok_or_else(|| item_not_found(key, kind))
+}
+
+fn display_name(
+    config: &PivotTableConfig,
+    kind: PivotHierarchyKind,
+    key: &str,
+) -> Result<String, PivotHierarchyError> {
+    if kind == PivotHierarchyKind::All {
+        return Ok(resolve_field(config, key)?.name.clone());
+    }
+    let placement = resolve_placement(config, kind, key)?;
+    if let Some(name) = placement.display_name.clone() {
+        return Ok(name);
+    }
+    let field = config
+        .get_field(placement.field_id.as_str())
+        .ok_or_else(|| item_not_found(key, kind))?;
+    if kind == PivotHierarchyKind::Data {
+        let aggregate = placement
+            .aggregate_function
+            .unwrap_or(AggregateFunction::Sum);
+        Ok(format!("{} of {}", aggregate_label(aggregate), field.name))
+    } else {
+        Ok(field.name.clone())
+    }
+}
+
+fn placement_key(placement: &PivotFieldPlacementFlat) -> String {
+    if placement.placement_id.is_empty() {
+        placement.field_id.to_string()
+    } else {
+        placement.placement_id.to_string()
+    }
+}
+
+fn aggregate_to_office(aggregate: AggregateFunction) -> String {
+    match aggregate {
+        AggregateFunction::Sum => "Sum",
+        AggregateFunction::Count | AggregateFunction::CountA => "Count",
+        AggregateFunction::Average => "Average",
+        AggregateFunction::Max => "Max",
+        AggregateFunction::Min => "Min",
+        AggregateFunction::Product => "Product",
+        AggregateFunction::CountUnique => "Count",
+        AggregateFunction::StdDev => "StandardDeviation",
+        AggregateFunction::StdDevP => "StandardDeviationP",
+        AggregateFunction::Var => "Variance",
+        AggregateFunction::VarP => "VarianceP",
+        _ => "Sum",
+    }
+    .to_string()
+}
+
+fn aggregate_from_office(value: &str) -> Result<AggregateFunction, PivotHierarchyError> {
+    match value {
+        "Unknown" | "Automatic" | "Sum" => Ok(AggregateFunction::Sum),
+        "Count" => Ok(AggregateFunction::Count),
+        "Average" => Ok(AggregateFunction::Average),
+        "Max" => Ok(AggregateFunction::Max),
+        "Min" => Ok(AggregateFunction::Min),
+        "Product" => Ok(AggregateFunction::Product),
+        "CountNumbers" => Ok(AggregateFunction::Count),
+        "StandardDeviation" => Ok(AggregateFunction::StdDev),
+        "StandardDeviationP" => Ok(AggregateFunction::StdDevP),
+        "Variance" => Ok(AggregateFunction::Var),
+        "VarianceP" => Ok(AggregateFunction::VarP),
+        _ => Err(invalid(format!(
+            "DataPivotHierarchy.summarizeBy has an invalid value '{value}'"
+        ))),
+    }
+}
+
+fn aggregate_label(aggregate: AggregateFunction) -> &'static str {
+    match aggregate {
+        AggregateFunction::Count | AggregateFunction::CountA | AggregateFunction::CountUnique => {
+            "Count"
+        }
+        AggregateFunction::Average => "Average",
+        AggregateFunction::Max => "Max",
+        AggregateFunction::Min => "Min",
+        AggregateFunction::Product => "Product",
+        AggregateFunction::StdDev => "StdDev",
+        AggregateFunction::StdDevP => "StdDevP",
+        AggregateFunction::Var => "Var",
+        AggregateFunction::VarP => "VarP",
+        AggregateFunction::Sum => "Sum",
+        _ => "Sum",
+    }
+}
+
+fn show_as_to_office(config: &ShowValuesAsConfig) -> Value {
+    let calculation = match config.calculation_type {
+        ShowValuesAs::NoCalculation => "None",
+        ShowValuesAs::PercentOfGrandTotal => "PercentOfGrandTotal",
+        ShowValuesAs::PercentOfColumnTotal => "PercentOfColumnTotal",
+        ShowValuesAs::PercentOfRowTotal => "PercentOfRowTotal",
+        ShowValuesAs::PercentOfParentRowTotal => "PercentOfParentRowTotal",
+        ShowValuesAs::PercentOfParentColumnTotal => "PercentOfParentColumnTotal",
+        ShowValuesAs::Difference => "DifferenceFrom",
+        ShowValuesAs::PercentDifference => "PercentDifferenceFrom",
+        ShowValuesAs::RunningTotal => "RunningTotal",
+        ShowValuesAs::PercentRunningTotal => "PercentRunningTotal",
+        ShowValuesAs::RankAscending => "RankAscending",
+        ShowValuesAs::RankDescending => "RankDecending",
+        ShowValuesAs::Index => "Index",
+        _ => "None",
+    };
+    let mut object = serde_json::Map::new();
+    object.insert(
+        "calculation".to_string(),
+        Value::String(calculation.to_string()),
+    );
+    if let Some(field) = &config.base_field {
+        object.insert("baseField".to_string(), json!({"id": field}));
+    }
+    if let Some(item) = &config.base_item {
+        object.insert("baseItem".to_string(), show_as_base_item_to_office(item));
+    }
+    Value::Object(object)
+}
+
+fn show_as_base_item_to_office(item: &ShowValuesAsBaseItem) -> Value {
+    match item {
+        ShowValuesAsBaseItem::Relative { position } => json!({
+            "type": "relative",
+            "position": match position {
+                domain_types::domain::pivot::RelativePosition::Previous => "previous",
+                domain_types::domain::pivot::RelativePosition::Next => "next",
+                _ => "previous",
+            },
+        }),
+        ShowValuesAsBaseItem::Specific { value } => json!({"type": "specific", "value": value}),
+    }
+}
+
+fn show_as_from_office(value: &Value) -> Result<ShowValuesAsConfig, PivotHierarchyError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid("DataPivotHierarchy.showAs must be an object"))?;
+    let calculation = object
+        .get("calculation")
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid("DataPivotHierarchy.showAs.calculation is required"))?;
+    let calculation_type = match calculation {
+        "Unknown" | "None" => ShowValuesAs::NoCalculation,
+        "PercentOfGrandTotal" => ShowValuesAs::PercentOfGrandTotal,
+        "PercentOfColumnTotal" => ShowValuesAs::PercentOfColumnTotal,
+        "PercentOfRowTotal" => ShowValuesAs::PercentOfRowTotal,
+        "PercentOfParentRowTotal" => ShowValuesAs::PercentOfParentRowTotal,
+        "PercentOfParentColumnTotal" | "PercentOfParentTotal" => {
+            ShowValuesAs::PercentOfParentColumnTotal
+        }
+        "DifferenceFrom" => ShowValuesAs::Difference,
+        "PercentDifferenceFrom" => ShowValuesAs::PercentDifference,
+        "RunningTotal" => ShowValuesAs::RunningTotal,
+        "PercentRunningTotal" => ShowValuesAs::PercentRunningTotal,
+        "RankAscending" => ShowValuesAs::RankAscending,
+        "RankDecending" => ShowValuesAs::RankDescending,
+        "Index" => ShowValuesAs::Index,
+        _ => {
+            return Err(invalid(format!(
+                "DataPivotHierarchy.showAs.calculation has an invalid value '{calculation}'"
+            )));
+        }
+    };
+    let base_field = object
+        .get("baseField")
+        .and_then(|value| value.get("id").or_else(|| value.get("name")))
+        .and_then(Value::as_str)
+        .map(domain_types::domain::pivot::FieldId::from);
+    let base_item = parse_show_as_base_item(object.get("baseItem"))?;
+    Ok(ShowValuesAsConfig {
+        calculation_type,
+        base_field,
+        base_item,
+    })
+}
+
+fn parse_show_as_base_item(
+    value: Option<&Value>,
+) -> Result<Option<ShowValuesAsBaseItem>, PivotHierarchyError> {
+    let Some(value) = value else { return Ok(None) };
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid("DataPivotHierarchy.showAs.baseItem must be an object"))?;
+    let item_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid("DataPivotHierarchy.showAs.baseItem.type is required"))?;
+    match item_type {
+        "relative" => {
+            let position = match object.get("position").and_then(Value::as_str) {
+                Some("previous") => domain_types::domain::pivot::RelativePosition::Previous,
+                Some("next") => domain_types::domain::pivot::RelativePosition::Next,
+                Some(other) => {
+                    return Err(invalid(format!(
+                        "DataPivotHierarchy.showAs.baseItem.position has an invalid value '{other}'"
+                    )));
+                }
+                None => {
+                    return Err(invalid(
+                        "DataPivotHierarchy.showAs.baseItem.position is required",
+                    ));
+                }
+            };
+            Ok(Some(ShowValuesAsBaseItem::Relative { position }))
+        }
+        "specific" => {
+            let raw = object
+                .get("value")
+                .cloned()
+                .or_else(|| object.get("name").cloned())
+                .or_else(|| object.get("id").cloned())
+                .ok_or_else(|| invalid("DataPivotHierarchy.showAs.baseItem.value is required"))?;
+            let value = serde_json::from_value::<CellValue>(raw).map_err(|error| {
+                invalid(format!(
+                    "DataPivotHierarchy.showAs.baseItem.value is invalid: {error}"
+                ))
+            })?;
+            Ok(Some(ShowValuesAsBaseItem::Specific { value }))
+        }
+        other => Err(invalid(format!(
+            "DataPivotHierarchy.showAs.baseItem.type has an invalid value '{other}'"
+        ))),
+    }
+}
+
+fn new_placement_id(config: &PivotTableConfig, kind: PivotHierarchyKind, field_id: &str) -> String {
+    let prefix = match kind {
+        PivotHierarchyKind::All => "all",
+        PivotHierarchyKind::Row => "row",
+        PivotHierarchyKind::Column => "column",
+        PivotHierarchyKind::Data => "data",
+        PivotHierarchyKind::Filter => "filter",
+    };
+    let stem = format!("officejs-{prefix}-{field_id}");
+    if !config
+        .placements
+        .iter()
+        .any(|placement| placement.placement_id.as_str() == stem)
+    {
+        return stem;
+    }
+    for suffix in 1..usize::MAX {
+        let candidate = format!("{stem}-{suffix}");
+        if !config
+            .placements
+            .iter()
+            .any(|placement| placement.placement_id.as_str() == candidate)
+        {
+            return candidate;
+        }
+    }
+    // The loop above cannot realistically exhaust a pivot config, but keeping
+    // a deterministic fallback avoids an unwrap in a host-facing path.
+    format!("{stem}-overflow")
+}
+
+fn reindex_area(config: &mut PivotTableConfig, area: PivotFieldArea) {
+    let mut indices: Vec<usize> = config
+        .placements
+        .iter()
+        .enumerate()
+        .filter(|(_, placement)| placement.area == area)
+        .map(|(index, _)| index)
+        .collect();
+    indices.sort_by_key(|index| config.placements[*index].position);
+    for (position, index) in indices.into_iter().enumerate() {
+        config.placements[index].position = position;
+    }
+}

--- a/compute/officejs/src/protection.js
+++ b/compute/officejs/src/protection.js
@@ -1,0 +1,323 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs;
+
+  function richApiError(code, message) {
+    var error = new OfficeExtension.Error({ code: code, message: message });
+    error.name = "RichApi.Error";
+    error.code = code;
+    return error;
+  }
+
+  function propertyNotLoaded(name) {
+    return richApiError(
+      "PropertyNotLoaded",
+      "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context."
+    );
+  }
+
+  function invalidArgument(message) {
+    return richApiError("InvalidArgument", message);
+  }
+
+  function unsupported(message) {
+    return richApiError("ApiNotFound", message);
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object";
+  }
+
+  function isPlainObject(value) {
+    if (!isObject(value)) return false;
+    var prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  }
+
+  var optionNames = [
+    "allowAutoFilter",
+    "allowDeleteColumns",
+    "allowDeleteRows",
+    "allowEditObjects",
+    "allowEditScenarios",
+    "allowFormatCells",
+    "allowFormatColumns",
+    "allowFormatRows",
+    "allowInsertColumns",
+    "allowInsertHyperlinks",
+    "allowInsertRows",
+    "allowPivotTables",
+    "allowSort",
+    "selectionMode",
+  ];
+
+  function normalizeOptions(value) {
+    if (value === undefined) return null;
+    if (!isPlainObject(value)) {
+      throw invalidArgument("WorksheetProtection.protect options must be an object");
+    }
+    var result = {};
+    Object.keys(value).forEach(function (name) {
+      if (optionNames.indexOf(name) < 0) {
+        throw invalidArgument(
+          "Unsupported WorksheetProtectionOptions property '" + name + "'"
+        );
+      }
+      if (value[name] === undefined) return;
+      if (name === "selectionMode") {
+        if (["Normal", "Unlocked", "None"].indexOf(value[name]) < 0) {
+          throw invalidArgument(
+            "WorksheetProtectionOptions.selectionMode must be Normal, Unlocked, or None"
+          );
+        }
+      } else if (typeof value[name] !== "boolean") {
+        throw invalidArgument(
+          "WorksheetProtectionOptions." + name + " must be a boolean"
+        );
+      }
+      result[name] = value[name];
+    });
+    return result;
+  }
+
+  function normalizePassword(value, member) {
+    // Office's optional string arguments are commonly passed as null by
+    // JavaScript callers. Treat null like an omitted password; the host only
+    // receives the transient value and hashes it before invoking the engine.
+    if (value === undefined || value === null) return null;
+    if (typeof value !== "string") {
+      throw invalidArgument(member + " password must be a string");
+    }
+    return value;
+  }
+
+  function newClientResult(context) {
+    if (officeJs && typeof officeJs.createClientResult === "function") {
+      return officeJs.createClientResult(context);
+    }
+    return new OfficeExtension.ClientResult(context);
+  }
+
+  var worksheetProtectionScalars = [
+    "protected",
+    "isPasswordProtected",
+    "options",
+    "savedOptions",
+  ];
+
+  function WorksheetProtection(context, worksheet) {
+    ClientObject.call(this, context);
+    this._worksheet = worksheet;
+    this._scalarProperties = worksheetProtectionScalars.slice();
+    this.context._queue.push({
+      op: "getWorksheetProtection",
+      id: this._id,
+      worksheetId: worksheet._id,
+    });
+  }
+  WorksheetProtection.prototype = Object.create(ClientObject.prototype);
+  WorksheetProtection.prototype.constructor = WorksheetProtection;
+
+  worksheetProtectionScalars.forEach(function (name) {
+    Object.defineProperty(WorksheetProtection.prototype, name, {
+      configurable: true,
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+    });
+  });
+
+  ["canPauseProtection", "isPaused"].forEach(function (name) {
+    Object.defineProperty(WorksheetProtection.prototype, name, {
+      configurable: true,
+      get: function () {
+        throw unsupported(
+          "WorksheetProtection." + name + " is unavailable because protection pause is not implemented"
+        );
+      },
+    });
+  });
+
+  Object.defineProperty(WorksheetProtection.prototype, "allowEditRanges", {
+    configurable: true,
+    get: function () {
+      throw unsupported(
+        "WorksheetProtection.allowEditRanges is unavailable because allow-edit ranges are not implemented"
+      );
+    },
+  });
+
+  WorksheetProtection.prototype.protect = function (options, password) {
+    if (typeof options === "string") {
+      throw invalidArgument(
+        "WorksheetProtection.protect expects options as its first argument and password as its second argument"
+      );
+    }
+    var normalizedOptions = normalizeOptions(options);
+    var normalizedPassword = normalizePassword(
+      password,
+      "WorksheetProtection.protect"
+    );
+    this.context._queue.push({
+      op: "worksheetProtectionProtect",
+      id: this._id,
+      options: normalizedOptions,
+      password: normalizedPassword,
+    });
+  };
+
+  WorksheetProtection.prototype.unprotect = function (password) {
+    var normalizedPassword = normalizePassword(
+      password,
+      "WorksheetProtection.unprotect"
+    );
+    this.context._queue.push({
+      op: "worksheetProtectionUnprotect",
+      id: this._id,
+      password: normalizedPassword,
+    });
+  };
+
+  WorksheetProtection.prototype.checkPassword = function (password) {
+    var normalizedPassword = normalizePassword(
+      password,
+      "WorksheetProtection.checkPassword"
+    );
+    var result = newClientResult(this.context);
+    this.context._queue.push({
+      op: "worksheetProtectionCheckPassword",
+      id: this._id,
+      resultId: result._id,
+      password: normalizedPassword,
+    });
+    return result;
+  };
+
+  WorksheetProtection.prototype.updateOptions = function (options) {
+    if (options === undefined) {
+      throw invalidArgument("WorksheetProtection.updateOptions requires options");
+    }
+    this.context._queue.push({
+      op: "worksheetProtectionUpdateOptions",
+      id: this._id,
+      options: normalizeOptions(options),
+    });
+  };
+
+  WorksheetProtection.prototype.pauseProtection = function () {
+    throw unsupported(
+      "WorksheetProtection.pauseProtection is unavailable because protection pause is not implemented"
+    );
+  };
+
+  WorksheetProtection.prototype.resumeProtection = function () {
+    throw unsupported(
+      "WorksheetProtection.resumeProtection is unavailable because protection pause is not implemented"
+    );
+  };
+
+  WorksheetProtection.prototype.setPassword = function () {
+    throw unsupported(
+      "WorksheetProtection.setPassword is unavailable because session-scoped protection pause is not implemented"
+    );
+  };
+
+  WorksheetProtection.prototype.toJSON = function () {
+    var result = {};
+    worksheetProtectionScalars.forEach(function (name) {
+      if (this._loaded[name]) result[name] = this["_" + name];
+    }, this);
+    return result;
+  };
+
+  function WorkbookProtection(context, workbook) {
+    ClientObject.call(this, context);
+    this._workbook = workbook;
+    this._scalarProperties = ["protected"];
+    this.context._queue.push({
+      op: "getWorkbookProtection",
+      id: this._id,
+    });
+  }
+  WorkbookProtection.prototype = Object.create(ClientObject.prototype);
+  WorkbookProtection.prototype.constructor = WorkbookProtection;
+
+  Object.defineProperty(WorkbookProtection.prototype, "protected", {
+    configurable: true,
+    get: function () {
+      if (!this._loaded.protected) throw propertyNotLoaded("protected");
+      return this._protected;
+    },
+  });
+
+  WorkbookProtection.prototype.protect = function (password) {
+    var normalizedPassword = normalizePassword(
+      password,
+      "WorkbookProtection.protect"
+    );
+    this.context._queue.push({
+      op: "workbookProtectionProtect",
+      id: this._id,
+      password: normalizedPassword,
+    });
+  };
+
+  WorkbookProtection.prototype.unprotect = function (password) {
+    var normalizedPassword = normalizePassword(
+      password,
+      "WorkbookProtection.unprotect"
+    );
+    this.context._queue.push({
+      op: "workbookProtectionUnprotect",
+      id: this._id,
+      password: normalizedPassword,
+    });
+  };
+
+  WorkbookProtection.prototype.toJSON = function () {
+    return this._loaded.protected ? { protected: this._protected } : {};
+  };
+
+  function worksheetProtection(worksheet) {
+    if (!worksheet._protection) {
+      worksheet._protection = new WorksheetProtection(worksheet.context, worksheet);
+    }
+    return worksheet._protection;
+  }
+
+  function workbookProtection(workbook) {
+    if (!workbook._protection) {
+      workbook._protection = new WorkbookProtection(workbook.context, workbook);
+    }
+    return workbook._protection;
+  }
+
+  Object.defineProperty(Excel.Worksheet.prototype, "protection", {
+    configurable: true,
+    get: function () {
+      return worksheetProtection(this);
+    },
+  });
+
+  Object.defineProperty(Excel.Workbook.prototype, "protection", {
+    configurable: true,
+    get: function () {
+      return workbookProtection(this);
+    },
+  });
+
+  if (officeJs && officeJs.addNavigationProperties) {
+    officeJs.addNavigationProperties(Excel.Worksheet.prototype, ["protection"]);
+    officeJs.addNavigationProperties(Excel.Workbook.prototype, ["protection"]);
+  }
+
+  Excel.WorksheetProtection = WorksheetProtection;
+  Excel.WorkbookProtection = WorkbookProtection;
+})(globalThis);

--- a/compute/officejs/src/protection.rs
+++ b/compute/officejs/src/protection.rs
@@ -1,0 +1,491 @@
+//! Office.js worksheet and workbook protection adapters.
+//!
+//! The Office.js protection objects are request-context proxies.  This module
+//! owns only the host-side references and the translation between the public
+//! Office option names and the durable compute-api protection state.  Password
+//! strings are converted to Excel's legacy worksheet/workbook hash at the
+//! boundary and are never retained on a proxy or in host state.
+
+use std::collections::HashMap;
+
+use compute_api::{ComputeApiError, Sheet, SheetProtectionOptions, Workbook};
+use serde_json::{Value, json};
+
+/// Error returned by an Office.js protection host operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProtectionError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+/// Host-side worksheet protection reference.
+///
+/// The reference is anchored by the engine's stable [`Sheet`] handle.  Every
+/// query resolves the current engine state, so a fresh Office.js protection
+/// proxy observes protection changes made by another request context.
+#[derive(Clone)]
+pub(crate) struct WorksheetProtectionRef {
+    workbook: Workbook,
+    sheet: Sheet,
+}
+
+impl WorksheetProtectionRef {
+    pub(crate) fn new(workbook: Workbook, sheet: Sheet) -> Self {
+        Self { workbook, sheet }
+    }
+
+    /// Load scalar properties exposed by the supported Office.js contract.
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, ProtectionError> {
+        let config = self
+            .sheet
+            .protection()
+            .get_config()
+            .map_err(compute_error)?;
+        let settings = self
+            .workbook
+            .sheets()
+            .get_sheet_settings(self.sheet.id())
+            .map_err(compute_error)?;
+        let options = settings.protection_options.unwrap_or_default();
+
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                // The host may ask for this inherited transport property
+                // explicitly; ordinary protection proxies are always real
+                // objects (there is no `getOrNullObject` protection API).
+                "isNullObject" => Value::Bool(false),
+                "protected" => Value::Bool(config.is_protected),
+                "isPasswordProtected" => Value::Bool(
+                    config
+                        .protection_password_hash
+                        .as_deref()
+                        .is_some_and(|hash| !hash.is_empty()),
+                ),
+                "options" | "savedOptions" => options_to_json(&options)?,
+                // The engine has no session-scoped pause state or edit-range
+                // collection.  Keep those members explicit instead of
+                // manufacturing values from the durable protection flag.
+                "canPauseProtection" | "isPaused" | "allowEditRanges" => {
+                    return Err(unsupported(format!(
+                        "WorksheetProtection.{property} is unavailable because protection pause and allow-edit ranges are not implemented"
+                    )));
+                }
+                other => return Err(unsupported_load_property("WorksheetProtection", other)),
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    /// Protect the worksheet, optionally replacing its complete option set.
+    pub(crate) fn protect(
+        &self,
+        options: Option<&Value>,
+        password: Option<&str>,
+    ) -> Result<(), ProtectionError> {
+        let config = self
+            .sheet
+            .protection()
+            .get_config()
+            .map_err(compute_error)?;
+        if config.is_protected {
+            return Err(invalid_operation(
+                "WorksheetProtection.protect cannot protect an already protected worksheet",
+            ));
+        }
+
+        let password_hash = password_hash(password);
+        match options {
+            Some(value) => {
+                let options = options_from_json(value, SheetProtectionOptions::default())?;
+                self.sheet
+                    .protection()
+                    .protect_with_options(password_hash, options)
+                    .map_err(compute_error)?;
+            }
+            None => {
+                // The engine's protect_sheet path preserves saved options,
+                // matching Office's omitted-options behavior.
+                self.sheet
+                    .protection()
+                    .protect(password_hash)
+                    .map_err(compute_error)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Unprotect the worksheet using the engine's password enforcement.
+    pub(crate) fn unprotect(&self, password: Option<&str>) -> Result<(), ProtectionError> {
+        self.sheet
+            .protection()
+            .unprotect(password_hash(password))
+            .map_err(compute_error)?;
+        Ok(())
+    }
+
+    /// Check a password without changing worksheet protection state.
+    pub(crate) fn check_password(&self, password: Option<&str>) -> Result<bool, ProtectionError> {
+        let config = self
+            .sheet
+            .protection()
+            .get_config()
+            .map_err(compute_error)?;
+        match (
+            config
+                .protection_password_hash
+                .as_deref()
+                .filter(|hash| !hash.is_empty()),
+            password,
+        ) {
+            (Some(stored), Some(provided)) => {
+                Ok(stored == password_hash(Some(provided)).as_deref().unwrap_or_default())
+            }
+            (Some(_), None) => Ok(false),
+            (None, Some(_)) => Ok(false),
+            // With no password required, an omitted password is usable to
+            // unlock the worksheet.  A supplied password is explicitly not.
+            (None, None) => Ok(true),
+        }
+    }
+
+    /// Update worksheet protection options while preserving state/password.
+    pub(crate) fn update_options(&self, value: &Value) -> Result<(), ProtectionError> {
+        let config = self
+            .sheet
+            .protection()
+            .get_config()
+            .map_err(compute_error)?;
+        if config.is_protected {
+            return Err(access_denied(
+                "WorksheetProtection.updateOptions requires protection to be disabled or paused",
+            ));
+        }
+
+        let current = self
+            .workbook
+            .sheets()
+            .get_sheet_settings(self.sheet.id())
+            .map_err(compute_error)?
+            .protection_options
+            .unwrap_or_default();
+        let options = options_from_json(value, current)?;
+        self.sheet
+            .protection()
+            .set_options(options)
+            .map_err(compute_error)?;
+        Ok(())
+    }
+}
+
+/// Host-side workbook protection reference.
+#[derive(Clone)]
+pub(crate) struct WorkbookProtectionRef {
+    workbook: Workbook,
+}
+
+impl WorkbookProtectionRef {
+    pub(crate) fn new(workbook: Workbook) -> Self {
+        Self { workbook }
+    }
+
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, ProtectionError> {
+        let protected = self
+            .workbook
+            .protection()
+            .is_workbook_protected()
+            .map_err(compute_error)?;
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                "isNullObject" => Value::Bool(false),
+                "protected" => Value::Bool(protected),
+                other => return Err(unsupported_load_property("WorkbookProtection", other)),
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn protect(&self, password: Option<&str>) -> Result<(), ProtectionError> {
+        if self
+            .workbook
+            .protection()
+            .is_workbook_protected()
+            .map_err(compute_error)?
+        {
+            return Err(invalid_operation(
+                "WorkbookProtection.protect cannot protect an already protected workbook",
+            ));
+        }
+        self.workbook
+            .protection()
+            .protect_workbook(password_hash(password))
+            .map_err(compute_error)?;
+        Ok(())
+    }
+
+    pub(crate) fn unprotect(&self, password: Option<&str>) -> Result<(), ProtectionError> {
+        let result = self
+            .workbook
+            .protection()
+            .unprotect_workbook(password_hash(password))
+            .map_err(compute_error)?;
+        // The workbook engine reports a password mismatch as successful
+        // dispatch with `MutationResult.data == false` (the sheet engine
+        // returns an error directly).  Normalize that engine result to the
+        // Office.js InvalidArgument contract without weakening the engine's
+        // password check or retaining the supplied password.
+        if result.data.as_ref().and_then(Value::as_bool) == Some(false) {
+            return Err(invalid_argument("Incorrect password"));
+        }
+        Ok(())
+    }
+}
+
+fn options_to_json(options: &SheetProtectionOptions) -> Result<Value, ProtectionError> {
+    Ok(json!({
+        "allowAutoFilter": options.use_auto_filter,
+        "allowDeleteColumns": options.delete_columns,
+        "allowDeleteRows": options.delete_rows,
+        "allowEditObjects": options.edit_objects,
+        "allowEditScenarios": options.edit_scenarios,
+        "allowFormatCells": options.format_cells,
+        "allowFormatColumns": options.format_columns,
+        "allowFormatRows": options.format_rows,
+        "allowInsertColumns": options.insert_columns,
+        "allowInsertHyperlinks": options.insert_hyperlinks,
+        "allowInsertRows": options.insert_rows,
+        "allowPivotTables": options.use_pivot_table_reports,
+        "allowSort": options.sort,
+        "selectionMode": selection_mode(options)?,
+    }))
+}
+
+fn selection_mode(options: &SheetProtectionOptions) -> Result<&'static str, ProtectionError> {
+    match (options.select_locked_cells, options.select_unlocked_cells) {
+        (true, true) => Ok("Normal"),
+        (false, true) => Ok("Unlocked"),
+        (false, false) => Ok("None"),
+        (true, false) => Err(unsupported(
+            "WorksheetProtection.options contains a selection combination with no Office.js selectionMode equivalent",
+        )),
+    }
+}
+
+fn options_from_json(
+    value: &Value,
+    mut options: SheetProtectionOptions,
+) -> Result<SheetProtectionOptions, ProtectionError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid_argument("WorksheetProtectionOptions must be a plain object"))?;
+    for (property, value) in object {
+        if value.is_null() {
+            return Err(invalid_argument(format!(
+                "WorksheetProtectionOptions.{property} cannot be null"
+            )));
+        }
+        match property.as_str() {
+            "allowAutoFilter" => options.use_auto_filter = bool_value(value, property)?,
+            "allowDeleteColumns" => options.delete_columns = bool_value(value, property)?,
+            "allowDeleteRows" => options.delete_rows = bool_value(value, property)?,
+            "allowEditObjects" => options.edit_objects = bool_value(value, property)?,
+            "allowEditScenarios" => options.edit_scenarios = bool_value(value, property)?,
+            "allowFormatCells" => options.format_cells = bool_value(value, property)?,
+            "allowFormatColumns" => options.format_columns = bool_value(value, property)?,
+            "allowFormatRows" => options.format_rows = bool_value(value, property)?,
+            "allowInsertColumns" => options.insert_columns = bool_value(value, property)?,
+            "allowInsertHyperlinks" => options.insert_hyperlinks = bool_value(value, property)?,
+            "allowInsertRows" => options.insert_rows = bool_value(value, property)?,
+            "allowPivotTables" => options.use_pivot_table_reports = bool_value(value, property)?,
+            "allowSort" => options.sort = bool_value(value, property)?,
+            "selectionMode" => match value.as_str() {
+                Some("Normal") => {
+                    options.select_locked_cells = true;
+                    options.select_unlocked_cells = true;
+                }
+                Some("Unlocked") => {
+                    options.select_locked_cells = false;
+                    options.select_unlocked_cells = true;
+                }
+                Some("None") => {
+                    options.select_locked_cells = false;
+                    options.select_unlocked_cells = false;
+                }
+                Some(other) => {
+                    return Err(invalid_argument(format!(
+                        "Unsupported WorksheetProtectionOptions.selectionMode value '{other}'"
+                    )));
+                }
+                None => {
+                    return Err(invalid_argument(
+                        "WorksheetProtectionOptions.selectionMode must be a string enum value",
+                    ));
+                }
+            },
+            other => {
+                return Err(invalid_argument(format!(
+                    "Unsupported WorksheetProtectionOptions property '{other}'"
+                )));
+            }
+        }
+    }
+    Ok(options)
+}
+
+fn bool_value(value: &Value, property: &str) -> Result<bool, ProtectionError> {
+    value.as_bool().ok_or_else(|| {
+        invalid_argument(format!(
+            "WorksheetProtectionOptions.{property} must be a boolean"
+        ))
+    })
+}
+
+/// Excel's legacy worksheet/workbook password hash.
+///
+/// This is the same byte-oriented legacy hash used by the OOXML writer in
+/// `file-io/xlsx/parser`.  Protection stores this value in the engine; keeping
+/// the adapter's implementation identical is what lets an Office.js password
+/// unlock a workbook that is later exported (and vice versa).
+fn password_hash(password: Option<&str>) -> Option<String> {
+    let password = password.filter(|password| !password.is_empty())?;
+    let bytes = password.as_bytes();
+    let mut hash: u16 = 0;
+    for (index, byte) in bytes.iter().enumerate() {
+        let shift = (index + 1) % 15;
+        let value = *byte as u16;
+        let rotated = if shift == 0 {
+            value
+        } else {
+            ((value << shift) | (value >> (15 - shift))) & 0x7fff
+        };
+        hash ^= rotated;
+    }
+    hash ^= bytes.len() as u16;
+    hash ^= 0xce4b;
+    Some(format!("{hash:04X}"))
+}
+
+fn compute_error(error: ComputeApiError) -> ProtectionError {
+    let error_message = error.to_string();
+    match error {
+        ComputeApiError::InvalidOperation(message) => ProtectionError {
+            code: "InvalidOperation",
+            message,
+        },
+        ComputeApiError::InvalidAddress { .. } | ComputeApiError::InvalidRange { .. } => {
+            ProtectionError {
+                code: "InvalidArgument",
+                message: error_message,
+            }
+        }
+        ComputeApiError::SheetNotFound { id } => ProtectionError {
+            code: "ItemNotFound",
+            message: format!("Worksheet '{id}' was not found"),
+        },
+        ComputeApiError::Compute(value_types::ComputeError::InvalidInput { message }) => {
+            let code = if message.to_ascii_lowercase().contains("incorrect password") {
+                "InvalidArgument"
+            } else {
+                "GeneralException"
+            };
+            ProtectionError { code, message }
+        }
+        other => ProtectionError {
+            code: "GeneralException",
+            message: other.to_string(),
+        },
+    }
+}
+
+fn unsupported_load_property(object: &str, property: &str) -> ProtectionError {
+    invalid_argument(format!("Unsupported {object} load property '{property}'"))
+}
+
+fn unsupported(message: impl Into<String>) -> ProtectionError {
+    ProtectionError {
+        code: "ApiNotFound",
+        message: message.into(),
+    }
+}
+
+fn invalid_argument(message: impl Into<String>) -> ProtectionError {
+    ProtectionError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn invalid_operation(message: impl Into<String>) -> ProtectionError {
+    ProtectionError {
+        code: "InvalidOperation",
+        message: message.into(),
+    }
+}
+
+fn access_denied(message: impl Into<String>) -> ProtectionError {
+    ProtectionError {
+        code: "AccessDenied",
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{options_from_json, password_hash};
+    use compute_api::SheetProtectionOptions;
+    use serde_json::json;
+
+    #[test]
+    fn excel_password_hash_uses_known_legacy_vectors() {
+        assert_eq!(password_hash(Some("password")).as_deref(), Some("83AF"));
+        assert_eq!(password_hash(Some("test")).as_deref(), Some("CBEB"));
+        assert_eq!(password_hash(Some("pass")).as_deref(), Some("CB83"));
+        assert_eq!(password_hash(Some("")).as_deref(), None);
+    }
+
+    #[test]
+    fn office_options_translate_to_engine_options() {
+        let options = options_from_json(
+            &json!({
+                "allowAutoFilter": true,
+                "allowDeleteColumns": true,
+                "allowDeleteRows": false,
+                "allowEditObjects": true,
+                "allowEditScenarios": false,
+                "allowFormatCells": true,
+                "allowFormatColumns": false,
+                "allowFormatRows": true,
+                "allowInsertColumns": true,
+                "allowInsertHyperlinks": false,
+                "allowInsertRows": true,
+                "allowPivotTables": true,
+                "allowSort": true,
+                "selectionMode": "Unlocked"
+            }),
+            SheetProtectionOptions::default(),
+        )
+        .expect("options should translate");
+
+        assert!(options.use_auto_filter);
+        assert!(options.delete_columns);
+        assert!(!options.delete_rows);
+        assert!(options.edit_objects);
+        assert!(options.format_cells);
+        assert!(options.format_rows);
+        assert!(options.insert_columns);
+        assert!(options.insert_rows);
+        assert!(options.use_pivot_table_reports);
+        assert!(options.sort);
+        assert!(!options.select_locked_cells);
+        assert!(options.select_unlocked_cells);
+    }
+}

--- a/compute/officejs/src/range_areas.js
+++ b/compute/officejs/src/range_areas.js
@@ -1,0 +1,378 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs;
+
+  function richApiError(code, message) {
+    var error = new OfficeExtension.Error({ code: code, message: message });
+    error.name = "RichApi.Error";
+    error.code = code;
+    return error;
+  }
+
+  function propertyNotLoaded(name) {
+    return richApiError(
+      "PropertyNotLoaded",
+      "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context."
+    );
+  }
+
+  function invalidArgument(message) {
+    return richApiError("InvalidArgument", message);
+  }
+
+  function invalidRequestContext() {
+    return richApiError(
+      "InvalidRequestContext",
+      "The object belongs to a different request context."
+    );
+  }
+
+  function requireContext(source, context, property) {
+    if (source.context !== context) throw invalidRequestContext();
+    return property;
+  }
+
+  function integerArgument(value, property) {
+    if (
+      typeof value !== "number" ||
+      !isFinite(value) ||
+      Math.floor(value) !== value
+    ) {
+      throw invalidArgument(property + " must be an integer");
+    }
+    return value;
+  }
+
+  function clearMode(value) {
+    if (value === undefined || value === null) return "All";
+    if (
+      value === "All" ||
+      value === "Formats" ||
+      value === "Contents" ||
+      value === "Hyperlinks" ||
+      value === "RemoveHyperlinks" ||
+      value === "ResetContents"
+    ) {
+      return value;
+    }
+    // Keep invalid values deferred until context.sync(), matching Range.clear.
+    return value;
+  }
+
+  function scalarProperties(object) {
+    var result = (object._scalarProperties || []).slice();
+    (object._additionalScalarProperties || []).forEach(function (name) {
+      if (result.indexOf(name) < 0) result.push(name);
+    });
+    return result;
+  }
+
+  function navigationProperties(object) {
+    var result = (object._navigationProperties || []).slice();
+    (object._additionalNavigationProperties || []).forEach(function (name) {
+      if (result.indexOf(name) < 0) result.push(name);
+    });
+    return result;
+  }
+
+  function requirePropertyObject(source) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+  }
+
+  function setProperties(source, options) {
+    requirePropertyObject(source);
+    var isClientObject = source instanceof ClientObject;
+    var properties = source;
+    if (isClientObject) {
+      if (Object.getPrototypeOf(this) !== Object.getPrototypeOf(source)) {
+        throw invalidArgument("The object passed to set must have the same type.");
+      }
+      properties = source.toJSON();
+    }
+
+    var throwOnReadOnly = !options || options.throwOnReadOnly !== false;
+    var names = scalarProperties(this);
+    var writable = { style: true };
+    for (var i = 0; i < names.length; i++) {
+      var name = names[i];
+      if (!Object.prototype.hasOwnProperty.call(properties, name)) continue;
+      if (properties[name] === undefined) continue;
+      if (!writable[name]) {
+        if (!isClientObject && throwOnReadOnly) {
+          throw invalidArgument("The property '" + name + "' is read-only.");
+        }
+        continue;
+      }
+      this[name] = properties[name];
+    }
+
+    // RangeAreas format and dataValidation are separate object paths. They
+    // are intentionally not synthesized here; unsupported members remain
+    // explicit until their production adapters exist.
+    var navigation = navigationProperties(this);
+    for (i = 0; i < navigation.length; i++) {
+      name = navigation[i];
+      if (!Object.prototype.hasOwnProperty.call(properties, name)) continue;
+      if (properties[name] === undefined) continue;
+      throw invalidArgument(
+        "RangeAreas." + name + " set is not supported by this host"
+      );
+    }
+  }
+
+  function toJSON() {
+    var data = {};
+    var names = scalarProperties(this);
+    for (var i = 0; i < names.length; i++) {
+      var name = names[i];
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }
+    var navigation = navigationProperties(this);
+    for (i = 0; i < navigation.length; i++) {
+      var child = this["_" + navigation[i]];
+      if (
+        child &&
+        (this._loaded[navigation[i]] ||
+          (navigation[i] === "areas" && child._loaded.items))
+      ) {
+        data[navigation[i]] =
+          typeof child.toJSON === "function" ? child.toJSON() : child;
+      }
+    }
+    return data;
+  }
+
+  function defineReadOnlyScalar(prototype, name) {
+    Object.defineProperty(prototype, name, {
+      configurable: true,
+      enumerable: true,
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+    });
+  }
+
+  function RangeAreas(context, worksheet) {
+    ClientObject.call(this, context);
+    this._worksheet = worksheet || null;
+    this._scalarProperties = [
+      "address",
+      "addressLocal",
+      "areaCount",
+      "cellCount",
+      "isEntireColumn",
+      "isEntireRow",
+      "style",
+    ];
+    this._navigationProperties = ["areas"];
+  }
+  RangeAreas.prototype = Object.create(ClientObject.prototype);
+  RangeAreas.prototype.constructor = RangeAreas;
+
+  RangeAreas.prototype.track = function () {
+    this.context.trackedObjects.add(this);
+    return this;
+  };
+
+  RangeAreas.prototype.untrack = function () {
+    this.context.trackedObjects.remove(this);
+    return this;
+  };
+
+  [
+    "address",
+    "addressLocal",
+    "areaCount",
+    "cellCount",
+    "isEntireColumn",
+    "isEntireRow",
+  ].forEach(function (name) {
+    defineReadOnlyScalar(RangeAreas.prototype, name);
+  });
+
+  Object.defineProperty(RangeAreas.prototype, "style", {
+    configurable: true,
+    enumerable: true,
+    get: function () {
+      if (!this._loaded.style) throw propertyNotLoaded("style");
+      return this._style;
+    },
+    set: function (value) {
+      if (value !== null && typeof value !== "string") {
+        throw invalidArgument("RangeAreas.style must be a string");
+      }
+      this._style = value;
+      this._loaded.style = true;
+      this.context._queue.push({
+        op: "set",
+        id: this._id,
+        property: "style",
+        value: value,
+      });
+    },
+  });
+
+  Object.defineProperty(RangeAreas.prototype, "areas", {
+    configurable: true,
+    get: function () {
+      if (!this._areas) this._areas = new RangeCollection(this.context, this);
+      return this._areas;
+    },
+  });
+
+  RangeAreas.prototype.set = setProperties;
+  RangeAreas.prototype.toJSON = toJSON;
+
+  RangeAreas.prototype.clear = function (applyTo) {
+    this.context._queue.push({
+      op: "rangeAreasClear",
+      id: this._id,
+      applyTo: clearMode(applyTo),
+    });
+  };
+
+  RangeAreas.prototype.getIntersectionOrNullObject = function (anotherRange) {
+    var argument;
+    if (anotherRange instanceof RangeAreas) {
+      requireContext(anotherRange, this.context);
+      argument = { rangeAreasId: anotherRange._id };
+    } else if (anotherRange instanceof Excel.Range) {
+      requireContext(anotherRange, this.context);
+      argument = { rangeId: anotherRange._id };
+    } else if (typeof anotherRange === "string") {
+      argument = anotherRange;
+    } else {
+      throw invalidArgument(
+        "RangeAreas.getIntersectionOrNullObject requires a Range, RangeAreas, or range address"
+      );
+    }
+
+    var result = new RangeAreas(this.context, this._worksheet);
+    this.context._queue.push({
+      op: "rangeAreasNavigation",
+      id: result._id,
+      rangeAreasId: this._id,
+      method: "getIntersectionOrNullObject",
+      args: [argument],
+    });
+    return result;
+  };
+
+  function RangeCollection(context, rangeAreas) {
+    ClientObject.call(this, context);
+    this._rangeAreas = rangeAreas;
+    this._worksheet = rangeAreas._worksheet;
+    this._scalarProperties = ["items"];
+    this._navigationProperties = [];
+    this._rangeCollectionConfigured = true;
+    context._queue.push({
+      op: "getRangeAreasCollection",
+      id: this._id,
+      rangeAreasId: rangeAreas._id,
+    });
+
+    officeJs.configureCollection(this, function (key) {
+      if (!this._worksheet) {
+        throw invalidArgument("RangeCollection items require a worksheet");
+      }
+      var range = this._worksheet.getRange(String(key));
+      range._collection = this;
+      range._rangeAreas = this._rangeAreas;
+      return range;
+    });
+  }
+  RangeCollection.prototype = Object.create(ClientObject.prototype);
+  RangeCollection.prototype.constructor = RangeCollection;
+
+  Object.defineProperty(RangeCollection.prototype, "items", {
+    configurable: true,
+    get: function () {
+      if (!this._loaded.items) throw propertyNotLoaded("items");
+      return this._items || [];
+    },
+  });
+
+  RangeCollection.prototype.getCount = function () {
+    var result = officeJs.createClientResult(this.context);
+    this.context._queue.push({
+      op: "rangeCollectionGetCount",
+      collectionId: this._id,
+      resultId: result._id,
+    });
+    return result;
+  };
+
+  RangeCollection.prototype.getItemAt = function (index) {
+    integerArgument(index, "RangeCollection.getItemAt index");
+    if (index < 0) throw invalidArgument("RangeCollection.getItemAt index must be non-negative");
+    var range = new Excel.Range(this.context, this._worksheet, null);
+    range._collection = this;
+    range._rangeAreas = this._rangeAreas;
+    this.context._queue.push({
+      op: "rangeCollectionGetItemAt",
+      id: range._id,
+      collectionId: this._id,
+      index: index,
+    });
+    return range;
+  };
+
+  RangeCollection.prototype.toJSON = function () {
+    if (!this._loaded.items) return {};
+    return {
+      items: (this.items || []).map(function (item) {
+        return item && typeof item.toJSON === "function" ? item.toJSON() : item;
+      }),
+    };
+  };
+
+  // Worksheet.getRanges is additive to the bootstrap Worksheet constructor.
+  Excel.Worksheet.prototype.getRanges = function (address) {
+    if (address !== undefined && typeof address !== "string") {
+      throw invalidArgument("Worksheet.getRanges address must be a string");
+    }
+    var result = new RangeAreas(this.context, this);
+    this.context._queue.push({
+      op: "getRangeAreas",
+      id: result._id,
+      worksheetId: this._id,
+      address: address === undefined ? null : address,
+    });
+    return result;
+  };
+
+  // Result-producing families can allocate a normal RangeAreas proxy and
+  // then queue their own typed host operation without depending on this
+  // module's private constructor.
+  officeJs.createRangeAreas = function (context, worksheet) {
+    return new RangeAreas(context, worksheet || null);
+  };
+
+  officeJs.queueRangeAreasOperation = function (rangeAreas, operation) {
+    if (!(rangeAreas instanceof RangeAreas)) {
+      throw invalidArgument("queueRangeAreasOperation requires a RangeAreas object");
+    }
+    if (!operation || typeof operation !== "object") {
+      throw invalidArgument("queueRangeAreasOperation requires an operation object");
+    }
+    var queued = {};
+    Object.keys(operation).forEach(function (name) {
+      queued[name] = operation[name];
+    });
+    queued.id = rangeAreas._id;
+    rangeAreas.context._queue.push(queued);
+    return rangeAreas;
+  };
+
+  Excel.RangeAreas = RangeAreas;
+  Excel.RangeCollection = RangeCollection;
+})(globalThis);

--- a/compute/officejs/src/range_areas.rs
+++ b/compute/officejs/src/range_areas.rs
@@ -1,0 +1,1006 @@
+//! Office.js discontiguous range geometry and collection helpers.
+//!
+//! A range-area object is represented by its rectangular references. This
+//! keeps whole-sheet references bounded in the representation and gives
+//! result-producing APIs (such as data validation) one reusable constructor.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use compute_api::{CellAddress, CellRange, CellValue, ComputeApiError, Sheet};
+use serde::Serialize;
+use serde_json::{Map, Value, json};
+
+use crate::dispatch::{ExtensionHandler, ExtensionObject, HostDispatchContext};
+use crate::host::{BatchError, RangeRef};
+use crate::range_content;
+use crate::range_navigation::{RangeAddress, RangeNavigationError, parse_range_address};
+
+/// Error returned by the RangeAreas host adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RangeAreasError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+/// Host-side reference for a RangeAreas object.
+#[derive(Clone)]
+pub(crate) struct RangeAreasRef {
+    sheet: Sheet,
+    areas: Vec<RangeAddress>,
+    is_null_object: bool,
+}
+
+/// Result type shared by result-producing Office.js families.
+pub(crate) type RangeAreasResult = RangeAreasRef;
+
+/// Collection descriptor consumed by the shared JavaScript collection
+/// hydrator. key is an unqualified canonical A1 reference.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct RangeAreaItem {
+    pub(crate) key: String,
+    pub(crate) properties: Map<String, Value>,
+}
+
+impl RangeAreasRef {
+    /// Parse a worksheet getRanges address. None represents one whole-sheet
+    /// area. Commas and semicolons delimit areas, except inside quoted sheet
+    /// names.
+    pub(crate) fn from_address(sheet: Sheet, raw: Option<&str>) -> Result<Self, RangeAreasError> {
+        let Some(raw) = raw else {
+            return Ok(Self {
+                sheet,
+                areas: vec![RangeAddress::WholeSheet],
+                is_null_object: false,
+            });
+        };
+
+        let pieces = split_area_references(raw);
+        if pieces.is_empty() {
+            return Err(invalid("RangeAreas address must contain at least one area"));
+        }
+
+        let mut areas = Vec::with_capacity(pieces.len());
+        for piece in pieces {
+            let piece = piece.trim();
+            if piece.is_empty() {
+                return Err(invalid(format!(
+                    "Invalid RangeAreas address '{raw}': empty area"
+                )));
+            }
+            areas.push(
+                parse_range_address(&sheet, piece)
+                    .map_err(|error| map_navigation_error(error, piece))?,
+            );
+        }
+        Ok(Self {
+            sheet,
+            areas,
+            is_null_object: false,
+        })
+    }
+
+    /// Parse a list of one-rectangle references into a RangeAreas object.
+    pub(crate) fn from_addresses<I, S>(sheet: Sheet, addresses: I) -> Result<Self, RangeAreasError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut areas = Vec::new();
+        for address in addresses {
+            let address = address.as_ref();
+            if address.trim().is_empty() {
+                return Err(invalid("RangeAreas address cannot contain an empty area"));
+            }
+            if split_area_references(address).len() != 1 {
+                return Err(invalid(format!(
+                    "RangeAreas area '{address}' contains multiple references"
+                )));
+            }
+            areas.push(
+                parse_range_address(&sheet, address)
+                    .map_err(|error| map_navigation_error(error, address))?,
+            );
+        }
+        if areas.is_empty() {
+            return Err(item_not_found("RangeAreas contains no areas"));
+        }
+        Ok(Self {
+            sheet,
+            areas,
+            is_null_object: false,
+        })
+    }
+
+    /// Construct a null result for an OrNullObject operation.
+    pub(crate) fn null(sheet: Sheet) -> Self {
+        Self {
+            sheet,
+            areas: Vec::new(),
+            is_null_object: true,
+        }
+    }
+
+    /// Construct a result from cell coordinates, compressing adjacent cells
+    /// into rectangles. Empty input is ItemNotFound; callers implementing an
+    /// OrNullObject operation can use null for that case.
+    pub(crate) fn from_cells<I>(sheet: Sheet, cells: I) -> Result<RangeAreasResult, RangeAreasError>
+    where
+        I: IntoIterator<Item = (u32, u32)>,
+    {
+        let mut cells: Vec<(u32, u32)> = cells.into_iter().collect();
+        if cells.is_empty() {
+            return Err(item_not_found("No cells matched the RangeAreas result"));
+        }
+        if cells
+            .iter()
+            .any(|(row, column)| *row >= EXCEL_MAX_ROWS || *column >= EXCEL_MAX_COLUMNS)
+        {
+            return Err(invalid(
+                "RangeAreas cell coordinates exceed the worksheet grid",
+            ));
+        }
+        cells.sort_unstable();
+        cells.dedup();
+
+        let mut row_runs = Vec::<CellRun>::new();
+        let mut index = 0usize;
+        while index < cells.len() {
+            let row = cells[index].0;
+            let mut start_column = cells[index].1;
+            let mut end_column = start_column;
+            index += 1;
+            while index < cells.len() && cells[index].0 == row {
+                let column = cells[index].1;
+                if column == end_column.saturating_add(1) {
+                    end_column = column;
+                } else {
+                    row_runs.push(CellRun {
+                        start_row: row,
+                        end_row: row,
+                        start_column,
+                        end_column,
+                    });
+                    start_column = column;
+                    end_column = column;
+                }
+                index += 1;
+            }
+            row_runs.push(CellRun {
+                start_row: row,
+                end_row: row,
+                start_column,
+                end_column,
+            });
+        }
+
+        // A run can merge only with one of the same width in the immediately
+        // preceding row. This is rectangle-level state, never cell-level
+        // materialization.
+        let mut rectangles = Vec::<CellRun>::new();
+        let mut active = HashMap::<(u32, u32), usize>::new();
+        let mut row_index = 0usize;
+        while row_index < row_runs.len() {
+            let row = row_runs[row_index].start_row;
+            let mut next_active = HashMap::<(u32, u32), usize>::new();
+            while row_index < row_runs.len() && row_runs[row_index].start_row == row {
+                let run = row_runs[row_index];
+                let key = (run.start_column, run.end_column);
+                let rectangle_index = if let Some(rectangle_index) = active.get(&key).copied()
+                    && rectangles[rectangle_index].end_row.saturating_add(1) == run.start_row
+                {
+                    rectangles[rectangle_index].end_row = run.end_row;
+                    rectangle_index
+                } else {
+                    let rectangle_index = rectangles.len();
+                    rectangles.push(run);
+                    rectangle_index
+                };
+                next_active.insert(key, rectangle_index);
+                row_index += 1;
+            }
+            active = next_active;
+        }
+
+        let areas = rectangles
+            .into_iter()
+            .map(|run| {
+                let text = format_bounds(
+                    run.start_row,
+                    run.start_column,
+                    run.end_row,
+                    run.end_column,
+                    false,
+                    false,
+                );
+                RangeAddress::parse(&text).map_err(|error| map_navigation_error(error, &text))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self {
+            sheet,
+            areas,
+            is_null_object: false,
+        })
+    }
+
+    pub(crate) fn sheet(&self) -> Sheet {
+        self.sheet.clone()
+    }
+
+    pub(crate) fn is_null_object(&self) -> bool {
+        self.is_null_object
+    }
+
+    /// Return unqualified canonical area addresses in first-seen order.
+    pub(crate) fn addresses(&self) -> Result<Vec<String>, RangeAreasError> {
+        self.ensure_live()?;
+        Ok(self.areas.iter().map(RangeAddress::to_a1).collect())
+    }
+
+    pub(crate) fn area_at(&self, index: usize) -> Result<String, RangeAreasError> {
+        self.ensure_live()?;
+        self.areas
+            .get(index)
+            .map(RangeAddress::to_a1)
+            .ok_or_else(|| item_not_found(format!("RangeCollection index {index} is out of range")))
+    }
+
+    pub(crate) fn area_count(&self) -> Result<usize, RangeAreasError> {
+        self.ensure_live()?;
+        Ok(self.areas.len())
+    }
+
+    /// Return the canonical qualified address used by RangeAreas.address.
+    pub(crate) fn canonical_address(&self) -> Result<String, RangeAreasError> {
+        self.address()
+    }
+
+    /// Return scalar metadata for a RangeAreas.load request.
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, RangeAreasError> {
+        self.ensure_live()?;
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                "address" | "addressLocal" => Value::String(self.address()?),
+                "areaCount" => json!(self.areas.len()),
+                "cellCount" => json!(self.cell_count()),
+                "isEntireColumn" => json!(self.all_entire_columns()),
+                "isEntireRow" => json!(self.all_entire_rows()),
+                "isNullObject" => Value::Bool(false),
+                other => return Err(unsupported_load_property("RangeAreas", other)),
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    /// Return descriptors for RangeAreas.areas / RangeCollection.items.
+    /// properties contains item names after stripping the items/ prefix.
+    pub(crate) fn collection_items(
+        &self,
+        properties: &[String],
+    ) -> Result<Vec<RangeAreaItem>, RangeAreasError> {
+        self.ensure_live()?;
+        let item_properties = properties
+            .iter()
+            .filter_map(|property| {
+                if property == "items" {
+                    None
+                } else {
+                    Some(
+                        property
+                            .strip_prefix("items/")
+                            .unwrap_or(property)
+                            .to_string(),
+                    )
+                }
+            })
+            .collect::<Vec<_>>();
+        self.validate_item_properties(&item_properties)?;
+        self.areas
+            .iter()
+            .map(|area| self.item(area, &item_properties))
+            .collect()
+    }
+
+    /// Load a `RangeCollection` projection for `RangeAreas.areas`.
+    ///
+    /// The collection is represented by the same typed range-area reference
+    /// in the host binding, but its wire surface is deliberately kept
+    /// separate from the parent scalar projection: collection loads accept
+    /// `items` and `items/<Range property>` paths only.
+    pub(crate) fn load_collection(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, RangeAreasError> {
+        let mut item_properties = Vec::new();
+        let mut wants_items = false;
+        for property in properties {
+            if property == "items" {
+                wants_items = true;
+            } else if let Some(item_property) = property.strip_prefix("items/") {
+                if item_property.is_empty() {
+                    return Err(unsupported_load_property("RangeCollection", property));
+                }
+                wants_items = true;
+                if !item_properties
+                    .iter()
+                    .any(|existing| existing == item_property)
+                {
+                    item_properties.push(item_property.to_string());
+                }
+            } else if property == "isNullObject" {
+                // The shared extension binding adds this property for every
+                // live object. Keep it accepted here for collection-specific
+                // handlers that project the property themselves.
+            } else {
+                return Err(unsupported_load_property("RangeCollection", property));
+            }
+        }
+
+        let mut result = HashMap::new();
+        if wants_items {
+            result.insert(
+                "items".to_string(),
+                serde_json::to_value(self.collection_items(&item_properties)?).map_err(
+                    |error| engine(format!("failed to encode RangeCollection items: {error}")),
+                )?,
+            );
+        }
+        Ok(result)
+    }
+
+    /// Clear every bounded area using an Office.js clear mode. Validate all
+    /// shapes before the first engine mutation.
+    pub(crate) fn clear(&self, apply_to: &str) -> Result<(), RangeAreasError> {
+        self.ensure_live()?;
+        self.ensure_bounded("RangeAreas.clear")?;
+        for area in &self.areas {
+            range_content::clear(&self.sheet, &area.to_a1(), apply_to).map_err(|error| {
+                RangeAreasError {
+                    code: error.code,
+                    message: error.message,
+                }
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Return rectangle intersections with another same-sheet collection.
+    pub(crate) fn intersection(
+        &self,
+        other: &RangeAreasRef,
+        or_null_object: bool,
+    ) -> Result<RangeAreasResult, RangeAreasError> {
+        self.ensure_live()?;
+        other.ensure_live()?;
+        if self.sheet.id() != other.sheet.id() {
+            return Err(invalid(
+                "RangeAreas arguments must belong to the same worksheet",
+            ));
+        }
+
+        let mut intersections = Vec::new();
+        let mut seen = HashSet::new();
+        for left in &self.areas {
+            for right in &other.areas {
+                let (left_start_row, left_start_column, left_end_row, left_end_column) =
+                    left.bounds();
+                let (right_start_row, right_start_column, right_end_row, right_end_column) =
+                    right.bounds();
+                let start_row = left_start_row.max(right_start_row);
+                let start_column = left_start_column.max(right_start_column);
+                let end_row = left_end_row.min(right_end_row);
+                let end_column = left_end_column.min(right_end_column);
+                if start_row > end_row || start_column > end_column {
+                    continue;
+                }
+
+                let rows_unbounded = (left.is_entire_row() || left.is_whole_sheet())
+                    && (right.is_entire_row() || right.is_whole_sheet());
+                let columns_unbounded = (left.is_entire_column() || left.is_whole_sheet())
+                    && (right.is_entire_column() || right.is_whole_sheet());
+                let text = format_bounds(
+                    start_row,
+                    start_column,
+                    end_row,
+                    end_column,
+                    rows_unbounded,
+                    columns_unbounded,
+                );
+                if seen.insert(text.clone()) {
+                    intersections.push(
+                        RangeAddress::parse(&text)
+                            .map_err(|error| map_navigation_error(error, &text))?,
+                    );
+                }
+            }
+        }
+
+        if intersections.is_empty() {
+            if or_null_object {
+                return Ok(Self::null(self.sheet.clone()));
+            }
+            return Err(item_not_found("The specified RangeAreas do not intersect"));
+        }
+
+        Ok(Self {
+            sheet: self.sheet.clone(),
+            areas: intersections,
+            is_null_object: false,
+        })
+    }
+
+    pub(crate) fn is_bounded(&self) -> Result<bool, RangeAreasError> {
+        self.ensure_live()?;
+        Ok(self.areas.iter().all(|area| {
+            !area.is_whole_sheet() && !area.is_entire_row() && !area.is_entire_column()
+        }))
+    }
+
+    fn address(&self) -> Result<String, RangeAreasError> {
+        self.ensure_live()?;
+        let name = self.sheet.name().map_err(engine)?;
+        let qualified = qualified_sheet_name(&name);
+        Ok(self
+            .areas
+            .iter()
+            .map(|area| format!("{qualified}!{}", area.to_a1()))
+            .collect::<Vec<_>>()
+            .join(", "))
+    }
+
+    fn cell_count(&self) -> i64 {
+        let mut total = 0u64;
+        for area in &self.areas {
+            let count = area.cell_count();
+            if count < 0 {
+                return -1;
+            }
+            total = match total.checked_add(count as u64) {
+                Some(total) if total <= i32::MAX as u64 => total,
+                _ => return -1,
+            };
+        }
+        total as i64
+    }
+
+    fn all_entire_columns(&self) -> bool {
+        !self.areas.is_empty()
+            && self
+                .areas
+                .iter()
+                .all(|area| area.is_entire_column() || area.is_whole_sheet())
+    }
+
+    fn all_entire_rows(&self) -> bool {
+        !self.areas.is_empty()
+            && self
+                .areas
+                .iter()
+                .all(|area| area.is_entire_row() || area.is_whole_sheet())
+    }
+
+    fn item(
+        &self,
+        area: &RangeAddress,
+        properties: &[String],
+    ) -> Result<RangeAreaItem, RangeAreasError> {
+        let mut item = Map::new();
+        let (start_row, start_column, end_row, end_column) = area.bounds();
+        let name = self.sheet.name().map_err(engine)?;
+        let qualified_address = format!("{}!{}", qualified_sheet_name(&name), area.to_a1());
+        let unbounded = area.is_whole_sheet() || area.is_entire_row() || area.is_entire_column();
+        for property in properties {
+            let value = match property.as_str() {
+                "isNullObject" => Value::Bool(false),
+                "address" | "addressLocal" => Value::String(qualified_address.clone()),
+                "rowIndex" => json!(start_row),
+                "columnIndex" => json!(start_column),
+                "rowCount" => json!(area.row_count()),
+                "columnCount" => json!(area.column_count()),
+                "cellCount" => json!(area.cell_count()),
+                "values" => {
+                    if unbounded {
+                        Value::Null
+                    } else {
+                        range_values_json(&self.sheet, area.to_a1().as_str())?
+                    }
+                }
+                "formulas" => {
+                    if unbounded {
+                        Value::Null
+                    } else {
+                        range_formulas_json(&self.sheet, area.to_a1().as_str())?
+                    }
+                }
+                "numberFormat" | "text" | "valueTypes" => {
+                    if unbounded {
+                        Value::Null
+                    } else {
+                        range_content::load(
+                            &self.sheet,
+                            area.to_a1().as_str(),
+                            std::slice::from_ref(property),
+                        )
+                        .map_err(|error| RangeAreasError {
+                            code: error.code,
+                            message: error.message,
+                        })?
+                        .get(property)
+                        .cloned()
+                        .unwrap_or(Value::Null)
+                    }
+                }
+                other => return Err(unsupported_load_property("RangeCollection item", other)),
+            };
+            item.insert(property.clone(), value);
+        }
+        Ok(RangeAreaItem {
+            key: area.to_a1(),
+            properties: item,
+        })
+    }
+
+    fn validate_item_properties(&self, properties: &[String]) -> Result<(), RangeAreasError> {
+        for property in properties {
+            match property.as_str() {
+                "isNullObject" | "address" | "addressLocal" | "rowIndex" | "columnIndex"
+                | "rowCount" | "columnCount" | "cellCount" | "values" | "formulas"
+                | "numberFormat" | "text" | "valueTypes" => {}
+                other => return Err(unsupported_load_property("RangeCollection item", other)),
+            }
+        }
+        Ok(())
+    }
+
+    fn ensure_bounded(&self, method: &str) -> Result<(), RangeAreasError> {
+        if self
+            .areas
+            .iter()
+            .any(|area| area.is_whole_sheet() || area.is_entire_row() || area.is_entire_column())
+        {
+            return Err(invalid(format!("{method} requires bounded ranges")));
+        }
+        Ok(())
+    }
+
+    fn ensure_live(&self) -> Result<(), RangeAreasError> {
+        if self.is_null_object {
+            return Err(RangeAreasError {
+                code: "InvalidObjectPath",
+                message: "The RangeAreas object is a null object.".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+pub(crate) const EXCEL_MAX_ROWS: u32 = 1_048_576;
+pub(crate) const EXCEL_MAX_COLUMNS: u32 = 16_384;
+
+#[derive(Debug, Clone, Copy)]
+struct CellRun {
+    start_row: u32,
+    end_row: u32,
+    start_column: u32,
+    end_column: u32,
+}
+
+fn range_values_json(sheet: &Sheet, address: &str) -> Result<Value, RangeAreasError> {
+    let (start_row, start_column, end_row, end_column) = CellRange::from(address)
+        .resolve()
+        .map_err(map_compute_error)?;
+    let values = sheet
+        .get_range_values_2d(CellRange::Bounds(
+            start_row,
+            start_column,
+            end_row,
+            end_column,
+        ))
+        .map_err(engine)?;
+    Ok(Value::Array(
+        values
+            .into_iter()
+            .map(|row| Value::Array(row.into_iter().map(cell_to_js).collect()))
+            .collect(),
+    ))
+}
+
+fn range_formulas_json(sheet: &Sheet, address: &str) -> Result<Value, RangeAreasError> {
+    let (start_row, start_column, end_row, end_column) = CellRange::from(address)
+        .resolve()
+        .map_err(map_compute_error)?;
+    let mut rows = Vec::new();
+    for row in start_row..=end_row {
+        let mut cells = Vec::new();
+        for column in start_column..=end_column {
+            let cell = CellAddress::Position(row, column);
+            if let Some(formula) = sheet.get_formula(cell.clone()).map_err(engine)? {
+                cells.push(Value::String(formula));
+            } else {
+                cells.push(cell_to_js(sheet.get_cell_value(cell).map_err(engine)?));
+            }
+        }
+        rows.push(Value::Array(cells));
+    }
+    Ok(Value::Array(rows))
+}
+
+fn cell_to_js(value: CellValue) -> Value {
+    match value {
+        CellValue::Null => Value::String(String::new()),
+        CellValue::Boolean(value) => Value::Bool(value),
+        CellValue::Number(_) => value
+            .as_number()
+            .map(|number| json!(number))
+            .unwrap_or(Value::Null),
+        CellValue::Text(value) => Value::String(value.to_string()),
+        CellValue::Error(error, _) => Value::String(error.to_string()),
+        other => Value::String(other.to_string()),
+    }
+}
+
+fn split_area_references(raw: &str) -> Vec<String> {
+    let mut references = Vec::new();
+    let mut start = 0usize;
+    let mut in_quote = false;
+    let bytes = raw.as_bytes();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' => {
+                if in_quote && bytes.get(index + 1) == Some(&b'\'') {
+                    index += 1;
+                } else {
+                    in_quote = !in_quote;
+                }
+            }
+            b',' | b';' if !in_quote => {
+                references.push(raw[start..index].to_string());
+                start = index + 1;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    references.push(raw[start..].to_string());
+    references
+        .into_iter()
+        .map(|reference| reference.trim().to_string())
+        .collect()
+}
+
+fn format_bounds(
+    start_row: u32,
+    start_column: u32,
+    end_row: u32,
+    end_column: u32,
+    rows_unbounded: bool,
+    columns_unbounded: bool,
+) -> String {
+    match (rows_unbounded, columns_unbounded) {
+        (true, true) => format!("1:{EXCEL_MAX_ROWS}"),
+        (true, false) => format!("{}:{}", column_name(start_column), column_name(end_column)),
+        (false, true) => format!("{}:{}", start_row + 1, end_row + 1),
+        (false, false) => {
+            let start = cell_name(start_row, start_column);
+            let end = cell_name(end_row, end_column);
+            if start == end {
+                start
+            } else {
+                format!("{start}:{end}")
+            }
+        }
+    }
+}
+
+fn cell_name(row: u32, column: u32) -> String {
+    format!("{}{}", column_name(column), row + 1)
+}
+
+fn column_name(mut column: u32) -> String {
+    let mut reversed = Vec::new();
+    loop {
+        reversed.push((b'A' + (column % 26) as u8) as char);
+        column /= 26;
+        if column == 0 {
+            break;
+        }
+        column -= 1;
+    }
+    reversed.into_iter().rev().collect()
+}
+
+fn qualified_sheet_name(name: &str) -> String {
+    if name
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || character == '_')
+    {
+        name.to_string()
+    } else {
+        format!("'{}'", name.replace('\'', "''"))
+    }
+}
+
+fn map_navigation_error(error: RangeNavigationError, address: &str) -> RangeAreasError {
+    RangeAreasError {
+        code: error.code,
+        message: format!("RangeAreas address '{address}': {}", error.message),
+    }
+}
+
+fn map_compute_error(error: ComputeApiError) -> RangeAreasError {
+    match error {
+        ComputeApiError::InvalidAddress { address, reason } => {
+            invalid(format!("invalid address: {address} — {reason}"))
+        }
+        ComputeApiError::InvalidRange { range, reason } => {
+            invalid(format!("invalid range: {range} — {reason}"))
+        }
+        other => engine(other),
+    }
+}
+
+fn engine(error: impl std::fmt::Display) -> RangeAreasError {
+    RangeAreasError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn invalid(message: impl Into<String>) -> RangeAreasError {
+    RangeAreasError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn item_not_found(message: impl Into<String>) -> RangeAreasError {
+    RangeAreasError {
+        code: "ItemNotFound",
+        message: message.into(),
+    }
+}
+
+fn unsupported_load_property(object: &str, property: &str) -> RangeAreasError {
+    RangeAreasError {
+        code: "InvalidArgument",
+        message: format!("Unsupported {object} load property '{property}'"),
+    }
+}
+
+/// Bind RangeAreas through the shared extension-object path. The parent and
+/// its `areas` collection can share this typed reference: the collection
+/// handler calls [`RangeAreasRef::load_collection`] for `items/...` paths,
+/// while ordinary loads use the scalar projection above.
+impl ExtensionObject for RangeAreasRef {
+    fn object_type(&self) -> &'static str {
+        "RangeAreas"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        let is_collection = properties
+            .iter()
+            .any(|property| property == "items" || property.starts_with("items/"));
+        let result = if is_collection {
+            self.load_collection(properties)
+        } else {
+            RangeAreasRef::load(self, properties)
+        };
+        result.map_err(range_areas_batch_error)
+    }
+
+    fn set(&self, property: &str, _value: &Value) -> Result<(), BatchError> {
+        Err(range_areas_batch_error(unsupported_set_property(
+            "RangeAreas",
+            property,
+        )))
+    }
+}
+
+fn range_areas_batch_error(error: RangeAreasError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn unsupported_set_property(object: &str, property: &str) -> RangeAreasError {
+    RangeAreasError {
+        code: "InvalidArgument",
+        message: format!("Unsupported {object} set property '{property}'"),
+    }
+}
+
+/// Host extension handler for the RangeAreas/RangeCollection wire family.
+///
+/// The handler binds a single typed [`RangeAreasRef`] for both the parent and
+/// its `areas` collection. Collection item-at results are deliberately bound
+/// through the core Range map, so the returned object keeps the complete
+/// Range content/navigation/format surface instead of becoming a second
+/// range-like shadow object.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct RangeAreasHandler;
+
+impl ExtensionHandler for RangeAreasHandler {
+    fn can_handle(&self, operation: &str) -> bool {
+        matches!(
+            operation,
+            "getRangeAreas"
+                | "getRangeAreasCollection"
+                | "rangeCollectionGetCount"
+                | "rangeCollectionGetItemAt"
+                | "rangeAreasClear"
+                | "rangeAreasNavigation"
+        )
+    }
+
+    fn handle(
+        &self,
+        operation: &Value,
+        context: &mut HostDispatchContext<'_>,
+    ) -> Result<bool, BatchError> {
+        let name = operation
+            .get("op")
+            .and_then(Value::as_str)
+            .ok_or_else(|| batch_invalid("RangeAreas operation has no op"))?;
+        match name {
+            "getRangeAreas" => {
+                let id = required_operation_string(operation, "id")?;
+                let worksheet_id = required_operation_string(operation, "worksheetId")?;
+                let worksheet = context.worksheet(worksheet_id)?;
+                let address = optional_operation_string(operation, "address")?;
+                let areas = RangeAreasRef::from_address(worksheet.sheet(), address)
+                    .map_err(range_areas_batch_error)?;
+                context.bind_object(id, Arc::new(areas));
+            }
+            "getRangeAreasCollection" => {
+                let id = required_operation_string(operation, "id")?;
+                let range_areas_id = required_operation_string(operation, "rangeAreasId")?;
+                let areas = context.extension_object::<RangeAreasRef>(range_areas_id)?;
+                // The collection uses the same geometry reference. Its
+                // `items/...` load paths are recognized by the typed object
+                // projection, while its proxy ID remains distinct.
+                context.bind_object(id, areas);
+            }
+            "rangeCollectionGetCount" => {
+                let collection_id = required_operation_string(operation, "collectionId")?;
+                let result_id = required_operation_string(operation, "resultId")?;
+                let areas = context.extension_object::<RangeAreasRef>(collection_id)?;
+                let count = areas.area_count().map_err(range_areas_batch_error)?;
+                context.set_result(result_id, json!(count));
+            }
+            "rangeCollectionGetItemAt" => {
+                let id = required_operation_string(operation, "id")?;
+                let collection_id = required_operation_string(operation, "collectionId")?;
+                let index = operation
+                    .get("index")
+                    .and_then(Value::as_u64)
+                    .and_then(|index| usize::try_from(index).ok())
+                    .ok_or_else(|| {
+                        batch_invalid("RangeCollection.getItemAt index must be a non-negative integer")
+                    })?;
+                let areas = context.extension_object::<RangeAreasRef>(collection_id)?;
+                let address = areas.area_at(index).map_err(range_areas_batch_error)?;
+                // RangeRef::new is the small host-owned constructor that
+                // preserves the core Range object path for collection items.
+                let range = RangeRef::new(areas.sheet(), Some(address), false);
+                context.bind_range(id, range);
+            }
+            "rangeAreasClear" => {
+                let id = required_operation_string(operation, "id")?;
+                let apply_to = required_operation_string(operation, "applyTo")?;
+                let areas = context.extension_object::<RangeAreasRef>(id)?;
+                areas.clear(apply_to).map_err(range_areas_batch_error)?;
+            }
+            "rangeAreasNavigation" => {
+                let id = required_operation_string(operation, "id")?;
+                let source_id = required_operation_string(operation, "rangeAreasId")?;
+                let method = required_operation_string(operation, "method")?;
+                if method != "getIntersectionOrNullObject" {
+                    return Err(batch_invalid(format!(
+                        "Unsupported RangeAreas navigation method '{method}'"
+                    )));
+                }
+                let arguments = operation
+                    .get("args")
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| batch_invalid("RangeAreas navigation requires an argument"))?;
+                if arguments.len() != 1 {
+                    return Err(batch_invalid(
+                        "RangeAreas.getIntersectionOrNullObject requires exactly one argument",
+                    ));
+                }
+                let source = context.extension_object::<RangeAreasRef>(source_id)?;
+                let other = intersection_argument(&arguments[0], &source, context)?;
+                let result = source
+                    .intersection(&other, true)
+                    .map_err(range_areas_batch_error)?;
+                if result.is_null_object() {
+                    context.bind_null_object(id);
+                } else {
+                    context.bind_object(id, Arc::new(result));
+                }
+            }
+            _ => unreachable!("can_handle and handle operation names differ"),
+        }
+        Ok(true)
+    }
+}
+
+fn intersection_argument(
+    argument: &Value,
+    source: &RangeAreasRef,
+    context: &HostDispatchContext<'_>,
+) -> Result<RangeAreasRef, BatchError> {
+    if let Some(object) = argument.as_object() {
+        let range_areas_id = object
+            .get("rangeAreasId")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty());
+        let range_id = object
+            .get("rangeId")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty());
+        return match (range_areas_id, range_id) {
+            (Some(_), Some(_)) => Err(batch_invalid(
+                "RangeAreas intersection argument cannot contain both Range and RangeAreas IDs",
+            )),
+            (Some(id), None) => context.extension_object::<RangeAreasRef>(id).map(|value| (*value).clone()),
+            (None, Some(id)) => {
+                let range = context.range(id)?;
+                if range.is_null_object() {
+                    return Err(BatchError {
+                        code: "InvalidObjectPath",
+                        message: "RangeAreas intersection cannot use a null Range.".to_string(),
+                    });
+                }
+                RangeAreasRef::from_address(range.sheet(), range.address())
+                    .map_err(range_areas_batch_error)
+            }
+            (None, None) => Err(batch_invalid(
+                "RangeAreas intersection argument requires a Range or RangeAreas ID",
+            )),
+        };
+    }
+    let address = argument
+        .as_str()
+        .ok_or_else(|| batch_invalid("RangeAreas intersection argument must be a Range, RangeAreas, or address"))?;
+    RangeAreasRef::from_address(source.sheet(), Some(address)).map_err(range_areas_batch_error)
+}
+
+fn required_operation_string<'a>(
+    operation: &'a Value,
+    field: &str,
+) -> Result<&'a str, BatchError> {
+    operation
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| batch_invalid(format!("RangeAreas operation requires a non-empty {field}")))
+}
+
+fn optional_operation_string<'a>(
+    operation: &'a Value,
+    field: &str,
+) -> Result<Option<&'a str>, BatchError> {
+    match operation.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.as_str())),
+        Some(_) => Err(batch_invalid(format!(
+            "RangeAreas operation field '{field}' must be a string or null"
+        ))),
+    }
+}
+
+fn batch_invalid(message: impl Into<String>) -> BatchError {
+    BatchError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}

--- a/compute/officejs/src/range_content.js
+++ b/compute/officejs/src/range_content.js
@@ -1,0 +1,198 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+
+  function propertyNotLoaded(name) {
+    var error = new global.OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function registerScalarProperties(names) {
+    // Runtime foundation owns the load normalization hook for all Office.js
+    // extension families. Registering through it keeps this projection on
+    // the production ClientObject.load path.
+    global.__mogOfficeJs.addScalarProperties(Excel.Range.prototype, names);
+  }
+
+  function invalidArgument(message) {
+    var error = new OfficeExtension.Error({
+      code: "InvalidArgument",
+      message: message,
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidArgument";
+    return error;
+  }
+
+  function requirePropertyObject(source) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+  }
+
+  function combinedProperties(object, primary, additional) {
+    var result = (object[primary] || []).slice();
+    (object[additional] || []).forEach(function (name) {
+      if (result.indexOf(name) < 0) result.push(name);
+    });
+    return result;
+  }
+
+  function scalarProperties(object) {
+    return combinedProperties(
+      object,
+      "_scalarProperties",
+      "_additionalScalarProperties"
+    );
+  }
+
+  function navigationProperties(object) {
+    return combinedProperties(
+      object,
+      "_navigationProperties",
+      "_additionalNavigationProperties"
+    );
+  }
+
+  // Range.set accepts the writable members represented by this projection.
+  // Keep the read-only list explicit so a plain object can honor the
+  // documented UpdateOptions.throwOnReadOnly behavior without touching any
+  // unloaded property getter. A Range source is copied from its loaded JSON,
+  // where read-only metadata is intentionally ignored by the copy operation.
+  var writableScalars = {
+    values: true,
+    formulas: true,
+    numberFormat: true,
+  };
+
+  function setProperties(source, options) {
+    requirePropertyObject(source);
+
+    var isClientObject = source instanceof ClientObject;
+    var properties = source;
+    if (isClientObject) {
+      if (Object.getPrototypeOf(this) !== Object.getPrototypeOf(source)) {
+        throw invalidArgument("The object passed to set must have the same type.");
+      }
+      properties = source.toJSON();
+    }
+
+    var throwOnReadOnly = !options || options.throwOnReadOnly !== false;
+    var names = scalarProperties(this);
+    for (var i = 0; i < names.length; i++) {
+      var name = names[i];
+      if (!Object.prototype.hasOwnProperty.call(properties, name)) continue;
+      if (properties[name] === undefined) continue;
+      if (!writableScalars[name]) {
+        if (!isClientObject && throwOnReadOnly) {
+          throw invalidArgument("The property '" + name + "' is read-only.");
+        }
+        continue;
+      }
+      this[name] = properties[name];
+    }
+
+    names = navigationProperties(this);
+    for (i = 0; i < names.length; i++) {
+      name = names[i];
+      if (!Object.prototype.hasOwnProperty.call(properties, name)) continue;
+      if (properties[name] === undefined) continue;
+      var child = isClientObject ? source[name] : properties[name];
+      this[name].set(child, options);
+    }
+  }
+
+  function toJSON() {
+    var data = {};
+    var names = scalarProperties(this);
+    for (var i = 0; i < names.length; i++) {
+      var name = names[i];
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }
+
+    names = navigationProperties(this);
+    for (i = 0; i < names.length; i++) {
+      var navigationName = names[i];
+      var child = this["_" + navigationName];
+      if (child !== undefined && child !== null) {
+        data[navigationName] =
+          typeof child.toJSON === "function" ? child.toJSON() : child;
+      }
+    }
+    return data;
+  }
+
+  function defineLoadedScalar(name) {
+    Object.defineProperty(Excel.Range.prototype, name, {
+      configurable: true,
+      enumerable: true,
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+    });
+  }
+
+  registerScalarProperties(["numberFormat", "text", "valueTypes"]);
+  defineLoadedScalar("text");
+  defineLoadedScalar("valueTypes");
+
+  Object.defineProperty(Excel.Range.prototype, "numberFormat", {
+    configurable: true,
+    enumerable: true,
+    get: function () {
+      if (!this._loaded.numberFormat) throw propertyNotLoaded("numberFormat");
+      return this._numberFormat;
+    },
+    set: function (value) {
+      this._numberFormat = value;
+      this._loaded.numberFormat = true;
+      this.context._queue.push({
+        op: "set",
+        id: this._id,
+        property: "numberFormat",
+        value: value,
+      });
+    },
+  });
+
+  // Excel.ClearApplyTo's documented string values are deliberately preserved
+  // on the wire. The Rust helper maps only modes backed by compute-api
+  // primitives; unsupported modes reject at context.sync().
+  var clearModes = {
+    All: "All",
+    Formats: "Formats",
+    Contents: "Contents",
+    Hyperlinks: "Hyperlinks",
+    RemoveHyperlinks: "RemoveHyperlinks",
+    ResetContents: "ResetContents",
+  };
+
+  Excel.Range.prototype.clear = function (applyTo) {
+    var mode = applyTo == null ? "All" : clearModes[applyTo];
+    if (mode === undefined) {
+      // Preserve deferred Rich API error timing: the invalid operation is
+      // reported by the host when this batch is synchronized.
+      mode = applyTo;
+    }
+    this.context._queue.push({
+      op: "rangeClear",
+      id: this._id,
+      applyTo: mode,
+    });
+  };
+
+  Excel.Range.prototype.set = setProperties;
+  Excel.Range.prototype.toJSON = toJSON;
+})(globalThis);

--- a/compute/officejs/src/range_content.rs
+++ b/compute/officejs/src/range_content.rs
@@ -1,0 +1,310 @@
+//! Range content projections for the embedded Office.js host.
+//!
+//! `Range` exposes a few properties whose values are naturally rectangular:
+//! `numberFormat`, `text`, and `valueTypes`.  The helpers in this module keep
+//! the Office.js wire shape at the boundary while delegating reads and writes
+//! to the public `compute-api` [`Sheet`] facade.
+//!
+//! The locale-aware `formulasLocal` property is intentionally not included.
+//! Translating formula names and separators without the workbook's culture
+//! would return a plausible but incorrect result.
+
+use std::collections::{BTreeMap, HashMap};
+
+use compute_api::{CellRange, CellValue, ComputeApiError, Sheet};
+use serde_json::{json, Value};
+
+/// Error returned by a Range content projection.
+///
+/// Office.js host routing uses the same two fields as the other embedded host
+/// adapters (`format` and `tables`) and maps them to a Rich API error at
+/// `context.sync()`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RangeContentError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+/// Load one or more supported rectangular Range content properties.
+///
+/// `address` is a bounded A1 range (for example, `"A1:C3"`).  The host keeps
+/// whole-worksheet ranges unbounded and must return `null` for their cell
+/// properties before calling this helper.
+pub(crate) fn load(
+    sheet: &Sheet,
+    address: &str,
+    properties: &[String],
+) -> Result<HashMap<String, Value>, RangeContentError> {
+    let bounds = resolve_bounds(address)?;
+    let mut result = HashMap::new();
+
+    for property in properties {
+        let value = match property.as_str() {
+            "numberFormat" => number_formats(sheet, bounds)?,
+            "text" => text(sheet, bounds)?,
+            "valueTypes" => value_types(sheet, bounds)?,
+            // In particular, do not approximate formulasLocal with A1
+            // formulas.  Its localized function names and separators require
+            // a real culture-aware implementation at a later boundary.
+            other => return Err(unsupported_load_property(other)),
+        };
+        result.insert(property.clone(), value);
+    }
+
+    Ok(result)
+}
+
+/// Set the `Range.numberFormat` projection.
+///
+/// The payload must be a 2D array whose dimensions exactly match `address`.
+/// `null` entries are Office.js preserve-cell sentinels and are skipped.  All
+/// payload cells are validated before the first engine mutation, so a bad
+/// shape or value cannot partially update a range.
+pub(crate) fn set(
+    sheet: &Sheet,
+    address: &str,
+    property: &str,
+    value: &Value,
+) -> Result<(), RangeContentError> {
+    if property != "numberFormat" {
+        return Err(unsupported_set_property(property));
+    }
+
+    let bounds = resolve_bounds(address)?;
+    let (start_row, start_col, end_row, end_col) = bounds;
+    let expected_rows = (end_row - start_row + 1) as usize;
+    let expected_cols = (end_col - start_col + 1) as usize;
+    let rows = value
+        .as_array()
+        .ok_or_else(|| invalid_shape("a 2-dimensional array"))?;
+
+    if rows.len() != expected_rows {
+        return Err(invalid_shape(format!(
+            "numberFormat has {} rows; target range requires {expected_rows}",
+            rows.len()
+        )));
+    }
+
+    // Group equal format codes so a heterogeneous payload still uses the
+    // range-level compute-api patch primitive and each distinct code is sent
+    // as one mutation. BTreeMap keeps mutation order deterministic.
+    let mut patches: BTreeMap<String, Vec<(u32, u32, u32, u32)>> = BTreeMap::new();
+    for (row_offset, row) in rows.iter().enumerate() {
+        let cells = row
+            .as_array()
+            .ok_or_else(|| invalid_shape("a 2-dimensional array"))?;
+        if cells.len() != expected_cols {
+            return Err(invalid_shape(format!(
+                "numberFormat row {row_offset} has {} columns; target range requires {expected_cols}",
+                cells.len()
+            )));
+        }
+        for (col_offset, cell) in cells.iter().enumerate() {
+            let Some(format_code) = cell.as_str() else {
+                if cell.is_null() {
+                    continue;
+                }
+                return Err(invalid_value(
+                    "Range.numberFormat cells must be strings or null",
+                ));
+            };
+            let row = start_row + row_offset as u32;
+            let col = start_col + col_offset as u32;
+            patches
+                .entry(format_code.to_owned())
+                .or_default()
+                .push((row, col, row, col));
+        }
+    }
+
+    for (format_code, ranges) in patches {
+        // `CellFormat` is owned by domain-types and is deliberately consumed
+        // through compute-api's public method here. Type inference keeps this
+        // module independent of a second direct domain-types dependency.
+        let format = serde_json::from_value(json!({ "numberFormat": format_code }))
+            .map_err(|error| encoding(error.to_string()))?;
+        sheet
+            .formats()
+            .patch_format_for_ranges(ranges, format, Vec::new())
+            .map_err(engine)?;
+    }
+
+    Ok(())
+}
+
+/// Clear a Range using an Office.js `ClearApplyTo` token.
+///
+/// The compute-api facade has production primitives for `All`, `Formats`,
+/// `Contents`, and `Hyperlinks`. `RemoveHyperlinks` additionally clears
+/// formatting while preserving content, and `ResetContents` has control-aware
+/// behavior; neither can be represented faithfully by the current facade, so
+/// they fail with `InvalidArgument` rather than silently doing the wrong thing.
+pub(crate) fn clear(sheet: &Sheet, address: &str, apply_to: &str) -> Result<(), RangeContentError> {
+    let mode = match apply_to {
+        "All" => "all",
+        "Formats" => "formats",
+        "Contents" => "contents",
+        "Hyperlinks" => "hyperlinks",
+        "RemoveHyperlinks" | "ResetContents" => {
+            return Err(unsupported_clear_mode(apply_to));
+        }
+        other => return Err(invalid_value(format!("Unsupported clear mode '{other}'"))),
+    };
+
+    let bounds = resolve_bounds(address)?;
+    sheet
+        .clear_with_mode(
+            CellRange::Bounds(bounds.0, bounds.1, bounds.2, bounds.3),
+            mode,
+        )
+        .map(|_| ())
+        .map_err(engine)
+}
+
+fn number_formats(
+    sheet: &Sheet,
+    (start_row, start_col, end_row, end_col): (u32, u32, u32, u32),
+) -> Result<Value, RangeContentError> {
+    let mut rows = Vec::with_capacity((end_row - start_row + 1) as usize);
+    for row in start_row..=end_row {
+        let mut cells = Vec::with_capacity((end_col - start_col + 1) as usize);
+        for col in start_col..=end_col {
+            let format = sheet.formats().get_cell_format(row, col).map_err(engine)?;
+            let format =
+                serde_json::to_value(format).map_err(|error| encoding(error.to_string()))?;
+            let number_format = format
+                .get("numberFormat")
+                .and_then(Value::as_str)
+                .unwrap_or("General");
+            cells.push(Value::String(number_format.to_owned()));
+        }
+        rows.push(Value::Array(cells));
+    }
+    Ok(Value::Array(rows))
+}
+
+fn text(
+    sheet: &Sheet,
+    (start_row, start_col, end_row, end_col): (u32, u32, u32, u32),
+) -> Result<Value, RangeContentError> {
+    let mut rows = Vec::with_capacity((end_row - start_row + 1) as usize);
+    for row in start_row..=end_row {
+        let mut cells = Vec::with_capacity((end_col - start_col + 1) as usize);
+        for col in start_col..=end_col {
+            // Sheet::get_display_value is the engine's formatted display
+            // projection. It does not depend on column width, so the '#'
+            // substitution used by Excel's UI never appears here.
+            cells.push(Value::String(
+                sheet.get_display_value((row, col)).map_err(engine)?,
+            ));
+        }
+        rows.push(Value::Array(cells));
+    }
+    Ok(Value::Array(rows))
+}
+
+fn value_types(
+    sheet: &Sheet,
+    (start_row, start_col, end_row, end_col): (u32, u32, u32, u32),
+) -> Result<Value, RangeContentError> {
+    let mut rows = Vec::with_capacity((end_row - start_row + 1) as usize);
+    for row in start_row..=end_row {
+        let mut cells = Vec::with_capacity((end_col - start_col + 1) as usize);
+        for col in start_col..=end_col {
+            let value = sheet.get_cell_value((row, col)).map_err(engine)?;
+            cells.push(Value::String(value_type_name(&value).to_owned()));
+        }
+        rows.push(Value::Array(cells));
+    }
+    Ok(Value::Array(rows))
+}
+
+fn value_type_name(value: &CellValue) -> &'static str {
+    match value {
+        CellValue::Null => "Empty",
+        CellValue::Text(_) => "String",
+        CellValue::Boolean(_) => "Boolean",
+        CellValue::Number(number) => {
+            // Excel exposes integral numeric cells as Integer and fractional
+            // numeric cells as Double. Dates remain numbers here; their date
+            // presentation is carried by numberFormat/text.
+            #[allow(clippy::float_cmp)]
+            if number.get().fract() == 0.0 {
+                "Integer"
+            } else {
+                "Double"
+            }
+        }
+        CellValue::Error(_, _) => "Error",
+        CellValue::Array(_) | CellValue::Control(_) | CellValue::Image(_) => "RichValue",
+    }
+}
+
+fn resolve_bounds(address: &str) -> Result<(u32, u32, u32, u32), RangeContentError> {
+    CellRange::from(address)
+        .resolve()
+        .map_err(map_address_error)
+}
+
+fn map_address_error(error: ComputeApiError) -> RangeContentError {
+    match error {
+        ComputeApiError::InvalidAddress { address, reason } => RangeContentError {
+            code: "InvalidArgument",
+            message: format!("invalid address: {address} — {reason}"),
+        },
+        ComputeApiError::InvalidRange { range, reason } => RangeContentError {
+            code: "InvalidArgument",
+            message: format!("invalid range: {range} — {reason}"),
+        },
+        other => engine(other),
+    }
+}
+
+fn engine(error: impl std::fmt::Display) -> RangeContentError {
+    RangeContentError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn encoding(message: impl Into<String>) -> RangeContentError {
+    RangeContentError {
+        code: "GeneralException",
+        message: format!("range content conversion failed: {}", message.into()),
+    }
+}
+
+fn invalid_shape(message: impl Into<String>) -> RangeContentError {
+    RangeContentError {
+        code: "InvalidArgument",
+        message: format!("Range.numberFormat requires {}", message.into()),
+    }
+}
+
+fn invalid_value(message: impl Into<String>) -> RangeContentError {
+    RangeContentError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn unsupported_load_property(property: &str) -> RangeContentError {
+    RangeContentError {
+        code: "InvalidArgument",
+        message: format!("Unsupported Range load property '{property}'"),
+    }
+}
+
+fn unsupported_set_property(property: &str) -> RangeContentError {
+    RangeContentError {
+        code: "InvalidArgument",
+        message: format!("Unsupported Range set property '{property}'"),
+    }
+}
+
+fn unsupported_clear_mode(mode: &str) -> RangeContentError {
+    RangeContentError {
+        code: "InvalidArgument",
+        message: format!("Range.clear mode '{mode}' is not supported by this host"),
+    }
+}

--- a/compute/officejs/src/range_copy.js
+++ b/compute/officejs/src/range_copy.js
@@ -1,0 +1,116 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+
+  // `Range.copyFrom` and `Range.moveTo` are mutations.  Keep argument checks
+  // that Office.js can perform without touching the workbook synchronous, and
+  // defer address/object-path/worksheet validation to context.sync().
+  function invalidArgument(message) {
+    var error = new OfficeExtension.Error({
+      code: "InvalidArgument",
+      message: message,
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidArgument";
+    return error;
+  }
+
+  function invalidRequestContext() {
+    var error = new OfficeExtension.Error({
+      code: "InvalidRequestContext",
+      message: "The object belongs to a different request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidRequestContext";
+    return error;
+  }
+
+  var copyTypes = {
+    All: true,
+    Formulas: true,
+    Values: true,
+    Formats: true,
+    Link: true,
+  };
+
+  function normalizeCopyType(copyType) {
+    if (copyType === undefined) return "All";
+    if (typeof copyType !== "string" || !copyTypes[copyType]) {
+      throw invalidArgument(
+        "Range.copyFrom copyType must be one of All, Formulas, Values, Formats, or Link."
+      );
+    }
+    return copyType;
+  }
+
+  function normalizeBoolean(value, name, defaultValue) {
+    if (value === undefined) return defaultValue;
+    if (typeof value !== "boolean") {
+      throw invalidArgument("Range.copyFrom " + name + " must be a boolean.");
+    }
+    return value;
+  }
+
+  function sourceDescriptor(range, context) {
+    if (range instanceof Excel.Range) {
+      if (range.context !== context) throw invalidRequestContext();
+      return { sourceRangeId: range._id };
+    }
+    if (typeof range === "string") {
+      if (range.trim().length === 0) {
+        throw invalidArgument("Range.copyFrom sourceRange cannot be empty.");
+      }
+      return { sourceAddress: range };
+    }
+    throw invalidArgument(
+      "Range.copyFrom sourceRange must be a Range or range address string."
+    );
+  }
+
+  function destinationDescriptor(range, context) {
+    if (range instanceof Excel.Range) {
+      if (range.context !== context) throw invalidRequestContext();
+      return { destinationRangeId: range._id };
+    }
+    if (typeof range === "string") {
+      if (range.trim().length === 0) {
+        throw invalidArgument("Range.moveTo destinationRange cannot be empty.");
+      }
+      return { destinationAddress: range };
+    }
+    throw invalidArgument(
+      "Range.moveTo destinationRange must be a Range or range address string."
+    );
+  }
+
+  Excel.Range.prototype.copyFrom = function (
+    sourceRange,
+    copyType,
+    skipBlanks,
+    transpose
+  ) {
+    var source = sourceDescriptor(sourceRange, this.context);
+    var op = {
+      op: "rangeCopy",
+      id: this._id,
+      copyType: normalizeCopyType(copyType),
+      skipBlanks: normalizeBoolean(skipBlanks, "skipBlanks", false),
+      transpose: normalizeBoolean(transpose, "transpose", false),
+    };
+    Object.keys(source).forEach(function (key) {
+      op[key] = source[key];
+    });
+    this.context._queue.push(op);
+  };
+
+  Excel.Range.prototype.moveTo = function (destinationRange) {
+    var destination = destinationDescriptor(destinationRange, this.context);
+    var op = { op: "rangeMove", id: this._id };
+    Object.keys(destination).forEach(function (key) {
+      op[key] = destination[key];
+    });
+    this.context._queue.push(op);
+  };
+})(globalThis);

--- a/compute/officejs/src/range_copy.rs
+++ b/compute/officejs/src/range_copy.rs
@@ -1,0 +1,319 @@
+//! Office.js `Range.copyFrom` and `Range.moveTo` adapters.
+//!
+//! The JavaScript proxy only records the source/destination object path.  This
+//! module resolves bounded A1 ranges and routes the mutation to the typed
+//! `compute-api` facade.  `copyFrom` deliberately uses the engine's copy
+//! mutation, which preserves formulas and formats according to `CopyType`;
+//! `moveTo` uses the identity-preserving relocation mutation rather than the
+//! legacy value-only relocation helper.
+
+use compute_api::{CellRange, ComputeApiError, CopyType, Sheet};
+
+/// Number of rows and columns in the Excel worksheet grid.
+const LAST_ROW: u32 = 1_048_575;
+const LAST_COLUMN: u32 = 16_383;
+
+/// Error returned by the Office.js range-copy boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RangeCopyError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+impl RangeCopyError {
+    fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            code: "InvalidArgument",
+            message: message.into(),
+        }
+    }
+
+    fn unsupported(message: impl Into<String>) -> Self {
+        Self {
+            code: "UnsupportedOperation",
+            message: message.into(),
+        }
+    }
+}
+
+impl From<ComputeApiError> for RangeCopyError {
+    fn from(error: ComputeApiError) -> Self {
+        match error {
+            ComputeApiError::InvalidAddress { .. }
+            | ComputeApiError::InvalidRange { .. }
+            | ComputeApiError::InvalidOperation(_) => Self::invalid(error.to_string()),
+            ComputeApiError::SheetNotFound { .. } => Self {
+                code: "ItemNotFound",
+                message: error.to_string(),
+            },
+            other => Self {
+                code: "GeneralException",
+                message: other.to_string(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Bounds {
+    start_row: u32,
+    start_col: u32,
+    end_row: u32,
+    end_col: u32,
+}
+
+impl Bounds {
+    fn parse(address: &str, operation: &str) -> Result<Self, RangeCopyError> {
+        let (start_row, start_col, end_row, end_col) = CellRange::from(address)
+            .resolve()
+            .map_err(|error| RangeCopyError::invalid(format!("{operation}: {error}")))?;
+        if start_row > end_row || start_col > end_col {
+            return Err(RangeCopyError::invalid(format!(
+                "{operation} range '{address}' has its end before its start"
+            )));
+        }
+        if end_row > LAST_ROW || end_col > LAST_COLUMN {
+            return Err(RangeCopyError::invalid(format!(
+                "{operation} range '{address}' exceeds the worksheet grid"
+            )));
+        }
+        Ok(Self {
+            start_row,
+            start_col,
+            end_row,
+            end_col,
+        })
+    }
+
+    fn rows(self) -> u32 {
+        self.end_row - self.start_row + 1
+    }
+
+    fn cols(self) -> u32 {
+        self.end_col - self.start_col + 1
+    }
+}
+
+/// Parse the Office.js `RangeCopyType` wire token.
+///
+/// `Link` is part of the pinned declaration but the compute engine has no
+/// linked-data copy primitive.  Keep it explicit so it cannot silently become
+/// an ordinary value copy.
+pub(crate) fn copy_type(value: &str) -> Result<CopyType, RangeCopyError> {
+    match value {
+        "All" => Ok(CopyType::All),
+        "Formulas" => Ok(CopyType::Formulas),
+        "Values" => Ok(CopyType::Values),
+        "Formats" => Ok(CopyType::Formats),
+        "Link" => Err(RangeCopyError::unsupported(
+            "Range.copyFrom copyType 'Link' requires linked-data support, which this engine does not provide",
+        )),
+        other => Err(RangeCopyError::invalid(format!(
+            "Unsupported Range.copyFrom copyType '{other}'"
+        ))),
+    }
+}
+
+fn validate_extent(
+    start_row: u32,
+    start_col: u32,
+    rows: u32,
+    cols: u32,
+    operation: &str,
+) -> Result<(), RangeCopyError> {
+    let end_row = start_row.checked_add(rows.checked_sub(1).ok_or_else(|| {
+        RangeCopyError::invalid(format!("{operation} requires a non-empty source range"))
+    })?);
+    let end_col = start_col.checked_add(cols.checked_sub(1).ok_or_else(|| {
+        RangeCopyError::invalid(format!("{operation} requires a non-empty source range"))
+    })?);
+    if end_row.is_none_or(|row| row > LAST_ROW) || end_col.is_none_or(|col| col > LAST_COLUMN) {
+        return Err(RangeCopyError::invalid(format!(
+            "{operation} destination exceeds the worksheet grid"
+        )));
+    }
+    Ok(())
+}
+
+/// Copy a source range to the current destination range.
+///
+/// The source and target addresses are unqualified, canonical A1 ranges.  A
+/// host resolving a sheet-qualified Office.js string must select the source
+/// sheet first and pass only its range portion here.  The destination starts at
+/// the top-left cell of `target_address`; when it is smaller than the source,
+/// the target is expanded.  Exact multiples of the source shape are repeated
+/// using the same production copy mutation for each tile.
+pub(crate) fn copy_from(
+    source_sheet: &Sheet,
+    source_address: &str,
+    target_sheet: &Sheet,
+    target_address: &str,
+    copy_type_wire: &str,
+    skip_blanks: bool,
+    transpose: bool,
+) -> Result<(), RangeCopyError> {
+    let copy_type = copy_type(copy_type_wire)?;
+    let source = Bounds::parse(source_address, "Range.copyFrom source")?;
+    let target = Bounds::parse(target_address, "Range.copyFrom destination")?;
+
+    let source_rows = source.rows();
+    let source_cols = source.cols();
+    let tile_rows = if transpose { source_cols } else { source_rows };
+    let tile_cols = if transpose { source_rows } else { source_cols };
+
+    // Office.js expands a destination that is smaller than the source.  When
+    // the destination is larger, a source is repeated only along dimensions
+    // that are exact multiples; a non-multiple dimension receives one source
+    // tile and retains cells beyond that tile.
+    let target_rows = target.rows().max(tile_rows);
+    let target_cols = target.cols().max(tile_cols);
+    let row_tiles = if target.rows() > tile_rows && target.rows() % tile_rows == 0 {
+        target.rows() / tile_rows
+    } else {
+        1
+    };
+    let col_tiles = if target.cols() > tile_cols && target.cols() % tile_cols == 0 {
+        target.cols() / tile_cols
+    } else {
+        1
+    };
+    validate_extent(
+        target.start_row,
+        target.start_col,
+        target_rows,
+        target_cols,
+        "Range.copyFrom",
+    )?;
+
+    // The engine snapshots its source for each individual copy mutation. When
+    // an exact-multiple destination overlaps the source, issuing every tile
+    // against the original source would let an earlier tile overwrite source
+    // cells needed by a later tile. For the ordinary (non-skip-blanks) copy
+    // contract, the first destination tile is itself a complete source
+    // snapshot; use it as the source for subsequent tiles. Formula rebasing
+    // composes across that first copy, and transposition is applied only on
+    // the first leg so later tiles retain the transposed shape.
+    //
+    // With skipBlanks, a blank source cell intentionally leaves the first
+    // destination tile's existing value in place, so that tile cannot be used
+    // as a faithful source snapshot. Keep the original source for each tile
+    // in that mode; the engine still snapshots each individual operation.
+    let mut use_staged_source = !skip_blanks && (row_tiles > 1 || col_tiles > 1);
+    let mut copy_source_sheet = source_sheet;
+    let mut copy_source = source;
+    let mut copy_transpose = transpose;
+
+    for row_tile in 0..row_tiles {
+        for col_tile in 0..col_tiles {
+            let row_offset = row_tile
+                .checked_mul(tile_rows)
+                .ok_or_else(|| RangeCopyError::invalid("Range.copyFrom destination overflow"))?;
+            let col_offset = col_tile
+                .checked_mul(tile_cols)
+                .ok_or_else(|| RangeCopyError::invalid("Range.copyFrom destination overflow"))?;
+            let destination_row = target
+                .start_row
+                .checked_add(row_offset)
+                .ok_or_else(|| RangeCopyError::invalid("Range.copyFrom destination overflow"))?;
+            let destination_col = target
+                .start_col
+                .checked_add(col_offset)
+                .ok_or_else(|| RangeCopyError::invalid("Range.copyFrom destination overflow"))?;
+
+            target_sheet
+                .copy_range(
+                    copy_source_sheet.id(),
+                    copy_source.start_row,
+                    copy_source.start_col,
+                    copy_source.end_row,
+                    copy_source.end_col,
+                    destination_row,
+                    destination_col,
+                    copy_type,
+                    skip_blanks,
+                    copy_transpose,
+                )
+                .map_err(RangeCopyError::from)?;
+
+            if use_staged_source {
+                // Every destination tile has the transposed dimensions after
+                // the first copy. It is safe to switch to the first tile as a
+                // source because all later copies use the same target sheet.
+                let staged_end_row =
+                    destination_row.checked_add(tile_rows - 1).ok_or_else(|| {
+                        RangeCopyError::invalid("Range.copyFrom destination overflow")
+                    })?;
+                let staged_end_col =
+                    destination_col.checked_add(tile_cols - 1).ok_or_else(|| {
+                        RangeCopyError::invalid("Range.copyFrom destination overflow")
+                    })?;
+                copy_source_sheet = target_sheet;
+                copy_source = Bounds {
+                    start_row: destination_row,
+                    start_col: destination_col,
+                    end_row: staged_end_row,
+                    end_col: staged_end_col,
+                };
+                copy_transpose = false;
+                use_staged_source = false;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Move the source range to the top-left cell of the destination range.
+///
+/// This calls the CellId-preserving relocation facade.  Moving the source
+/// range therefore carries formulas, formats, and references with the cells;
+/// callers must not substitute the legacy value-only `relocate_cells` method.
+pub(crate) fn move_to(
+    source_sheet: &Sheet,
+    source_address: &str,
+    target_sheet: &Sheet,
+    target_address: &str,
+) -> Result<(), RangeCopyError> {
+    let source = Bounds::parse(source_address, "Range.moveTo source")?;
+    let target = Bounds::parse(target_address, "Range.moveTo destination")?;
+    validate_extent(
+        target.start_row,
+        target.start_col,
+        source.rows(),
+        source.cols(),
+        "Range.moveTo",
+    )?;
+
+    target_sheet
+        .relocate_cells_yrs(
+            source_sheet.id(),
+            source.start_row,
+            source.start_col,
+            source.end_row,
+            source.end_col,
+            target.start_row,
+            target.start_col,
+        )
+        .map_err(RangeCopyError::from)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn copy_type_maps_supported_tokens_and_rejects_link() {
+        assert_eq!(copy_type("All").unwrap(), CopyType::All);
+        assert_eq!(copy_type("Formulas").unwrap(), CopyType::Formulas);
+        assert_eq!(copy_type("Values").unwrap(), CopyType::Values);
+        assert_eq!(copy_type("Formats").unwrap(), CopyType::Formats);
+        assert_eq!(copy_type("Link").unwrap_err().code, "UnsupportedOperation");
+    }
+
+    #[test]
+    fn copy_destination_expansion_checks_the_transposed_extent() {
+        let target = Bounds::parse("XFD1", "target").unwrap();
+        assert!(validate_extent(target.start_row, target.start_col, 1, 2, "copy").is_err());
+        assert!(validate_extent(0, 0, 2, 1, "copy").is_ok());
+    }
+}

--- a/compute/officejs/src/range_fill.js
+++ b/compute/officejs/src/range_fill.js
@@ -1,0 +1,95 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+
+  function invalidArgument(message) {
+    var error = new OfficeExtension.Error({
+      code: "InvalidArgument",
+      message: message,
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidArgument";
+    return error;
+  }
+
+  function invalidRequestContext() {
+    var error = new global.OfficeExtension.Error({
+      code: "InvalidRequestContext",
+      message: "The object belongs to a different request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidRequestContext";
+    return error;
+  }
+
+  function rangeArgument(source, value) {
+    if (value instanceof Excel.Range) {
+      if (value.context !== source.context) throw invalidRequestContext();
+      return { destinationRangeId: value._id };
+    }
+    if (typeof value === "string") {
+      if (value.trim().length === 0) {
+        throw invalidArgument("Range.autoFill destinationRange cannot be empty.");
+      }
+      return { destinationAddress: value };
+    }
+    if (value === undefined || value === null) return {};
+    throw invalidArgument(
+      "Range.autoFill destinationRange must be a Range, range address string, or null."
+    );
+  }
+
+  var autoFillTypes = {
+    FillDefault: true,
+    FillCopy: true,
+    FillSeries: true,
+    FillFormats: true,
+    FillValues: true,
+    FillDays: true,
+    FillWeekdays: true,
+    FillMonths: true,
+    FillYears: true,
+    LinearTrend: true,
+    GrowthTrend: true,
+    FlashFill: true,
+  };
+
+  function normalizeAutoFillType(value) {
+    if (value === undefined) return null;
+    if (
+      typeof value !== "string" ||
+      !Object.prototype.hasOwnProperty.call(autoFillTypes, value)
+    ) {
+      throw invalidArgument(
+        "Range.autoFill autoFillType must be one of FillDefault, FillCopy, FillSeries, FillFormats, FillValues, FillDays, FillWeekdays, FillMonths, FillYears, LinearTrend, GrowthTrend, or FlashFill."
+      );
+    }
+    return value;
+  }
+
+  // Range.autoFill and Range.flashFill are the complete fill-method surface
+  // in the pinned Excel declarations. In particular, the declarations do not
+  // contain Range.fillDown/fillRight/fillUp/fillLeft; adding those would make
+  // this runtime expose an API that Microsoft does not declare.
+  Excel.Range.prototype.autoFill = function (destinationRange, autoFillType) {
+    var op = {
+      op: "rangeAutoFill",
+      id: this._id,
+      autoFillType: normalizeAutoFillType(autoFillType),
+    };
+    var destination = rangeArgument(this, destinationRange);
+    Object.keys(destination).forEach(function (key) {
+      op[key] = destination[key];
+    });
+    this.context._queue.push(op);
+  };
+
+  Excel.Range.prototype.flashFill = function () {
+    this.context._queue.push({
+      op: "rangeFlashFill",
+      id: this._id,
+    });
+  };
+})(globalThis);

--- a/compute/officejs/src/range_fill.rs
+++ b/compute/officejs/src/range_fill.rs
@@ -1,0 +1,711 @@
+//! Office.js `Range.autoFill` and `Range.flashFill` adapters.
+//!
+//! The JavaScript proxy queues only object-path information. This module owns
+//! the typed boundary: it resolves bounded A1 ranges, validates the
+//! destination geometry against the Office.js contract, maps the exact
+//! `AutoFillType` strings to the production compute-fill modes, and calls the
+//! compute-api fill facade. `Range.flashFill` uses the adjacent populated
+//! column as its source, matching the Excel operation's surrounding-data
+//! behavior.
+
+use compute_api::{ComputeApiError, Sheet};
+use serde_json::{json, Value};
+
+use crate::dispatch::{ExtensionHandler, HostDispatchContext};
+use crate::host::{BatchError, RangeRef};
+use crate::range_navigation::{
+    parse_range_address, RangeAddress, RangeNavigationError, EXCEL_MAX_COLUMNS, EXCEL_MAX_ROWS,
+};
+
+/// Error returned by the Office.js range-fill boundary.
+///
+/// `Host` maps this to a Rich API error when the queued operation is
+/// synchronized. Keeping the Office error code here makes unsupported fill
+/// variants explicit instead of turning them into a silent no-op.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RangeFillError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Bounds {
+    start_row: u32,
+    start_col: u32,
+    end_row: u32,
+    end_col: u32,
+}
+
+impl Bounds {
+    fn from_range(address: &RangeAddress, label: &str) -> Result<Self, RangeFillError> {
+        if address.is_whole_sheet() || address.is_entire_row() || address.is_entire_column() {
+            return Err(invalid(format!(
+                "Range.{label} requires a bounded cell range"
+            )));
+        }
+
+        let (start_row, start_col, end_row, end_col) = address.bounds();
+        if start_row > end_row || start_col > end_col {
+            return Err(invalid(format!("Range.{label} requires a non-empty range")));
+        }
+        if end_row >= EXCEL_MAX_ROWS || end_col >= EXCEL_MAX_COLUMNS {
+            return Err(invalid(format!(
+                "Range.{label} destination is outside the worksheet grid"
+            )));
+        }
+        Ok(Self {
+            start_row,
+            start_col,
+            end_row,
+            end_col,
+        })
+    }
+
+    fn row_count(self) -> u32 {
+        self.end_row - self.start_row + 1
+    }
+
+    fn col_count(self) -> u32 {
+        self.end_col - self.start_col + 1
+    }
+
+    fn contains(self, other: Self) -> bool {
+        self.start_row <= other.start_row
+            && self.start_col <= other.start_col
+            && self.end_row >= other.end_row
+            && self.end_col >= other.end_col
+    }
+
+    fn to_wire(self) -> Value {
+        json!({
+            "startRow": self.start_row,
+            "startCol": self.start_col,
+            "endRow": self.end_row,
+            "endCol": self.end_col,
+        })
+    }
+}
+
+/// The exact string-valued enum members declared by Microsoft for
+/// `Excel.AutoFillType`. Keep this list in one place so validation and tests
+/// cannot drift from the pinned declarations.
+pub(crate) const AUTO_FILL_TYPES: &[&str] = &[
+    "FillDefault",
+    "FillCopy",
+    "FillSeries",
+    "FillFormats",
+    "FillValues",
+    "FillDays",
+    "FillWeekdays",
+    "FillMonths",
+    "FillYears",
+    "LinearTrend",
+    "GrowthTrend",
+    "FlashFill",
+];
+
+/// Queue target-independent autofill data for a host caller.
+///
+/// The host passes the current Range address and, when supplied, the
+/// destination Range address. `None` follows Excel's double-click fill-handle
+/// behavior by looking for a contiguous populated neighboring lane. A
+/// destination must contain the source range and extend it on exactly one
+/// axis, because the pinned Office.js contract says it can extend horizontally
+/// or vertically.
+pub(crate) fn auto_fill(
+    sheet: &Sheet,
+    source_address: &str,
+    destination_address: Option<&str>,
+    auto_fill_type: Option<&str>,
+) -> Result<(), RangeFillError> {
+    let source = bounds_for(sheet, source_address, "autoFill source")?;
+    let kind = auto_fill_type.unwrap_or("FillDefault");
+    validate_auto_fill_type(kind)?;
+
+    // The compute-fill engine has a separate Flash Fill input contract. It
+    // cannot faithfully interpret AutoFillType.FlashFill as a source-to-
+    // destination series, so reject this enum member rather than mapping it
+    // to ordinary autofill and producing the wrong data.
+    if kind == "FlashFill" {
+        return Err(unsupported(
+            "Range.autoFill with AutoFillType.FlashFill is not supported; use Range.flashFill()"
+                .to_string(),
+        ));
+    }
+
+    let destination = match destination_address {
+        Some(address) => bounds_for(sheet, address, "autoFill destination")?,
+        None => match infer_destination(sheet, source)? {
+            Some((destination, _direction)) => destination,
+            None => {
+                // Excel's fill-handle operation has no target when there is
+                // no adjacent data. Treat it as an empty operation, matching
+                // the host's no-op behavior while retaining validation for an
+                // invalid explicit destination.
+                return Ok(());
+            }
+        },
+    };
+
+    let direction = validate_destination(source, destination)?;
+    let mode = mode_for_auto_fill_type(kind);
+    let request = json!({
+        "sourceRange": source.to_wire(),
+        "targetRange": destination.to_wire(),
+        "direction": direction,
+        "mode": mode,
+        "includeFormulas": true,
+        "includeValues": true,
+        "includeFormats": true,
+        "stepValue": 1.0,
+    });
+
+    // The compute-api facade owns the typed BridgeAutoFillRequest and invokes
+    // the production compute-fill engine. Deserializing through Value keeps
+    // this adapter independent of the core crate's internal module path; the
+    // argument type is inferred by Sheet::auto_fill.
+    sheet
+        .auto_fill(serde_json::from_value(request).map_err(|error| encoding(error.to_string()))?)
+        .map(|_| ())
+        .map_err(engine)
+}
+
+/// Apply `Range.flashFill` to a bounded single-column range.
+///
+/// The production flash-fill engine consumes an input column and an example
+/// output column. Office.js exposes only the output Range, so the host chooses
+/// the populated immediate neighbor (left first on a tie) as the input column.
+/// Both ranges have exactly the selected row span; the compute engine then
+/// infers the transformation from already-entered examples in the target.
+pub(crate) fn flash_fill(sheet: &Sheet, target_address: &str) -> Result<(), RangeFillError> {
+    let target = bounds_for(sheet, target_address, "flashFill")?;
+    if target.col_count() != 1 {
+        return Err(invalid(
+            "Range.flashFill requires a single-column range".to_string(),
+        ));
+    }
+
+    let source_col = neighboring_source_column(sheet, target)?;
+    let source = Bounds {
+        start_row: target.start_row,
+        end_row: target.end_row,
+        start_col: source_col,
+        end_col: source_col,
+    };
+    let request = json!({
+        "sourceRange": source.to_wire(),
+        "targetRange": target.to_wire(),
+    });
+
+    sheet
+        .flash_fill(serde_json::from_value(request).map_err(|error| encoding(error.to_string()))?)
+        .map(|_| ())
+        .map_err(engine)
+}
+
+fn bounds_for(sheet: &Sheet, address: &str, label: &str) -> Result<Bounds, RangeFillError> {
+    let parsed = parse_range_address(sheet, address).map_err(navigation)?;
+    Bounds::from_range(&parsed, label)
+}
+
+fn validate_auto_fill_type(kind: &str) -> Result<(), RangeFillError> {
+    if AUTO_FILL_TYPES.contains(&kind) {
+        Ok(())
+    } else {
+        Err(invalid(format!(
+            "Unsupported AutoFillType '{kind}'; expected one of {}",
+            AUTO_FILL_TYPES.join(", ")
+        )))
+    }
+}
+
+fn mode_for_auto_fill_type(kind: &str) -> &'static str {
+    match kind {
+        "FillCopy" => "copy",
+        "FillSeries" => "series",
+        "FillFormats" => "formats",
+        "FillValues" => "values",
+        "FillDays" => "days",
+        "FillWeekdays" => "weekdays",
+        "FillMonths" => "months",
+        "FillYears" => "years",
+        "LinearTrend" => "linearTrend",
+        "GrowthTrend" => "growthTrend",
+        // FillDefault is the engine's pattern-detecting mode.
+        "FillDefault" => "auto",
+        // Validated before this function is called. Keep a total match for
+        // future enum additions while ensuring FlashFill is never coerced.
+        "FlashFill" => "auto",
+        _ => "auto",
+    }
+}
+
+fn validate_destination(
+    source: Bounds,
+    destination: Bounds,
+) -> Result<&'static str, RangeFillError> {
+    if !destination.contains(source) {
+        return Err(invalid(
+            "Range.autoFill destination must contain the source range".to_string(),
+        ));
+    }
+
+    let rows_extended =
+        destination.start_row < source.start_row || destination.end_row > source.end_row;
+    let cols_extended =
+        destination.start_col < source.start_col || destination.end_col > source.end_col;
+    if rows_extended && cols_extended {
+        return Err(invalid(
+            "Range.autoFill destination may extend the source horizontally or vertically, not both"
+                .to_string(),
+        ));
+    }
+
+    if rows_extended {
+        if destination.start_col != source.start_col || destination.end_col != source.end_col {
+            return Err(invalid(
+                "Range.autoFill vertical fill requires the source columns to stay aligned"
+                    .to_string(),
+            ));
+        }
+        if destination.start_row < source.start_row && destination.end_row > source.end_row {
+            return Err(invalid(
+                "Range.autoFill cannot extend above and below the source in one operation"
+                    .to_string(),
+            ));
+        }
+        return Ok(if destination.end_row > source.end_row {
+            "down"
+        } else {
+            "up"
+        });
+    }
+
+    if cols_extended {
+        if destination.start_row != source.start_row || destination.end_row != source.end_row {
+            return Err(invalid(
+                "Range.autoFill horizontal fill requires the source rows to stay aligned"
+                    .to_string(),
+            ));
+        }
+        if destination.start_col < source.start_col && destination.end_col > source.end_col {
+            return Err(invalid(
+                "Range.autoFill cannot extend left and right of the source in one operation"
+                    .to_string(),
+            ));
+        }
+        return Ok(if destination.end_col > source.end_col {
+            "right"
+        } else {
+            "left"
+        });
+    }
+
+    // An exact source/destination range is a valid no-op. The direction does
+    // not affect the result, but Down is the engine's documented default.
+    Ok("down")
+}
+
+/// Infer the destination used by `autoFill(null)` from contiguous data in an
+/// immediate neighboring lane. Returns the longest candidate, with a stable
+/// Down, Up, Right, Left tie-break order.
+fn infer_destination(
+    sheet: &Sheet,
+    source: Bounds,
+) -> Result<Option<(Bounds, &'static str)>, RangeFillError> {
+    let mut candidates = Vec::new();
+
+    if source.end_row + 1 < EXCEL_MAX_ROWS {
+        for col in neighboring_columns(source) {
+            if let Some(end_row) = contiguous_down(sheet, col, source.end_row + 1)? {
+                candidates.push((
+                    Bounds {
+                        start_row: source.start_row,
+                        start_col: source.start_col,
+                        end_row,
+                        end_col: source.end_col,
+                    },
+                    "down",
+                ));
+            }
+        }
+    }
+    if source.start_row > 0 {
+        for col in neighboring_columns(source) {
+            if let Some(start_row) = contiguous_up(sheet, col, source.start_row - 1)? {
+                candidates.push((
+                    Bounds {
+                        start_row,
+                        start_col: source.start_col,
+                        end_row: source.end_row,
+                        end_col: source.end_col,
+                    },
+                    "up",
+                ));
+            }
+        }
+    }
+    if source.end_col + 1 < EXCEL_MAX_COLUMNS {
+        for row in source.start_row..=source.end_row {
+            if let Some(end_col) = contiguous_right(sheet, row, source.end_col + 1)? {
+                candidates.push((
+                    Bounds {
+                        start_row: source.start_row,
+                        start_col: source.start_col,
+                        end_row: source.end_row,
+                        end_col,
+                    },
+                    "right",
+                ));
+            }
+        }
+    }
+    if source.start_col > 0 {
+        for row in source.start_row..=source.end_row {
+            if let Some(start_col) = contiguous_left(sheet, row, source.start_col - 1)? {
+                candidates.push((
+                    Bounds {
+                        start_row: source.start_row,
+                        start_col,
+                        end_row: source.end_row,
+                        end_col: source.end_col,
+                    },
+                    "left",
+                ));
+            }
+        }
+    }
+
+    Ok(candidates.into_iter().max_by_key(|(bounds, direction)| {
+        let extension = match *direction {
+            "down" | "up" => bounds.row_count() - source.row_count(),
+            "right" | "left" => bounds.col_count() - source.col_count(),
+            _ => 0,
+        };
+        // The direction rank is inverted into a tie-break key only after the
+        // extension length. `max_by_key` therefore prefers Left on a tie;
+        // reorder the rank so Down is the greatest stable preference.
+        let rank = match *direction {
+            "down" => 4u32,
+            "up" => 3,
+            "right" => 2,
+            "left" => 1,
+            _ => 0,
+        };
+        (extension, rank)
+    }))
+}
+
+fn neighboring_columns(source: Bounds) -> impl Iterator<Item = u32> {
+    let left = source.start_col.checked_sub(1);
+    let right = (source.end_col + 1 < EXCEL_MAX_COLUMNS).then_some(source.end_col + 1);
+    left.into_iter().chain(right)
+}
+
+fn contiguous_down(sheet: &Sheet, col: u32, first_row: u32) -> Result<Option<u32>, RangeFillError> {
+    let mut row = first_row;
+    let mut last = None;
+    while row < EXCEL_MAX_ROWS && populated(sheet, row, col)? {
+        last = Some(row);
+        row += 1;
+    }
+    Ok(last)
+}
+
+fn contiguous_up(sheet: &Sheet, col: u32, first_row: u32) -> Result<Option<u32>, RangeFillError> {
+    let mut row = first_row;
+    let mut first = None;
+    loop {
+        if !populated(sheet, row, col)? {
+            break;
+        }
+        first = Some(row);
+        if row == 0 {
+            break;
+        }
+        row -= 1;
+    }
+    Ok(first)
+}
+
+fn contiguous_right(
+    sheet: &Sheet,
+    row: u32,
+    first_col: u32,
+) -> Result<Option<u32>, RangeFillError> {
+    let mut col = first_col;
+    let mut last = None;
+    while col < EXCEL_MAX_COLUMNS && populated(sheet, row, col)? {
+        last = Some(col);
+        col += 1;
+    }
+    Ok(last)
+}
+
+fn contiguous_left(sheet: &Sheet, row: u32, first_col: u32) -> Result<Option<u32>, RangeFillError> {
+    let mut col = first_col;
+    let mut first = None;
+    loop {
+        if !populated(sheet, row, col)? {
+            break;
+        }
+        first = Some(col);
+        if col == 0 {
+            break;
+        }
+        col -= 1;
+    }
+    Ok(first)
+}
+
+fn neighboring_source_column(sheet: &Sheet, target: Bounds) -> Result<u32, RangeFillError> {
+    let left = target.start_col.checked_sub(1);
+    let right = (target.end_col + 1 < EXCEL_MAX_COLUMNS).then_some(target.end_col + 1);
+    let mut candidates = Vec::new();
+    if let Some(col) = left {
+        candidates.push((
+            non_empty_count(sheet, target.start_row, target.end_row, col)?,
+            col,
+            1,
+        ));
+    }
+    if let Some(col) = right {
+        candidates.push((
+            non_empty_count(sheet, target.start_row, target.end_row, col)?,
+            col,
+            0,
+        ));
+    }
+    let (count, col, _) = candidates
+        .into_iter()
+        .max_by_key(|(count, _col, left_preference)| (*count, *left_preference))
+        .ok_or_else(|| {
+            invalid("Range.flashFill cannot find a neighboring worksheet column".to_string())
+        })?;
+    if count == 0 {
+        return Err(invalid(
+            "Range.flashFill requires populated data in a neighboring worksheet column".to_string(),
+        ));
+    }
+    Ok(col)
+}
+
+fn non_empty_count(
+    sheet: &Sheet,
+    start_row: u32,
+    end_row: u32,
+    col: u32,
+) -> Result<u32, RangeFillError> {
+    let mut count = 0;
+    for row in start_row..=end_row {
+        if populated(sheet, row, col)? {
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+fn populated(sheet: &Sheet, row: u32, col: u32) -> Result<bool, RangeFillError> {
+    sheet
+        .get_cell_value((row, col))
+        .map(|value| !matches!(value, compute_api::CellValue::Null))
+        .map_err(engine)
+}
+
+fn navigation(error: RangeNavigationError) -> RangeFillError {
+    RangeFillError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn engine(error: ComputeApiError) -> RangeFillError {
+    match error {
+        ComputeApiError::InvalidAddress { .. }
+        | ComputeApiError::InvalidRange { .. }
+        | ComputeApiError::InvalidOperation(_) => invalid(error.to_string()),
+        ComputeApiError::SheetNotFound { .. } => RangeFillError {
+            code: "ItemNotFound",
+            message: error.to_string(),
+        },
+        ComputeApiError::Compute(value_types::ComputeError::InvalidInput { .. }) => {
+            invalid(error.to_string())
+        }
+        other => RangeFillError {
+            code: "GeneralException",
+            message: other.to_string(),
+        },
+    }
+}
+
+fn invalid(message: String) -> RangeFillError {
+    RangeFillError {
+        code: "InvalidArgument",
+        message,
+    }
+}
+
+fn unsupported(message: String) -> RangeFillError {
+    RangeFillError {
+        code: "UnsupportedOperation",
+        message,
+    }
+}
+
+fn encoding(message: String) -> RangeFillError {
+    RangeFillError {
+        code: "GeneralException",
+        message: format!("Range fill request conversion failed: {message}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host extension dispatch
+// ---------------------------------------------------------------------------
+
+/// Host dispatcher for the two Range fill operations emitted by
+/// `range_fill.js`. The central host keeps the operation enum stable; this
+/// handler resolves the existing Range proxy bindings and delegates all
+/// address, shape, inference, and engine validation to the helpers above.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct RangeFillHandler;
+
+/// Construct the handler for registration by the runtime host owner.
+pub(crate) fn handler() -> RangeFillHandler {
+    RangeFillHandler
+}
+
+impl ExtensionHandler for RangeFillHandler {
+    fn can_handle(&self, operation: &str) -> bool {
+        matches!(operation, "rangeAutoFill" | "rangeFlashFill")
+    }
+
+    fn handle(
+        &self,
+        operation: &Value,
+        context: &mut HostDispatchContext<'_>,
+    ) -> Result<bool, BatchError> {
+        let operation_name = required_string(operation, "op")?;
+        match operation_name {
+            "rangeAutoFill" => handle_auto_fill_operation(operation, context),
+            "rangeFlashFill" => handle_flash_fill_operation(operation, context),
+            _ => Ok(false),
+        }
+    }
+}
+
+fn handle_auto_fill_operation(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+) -> Result<bool, BatchError> {
+    let source_id = required_string(operation, "id")?;
+    let source = context.range(source_id)?;
+    let source_sheet = source.sheet();
+    let source_address = bounded_address(&source, "Range.autoFill source")?.to_string();
+
+    // The proxy emits exactly one of these fields for an explicit destination,
+    // and emits neither for an omitted or null destination. Reject a payload
+    // carrying both so a caller cannot silently choose one object path over a
+    // conflicting raw address.
+    let destination_id = optional_string(operation, "destinationRangeId")?;
+    let destination_wire = optional_string(operation, "destinationAddress")?;
+    if destination_id.is_some() && destination_wire.is_some() {
+        return Err(invalid_batch(
+            "Range.autoFill destination cannot contain both a Range object and an address",
+        ));
+    }
+
+    let destination_address = if let Some(destination_id) = destination_id {
+        let destination = context.range(destination_id)?;
+        if destination.is_null_object() {
+            return Err(BatchError {
+                code: "InvalidObjectPath",
+                message: "Range.autoFill destination Range is a null object.".to_string(),
+            });
+        }
+        let destination_sheet = destination.sheet();
+        if destination_sheet.id() != source_sheet.id() {
+            return Err(invalid_batch(
+                "Range.autoFill source and destination must belong to the same worksheet",
+            ));
+        }
+        Some(bounded_address(&destination, "Range.autoFill destination")?.to_string())
+    } else {
+        destination_wire.map(str::to_owned)
+    };
+
+    let auto_fill_type = optional_string(operation, "autoFillType")?;
+    auto_fill(
+        &source_sheet,
+        &source_address,
+        destination_address.as_deref(),
+        auto_fill_type,
+    )
+    .map_err(batch_error)?;
+    Ok(true)
+}
+
+fn handle_flash_fill_operation(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+) -> Result<bool, BatchError> {
+    let target_id = required_string(operation, "id")?;
+    let target = context.range(target_id)?;
+    let target_sheet = target.sheet();
+    let target_address = bounded_address(&target, "Range.flashFill target")?.to_string();
+    flash_fill(&target_sheet, &target_address).map_err(batch_error)?;
+    Ok(true)
+}
+
+fn bounded_address<'a>(range: &'a RangeRef, operation: &str) -> Result<&'a str, BatchError> {
+    if range.is_null_object() {
+        return Err(BatchError {
+            code: "InvalidObjectPath",
+            message: format!("{operation} cannot use a null Range object"),
+        });
+    }
+    range
+        .address()
+        .ok_or_else(|| invalid_batch(format!("{operation} requires a bounded cell range")))
+}
+
+fn required_string<'a>(operation: &'a Value, field: &str) -> Result<&'a str, BatchError> {
+    operation
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            invalid_batch(format!(
+                "range fill operation requires a non-empty string '{field}'"
+            ))
+        })
+}
+
+fn optional_string<'a>(operation: &'a Value, field: &str) -> Result<Option<&'a str>, BatchError> {
+    match operation.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value
+            .as_str()
+            .filter(|value| !value.is_empty())
+            .map(Some)
+            .ok_or_else(|| {
+                invalid_batch(format!(
+                    "range fill operation field '{field}' must be a non-empty string"
+                ))
+            }),
+    }
+}
+
+fn invalid_batch(message: impl Into<String>) -> BatchError {
+    BatchError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn batch_error(error: RangeFillError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}

--- a/compute/officejs/src/range_metadata.js
+++ b/compute/officejs/src/range_metadata.js
@@ -1,0 +1,169 @@
+(function (global) {
+  "use strict";
+
+  // Range metadata is installed after range_content.js.  The bootstrap owns
+  // load normalization and hydration; this file only adds the Range members
+  // whose wire values are scalar (or rectangular scalar) projections.
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+
+  function propertyNotLoaded(name) {
+    var error = new OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function invalidArgument(message) {
+    var error = new OfficeExtension.Error({
+      code: "InvalidArgument",
+      message: message,
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidArgument";
+    return error;
+  }
+
+  var scalarProperties = [
+    "formulasR1C1",
+    "formulasLocal",
+    "numberFormatLocal",
+    "numberFormatCategories",
+    "hasSpill",
+    "hidden",
+    "rowHidden",
+    "columnHidden",
+    "isEntireRow",
+    "isEntireColumn",
+    // The compute layout facade exposes pixels while Office.js pins these
+    // values in points. Keep descriptors installed so an unsupported read is
+    // reported by context.sync instead of becoming an undefined JS member.
+    "height",
+    "width",
+    "left",
+    "top",
+  ];
+
+  // Keep locale, point-based dimensions, and hasSpill out of the default load
+  // set: the host deliberately reports those capabilities as unavailable for
+  // some ranges, and a default Range.load() must continue to work. Explicit
+  // load("...") calls still reach the host because ClientObject.load accepts
+  // named scalar paths and hydration uses these descriptors below.
+  var registeredScalarProperties = [
+    "formulasR1C1",
+    "numberFormatCategories",
+    "hidden",
+    "rowHidden",
+    "columnHidden",
+    "isEntireRow",
+    "isEntireColumn",
+  ];
+
+  global.__mogOfficeJs.addScalarProperties(Excel.Range.prototype, registeredScalarProperties);
+
+  var writable = {
+    formulasR1C1: true,
+    formulasLocal: true,
+    numberFormatLocal: true,
+    rowHidden: true,
+    columnHidden: true,
+  };
+
+  function defineLoadedScalar(name) {
+    Object.defineProperty(Excel.Range.prototype, name, {
+      configurable: true,
+      enumerable: true,
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+    });
+  }
+
+  scalarProperties.forEach(function (name) {
+    if (writable[name]) {
+      Object.defineProperty(Excel.Range.prototype, name, {
+        configurable: true,
+        enumerable: true,
+        get: function () {
+          if (!this._loaded[name]) throw propertyNotLoaded(name);
+          return this["_" + name];
+        },
+        set: function (value) {
+          this["_" + name] = value;
+          this._loaded[name] = true;
+          this.context._queue.push({
+            op: "set",
+            id: this._id,
+            property: name,
+            value: value,
+          });
+        },
+      });
+    } else {
+      defineLoadedScalar(name);
+    }
+  });
+
+  // range_content.js predates these members and keeps its own writable list.
+  // Wrap its generic set implementation so a property object can use the
+  // newly registered setters while retaining its read-only and navigation
+  // behavior.  The wrapper delegates all pre-existing members back to the
+  // production implementation and only removes these five names from the
+  // object passed to it.
+  var previousSet = Excel.Range.prototype.set;
+  var previousToJSON = Excel.Range.prototype.toJSON;
+
+  Excel.Range.prototype.toJSON = function () {
+    var data = typeof previousToJSON === "function" ? previousToJSON.call(this) : {};
+    scalarProperties.forEach(function (name) {
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }, this);
+    return data;
+  };
+
+  Excel.Range.prototype.set = function (source, options) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+
+    var isClientObject = source instanceof ClientObject;
+    if (isClientObject && Object.getPrototypeOf(this) !== Object.getPrototypeOf(source)) {
+      throw invalidArgument("The object passed to set must have the same type.");
+    }
+
+    var properties = isClientObject && typeof source.toJSON === "function" ? source.toJSON() : source;
+    var metadata = {};
+    var delegated = {};
+    var allScalars = (this._scalarProperties || []).concat(this._additionalScalarProperties || []);
+    var throwOnReadOnly = !options || options.throwOnReadOnly !== false;
+    Object.keys(properties).forEach(function (name) {
+      if (writable[name]) metadata[name] = properties[name];
+      else if (isClientObject && allScalars.indexOf(name) >= 0) {
+        // Range.set(sourceRange) ignores read-only scalar members from the
+        // source object's JSON. Keep that behavior while handling the new
+        // writable metadata members above.
+      }
+      else if (scalarProperties.indexOf(name) >= 0) {
+        if (!isClientObject && throwOnReadOnly) {
+          throw invalidArgument("The property '" + name + "' is read-only.");
+        }
+      }
+      else delegated[name] = properties[name];
+    });
+
+    // This preserves the original Range.set behavior for values, formulas,
+    // numberFormat, format, and all read-only members.
+    previousSet.call(this, delegated, options);
+    Object.keys(metadata).forEach(function (name) {
+      if (metadata[name] !== undefined) this[name] = metadata[name];
+    }, this);
+  };
+})(globalThis);

--- a/compute/officejs/src/range_metadata.rs
+++ b/compute/officejs/src/range_metadata.rs
@@ -1,0 +1,972 @@
+//! Range metadata projections for the embedded Office.js host.
+//!
+//! This module owns the Range members whose values are derived from worksheet
+//! geometry, layout state, formula reference style, and effective number
+//! formats.  It deliberately keeps locale-aware properties explicit: the
+//! compute API currently has no workbook culture/formula-localization
+//! contract, so `formulasLocal` and `numberFormatLocal` return a deferred
+//! `InvalidArgument` instead of presenting A1/canonical values as localized.
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+
+use cell_types::{CellId, ColId, RowId, SheetId};
+use compute_api::{CellAddress, CellRange, Sheet, mutation::CellInput};
+use compute_formats::detect_format_type;
+use compute_parser::{IdentityResolver, to_identity_formula, to_r1c1_string};
+use formula_types::WorkbookLookup;
+use serde_json::{Value, json};
+use value_types::CellValue;
+
+use crate::range_navigation::{EXCEL_MAX_COLUMNS, EXCEL_MAX_ROWS, RangeAddress};
+
+/// Error returned by a Range metadata projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RangeMetadataError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+/// Load the metadata properties requested for a Range.
+///
+/// The host passes the parsed [`RangeAddress`] so this helper handles omitted
+/// worksheet addresses and full-row/full-column ranges consistently with the
+/// navigation family.  Rectangular cell properties remain `null` for an
+/// unbounded axis, matching the existing Range values/formulas contract.
+pub(crate) fn load(
+    sheet: &Sheet,
+    range: &RangeAddress,
+    properties: &[String],
+) -> Result<HashMap<String, Value>, RangeMetadataError> {
+    let mut result = HashMap::new();
+    let (start_row, start_col, end_row, end_col) = range.bounds();
+    let unbounded = range.is_whole_sheet() || range.is_entire_row() || range.is_entire_column();
+
+    for property in properties {
+        let value = match property.as_str() {
+            "formulasR1C1" => {
+                if unbounded {
+                    Value::Null
+                } else {
+                    formulas_r1c1(sheet, (start_row, start_col, end_row, end_col))?
+                }
+            }
+            "formulasLocal" => return Err(locale_unsupported("formulasLocal")),
+            "numberFormatLocal" => return Err(locale_unsupported("numberFormatLocal")),
+            "numberFormatCategories" => {
+                if unbounded {
+                    Value::Null
+                } else {
+                    number_format_categories(sheet, (start_row, start_col, end_row, end_col))?
+                }
+            }
+            "hasSpill" => {
+                if unbounded {
+                    return Err(unsupported(
+                        "Range.hasSpill is not available for an unbounded worksheet range",
+                    ));
+                }
+                has_spill(sheet, (start_row, start_col, end_row, end_col))?
+            }
+            "hidden" => hidden(sheet, range)?,
+            "rowHidden" => axis_hidden(sheet, range, Axis::Rows)?,
+            "columnHidden" => axis_hidden(sheet, range, Axis::Columns)?,
+            "isEntireRow" => Value::Bool(range.is_entire_row()),
+            "isEntireColumn" => Value::Bool(range.is_entire_column()),
+            "height" | "width" | "left" | "top" => {
+                return Err(unsupported(format!(
+                    "Range.{property} requires an exact point-based layout projection"
+                )));
+            }
+            other => {
+                return Err(unsupported(format!(
+                    "Unsupported Range load property '{other}'"
+                )));
+            }
+        };
+        result.insert(property.clone(), value);
+    }
+
+    Ok(result)
+}
+
+/// Set a writable metadata property on a Range.
+///
+/// `rowHidden` and `columnHidden` are layout mutations and are valid for
+/// bounded, full-row, full-column, and whole-sheet ranges.  R1C1 formulas are
+/// converted to canonical A1 formulas before entering the engine's typed
+/// write path, preserving the engine as the source of truth for formula
+/// parsing and calculation.
+pub(crate) fn set(
+    sheet: &Sheet,
+    range: &RangeAddress,
+    property: &str,
+    value: &Value,
+) -> Result<(), RangeMetadataError> {
+    match property {
+        "formulasR1C1" => {
+            if range.is_whole_sheet() || range.is_entire_row() || range.is_entire_column() {
+                return Err(unsupported(
+                    "Range.formulasR1C1 requires a bounded cell range",
+                ));
+            }
+            set_formulas_r1c1(sheet, range, value)
+        }
+        "formulasLocal" | "numberFormatLocal" => Err(locale_unsupported(property)),
+        "rowHidden" => set_axis_hidden(sheet, range, Axis::Rows, value),
+        "columnHidden" => set_axis_hidden(sheet, range, Axis::Columns, value),
+        "hidden"
+        | "hasSpill"
+        | "numberFormatCategories"
+        | "isEntireRow"
+        | "isEntireColumn"
+        | "height"
+        | "width"
+        | "left"
+        | "top" => Err(read_only(property)),
+        other => Err(unsupported(format!(
+            "Unsupported Range set property '{other}'"
+        ))),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Axis {
+    Rows,
+    Columns,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum VisibilityState {
+    All,
+    None,
+    Mixed,
+}
+
+fn hidden(sheet: &Sheet, range: &RangeAddress) -> Result<Value, RangeMetadataError> {
+    let rows = axis_hidden_state(sheet, range, Axis::Rows)?;
+    let columns = axis_hidden_state(sheet, range, Axis::Columns)?;
+    // A cell is hidden when either its row or its column is hidden.  Thus all
+    // cells are hidden when every row OR every column is hidden; no cells are
+    // hidden only when neither axis contains a hidden member.
+    let value = if rows == VisibilityState::All || columns == VisibilityState::All {
+        Value::Bool(true)
+    } else if rows == VisibilityState::None && columns == VisibilityState::None {
+        Value::Bool(false)
+    } else {
+        Value::Null
+    };
+    Ok(value)
+}
+
+fn axis_hidden(
+    sheet: &Sheet,
+    range: &RangeAddress,
+    axis: Axis,
+) -> Result<Value, RangeMetadataError> {
+    Ok(match axis_hidden_state(sheet, range, axis)? {
+        VisibilityState::All => Value::Bool(true),
+        VisibilityState::None => Value::Bool(false),
+        VisibilityState::Mixed => Value::Null,
+    })
+}
+
+fn axis_hidden_state(
+    sheet: &Sheet,
+    range: &RangeAddress,
+    axis: Axis,
+) -> Result<VisibilityState, RangeMetadataError> {
+    let (start_row, start_col, end_row, end_col) = range.bounds();
+    let (start, end, hidden_indices) = match axis {
+        Axis::Rows => (
+            start_row,
+            end_row,
+            sheet.layout().get_hidden_rows().map_err(engine)?,
+        ),
+        Axis::Columns => (
+            start_col,
+            end_col,
+            sheet.layout().get_hidden_columns().map_err(engine)?,
+        ),
+    };
+    let count = u64::from(end - start + 1);
+    let hidden_count = hidden_indices
+        .into_iter()
+        .filter(|index| *index >= start && *index <= end)
+        .count() as u64;
+    Ok(if hidden_count == 0 {
+        VisibilityState::None
+    } else if hidden_count == count {
+        VisibilityState::All
+    } else {
+        VisibilityState::Mixed
+    })
+}
+
+fn set_axis_hidden(
+    sheet: &Sheet,
+    range: &RangeAddress,
+    axis: Axis,
+    value: &Value,
+) -> Result<(), RangeMetadataError> {
+    let hidden = value
+        .as_bool()
+        .ok_or_else(|| invalid_value(format!("Range.{} must be a boolean", axis_name(axis))))?;
+    let (start, end) = match axis {
+        Axis::Rows => {
+            let (start, _, end, _) = range.bounds();
+            (start, end)
+        }
+        Axis::Columns => {
+            let (_, start, _, end) = range.bounds();
+            (start, end)
+        }
+    };
+    let indices: Vec<u32> = (start..=end).collect();
+    let result = match axis {
+        Axis::Rows if hidden => sheet.layout().hide_rows(indices),
+        Axis::Rows => sheet.layout().unhide_rows(indices),
+        Axis::Columns if hidden => sheet.layout().hide_columns(indices),
+        Axis::Columns => sheet.layout().unhide_columns(indices),
+    };
+    result.map(|_| ()).map_err(engine)
+}
+
+fn axis_name(axis: Axis) -> &'static str {
+    match axis {
+        Axis::Rows => "rowHidden",
+        Axis::Columns => "columnHidden",
+    }
+}
+
+fn formulas_r1c1(
+    sheet: &Sheet,
+    (start_row, start_col, end_row, end_col): (u32, u32, u32, u32),
+) -> Result<Value, RangeMetadataError> {
+    let sheet_name = sheet.name().map_err(engine)?;
+    let mut rows = Vec::with_capacity((end_row - start_row + 1) as usize);
+    for row in start_row..=end_row {
+        let mut cells = Vec::with_capacity((end_col - start_col + 1) as usize);
+        for col in start_col..=end_col {
+            let address = CellAddress::Position(row, col);
+            if let Some(formula) = sheet.get_formula(address.clone()).map_err(engine)? {
+                let lookup = FormulaLookup::new(*sheet.id(), &sheet_name, &formula);
+                let identity = to_identity_formula(&formula, &lookup).map_err(|error| {
+                    formula_error(format!(
+                        "unable to render formula at ({row}, {col}) as R1C1: {error}"
+                    ))
+                })?;
+                cells.push(Value::String(to_r1c1_string(&identity, &lookup, row, col)));
+            } else {
+                cells.push(cell_to_js(sheet.get_cell_value(address).map_err(engine)?));
+            }
+        }
+        rows.push(Value::Array(cells));
+    }
+    Ok(Value::Array(rows))
+}
+
+fn set_formulas_r1c1(
+    sheet: &Sheet,
+    range: &RangeAddress,
+    value: &Value,
+) -> Result<(), RangeMetadataError> {
+    let (start_row, start_col, end_row, end_col) = range.bounds();
+    let expected_rows = (end_row - start_row + 1) as usize;
+    let expected_cols = (end_col - start_col + 1) as usize;
+    let rows = value
+        .as_array()
+        .ok_or_else(|| invalid_shape("a 2-dimensional array"))?;
+    if rows.len() != expected_rows {
+        return Err(invalid_shape(format!(
+            "formulasR1C1 has {} rows; target range requires {expected_rows}",
+            rows.len()
+        )));
+    }
+
+    let mut grid = Vec::with_capacity(expected_rows);
+    for (row_offset, row) in rows.iter().enumerate() {
+        let cells = row
+            .as_array()
+            .ok_or_else(|| invalid_shape("a 2-dimensional array"))?;
+        if cells.len() != expected_cols {
+            return Err(invalid_shape(format!(
+                "formulasR1C1 row {row_offset} has {} columns; target range requires {expected_cols}",
+                cells.len()
+            )));
+        }
+        let mut out = Vec::with_capacity(expected_cols);
+        for (col_offset, cell) in cells.iter().enumerate() {
+            let row = start_row + row_offset as u32;
+            let col = start_col + col_offset as u32;
+            out.push(r1c1_cell_input(cell, row, col)?);
+        }
+        grid.push(out);
+    }
+
+    sheet
+        .set_range_typed(
+            CellRange::Bounds(start_row, start_col, end_row, end_col),
+            &grid,
+        )
+        .map(|_| ())
+        .map_err(engine)
+}
+
+fn r1c1_cell_input(
+    value: &Value,
+    row: u32,
+    col: u32,
+) -> Result<Option<CellInput>, RangeMetadataError> {
+    match value {
+        // As with Range.formulas, null preserves the existing cell.
+        Value::Null => Ok(None),
+        Value::Bool(value) => Ok(Some(CellInput::Value {
+            value: CellValue::Boolean(*value),
+        })),
+        Value::Number(value) => value
+            .as_f64()
+            .map(CellValue::from)
+            .map(|value| Some(CellInput::Value { value }))
+            .ok_or_else(|| invalid_value("Range.formulasR1C1 numbers must be finite")),
+        Value::String(value) if value.is_empty() => Ok(Some(CellInput::Clear)),
+        Value::String(value) if value.starts_with('=') => {
+            let formula = r1c1_to_a1(value, row, col)?;
+            Ok(Some(CellInput::formula(&formula)))
+        }
+        Value::String(value) => Ok(Some(CellInput::Literal {
+            text: value.clone(),
+        })),
+        _ => Err(invalid_value(
+            "Range.formulasR1C1 must contain only strings, numbers, booleans, or null",
+        )),
+    }
+}
+
+fn number_format_categories(
+    sheet: &Sheet,
+    (start_row, start_col, end_row, end_col): (u32, u32, u32, u32),
+) -> Result<Value, RangeMetadataError> {
+    let mut rows = Vec::with_capacity((end_row - start_row + 1) as usize);
+    for row in start_row..=end_row {
+        let mut cells = Vec::with_capacity((end_col - start_col + 1) as usize);
+        for col in start_col..=end_col {
+            let format = sheet.formats().get_cell_format(row, col).map_err(engine)?;
+            let format = serde_json::to_value(format)
+                .map_err(|error| encoding(error.to_string()))?;
+            let code = format
+                .get("numberFormat")
+                .and_then(Value::as_str)
+                .unwrap_or("General");
+            // Keep the category detector in compute-formats as the source of
+            // truth. Its Display names are the exact Office
+            // NumberFormatCategory wire values (General, Number, Currency, ...).
+            cells.push(Value::String(detect_format_type(code).to_string()));
+        }
+        rows.push(Value::Array(cells));
+    }
+    Ok(Value::Array(rows))
+}
+
+fn has_spill(
+    sheet: &Sheet,
+    (start_row, start_col, end_row, end_col): (u32, u32, u32, u32),
+) -> Result<Value, RangeMetadataError> {
+    let mut any = false;
+    let mut all = true;
+    for row in start_row..=end_row {
+        for col in start_col..=end_col {
+            let spilled = sheet
+                .get_cell_data(CellAddress::Position(row, col))
+                .map_err(engine)?
+                .and_then(|data| data.get("region").cloned())
+                .and_then(|region| region.get("kind").cloned())
+                .and_then(|kind| kind.as_str().map(|kind| kind == "arraySpill"))
+                .unwrap_or(false);
+            any |= spilled;
+            all &= spilled;
+            if any && !all {
+                return Ok(Value::Null);
+            }
+        }
+    }
+    Ok(Value::Bool(all))
+}
+
+fn cell_to_js(value: CellValue) -> Value {
+    match value {
+        CellValue::Null => Value::String(String::new()),
+        CellValue::Boolean(value) => Value::Bool(value),
+        CellValue::Number(value) => json!(value.get()),
+        CellValue::Text(value) => Value::String(value.to_string()),
+        CellValue::Error(error, _) => Value::String(error.to_string()),
+        other => Value::String(other.to_string()),
+    }
+}
+
+fn r1c1_to_a1(formula: &str, base_row: u32, base_col: u32) -> Result<String, RangeMetadataError> {
+    // compute-parser intentionally exposes R1C1 as a display formatter; its
+    // input grammar is A1. Convert only reference tokens here, then hand the
+    // resulting formula to CellInput::formula so the engine remains the
+    // parser/calculation authority. String literals and function/name text
+    // are copied byte-for-byte.
+    let bytes = formula.as_bytes();
+    let mut output = String::with_capacity(formula.len());
+    let mut cursor = 0;
+    let mut in_string = false;
+
+    while cursor < bytes.len() {
+        let byte = bytes[cursor];
+        if byte == b'\'' {
+            // Single quotes delimit a worksheet qualifier. A sheet can be
+            // named `R1C1`, so do not reinterpret text inside `'...'` as a
+            // reference while converting the formula body.
+            output.push('\'');
+            cursor += 1;
+            while cursor < bytes.len() {
+                if bytes[cursor] == b'\'' {
+                    output.push('\'');
+                    if bytes.get(cursor + 1) == Some(&b'\'') {
+                        output.push('\'');
+                        cursor += 2;
+                        continue;
+                    }
+                    cursor += 1;
+                    break;
+                }
+                push_formula_char(&mut output, formula, &mut cursor);
+            }
+            continue;
+        }
+        if byte == b'"' {
+            output.push('"');
+            cursor += 1;
+            if in_string && cursor < bytes.len() && bytes[cursor] == b'"' {
+                output.push('"');
+                cursor += 1;
+            } else {
+                in_string = !in_string;
+            }
+            continue;
+        }
+        if in_string || !reference_boundary_before(bytes, cursor) {
+            push_formula_char(&mut output, formula, &mut cursor);
+            continue;
+        }
+
+        if let Some((end, replacement)) = parse_r1c1_reference(bytes, cursor, base_row, base_col)? {
+            output.push_str(&replacement);
+            cursor = end;
+        } else {
+            push_formula_char(&mut output, formula, &mut cursor);
+        }
+    }
+
+    Ok(output)
+}
+
+/// Copy one Unicode scalar from the source formula without reducing a
+/// multi-byte UTF-8 character to a sequence of unrelated bytes. Reference
+/// tokens are ASCII, so this helper is used only for untouched formula text,
+/// string literals, and quoted sheet names.
+fn push_formula_char(output: &mut String, formula: &str, cursor: &mut usize) {
+    if let Some(character) = formula.get(*cursor..).and_then(|tail| tail.chars().next()) {
+        output.push(character);
+        *cursor += character.len_utf8();
+    }
+}
+
+#[derive(Clone, Copy)]
+struct R1C1Axis {
+    index: u32,
+    absolute: bool,
+}
+
+#[derive(Clone, Copy)]
+enum R1C1Endpoint {
+    Cell { row: R1C1Axis, col: R1C1Axis },
+    Row(R1C1Axis),
+    Column(R1C1Axis),
+}
+
+fn parse_r1c1_reference(
+    bytes: &[u8],
+    start: usize,
+    base_row: u32,
+    base_col: u32,
+) -> Result<Option<(usize, String)>, RangeMetadataError> {
+    if let Some((first, first_end)) = parse_r1c1_endpoint(bytes, start, base_row, base_col)? {
+        if !reference_boundary_after(bytes, first_end) {
+            return Ok(None);
+        }
+        // A token immediately followed by ! is a worksheet qualifier (for
+        // example a sheet named R1C1), not a cell reference.
+        if bytes.get(first_end) == Some(&b'!') {
+            return Ok(None);
+        }
+        if bytes.get(first_end) == Some(&b':')
+            && let Some((second, end)) =
+                parse_r1c1_endpoint(bytes, first_end + 1, base_row, base_col)?
+            && reference_boundary_after(bytes, end)
+            && (matches!(
+                (first, second),
+                (R1C1Endpoint::Cell { .. }, R1C1Endpoint::Cell { .. })
+            ) || matches!(
+                (first, second),
+                (R1C1Endpoint::Row(_), R1C1Endpoint::Row(_))
+            ) || matches!(
+                (first, second),
+                (R1C1Endpoint::Column(_), R1C1Endpoint::Column(_))
+            ))
+        {
+            let first = format_endpoint(first, true)?;
+            let second = format_endpoint(second, true)?;
+            return Ok(Some((end, format!("{first}:{second}"))));
+        }
+        if matches!(first, R1C1Endpoint::Cell { .. }) {
+            return Ok(Some((first_end, format_endpoint(first, false)?)));
+        }
+    }
+    Ok(None)
+}
+
+fn parse_r1c1_endpoint(
+    bytes: &[u8],
+    start: usize,
+    base_row: u32,
+    base_col: u32,
+) -> Result<Option<(R1C1Endpoint, usize)>, RangeMetadataError> {
+    if start >= bytes.len() {
+        return Ok(None);
+    }
+    let marker = bytes[start].to_ascii_uppercase();
+    if marker == b'R' {
+        let Some((row, after_row)) = parse_r1c1_axis(bytes, start + 1, base_row, "row")? else {
+            return Ok(None);
+        };
+        if bytes.get(after_row).map(u8::to_ascii_uppercase) == Some(b'C') {
+            let Some((col, end)) = parse_r1c1_axis(bytes, after_row + 1, base_col, "column")?
+            else {
+                return Ok(None);
+            };
+            return Ok(Some((R1C1Endpoint::Cell { row, col }, end)));
+        }
+        return Ok(Some((R1C1Endpoint::Row(row), after_row)));
+    }
+    if marker == b'C' {
+        let Some((column, end)) = parse_r1c1_axis(bytes, start + 1, base_col, "column")? else {
+            return Ok(None);
+        };
+        return Ok(Some((R1C1Endpoint::Column(column), end)));
+    }
+    Ok(None)
+}
+
+fn parse_r1c1_axis(
+    bytes: &[u8],
+    start: usize,
+    base: u32,
+    axis: &str,
+) -> Result<Option<(R1C1Axis, usize)>, RangeMetadataError> {
+    if bytes.get(start) == Some(&b'[') {
+        let mut cursor = start + 1;
+        let negative = bytes.get(cursor) == Some(&b'-');
+        if negative {
+            cursor += 1;
+        }
+        let number_start = cursor;
+        while bytes.get(cursor).is_some_and(u8::is_ascii_digit) {
+            cursor += 1;
+        }
+        if cursor == number_start || bytes.get(cursor) != Some(&b']') {
+            return Err(invalid_value(format!("invalid R1C1 {axis} reference")));
+        }
+        let magnitude = parse_u32_ascii(&bytes[number_start..cursor])?;
+        let offset = if negative {
+            -(i64::from(magnitude))
+        } else {
+            i64::from(magnitude)
+        };
+        let index = checked_relative_index(base, offset, axis)?;
+        return Ok(Some((
+            R1C1Axis {
+                index,
+                absolute: false,
+            },
+            cursor + 1,
+        )));
+    }
+
+    let number_start = start;
+    let mut cursor = start;
+    while bytes.get(cursor).is_some_and(u8::is_ascii_digit) {
+        cursor += 1;
+    }
+    if cursor == number_start {
+        return Ok(Some((
+            R1C1Axis {
+                index: base,
+                absolute: false,
+            },
+            start,
+        )));
+    }
+    let one_based = parse_u32_ascii(&bytes[number_start..cursor])?;
+    if one_based == 0 {
+        return Err(invalid_value(format!("R1C1 {axis} references are 1-based")));
+    }
+    let index = one_based - 1;
+    let limit = if axis == "row" {
+        EXCEL_MAX_ROWS
+    } else {
+        EXCEL_MAX_COLUMNS
+    };
+    if index >= limit {
+        return Err(invalid_value(format!(
+            "R1C1 {axis} is outside the worksheet grid"
+        )));
+    }
+    Ok(Some((
+        R1C1Axis {
+            index,
+            absolute: true,
+        },
+        cursor,
+    )))
+}
+
+fn format_endpoint(endpoint: R1C1Endpoint, in_range: bool) -> Result<String, RangeMetadataError> {
+    match endpoint {
+        R1C1Endpoint::Cell { row, col } => {
+            if row.index >= EXCEL_MAX_ROWS || col.index >= EXCEL_MAX_COLUMNS {
+                return Err(invalid_value(
+                    "R1C1 reference is outside the worksheet grid",
+                ));
+            }
+            let mut value = String::new();
+            if col.absolute {
+                value.push('$');
+            }
+            value.push_str(&column_name(col.index));
+            if row.absolute {
+                value.push('$');
+            }
+            value.push_str(&(row.index + 1).to_string());
+            Ok(value)
+        }
+        R1C1Endpoint::Row(row) => {
+            if !in_range {
+                return Err(invalid_value("R1C1 row references must be ranges"));
+            }
+            if !row.absolute {
+                return Err(invalid_value(
+                    "relative R1C1 full-row references cannot be represented in A1",
+                ));
+            }
+            if row.index >= EXCEL_MAX_ROWS {
+                return Err(invalid_value("R1C1 row is outside the worksheet grid"));
+            }
+            Ok((row.index + 1).to_string())
+        }
+        R1C1Endpoint::Column(col) => {
+            if !in_range {
+                return Err(invalid_value("R1C1 column references must be ranges"));
+            }
+            if !col.absolute {
+                return Err(invalid_value(
+                    "relative R1C1 full-column references cannot be represented in A1",
+                ));
+            }
+            if col.index >= EXCEL_MAX_COLUMNS {
+                return Err(invalid_value("R1C1 column is outside the worksheet grid"));
+            }
+            Ok(column_name(col.index))
+        }
+    }
+}
+
+fn checked_relative_index(base: u32, offset: i64, axis: &str) -> Result<u32, RangeMetadataError> {
+    let index = i64::from(base) + offset;
+    let limit = if axis == "row" {
+        i64::from(EXCEL_MAX_ROWS)
+    } else {
+        i64::from(EXCEL_MAX_COLUMNS)
+    };
+    if !(0..limit).contains(&index) {
+        return Err(invalid_value(format!(
+            "R1C1 {axis} is outside the worksheet grid"
+        )));
+    }
+    Ok(index as u32)
+}
+
+fn parse_u32_ascii(bytes: &[u8]) -> Result<u32, RangeMetadataError> {
+    let text = std::str::from_utf8(bytes).map_err(|_| invalid_value("invalid R1C1 number"))?;
+    text.parse::<u32>()
+        .map_err(|_| invalid_value("R1C1 number is too large"))
+}
+
+fn reference_boundary_before(bytes: &[u8], cursor: usize) -> bool {
+    cursor == 0
+        || !bytes[cursor - 1].is_ascii_alphanumeric()
+            && bytes[cursor - 1] != b'_'
+            && bytes[cursor - 1] != b'.'
+}
+
+fn reference_boundary_after(bytes: &[u8], cursor: usize) -> bool {
+    bytes
+        .get(cursor)
+        .is_none_or(|byte| !byte.is_ascii_alphanumeric() && *byte != b'_' && *byte != b'.')
+}
+
+fn column_name(mut column: u32) -> String {
+    let mut result = String::new();
+    loop {
+        result.push(char::from(b'A' + (column % 26) as u8));
+        if column < 26 {
+            break;
+        }
+        column = column / 26 - 1;
+    }
+    result.chars().rev().collect()
+}
+
+/// A small synthetic identity/lookup view lets the Office adapter reuse the
+/// engine parser and R1C1 formatter without allocating workbook identities or
+/// mutating the live document while reading a formula.
+struct FormulaLookup {
+    current_sheet: SheetId,
+    sheet_ids: HashMap<String, SheetId>,
+    sheet_names: HashMap<SheetId, String>,
+    cells: RefCell<HashMap<(SheetId, u32, u32), CellId>>,
+    cell_positions: RefCell<HashMap<CellId, (SheetId, u32, u32)>>,
+    rows: RefCell<HashMap<(SheetId, u32), RowId>>,
+    row_indices: RefCell<HashMap<RowId, (SheetId, u32)>>,
+    columns: RefCell<HashMap<(SheetId, u32), ColId>>,
+    col_indices: RefCell<HashMap<ColId, (SheetId, u32)>>,
+    next_id: Cell<u128>,
+}
+
+impl FormulaLookup {
+    fn new(current_sheet: SheetId, current_name: &str, formula: &str) -> Self {
+        let mut sheet_ids = HashMap::new();
+        let mut sheet_names = HashMap::new();
+        sheet_ids.insert(current_name.to_ascii_lowercase(), current_sheet);
+        sheet_names.insert(current_sheet, current_name.to_owned());
+
+        let mut next_sheet = 1u128;
+        for name in referenced_sheet_names(formula) {
+            let key = name.to_ascii_lowercase();
+            if sheet_ids.contains_key(&key) {
+                continue;
+            }
+            let mut id = SheetId::from_raw(next_sheet);
+            while sheet_names.contains_key(&id) {
+                next_sheet += 1;
+                id = SheetId::from_raw(next_sheet);
+            }
+            next_sheet += 1;
+            sheet_ids.insert(key, id);
+            sheet_names.insert(id, name);
+        }
+
+        Self {
+            current_sheet,
+            sheet_ids,
+            sheet_names,
+            cells: RefCell::new(HashMap::new()),
+            cell_positions: RefCell::new(HashMap::new()),
+            rows: RefCell::new(HashMap::new()),
+            row_indices: RefCell::new(HashMap::new()),
+            columns: RefCell::new(HashMap::new()),
+            col_indices: RefCell::new(HashMap::new()),
+            next_id: Cell::new(1),
+        }
+    }
+
+    fn allocate_id(&self) -> u128 {
+        let id = self.next_id.get();
+        self.next_id.set(id + 1);
+        id
+    }
+}
+
+impl IdentityResolver for FormulaLookup {
+    fn get_or_create_cell_id(&self, sheet: &SheetId, row: u32, col: u32) -> CellId {
+        if let Some(id) = self.cells.borrow().get(&(*sheet, row, col)).copied() {
+            return id;
+        }
+        let id = CellId::from_raw(self.allocate_id());
+        self.cells.borrow_mut().insert((*sheet, row, col), id);
+        self.cell_positions
+            .borrow_mut()
+            .insert(id, (*sheet, row, col));
+        id
+    }
+
+    fn get_row_id(&self, sheet: &SheetId, row: u32) -> Option<RowId> {
+        if let Some(id) = self.rows.borrow().get(&(*sheet, row)).copied() {
+            return Some(id);
+        }
+        let id = RowId::from_raw(self.allocate_id());
+        self.rows.borrow_mut().insert((*sheet, row), id);
+        self.row_indices.borrow_mut().insert(id, (*sheet, row));
+        Some(id)
+    }
+
+    fn get_col_id(&self, sheet: &SheetId, col: u32) -> Option<ColId> {
+        if let Some(id) = self.columns.borrow().get(&(*sheet, col)).copied() {
+            return Some(id);
+        }
+        let id = ColId::from_raw(self.allocate_id());
+        self.columns.borrow_mut().insert((*sheet, col), id);
+        self.col_indices.borrow_mut().insert(id, (*sheet, col));
+        Some(id)
+    }
+
+    fn resolve_sheet_name(&self, name: &str) -> Option<SheetId> {
+        self.sheet_ids.get(&name.to_ascii_lowercase()).copied()
+    }
+
+    fn current_sheet(&self) -> SheetId {
+        self.current_sheet
+    }
+}
+
+impl WorkbookLookup for FormulaLookup {
+    fn cell_position(&self, cell_id: &CellId) -> Option<(SheetId, u32, u32)> {
+        self.cell_positions.borrow().get(cell_id).copied()
+    }
+
+    fn row_index(&self, row_id: &RowId) -> Option<(SheetId, u32)> {
+        self.row_indices.borrow().get(row_id).copied()
+    }
+
+    fn col_index(&self, col_id: &ColId) -> Option<(SheetId, u32)> {
+        self.col_indices.borrow().get(col_id).copied()
+    }
+
+    fn sheet_name(&self, sheet_id: &SheetId) -> Option<&str> {
+        self.sheet_names.get(sheet_id).map(String::as_str)
+    }
+
+    fn formula_sheet(&self) -> SheetId {
+        self.current_sheet
+    }
+}
+
+fn referenced_sheet_names(formula: &str) -> Vec<String> {
+    let bytes = formula.as_bytes();
+    let mut result = Vec::new();
+    let mut in_string = false;
+    for (index, byte) in bytes.iter().enumerate() {
+        if *byte == b'"' {
+            in_string = !in_string;
+            continue;
+        }
+        if in_string || *byte != b'!' || index == 0 {
+            continue;
+        }
+        if let Some(name) = sheet_name_before_bang(bytes, index)
+            && !result
+                .iter()
+                .any(|existing| existing.eq_ignore_ascii_case(&name))
+        {
+            result.push(name);
+        }
+    }
+    result
+}
+
+fn sheet_name_before_bang(bytes: &[u8], bang: usize) -> Option<String> {
+    if bytes.get(bang - 1) == Some(&b'\'') {
+        let mut cursor = bang - 2;
+        loop {
+            if bytes[cursor] == b'\'' {
+                if cursor > 0 && bytes[cursor - 1] == b'\'' {
+                    cursor -= 2;
+                    continue;
+                }
+                let name = std::str::from_utf8(&bytes[cursor + 1..bang - 1]).ok()?;
+                return Some(name.replace("''", "'"));
+            }
+            if cursor == 0 {
+                return None;
+            }
+            cursor -= 1;
+        }
+    }
+
+    let mut start = bang;
+    while start > 0 && is_sheet_name_byte(bytes[start - 1]) {
+        start -= 1;
+    }
+    if start == bang {
+        None
+    } else {
+        std::str::from_utf8(&bytes[start..bang])
+            .ok()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(ToOwned::to_owned)
+    }
+}
+
+fn is_sheet_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b' ' | b'[' | b']' | b'$')
+}
+
+fn engine(error: impl std::fmt::Display) -> RangeMetadataError {
+    RangeMetadataError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn encoding(message: impl Into<String>) -> RangeMetadataError {
+    RangeMetadataError {
+        code: "GeneralException",
+        message: format!("range metadata conversion failed: {}", message.into()),
+    }
+}
+
+fn formula_error(message: impl Into<String>) -> RangeMetadataError {
+    RangeMetadataError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn invalid_shape(message: impl Into<String>) -> RangeMetadataError {
+    RangeMetadataError {
+        code: "InvalidArgument",
+        message: format!("Range.formulasR1C1 requires {}", message.into()),
+    }
+}
+
+fn invalid_value(message: impl Into<String>) -> RangeMetadataError {
+    RangeMetadataError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn read_only(property: &str) -> RangeMetadataError {
+    RangeMetadataError {
+        code: "InvalidArgument",
+        message: format!("Range.{property} is read-only"),
+    }
+}
+
+fn unsupported(message: impl Into<String>) -> RangeMetadataError {
+    RangeMetadataError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn locale_unsupported(property: &str) -> RangeMetadataError {
+    unsupported(format!(
+        "Range.{property} requires workbook locale support; this host has no localized formula/number-format context"
+    ))
+}

--- a/compute/officejs/src/range_navigation.js
+++ b/compute/officejs/src/range_navigation.js
@@ -1,0 +1,125 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+
+  function invalidRequestContext() {
+    return new OfficeExtension.Error({
+      code: "InvalidRequestContext",
+      message: "The object belongs to a different request context.",
+    });
+  }
+
+  function queueRange(source, method, args) {
+    var result = new Excel.Range(source.context, source._worksheet, null);
+    source.context._queue.push({
+      op: "rangeNavigation",
+      id: result._id,
+      rangeId: source._id,
+      method: method,
+      args: args || [],
+    });
+    return result;
+  }
+
+  function queueWorksheetRange(worksheet, method, args) {
+    var result = new Excel.Range(worksheet.context, worksheet, null);
+    worksheet.context._queue.push({
+      op: "rangeNavigation",
+      id: result._id,
+      worksheetId: worksheet._id,
+      method: method,
+      args: args || [],
+    });
+    return result;
+  }
+
+  function rangeArgument(source, value) {
+    if (value instanceof Excel.Range) {
+      if (value.context !== source.context) throw invalidRequestContext();
+      return { rangeId: value._id };
+    }
+    return value;
+  }
+
+  function optionalCount(count) {
+    return count === undefined ? 1 : count;
+  }
+
+  // Worksheet.getCell(row, column)
+  Excel.Worksheet.prototype.getCell = function (row, column) {
+    return queueWorksheetRange(this, "worksheet.getCell", [row, column]);
+  };
+
+  // Range methods that return another Range. The returned proxy is created
+  // immediately, while all geometry and error handling stays deferred to the
+  // host's rangeNavigation operation at context.sync().
+  Excel.Range.prototype.getCell = function (row, column) {
+    return queueRange(this, "getCell", [row, column]);
+  };
+
+  Excel.Range.prototype.getRow = function (row) {
+    return queueRange(this, "getRow", [row]);
+  };
+
+  Excel.Range.prototype.getColumn = function (column) {
+    return queueRange(this, "getColumn", [column]);
+  };
+
+  Excel.Range.prototype.getLastCell = function () {
+    return queueRange(this, "getLastCell");
+  };
+
+  Excel.Range.prototype.getLastRow = function () {
+    return queueRange(this, "getLastRow");
+  };
+
+  Excel.Range.prototype.getLastColumn = function () {
+    return queueRange(this, "getLastColumn");
+  };
+
+  Excel.Range.prototype.getOffsetRange = function (rowOffset, columnOffset) {
+    return queueRange(this, "getOffsetRange", [rowOffset, columnOffset]);
+  };
+
+  Excel.Range.prototype.getResizedRange = function (deltaRows, deltaColumns) {
+    return queueRange(this, "getResizedRange", [deltaRows, deltaColumns]);
+  };
+
+  Excel.Range.prototype.getAbsoluteResizedRange = function (numRows, numColumns) {
+    return queueRange(this, "getAbsoluteResizedRange", [numRows, numColumns]);
+  };
+
+  Excel.Range.prototype.getRowsAbove = function (count) {
+    return queueRange(this, "getRowsAbove", [optionalCount(count)]);
+  };
+
+  Excel.Range.prototype.getRowsBelow = function (count) {
+    return queueRange(this, "getRowsBelow", [optionalCount(count)]);
+  };
+
+  Excel.Range.prototype.getColumnsBefore = function (count) {
+    return queueRange(this, "getColumnsBefore", [optionalCount(count)]);
+  };
+
+  Excel.Range.prototype.getColumnsAfter = function (count) {
+    return queueRange(this, "getColumnsAfter", [optionalCount(count)]);
+  };
+
+  Excel.Range.prototype.getBoundingRect = function (anotherRange) {
+    return queueRange(this, "getBoundingRect", [rangeArgument(this, anotherRange)]);
+  };
+
+  Excel.Range.prototype.getIntersection = function (anotherRange) {
+    return queueRange(this, "getIntersection", [rangeArgument(this, anotherRange)]);
+  };
+
+  Excel.Range.prototype.getEntireRow = function () {
+    return queueRange(this, "getEntireRow");
+  };
+
+  Excel.Range.prototype.getEntireColumn = function () {
+    return queueRange(this, "getEntireColumn");
+  };
+})(globalThis);

--- a/compute/officejs/src/range_navigation.rs
+++ b/compute/officejs/src/range_navigation.rs
@@ -1,0 +1,998 @@
+use compute_api::Sheet;
+use serde_json::Value;
+
+/// The number of rows in an Excel worksheet.
+pub(crate) const EXCEL_MAX_ROWS: u32 = 1_048_576;
+/// The number of columns in an Excel worksheet.
+pub(crate) const EXCEL_MAX_COLUMNS: u32 = 16_384;
+
+const LAST_ROW: u32 = EXCEL_MAX_ROWS - 1;
+const LAST_COLUMN: u32 = EXCEL_MAX_COLUMNS - 1;
+
+/// The address shape carried by an Office.js Range proxy.
+///
+/// `WholeSheet` is used for `Worksheet.getRange()` (an omitted address). A
+/// textual full-row or full-column address remains tagged as `Rows` or
+/// `Columns`, even when it happens to cover the complete worksheet extent.
+/// This prevents the host from accidentally treating an unbounded range as a
+/// bounded cell matrix for values/formulas or formatting operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RangeAddress {
+    WholeSheet,
+    Rows {
+        start: u32,
+        end: u32,
+    },
+    Columns {
+        start: u32,
+        end: u32,
+    },
+    Cells {
+        start_row: u32,
+        start_column: u32,
+        end_row: u32,
+        end_column: u32,
+    },
+}
+
+impl RangeAddress {
+    /// Parses an unqualified A1 range or full-row/full-column reference.
+    pub(crate) fn parse(raw: &str) -> Result<Self, RangeNavigationError> {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return Err(invalid("Range address cannot be empty"));
+        }
+
+        let pieces: Vec<&str> = raw.split(':').map(str::trim).collect();
+        if pieces.len() == 1 {
+            return parse_single_reference(pieces[0], raw);
+        }
+        if pieces.len() != 2 || pieces.iter().any(|piece| piece.is_empty()) {
+            return Err(invalid(format!(
+                "Invalid range address '{raw}'; expected A1, A1:B2, row:row, or column:column"
+            )));
+        }
+
+        if let (Some(start), Some(end)) = (
+            parse_row_reference(pieces[0]),
+            parse_row_reference(pieces[1]),
+        ) {
+            return make_rows(start, end, raw);
+        }
+        if let (Some(start), Some(end)) = (
+            parse_column_reference(pieces[0]),
+            parse_column_reference(pieces[1]),
+        ) {
+            return make_columns(start, end, raw);
+        }
+
+        let start =
+            parse_cell_reference(pieces[0]).map_err(|message| invalid_range(raw, message))?;
+        let end = parse_cell_reference(pieces[1]).map_err(|message| invalid_range(raw, message))?;
+        make_cells(start.0, start.1, end.0, end.1, raw)
+    }
+
+    /// Returns the rectangular worksheet bounds represented by this shape.
+    pub(crate) fn bounds(&self) -> (u32, u32, u32, u32) {
+        match *self {
+            Self::WholeSheet => (0, 0, LAST_ROW, LAST_COLUMN),
+            Self::Rows { start, end } => (start, 0, end, LAST_COLUMN),
+            Self::Columns { start, end } => (0, start, LAST_ROW, end),
+            Self::Cells {
+                start_row,
+                start_column,
+                end_row,
+                end_column,
+            } => (start_row, start_column, end_row, end_column),
+        }
+    }
+
+    pub(crate) fn row_count(&self) -> u32 {
+        let (start_row, _, end_row, _) = self.bounds();
+        end_row - start_row + 1
+    }
+
+    pub(crate) fn column_count(&self) -> u32 {
+        let (_, start_column, _, end_column) = self.bounds();
+        end_column - start_column + 1
+    }
+
+    pub(crate) fn cell_count(&self) -> i64 {
+        let count = u64::from(self.row_count()) * u64::from(self.column_count());
+        if count > i32::MAX as u64 {
+            -1
+        } else {
+            count as i64
+        }
+    }
+
+    pub(crate) fn is_whole_sheet(&self) -> bool {
+        matches!(self, Self::WholeSheet)
+    }
+
+    pub(crate) fn is_entire_row(&self) -> bool {
+        matches!(self, Self::Rows { .. })
+    }
+
+    pub(crate) fn is_entire_column(&self) -> bool {
+        matches!(self, Self::Columns { .. })
+    }
+
+    /// Renders the unqualified canonical A1 address used by Range metadata.
+    pub(crate) fn to_a1(&self) -> String {
+        match *self {
+            Self::WholeSheet => format!("1:{EXCEL_MAX_ROWS}"),
+            Self::Rows { start, end } => format!("{}:{}", start + 1, end + 1),
+            Self::Columns { start, end } => {
+                format!("{}:{}", column_name(start), column_name(end))
+            }
+            Self::Cells {
+                start_row,
+                start_column,
+                end_row,
+                end_column,
+            } => {
+                let start = cell_name(start_row, start_column);
+                let end = cell_name(end_row, end_column);
+                if start == end {
+                    start
+                } else {
+                    format!("{start}:{end}")
+                }
+            }
+        }
+    }
+
+    fn flags(&self) -> (bool, bool) {
+        match self {
+            Self::WholeSheet => (true, true),
+            Self::Rows { .. } => (false, true),
+            Self::Columns { .. } => (true, false),
+            Self::Cells { .. } => (false, false),
+        }
+    }
+}
+
+/// A range returned by a navigation operation.
+///
+/// The worksheet is retained even though the current family never changes
+/// sheets.  That keeps the result directly usable by the host's RangeRef map
+/// and lets the host reject cross-sheet Range arguments before geometry runs.
+#[derive(Clone)]
+pub(crate) struct RangeNavigationResult {
+    pub(crate) sheet: Sheet,
+    pub(crate) address: RangeAddress,
+}
+
+/// Errors returned by the pure navigation dispatcher.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RangeNavigationError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+/// Apply one queued `Worksheet.getCell` or `Range` navigation operation.
+///
+/// `address == None` represents `Worksheet.getRange()` and therefore starts
+/// at A1 with the complete Excel grid. For `getBoundingRect` and
+/// `getIntersection`, the host should resolve Range proxy arguments to their
+/// same-sheet canonical address before calling this function. A plain string
+/// argument is parsed here, including a sheet-qualified A1 address whose
+/// qualifier must match `sheet`.
+pub(crate) fn navigate_range(
+    sheet: Sheet,
+    address: Option<&str>,
+    method: &str,
+    args: &[Value],
+) -> Result<RangeNavigationResult, RangeNavigationError> {
+    let current = match address {
+        Some(address) => parse_range_address(&sheet, address)?,
+        None => RangeAddress::WholeSheet,
+    };
+
+    let result = match method {
+        // The worksheet method is dispatched with address == None. Treating
+        // it as a method alias also makes the helper convenient for callers
+        // that have already distinguished Worksheet from Range in the wire
+        // operation.
+        "worksheet.getCell" | "Worksheet.getCell" => {
+            expect_arg_count(method, args, 2)?;
+            let row = number_arg(args, 0, method)?;
+            let column = number_arg(args, 1, method)?;
+            make_cells(row, column, row, column, method)?
+        }
+        "getCell" => {
+            expect_arg_count(method, args, 2)?;
+            let row_offset = number_arg(args, 0, method)?;
+            let column_offset = number_arg(args, 1, method)?;
+            let (start_row, start_column, _, _) = current.bounds();
+            let row = checked_add_offset(start_row, i64::from(row_offset), "row", method)?;
+            let column =
+                checked_add_offset(start_column, i64::from(column_offset), "column", method)?;
+            make_cells(row, column, row, column, method)?
+        }
+        "getRow" => {
+            expect_arg_count(method, args, 1)?;
+            let index = bounded_index(args, 0, current.row_count(), "row", method)?;
+            let (start_row, start_column, _, end_column) = current.bounds();
+            let row = start_row + index;
+            make_address(
+                row,
+                start_column,
+                row,
+                end_column,
+                false,
+                current.flags().1,
+                method,
+            )?
+        }
+        "getColumn" => {
+            expect_arg_count(method, args, 1)?;
+            let index = bounded_index(args, 0, current.column_count(), "column", method)?;
+            let (start_row, start_column, end_row, _) = current.bounds();
+            let column = start_column + index;
+            make_address(
+                start_row,
+                column,
+                end_row,
+                column,
+                current.flags().0,
+                false,
+                method,
+            )?
+        }
+        "getLastCell" => {
+            expect_arg_count(method, args, 0)?;
+            let (_, _, end_row, end_column) = current.bounds();
+            make_cells(end_row, end_column, end_row, end_column, method)?
+        }
+        "getLastRow" => {
+            expect_arg_count(method, args, 0)?;
+            let (_, start_column, end_row, end_column) = current.bounds();
+            make_address(
+                end_row,
+                start_column,
+                end_row,
+                end_column,
+                false,
+                current.flags().1,
+                method,
+            )?
+        }
+        "getLastColumn" => {
+            expect_arg_count(method, args, 0)?;
+            let (start_row, _, end_row, end_column) = current.bounds();
+            make_address(
+                start_row,
+                end_column,
+                end_row,
+                end_column,
+                current.flags().0,
+                false,
+                method,
+            )?
+        }
+        "getOffsetRange" => {
+            expect_arg_count(method, args, 2)?;
+            let row_offset = signed_arg(args, 0, method)?;
+            let column_offset = signed_arg(args, 1, method)?;
+            offset_range(&current, row_offset, column_offset, method)?
+        }
+        "getResizedRange" => {
+            expect_arg_count(method, args, 2)?;
+            let delta_rows = signed_arg(args, 0, method)?;
+            let delta_columns = signed_arg(args, 1, method)?;
+            resize_range(&current, delta_rows, delta_columns, method)?
+        }
+        "getAbsoluteResizedRange" => {
+            expect_arg_count(method, args, 2)?;
+            let rows = positive_size_arg(args, 0, "rows", method)?;
+            let columns = positive_size_arg(args, 1, "columns", method)?;
+            absolute_resize_range(&current, rows, columns, method)?
+        }
+        "getRowsAbove" => {
+            expect_optional_count(args, method)?;
+            let count = optional_count(args, method)?;
+            adjacent_rows(&current, count, true, method)?
+        }
+        "getRowsBelow" => {
+            expect_optional_count(args, method)?;
+            let count = optional_count(args, method)?;
+            adjacent_rows(&current, count, false, method)?
+        }
+        "getColumnsBefore" => {
+            expect_optional_count(args, method)?;
+            let count = optional_count(args, method)?;
+            adjacent_columns(&current, count, true, method)?
+        }
+        "getColumnsAfter" => {
+            expect_optional_count(args, method)?;
+            let count = optional_count(args, method)?;
+            adjacent_columns(&current, count, false, method)?
+        }
+        "getEntireRow" => {
+            expect_arg_count(method, args, 0)?;
+            let (start_row, _, end_row, _) = current.bounds();
+            make_address(start_row, 0, end_row, LAST_COLUMN, false, true, method)?
+        }
+        "getEntireColumn" => {
+            expect_arg_count(method, args, 0)?;
+            let (_, start_column, _, end_column) = current.bounds();
+            make_address(0, start_column, LAST_ROW, end_column, true, false, method)?
+        }
+        "getBoundingRect" => {
+            expect_arg_count(method, args, 1)?;
+            let other = argument_range(&sheet, &args[0], method)?;
+            bounding_rect(&current, &other, method)?
+        }
+        "getIntersection" => {
+            expect_arg_count(method, args, 1)?;
+            let other = argument_range(&sheet, &args[0], method)?;
+            intersection(&current, &other, method)?
+        }
+        other => {
+            return Err(invalid(format!(
+                "Unsupported Range navigation method '{other}'"
+            )))
+        }
+    };
+
+    Ok(RangeNavigationResult {
+        sheet,
+        address: result,
+    })
+}
+
+/// Parses an A1, full-row, or full-column address and validates an optional
+/// worksheet qualifier against `sheet`.
+pub(crate) fn parse_range_address(
+    sheet: &Sheet,
+    raw: &str,
+) -> Result<RangeAddress, RangeNavigationError> {
+    let raw = raw.trim();
+    let Some(separator) = raw.rfind('!') else {
+        return RangeAddress::parse(raw);
+    };
+
+    let qualifier = raw[..separator].trim();
+    let reference = raw[separator + 1..].trim();
+    if qualifier.is_empty() || reference.is_empty() {
+        return Err(invalid(format!(
+            "Invalid sheet-qualified range address '{raw}'"
+        )));
+    }
+    let qualifier = unquote_sheet_name(qualifier).ok_or_else(|| {
+        invalid(format!(
+            "Invalid worksheet qualifier in range address '{raw}'"
+        ))
+    })?;
+    let sheet_name = sheet.name().map_err(|error| RangeNavigationError {
+        code: "GeneralException",
+        message: error.to_string(),
+    })?;
+    if !sheet_name.eq_ignore_ascii_case(&qualifier) {
+        return Err(invalid(format!(
+            "Range address '{raw}' belongs to worksheet '{qualifier}', not '{sheet_name}'"
+        )));
+    }
+    RangeAddress::parse(reference)
+}
+
+fn argument_range(
+    sheet: &Sheet,
+    value: &Value,
+    method: &str,
+) -> Result<RangeAddress, RangeNavigationError> {
+    match value {
+        Value::String(address) => parse_range_address(sheet, address),
+        // The host may enrich a resolved Range proxy argument before handing
+        // it to this pure helper. Accepting an `address` field keeps that
+        // contract explicit while still rejecting a raw, unresolved object.
+        Value::Object(object) => {
+            if let Some(address) = object.get("address").and_then(Value::as_str) {
+                parse_range_address(sheet, address)
+            } else {
+                Err(invalid(format!(
+                    "{method} requires a Range object or range address"
+                )))
+            }
+        }
+        _ => Err(invalid(format!(
+            "{method} requires a Range object or range address"
+        ))),
+    }
+}
+
+fn bounding_rect(
+    left: &RangeAddress,
+    right: &RangeAddress,
+    method: &str,
+) -> Result<RangeAddress, RangeNavigationError> {
+    let (left_start_row, left_start_column, left_end_row, left_end_column) = left.bounds();
+    let (right_start_row, right_start_column, right_end_row, right_end_column) = right.bounds();
+    make_address(
+        left_start_row.min(right_start_row),
+        left_start_column.min(right_start_column),
+        left_end_row.max(right_end_row),
+        left_end_column.max(right_end_column),
+        left.flags().0 || right.flags().0,
+        left.flags().1 || right.flags().1,
+        method,
+    )
+}
+
+fn intersection(
+    left: &RangeAddress,
+    right: &RangeAddress,
+    method: &str,
+) -> Result<RangeAddress, RangeNavigationError> {
+    let (left_start_row, left_start_column, left_end_row, left_end_column) = left.bounds();
+    let (right_start_row, right_start_column, right_end_row, right_end_column) = right.bounds();
+    let start_row = left_start_row.max(right_start_row);
+    let start_column = left_start_column.max(right_start_column);
+    let end_row = left_end_row.min(right_end_row);
+    let end_column = left_end_column.min(right_end_column);
+    if start_row > end_row || start_column > end_column {
+        return Err(RangeNavigationError {
+            code: "ItemNotFound",
+            message: "The specified ranges do not intersect".to_string(),
+        });
+    }
+
+    make_address(
+        start_row,
+        start_column,
+        end_row,
+        end_column,
+        left.flags().0 && right.flags().0,
+        left.flags().1 && right.flags().1,
+        method,
+    )
+}
+
+fn offset_range(
+    current: &RangeAddress,
+    row_offset: i64,
+    column_offset: i64,
+    method: &str,
+) -> Result<RangeAddress, RangeNavigationError> {
+    let (start_row, start_column, end_row, end_column) = current.bounds();
+    let (rows_unbounded, columns_unbounded) = current.flags();
+    if (rows_unbounded && row_offset != 0) || (columns_unbounded && column_offset != 0) {
+        return Err(invalid(format!(
+            "{method} would move an entire worksheet axis outside the worksheet grid"
+        )));
+    }
+    let start_row = checked_add_offset(start_row, row_offset, "row", method)?;
+    let start_column = checked_add_offset(start_column, column_offset, "column", method)?;
+    let end_row = checked_add_offset(end_row, row_offset, "row", method)?;
+    let end_column = checked_add_offset(end_column, column_offset, "column", method)?;
+    make_address(
+        start_row,
+        start_column,
+        end_row,
+        end_column,
+        rows_unbounded,
+        columns_unbounded,
+        method,
+    )
+}
+
+fn resize_range(
+    current: &RangeAddress,
+    delta_rows: i64,
+    delta_columns: i64,
+    method: &str,
+) -> Result<RangeAddress, RangeNavigationError> {
+    let (start_row, start_column, end_row, end_column) = current.bounds();
+    let end_row = checked_add_offset(end_row, delta_rows, "row", method)?;
+    let end_column = checked_add_offset(end_column, delta_columns, "column", method)?;
+    if end_row < start_row || end_column < start_column {
+        return Err(invalid(format!(
+            "{method} cannot reduce a range below one row and one column"
+        )));
+    }
+    let (rows_unbounded, columns_unbounded) = current.flags();
+    make_address(
+        start_row,
+        start_column,
+        end_row,
+        end_column,
+        rows_unbounded && end_row == LAST_ROW,
+        columns_unbounded && end_column == LAST_COLUMN,
+        method,
+    )
+}
+
+fn absolute_resize_range(
+    current: &RangeAddress,
+    rows: u32,
+    columns: u32,
+    method: &str,
+) -> Result<RangeAddress, RangeNavigationError> {
+    let (start_row, start_column, _, _) = current.bounds();
+    let end_row = start_row
+        .checked_add(rows - 1)
+        .ok_or_else(|| invalid(format!("{method} exceeds the worksheet row limit")))?;
+    let end_column = start_column
+        .checked_add(columns - 1)
+        .ok_or_else(|| invalid(format!("{method} exceeds the worksheet column limit")))?;
+    if end_row > LAST_ROW || end_column > LAST_COLUMN {
+        return Err(invalid(format!("{method} exceeds the worksheet grid")));
+    }
+
+    let (rows_unbounded, columns_unbounded) = current.flags();
+    make_address(
+        start_row,
+        start_column,
+        end_row,
+        end_column,
+        rows_unbounded && end_row == LAST_ROW && rows == EXCEL_MAX_ROWS,
+        columns_unbounded && end_column == LAST_COLUMN && columns == EXCEL_MAX_COLUMNS,
+        method,
+    )
+}
+
+fn adjacent_rows(
+    current: &RangeAddress,
+    count: i64,
+    above: bool,
+    method: &str,
+) -> Result<RangeAddress, RangeNavigationError> {
+    if count == 0 {
+        return Err(invalid(format!("{method} count cannot be zero")));
+    }
+    let (start_row, start_column, end_row, end_column) = current.bounds();
+    let (_, columns_unbounded) = current.flags();
+    let (start_row, end_row, preserve_columns_unbounded) = if count > 0 {
+        let count = u32::try_from(count)
+            .map_err(|_| invalid(format!("{method} count is outside the supported range")))?;
+        if above {
+            if count > start_row {
+                return Err(invalid(format!(
+                    "{method} would move above the worksheet grid"
+                )));
+            }
+            (start_row - count, start_row - 1, columns_unbounded)
+        } else {
+            let end = end_row
+                .checked_add(count)
+                .ok_or_else(|| invalid(format!("{method} exceeds the worksheet grid")))?;
+            if end > LAST_ROW {
+                return Err(invalid(format!(
+                    "{method} would move below the worksheet grid"
+                )));
+            }
+            (end_row + 1, end, columns_unbounded)
+        }
+    } else {
+        let count = count
+            .checked_abs()
+            .and_then(|count| u32::try_from(count).ok())
+            .ok_or_else(|| invalid(format!("{method} count is outside the supported range")))?;
+        let parent_rows = end_row - start_row + 1;
+        if count > parent_rows {
+            return Err(invalid(format!(
+                "{method} count exceeds the containing range"
+            )));
+        }
+        if above {
+            (start_row, start_row + count - 1, columns_unbounded)
+        } else {
+            (end_row - count + 1, end_row, columns_unbounded)
+        }
+    };
+    make_address(
+        start_row,
+        start_column,
+        end_row,
+        end_column,
+        false,
+        preserve_columns_unbounded,
+        method,
+    )
+}
+
+fn adjacent_columns(
+    current: &RangeAddress,
+    count: i64,
+    before: bool,
+    method: &str,
+) -> Result<RangeAddress, RangeNavigationError> {
+    if count == 0 {
+        return Err(invalid(format!("{method} count cannot be zero")));
+    }
+    let (start_row, start_column, end_row, end_column) = current.bounds();
+    let (rows_unbounded, _) = current.flags();
+    let (start_column, end_column, preserve_rows_unbounded) = if count > 0 {
+        let count = u32::try_from(count)
+            .map_err(|_| invalid(format!("{method} count is outside the supported range")))?;
+        if before {
+            if count > start_column {
+                return Err(invalid(format!(
+                    "{method} would move before the worksheet grid"
+                )));
+            }
+            (start_column - count, start_column - 1, rows_unbounded)
+        } else {
+            let end = end_column
+                .checked_add(count)
+                .ok_or_else(|| invalid(format!("{method} exceeds the worksheet grid")))?;
+            if end > LAST_COLUMN {
+                return Err(invalid(format!(
+                    "{method} would move after the worksheet grid"
+                )));
+            }
+            (end_column + 1, end, rows_unbounded)
+        }
+    } else {
+        let count = count
+            .checked_abs()
+            .and_then(|count| u32::try_from(count).ok())
+            .ok_or_else(|| invalid(format!("{method} count is outside the supported range")))?;
+        let parent_columns = end_column - start_column + 1;
+        if count > parent_columns {
+            return Err(invalid(format!(
+                "{method} count exceeds the containing range"
+            )));
+        }
+        if before {
+            (start_column, start_column + count - 1, rows_unbounded)
+        } else {
+            (end_column - count + 1, end_column, rows_unbounded)
+        }
+    };
+    make_address(
+        start_row,
+        start_column,
+        end_row,
+        end_column,
+        preserve_rows_unbounded,
+        false,
+        method,
+    )
+}
+
+fn make_address(
+    start_row: u32,
+    start_column: u32,
+    end_row: u32,
+    end_column: u32,
+    rows_unbounded: bool,
+    columns_unbounded: bool,
+    method: &str,
+) -> Result<RangeAddress, RangeNavigationError> {
+    if start_row > end_row || start_column > end_column {
+        return Err(invalid(format!("{method} produced an empty range")));
+    }
+    if end_row > LAST_ROW || end_column > LAST_COLUMN {
+        return Err(invalid(format!("{method} exceeds the worksheet grid")));
+    }
+    if rows_unbounded && end_row != LAST_ROW {
+        return Err(invalid(format!(
+            "{method} produced an invalid unbounded-row range"
+        )));
+    }
+    if columns_unbounded && end_column != LAST_COLUMN {
+        return Err(invalid(format!(
+            "{method} produced an invalid unbounded-column range"
+        )));
+    }
+    if rows_unbounded && start_row != 0 {
+        return Err(invalid(format!(
+            "{method} produced an invalid unbounded-row origin"
+        )));
+    }
+    if columns_unbounded && start_column != 0 {
+        return Err(invalid(format!(
+            "{method} produced an invalid unbounded-column origin"
+        )));
+    }
+
+    Ok(match (rows_unbounded, columns_unbounded) {
+        (true, true) => RangeAddress::WholeSheet,
+        (true, false) => RangeAddress::Columns {
+            start: start_column,
+            end: end_column,
+        },
+        (false, true) => RangeAddress::Rows {
+            start: start_row,
+            end: end_row,
+        },
+        (false, false) => RangeAddress::Cells {
+            start_row,
+            start_column,
+            end_row,
+            end_column,
+        },
+    })
+}
+
+fn make_cells(
+    start_row: u32,
+    start_column: u32,
+    end_row: u32,
+    end_column: u32,
+    method: &str,
+) -> Result<RangeAddress, RangeNavigationError> {
+    make_address(
+        start_row,
+        start_column,
+        end_row,
+        end_column,
+        false,
+        false,
+        method,
+    )
+}
+
+fn make_rows(start: u32, end: u32, raw: &str) -> Result<RangeAddress, RangeNavigationError> {
+    if start > end {
+        return Err(invalid_range(
+            raw,
+            "the first row must not be below the second row",
+        ));
+    }
+    Ok(RangeAddress::Rows { start, end })
+}
+
+fn make_columns(start: u32, end: u32, raw: &str) -> Result<RangeAddress, RangeNavigationError> {
+    if start > end {
+        return Err(invalid_range(
+            raw,
+            "the first column must not be to the right of the second column",
+        ));
+    }
+    Ok(RangeAddress::Columns { start, end })
+}
+
+fn parse_single_reference(
+    reference: &str,
+    raw: &str,
+) -> Result<RangeAddress, RangeNavigationError> {
+    if let Some(row) = parse_row_reference(reference) {
+        return Ok(RangeAddress::Rows {
+            start: row,
+            end: row,
+        });
+    }
+    if let Some(column) = parse_column_reference(reference) {
+        return Ok(RangeAddress::Columns {
+            start: column,
+            end: column,
+        });
+    }
+    let (row, column) =
+        parse_cell_reference(reference).map_err(|message| invalid_range(raw, message))?;
+    Ok(RangeAddress::Cells {
+        start_row: row,
+        start_column: column,
+        end_row: row,
+        end_column: column,
+    })
+}
+
+fn parse_row_reference(reference: &str) -> Option<u32> {
+    let stripped = reference
+        .trim()
+        .strip_prefix('$')
+        .unwrap_or(reference.trim());
+    if stripped.is_empty() || !stripped.chars().all(|character| character.is_ascii_digit()) {
+        return None;
+    }
+    let row = stripped.parse::<u32>().ok()?;
+    (1..=EXCEL_MAX_ROWS).contains(&row).then_some(row - 1)
+}
+
+fn parse_column_reference(reference: &str) -> Option<u32> {
+    let stripped = reference
+        .trim()
+        .strip_prefix('$')
+        .unwrap_or(reference.trim());
+    if stripped.is_empty()
+        || !stripped
+            .chars()
+            .all(|character| character.is_ascii_alphabetic())
+    {
+        return None;
+    }
+    let mut value = 0u32;
+    for character in stripped.bytes() {
+        let digit = u32::from(character.to_ascii_uppercase() - b'A' + 1);
+        value = value.checked_mul(26)?.checked_add(digit)?;
+    }
+    (1..=EXCEL_MAX_COLUMNS)
+        .contains(&value)
+        .then_some(value - 1)
+}
+
+fn parse_cell_reference(reference: &str) -> Result<(u32, u32), &'static str> {
+    let stripped: String = reference
+        .chars()
+        .filter(|character| *character != '$')
+        .collect();
+    let first_digit = stripped
+        .find(|character: char| character.is_ascii_digit())
+        .ok_or("missing row number")?;
+    if first_digit == 0 {
+        return Err("missing column letters");
+    }
+    let column =
+        parse_column_reference(&stripped[..first_digit]).ok_or("invalid column letters")?;
+    let row = stripped[first_digit..]
+        .parse::<u32>()
+        .map_err(|_| "invalid row number")?;
+    if row == 0 || row > EXCEL_MAX_ROWS {
+        return Err("row is outside the worksheet grid");
+    }
+    Ok((row - 1, column))
+}
+
+fn unquote_sheet_name(qualifier: &str) -> Option<String> {
+    if qualifier.len() >= 2 && qualifier.starts_with('\'') && qualifier.ends_with('\'') {
+        let inner = &qualifier[1..qualifier.len() - 1];
+        Some(inner.replace("''", "'"))
+    } else if qualifier
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || character == '_' || character == '.')
+    {
+        Some(qualifier.to_string())
+    } else {
+        None
+    }
+}
+
+fn checked_add_offset(
+    value: u32,
+    offset: i64,
+    axis: &str,
+    method: &str,
+) -> Result<u32, RangeNavigationError> {
+    let result = i128::from(value) + i128::from(offset);
+    let max = if axis == "row" {
+        i128::from(LAST_ROW)
+    } else {
+        i128::from(LAST_COLUMN)
+    };
+    if result < 0 || result > max {
+        return Err(invalid(format!(
+            "{method} produced a {axis} outside the worksheet grid"
+        )));
+    }
+    Ok(result as u32)
+}
+
+fn number_arg(args: &[Value], index: usize, method: &str) -> Result<u32, RangeNavigationError> {
+    let value = args
+        .get(index)
+        .ok_or_else(|| invalid(format!("{method} is missing argument {}", index + 1)))?;
+    let number = value.as_f64().ok_or_else(|| {
+        invalid(format!(
+            "{method} argument {} must be an integer",
+            index + 1
+        ))
+    })?;
+    if !number.is_finite() || number.fract() != 0.0 || number < 0.0 {
+        return Err(invalid(format!(
+            "{method} argument {} must be a non-negative integer",
+            index + 1
+        )));
+    }
+    if number > f64::from(u32::MAX) {
+        return Err(invalid(format!(
+            "{method} argument {} is outside the supported range",
+            index + 1
+        )));
+    }
+    Ok(number as u32)
+}
+
+fn signed_arg(args: &[Value], index: usize, method: &str) -> Result<i64, RangeNavigationError> {
+    let value = args
+        .get(index)
+        .ok_or_else(|| invalid(format!("{method} is missing argument {}", index + 1)))?;
+    let number = value.as_f64().ok_or_else(|| {
+        invalid(format!(
+            "{method} argument {} must be an integer",
+            index + 1
+        ))
+    })?;
+    if !number.is_finite() || number.fract() != 0.0 {
+        return Err(invalid(format!(
+            "{method} argument {} must be an integer",
+            index + 1
+        )));
+    }
+    if number < i64::MIN as f64 || number > i64::MAX as f64 {
+        return Err(invalid(format!(
+            "{method} argument {} is outside the supported range",
+            index + 1
+        )));
+    }
+    Ok(number as i64)
+}
+
+fn positive_size_arg(
+    args: &[Value],
+    index: usize,
+    axis: &str,
+    method: &str,
+) -> Result<u32, RangeNavigationError> {
+    let value = number_arg(args, index, method)?;
+    if value == 0 {
+        return Err(invalid(format!("{method} {axis} count must be positive")));
+    }
+    Ok(value)
+}
+
+fn bounded_index(
+    args: &[Value],
+    index: usize,
+    length: u32,
+    axis: &str,
+    method: &str,
+) -> Result<u32, RangeNavigationError> {
+    let value = number_arg(args, index, method)?;
+    if value >= length {
+        return Err(invalid(format!(
+            "{method} {axis} index {value} is outside the containing range"
+        )));
+    }
+    Ok(value)
+}
+
+fn optional_count(args: &[Value], method: &str) -> Result<i64, RangeNavigationError> {
+    if args.is_empty() {
+        return Ok(1);
+    }
+    signed_arg(args, 0, method)
+}
+
+fn expect_optional_count(args: &[Value], method: &str) -> Result<(), RangeNavigationError> {
+    if args.len() > 1 {
+        return Err(invalid(format!("{method} accepts at most one argument")));
+    }
+    Ok(())
+}
+
+fn expect_arg_count(
+    method: &str,
+    args: &[Value],
+    expected: usize,
+) -> Result<(), RangeNavigationError> {
+    if args.len() != expected {
+        return Err(invalid(format!(
+            "{method} expects {expected} argument{}",
+            if expected == 1 { "" } else { "s" }
+        )));
+    }
+    Ok(())
+}
+
+fn cell_name(row: u32, column: u32) -> String {
+    format!("{}{}", column_name(column), row + 1)
+}
+
+fn column_name(mut column: u32) -> String {
+    let mut reversed = Vec::new();
+    loop {
+        reversed.push((b'A' + (column % 26) as u8) as char);
+        column /= 26;
+        if column == 0 {
+            break;
+        }
+        column -= 1;
+    }
+    reversed.into_iter().rev().collect()
+}
+
+fn invalid(message: impl Into<String>) -> RangeNavigationError {
+    RangeNavigationError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn invalid_range(raw: &str, reason: impl std::fmt::Display) -> RangeNavigationError {
+    invalid(format!("Invalid range address '{raw}': {reason}"))
+}

--- a/compute/officejs/src/range_search.js
+++ b/compute/officejs/src/range_search.js
@@ -1,0 +1,254 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var officeJs = global.__mogOfficeJs || {};
+
+  function invalidArgument(message) {
+    var error = new OfficeExtension.Error({
+      code: "InvalidArgument",
+      message: message,
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidArgument";
+    return error;
+  }
+
+  function requireString(value, name) {
+    if (typeof value !== "string") {
+      throw invalidArgument(name + " must be a string");
+    }
+    return value;
+  }
+
+  function requireOptionalBoolean(value, name) {
+    if (value !== undefined && value !== null && typeof value !== "boolean") {
+      throw invalidArgument(name + " must be a boolean");
+    }
+    return value === true;
+  }
+
+  function criteriaObject(criteria, allowDirection) {
+    if (criteria == null || typeof criteria !== "object" || Array.isArray(criteria)) {
+      throw invalidArgument("Search criteria must be an object");
+    }
+
+    var completeMatch = criteria.completeMatch;
+    var matchCase = criteria.matchCase;
+    if (completeMatch !== undefined && typeof completeMatch !== "boolean") {
+      throw invalidArgument("SearchCriteria.completeMatch must be a boolean");
+    }
+    if (matchCase !== undefined && typeof matchCase !== "boolean") {
+      throw invalidArgument("SearchCriteria.matchCase must be a boolean");
+    }
+
+    var result = {
+      completeMatch: completeMatch === true,
+      matchCase: matchCase === true,
+    };
+    if (allowDirection) {
+      var direction = criteria.searchDirection;
+      if (direction !== undefined && direction !== "Forward" && direction !== "Backwards") {
+        throw invalidArgument(
+          "SearchCriteria.searchDirection must be 'Forward' or 'Backwards'"
+        );
+      }
+      result.searchDirection = direction === "Backwards" ? "Backwards" : "Forward";
+    }
+    return result;
+  }
+
+  function cellValueType(value) {
+    return value === undefined ? null : value;
+  }
+
+  // RangeAreas is supplied by the range-areas family.  Its constructor takes
+  // the same context/worksheet/object-path shape as Range in this runtime;
+  // the hook lets that family choose a richer constructor without making this
+  // search adapter depend on its private implementation.
+  function newRangeAreas(context, worksheet) {
+    if (typeof officeJs.createRangeAreas === "function") {
+      return officeJs.createRangeAreas(context, worksheet || null);
+    }
+    if (typeof Excel.RangeAreas !== "function") {
+      throw invalidArgument("RangeAreas is not available in this host");
+    }
+    return new Excel.RangeAreas(context, worksheet || null, null);
+  }
+
+  function newRange(context, worksheet) {
+    return new Excel.Range(context, worksheet || null, null);
+  }
+
+  function queueRangeSearch(source, method, args, orNullObject) {
+    var result = newRange(source.context, source._worksheet);
+    source.context._queue.push({
+      op: "rangeSearch",
+      id: result._id,
+      rangeId: source._id,
+      method: method,
+      args: args || [],
+      orNullObject: orNullObject === true,
+    });
+    return result;
+  }
+
+  function queueWorksheetSearch(source, method, args, orNullObject) {
+    var result = newRange(source.context, source);
+    source.context._queue.push({
+      op: "worksheetSearch",
+      id: result._id,
+      worksheetId: source._id,
+      method: method,
+      args: args || [],
+      orNullObject: orNullObject === true,
+    });
+    return result;
+  }
+
+  function queueRangeAreasSearch(source, method, args, orNullObject, isWorksheet) {
+    var result = newRangeAreas(source.context, isWorksheet ? source : source._worksheet);
+    source.context._queue.push({
+      op: isWorksheet ? "worksheetRangeAreasSearch" : "rangeAreasSearch",
+      id: result._id,
+      rangeId: isWorksheet ? undefined : source._id,
+      worksheetId: isWorksheet ? source._id : undefined,
+      method: method,
+      args: args || [],
+      orNullObject: orNullObject === true,
+    });
+    return result;
+  }
+
+  function newClientResult(context) {
+    if (typeof officeJs.createClientResult === "function") {
+      return officeJs.createClientResult(context);
+    }
+    return new OfficeExtension.ClientResult(context);
+  }
+
+  function queueReplaceAll(source, text, replacement, criteria, isWorksheet) {
+    var result = newClientResult(source.context);
+    source.context._queue.push({
+      op: isWorksheet ? "worksheetReplaceAll" : "rangeReplaceAll",
+      resultId: result._id,
+      rangeId: isWorksheet ? undefined : source._id,
+      worksheetId: isWorksheet ? source._id : undefined,
+      text: text,
+      replacement: replacement,
+      criteria: criteria,
+    });
+    return result;
+  }
+
+  function usedRange(source, valuesOnly, isWorksheet, orNullObject) {
+    var values = requireOptionalBoolean(valuesOnly, "valuesOnly");
+    var args = [values];
+    if (isWorksheet) {
+      return queueWorksheetSearch(source, "getUsedRange", args, orNullObject);
+    }
+    return queueRangeSearch(source, "getUsedRange", args, orNullObject);
+  }
+
+  // Worksheet search and used-range members.
+  Excel.Worksheet.prototype.findAll = function (text, criteria) {
+    return queueRangeAreasSearch(
+      this,
+      "findAll",
+      [requireString(text, "Worksheet.findAll text"), criteriaObject(criteria, false)],
+      false,
+      true
+    );
+  };
+
+  Excel.Worksheet.prototype.findAllOrNullObject = function (text, criteria) {
+    return queueRangeAreasSearch(
+      this,
+      "findAll",
+      [requireString(text, "Worksheet.findAllOrNullObject text"), criteriaObject(criteria, false)],
+      true,
+      true
+    );
+  };
+
+  Excel.Worksheet.prototype.getUsedRange = function (valuesOnly) {
+    return usedRange(this, valuesOnly, true, false);
+  };
+
+  Excel.Worksheet.prototype.getUsedRangeOrNullObject = function (valuesOnly) {
+    return usedRange(this, valuesOnly, true, true);
+  };
+
+  Excel.Worksheet.prototype.replaceAll = function (text, replacement, criteria) {
+    return queueReplaceAll(
+      this,
+      requireString(text, "Worksheet.replaceAll text"),
+      requireString(replacement, "Worksheet.replaceAll replacement"),
+      criteriaObject(criteria, false),
+      true
+    );
+  };
+
+  // Range search and used-range members.
+  Excel.Range.prototype.find = function (text, criteria) {
+    return queueRangeSearch(
+      this,
+      "find",
+      [requireString(text, "Range.find text"), criteriaObject(criteria, true)],
+      false
+    );
+  };
+
+  Excel.Range.prototype.findOrNullObject = function (text, criteria) {
+    return queueRangeSearch(
+      this,
+      "find",
+      [requireString(text, "Range.findOrNullObject text"), criteriaObject(criteria, true)],
+      true
+    );
+  };
+
+  Excel.Range.prototype.getUsedRange = function (valuesOnly) {
+    return usedRange(this, valuesOnly, false, false);
+  };
+
+  Excel.Range.prototype.getUsedRangeOrNullObject = function (valuesOnly) {
+    return usedRange(this, valuesOnly, false, true);
+  };
+
+  Excel.Range.prototype.replaceAll = function (text, replacement, criteria) {
+    return queueReplaceAll(
+      this,
+      requireString(text, "Range.replaceAll text"),
+      requireString(replacement, "Range.replaceAll replacement"),
+      criteriaObject(criteria, false),
+      false
+    );
+  };
+
+  function specialCells(source, cellType, cellValueTypeArg, orNullObject) {
+    requireString(cellType, "Range.getSpecialCells cellType");
+    if (cellValueTypeArg !== undefined && cellValueTypeArg !== null) {
+      requireString(cellValueTypeArg, "Range.getSpecialCells cellValueType");
+    }
+    return queueRangeAreasSearch(
+      source,
+      "getSpecialCells",
+      [cellType, cellValueType(cellValueTypeArg)],
+      orNullObject,
+      false
+    );
+  }
+
+  Excel.Range.prototype.getSpecialCells = function (cellType, cellValueTypeArg) {
+    return specialCells(this, cellType, cellValueTypeArg, false);
+  };
+
+  Excel.Range.prototype.getSpecialCellsOrNullObject = function (
+    cellType,
+    cellValueTypeArg
+  ) {
+    return specialCells(this, cellType, cellValueTypeArg, true);
+  };
+})(globalThis);

--- a/compute/officejs/src/range_search.rs
+++ b/compute/officejs/src/range_search.rs
@@ -1,0 +1,1118 @@
+//! Office.js Range and Worksheet search helpers.
+//!
+//! The Office.js surface keeps search and used-range calls deferred: the
+//! JavaScript adapter queues an operation and the host binds the returned
+//! `Range` (or `RangeAreas`) during `context.sync()`.  This module owns the
+//! translation from that wire operation to the production [`Sheet`] facade.
+//!
+//! The host routing contract is intentionally small and typed at the edge:
+//!
+//! * `used_range(sheet, address, values_only)` returns a canonical unqualified
+//!   A1 address, or `None` when a bounded Range contains no used cells.  A
+//!   worksheet call passes `address = None`; a worksheet `getUsedRange` on an
+//!   empty sheet is handled by the host as `A1`, while the Range variant uses
+//!   the `None` result to produce `ItemNotFound`/a null object.
+//! * `find` returns one `(row, column)` cell address.  `find_all` returns
+//!   individual coordinates and `matches_to_areas` coalesces those coordinates
+//!   into rectangular `SearchArea` values for the RangeAreas adapter.
+//! * `replace_all` returns the deferred ClientResult number after applying
+//!   value/formula replacements through `Sheet::set_cell`.
+//! * `special_cells` only accepts bounded cell ranges and the primitive cell
+//!   types backed by the current engine: `Blanks`, `Constants`, and `Formulas`.
+//!
+//! The current compute-api extent query is the persisted non-null data extent.
+//! It deliberately does not expose format-only cells, so `valuesOnly` is
+//! accepted and preserved by the Office.js contract while both modes use that
+//! same production extent.  This is preferable to inventing a shadow extent or
+//! scanning the complete Excel grid.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use compute_api::{CellRange, CellValue, Sheet};
+use serde_json::{Value, json};
+
+use crate::dispatch::{ExtensionHandler, HostDispatchContext};
+use crate::host::{BatchError, RangeRef};
+use crate::range_areas::RangeAreasRef;
+use crate::range_navigation::{
+    EXCEL_MAX_COLUMNS, EXCEL_MAX_ROWS, RangeAddress, RangeNavigationError, parse_range_address,
+};
+
+const LAST_ROW: u32 = EXCEL_MAX_ROWS - 1;
+const LAST_COLUMN: u32 = EXCEL_MAX_COLUMNS - 1;
+
+/// Errors returned by the pure Range/Worksheet search dispatcher.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RangeSearchError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+/// Normalized `SearchCriteria`/`WorksheetSearchCriteria` values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SearchCriteria {
+    pub(crate) complete_match: bool,
+    pub(crate) match_case: bool,
+    pub(crate) backwards: bool,
+}
+
+impl Default for SearchCriteria {
+    fn default() -> Self {
+        Self {
+            complete_match: false,
+            match_case: false,
+            backwards: false,
+        }
+    }
+}
+
+/// A rectangular area of cells returned by a multi-cell search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct SearchArea {
+    pub(crate) start_row: u32,
+    pub(crate) start_col: u32,
+    pub(crate) end_row: u32,
+    pub(crate) end_col: u32,
+}
+
+/// Register the search/used-range bridge with an Office.js host.
+///
+/// The handler is intentionally stateless.  Search always resolves against
+/// the current `Sheet` handle supplied by the bound Worksheet/Range proxy, so
+/// a second cache of workbook or range state cannot drift from the engine.
+pub(crate) fn register(host: &crate::host::Host) {
+    host.register_extension(RangeSearchHandler);
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct RangeSearchHandler;
+
+impl ExtensionHandler for RangeSearchHandler {
+    fn can_handle(&self, operation: &str) -> bool {
+        matches!(
+            operation,
+            "rangeSearch"
+                | "worksheetSearch"
+                | "rangeAreasSearch"
+                | "worksheetRangeAreasSearch"
+                | "rangeReplaceAll"
+                | "worksheetReplaceAll"
+        )
+    }
+
+    fn handle(
+        &self,
+        operation: &Value,
+        context: &mut HostDispatchContext<'_>,
+    ) -> Result<bool, BatchError> {
+        let op = required_non_empty_string(operation, "op")?;
+        match op {
+            "rangeSearch" => handle_range_search(operation, context)?,
+            "worksheetSearch" => handle_worksheet_search(operation, context)?,
+            "rangeAreasSearch" => handle_range_areas_search(operation, context)?,
+            "worksheetRangeAreasSearch" => handle_worksheet_range_areas_search(operation, context)?,
+            "rangeReplaceAll" | "worksheetReplaceAll" => handle_replace_all(operation, context)?,
+            _ => return Ok(false),
+        }
+        Ok(true)
+    }
+}
+
+fn handle_range_search(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+) -> Result<(), BatchError> {
+    let id = required_non_empty_string(operation, "id")?;
+    let source = context.range(required_non_empty_string(operation, "rangeId")?)?;
+    let sheet = source.sheet();
+    let method = required_non_empty_string(operation, "method")?;
+    let or_null_object = optional_bool(operation, "orNullObject", false)?;
+    let args = operation_args(operation)?;
+
+    if source.is_null_object() {
+        return Err(invalid("Cannot invoke search on a null Range object"));
+    }
+
+    match method {
+        "getUsedRange" => {
+            let values_only = argument_bool(args, 0, "valuesOnly")?;
+            let address =
+                used_range(&sheet, source.address(), values_only).map_err(search_error)?;
+            bind_used_range(context, id, sheet, address, or_null_object, false)
+        }
+        "find" => {
+            let text = argument_string(args, 0, "text")?;
+            let criteria = argument_criteria(args, 1)?;
+            let match_cell =
+                find(&sheet, source.address(), text, criteria).map_err(search_error)?;
+            bind_found_range(context, id, sheet, match_cell, or_null_object)
+        }
+        _ => Err(unsupported(format!(
+            "Unsupported Range search method '{method}'"
+        ))),
+    }
+}
+
+fn handle_worksheet_search(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+) -> Result<(), BatchError> {
+    let id = required_non_empty_string(operation, "id")?;
+    let worksheet = context.worksheet(required_non_empty_string(operation, "worksheetId")?)?;
+    let sheet = worksheet.sheet();
+    let method = required_non_empty_string(operation, "method")?;
+    let or_null_object = optional_bool(operation, "orNullObject", false)?;
+    let args = operation_args(operation)?;
+
+    match method {
+        "getUsedRange" => {
+            let values_only = argument_bool(args, 0, "valuesOnly")?;
+            let address = used_range(&sheet, None, values_only).map_err(search_error)?;
+            // Office's Worksheet.getUsedRange has a top-left fallback on an
+            // entirely blank sheet. Its OrNullObject form exposes a null
+            // Range for the same condition.
+            bind_used_range(context, id, sheet, address, or_null_object, true)
+        }
+        _ => Err(unsupported(format!(
+            "Unsupported Worksheet search method '{method}'"
+        ))),
+    }
+}
+
+fn handle_range_areas_search(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+) -> Result<(), BatchError> {
+    let id = required_non_empty_string(operation, "id")?;
+    let source = context.range(required_non_empty_string(operation, "rangeId")?)?;
+    if source.is_null_object() {
+        return Err(invalid("Cannot invoke search on a null Range object"));
+    }
+    let sheet = source.sheet();
+    let method = required_non_empty_string(operation, "method")?;
+    let or_null_object = optional_bool(operation, "orNullObject", false)?;
+    let args = operation_args(operation)?;
+
+    match method {
+        "getSpecialCells" => {
+            let address = source
+                .address()
+                .ok_or_else(|| invalid("Range.getSpecialCells requires a bounded Range"))?;
+            let cell_type = argument_string(args, 0, "cellType")?;
+            let value_type = argument_optional_string(args, 1, "cellValueType")?;
+            let areas =
+                special_cells(&sheet, address, cell_type, value_type).map_err(search_error)?;
+            bind_range_areas(context, id, sheet, areas, or_null_object)
+        }
+        _ => Err(unsupported(format!(
+            "Unsupported RangeAreas search method '{method}'"
+        ))),
+    }
+}
+
+fn handle_worksheet_range_areas_search(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+) -> Result<(), BatchError> {
+    let id = required_non_empty_string(operation, "id")?;
+    let worksheet = context.worksheet(required_non_empty_string(operation, "worksheetId")?)?;
+    let sheet = worksheet.sheet();
+    let method = required_non_empty_string(operation, "method")?;
+    let or_null_object = optional_bool(operation, "orNullObject", false)?;
+    let args = operation_args(operation)?;
+
+    match method {
+        "findAll" => {
+            let text = argument_string(args, 0, "text")?;
+            let criteria = argument_criteria(args, 1)?;
+            let matches = find_all(&sheet, None, text, criteria).map_err(search_error)?;
+            bind_range_areas_from_cells(context, id, sheet, matches, or_null_object)
+        }
+        _ => Err(unsupported(format!(
+            "Unsupported Worksheet RangeAreas search method '{method}'"
+        ))),
+    }
+}
+
+fn handle_replace_all(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+) -> Result<(), BatchError> {
+    let result_id = required_non_empty_string(operation, "resultId")?;
+    let is_worksheet = operation
+        .get("op")
+        .and_then(Value::as_str)
+        .is_some_and(|op| op == "worksheetReplaceAll");
+    let (sheet, address) = if is_worksheet {
+        let worksheet = context.worksheet(required_non_empty_string(operation, "worksheetId")?)?;
+        (worksheet.sheet(), None)
+    } else {
+        let range = context.range(required_non_empty_string(operation, "rangeId")?)?;
+        if range.is_null_object() {
+            return Err(invalid("Cannot replace through a null Range object"));
+        }
+        (range.sheet(), range.address().map(ToOwned::to_owned))
+    };
+    let text = required_string(operation, "text")?;
+    let replacement = required_string(operation, "replacement")?;
+    let criteria = operation_criteria(operation, "criteria")?;
+    let count = replace_all(&sheet, address.as_deref(), text, replacement, criteria)
+        .map_err(search_error)?;
+    context.set_result(result_id, json!(count));
+    Ok(())
+}
+
+fn bind_used_range(
+    context: &mut HostDispatchContext<'_>,
+    id: &str,
+    sheet: Sheet,
+    address: Option<String>,
+    or_null_object: bool,
+    worksheet_scope: bool,
+) -> Result<(), BatchError> {
+    match address {
+        Some(address) => {
+            context.bind_range(id, RangeRef::new(sheet, Some(address), false));
+            Ok(())
+        }
+        None if worksheet_scope && !or_null_object => {
+            context.bind_range(id, RangeRef::new(sheet, Some("A1".to_string()), false));
+            Ok(())
+        }
+        None if or_null_object => {
+            context.bind_range(id, RangeRef::new(sheet, None, true));
+            context.set_loaded(id, "isNullObject", Value::Bool(true));
+            Ok(())
+        }
+        None => Err(item_not_found("The specified Range has no used cells")),
+    }
+}
+
+fn bind_found_range(
+    context: &mut HostDispatchContext<'_>,
+    id: &str,
+    sheet: Sheet,
+    match_cell: Option<(u32, u32)>,
+    or_null_object: bool,
+) -> Result<(), BatchError> {
+    match match_cell {
+        Some((row, column)) => {
+            let address = SearchArea {
+                start_row: row,
+                start_col: column,
+                end_row: row,
+                end_col: column,
+            }
+            .to_a1();
+            context.bind_range(id, RangeRef::new(sheet, Some(address), false));
+            Ok(())
+        }
+        None if or_null_object => {
+            context.bind_range(id, RangeRef::new(sheet, None, true));
+            context.set_loaded(id, "isNullObject", Value::Bool(true));
+            Ok(())
+        }
+        None => Err(item_not_found("The search text was not found")),
+    }
+}
+
+fn bind_range_areas(
+    context: &mut HostDispatchContext<'_>,
+    id: &str,
+    sheet: Sheet,
+    areas: Vec<SearchArea>,
+    or_null_object: bool,
+) -> Result<(), BatchError> {
+    if areas.is_empty() {
+        if or_null_object {
+            context.bind_null_object(id);
+            return Ok(());
+        }
+        return Err(item_not_found("No cells matched the RangeAreas result"));
+    }
+    let addresses = areas.iter().map(|area| area.to_a1()).collect::<Vec<_>>();
+    let range_areas = RangeAreasRef::from_addresses(sheet, addresses).map_err(range_areas_error)?;
+    context.bind_object(id, Arc::new(range_areas));
+    Ok(())
+}
+
+fn bind_range_areas_from_cells(
+    context: &mut HostDispatchContext<'_>,
+    id: &str,
+    sheet: Sheet,
+    matches: Vec<(u32, u32)>,
+    or_null_object: bool,
+) -> Result<(), BatchError> {
+    if matches.is_empty() {
+        if or_null_object {
+            context.bind_null_object(id);
+            return Ok(());
+        }
+        return Err(item_not_found("No cells matched the RangeAreas result"));
+    }
+    let range_areas = RangeAreasRef::from_cells(sheet, matches).map_err(range_areas_error)?;
+    context.bind_object(id, Arc::new(range_areas));
+    Ok(())
+}
+
+fn operation_args(operation: &Value) -> Result<&[Value], BatchError> {
+    operation
+        .get("args")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .ok_or_else(|| invalid("Search operation requires an args array"))
+}
+
+fn argument_string<'a>(args: &'a [Value], index: usize, name: &str) -> Result<&'a str, BatchError> {
+    args.get(index)
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid(format!("Search operation argument {name} must be a string")))
+}
+
+fn argument_optional_string<'a>(
+    args: &'a [Value],
+    index: usize,
+    name: &str,
+) -> Result<Option<&'a str>, BatchError> {
+    match args.get(index) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value
+            .as_str()
+            .map(Some)
+            .ok_or_else(|| invalid(format!("Search operation argument {name} must be a string"))),
+    }
+}
+
+fn argument_bool(args: &[Value], index: usize, name: &str) -> Result<bool, BatchError> {
+    match args.get(index) {
+        None | Some(Value::Null) => Ok(false),
+        Some(Value::Bool(value)) => Ok(*value),
+        Some(_) => Err(invalid(format!(
+            "Search operation argument {name} must be a boolean"
+        ))),
+    }
+}
+
+fn argument_criteria(args: &[Value], index: usize) -> Result<SearchCriteria, BatchError> {
+    let value = args
+        .get(index)
+        .ok_or_else(|| invalid("Search operation requires criteria"))?;
+    parse_criteria(value)
+}
+
+fn operation_criteria<'a>(operation: &'a Value, field: &str) -> Result<SearchCriteria, BatchError> {
+    let value = operation
+        .get(field)
+        .ok_or_else(|| invalid(format!("Search operation requires {field}")))?;
+    parse_criteria(value)
+}
+
+fn parse_criteria(value: &Value) -> Result<SearchCriteria, BatchError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid("Search criteria must be an object"))?;
+    let complete_match = object_bool(object, "completeMatch")?.unwrap_or(false);
+    let match_case = object_bool(object, "matchCase")?.unwrap_or(false);
+    let backwards = match object.get("searchDirection") {
+        None | Some(Value::Null) => false,
+        Some(Value::String(value)) if value == "Forward" => false,
+        Some(Value::String(value)) if value == "Backwards" => true,
+        Some(_) => {
+            return Err(invalid(
+                "SearchCriteria.searchDirection must be 'Forward' or 'Backwards'",
+            ));
+        }
+    };
+    Ok(SearchCriteria {
+        complete_match,
+        match_case,
+        backwards,
+    })
+}
+
+fn object_bool(
+    object: &serde_json::Map<String, Value>,
+    field: &str,
+) -> Result<Option<bool>, BatchError> {
+    match object.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        Some(_) => Err(invalid(format!("SearchCriteria.{field} must be a boolean"))),
+    }
+}
+
+fn optional_bool(operation: &Value, field: &str, default: bool) -> Result<bool, BatchError> {
+    match operation.get(field) {
+        None | Some(Value::Null) => Ok(default),
+        Some(Value::Bool(value)) => Ok(*value),
+        Some(_) => Err(invalid(format!(
+            "Search operation {field} must be a boolean"
+        ))),
+    }
+}
+
+fn required_string<'a>(operation: &'a Value, field: &str) -> Result<&'a str, BatchError> {
+    operation
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid(format!("Search operation requires string {field}")))
+}
+
+fn required_non_empty_string<'a>(operation: &'a Value, field: &str) -> Result<&'a str, BatchError> {
+    let value = required_string(operation, field)?;
+    if value.trim().is_empty() {
+        return Err(invalid(format!(
+            "Search operation requires non-empty {field}"
+        )));
+    }
+    Ok(value)
+}
+
+fn search_error(error: RangeSearchError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn range_areas_error(error: crate::range_areas::RangeAreasError) -> BatchError {
+    BatchError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn item_not_found(message: impl Into<String>) -> BatchError {
+    BatchError {
+        code: "ItemNotFound",
+        message: message.into(),
+    }
+}
+
+fn invalid(message: impl Into<String>) -> BatchError {
+    BatchError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn unsupported(message: impl Into<String>) -> BatchError {
+    BatchError {
+        code: "UnsupportedOperation",
+        message: message.into(),
+    }
+}
+
+impl SearchArea {
+    /// Render the canonical unqualified A1 address used by RangeAreas.
+    pub(crate) fn to_a1(self) -> String {
+        let start = cell_name(self.start_row, self.start_col);
+        let end = cell_name(self.end_row, self.end_col);
+        if start == end {
+            start
+        } else {
+            format!("{start}:{end}")
+        }
+    }
+}
+
+/// Return the used extent of a worksheet or bounded Range.
+///
+/// `address == None` denotes a worksheet call.  For a Range address, the
+/// result is the intersection of the Range and the persisted sheet extent.
+/// `values_only` is part of the Office.js contract; the current engine's
+/// `get_data_bounds` already excludes format-only cells, so both modes use the
+/// same production query until a format-aware extent primitive exists.
+pub(crate) fn used_range(
+    sheet: &Sheet,
+    address: Option<&str>,
+    values_only: bool,
+) -> Result<Option<String>, RangeSearchError> {
+    let _ = values_only;
+    let scope = scope_bounds(sheet, address)?;
+    let Some(data) = sheet.get_data_bounds().map_err(engine)? else {
+        return Ok(None);
+    };
+    let data = (data.min_row, data.min_col, data.max_row, data.max_col);
+    let Some(bounds) = intersect(scope, data) else {
+        return Ok(None);
+    };
+    Ok(Some(SearchArea::from_bounds(bounds).to_a1()))
+}
+
+/// Find the first matching cell in a Worksheet or Range.
+///
+/// A Range larger than one cell is searched in its own bounds.  A single-cell
+/// Range follows Office.js's documented special case: the entire used sheet
+/// extent is searched, beginning after that cell and wrapping once.  Forward
+/// searches use row-major order; backwards searches use the reverse order.
+pub(crate) fn find(
+    sheet: &Sheet,
+    address: Option<&str>,
+    text: &str,
+    criteria: SearchCriteria,
+) -> Result<Option<(u32, u32)>, RangeSearchError> {
+    let parsed = address
+        .map(|raw| parse_range_address(sheet, raw).map_err(map_address_error))
+        .transpose()?;
+    let single_cell = parsed.as_ref().is_some_and(|range| {
+        matches!(range, RangeAddress::Cells { start_row, start_column, end_row, end_column }
+            if start_row == end_row && start_column == end_column)
+    });
+
+    let bounds = if single_cell {
+        let Some(data) = sheet.get_data_bounds().map_err(engine)? else {
+            return Ok(None);
+        };
+        (data.min_row, data.min_col, data.max_row, data.max_col)
+    } else {
+        let scope = parsed
+            .as_ref()
+            .map_or((0, 0, LAST_ROW, LAST_COLUMN), RangeAddress::bounds);
+        let Some(data) = sheet.get_data_bounds().map_err(engine)? else {
+            return Ok(None);
+        };
+        let data = (data.min_row, data.min_col, data.max_row, data.max_col);
+        let Some(intersection) = intersect(scope, data) else {
+            return Ok(None);
+        };
+        intersection
+    };
+
+    let matches = find_matches(sheet, bounds, text, criteria)?;
+    if matches.is_empty() {
+        return Ok(None);
+    }
+
+    if single_cell {
+        let RangeAddress::Cells {
+            start_row,
+            start_column,
+            ..
+        } = parsed.expect("single-cell address was parsed")
+        else {
+            unreachable!("single-cell marker requires a Cells address")
+        };
+        return Ok(Some(select_after_anchor(
+            &matches,
+            (start_row, start_column),
+            criteria.backwards,
+        )));
+    }
+
+    Ok(Some(if criteria.backwards {
+        *matches.last().expect("non-empty matches")
+    } else {
+        matches[0]
+    }))
+}
+
+/// Find all matching cells in a Worksheet or bounded Range.
+///
+/// Unlike `Range.find`, a worksheet `findAll` call has no search direction and
+/// a RangeAreas result is represented by all matching coordinates.  The host
+/// should call [`matches_to_areas`] before constructing its RangeAreas proxy.
+pub(crate) fn find_all(
+    sheet: &Sheet,
+    address: Option<&str>,
+    text: &str,
+    criteria: SearchCriteria,
+) -> Result<Vec<(u32, u32)>, RangeSearchError> {
+    let parsed = address
+        .map(|raw| parse_range_address(sheet, raw).map_err(map_address_error))
+        .transpose()?;
+    let scope = parsed
+        .as_ref()
+        .map_or((0, 0, LAST_ROW, LAST_COLUMN), RangeAddress::bounds);
+    let Some(data) = sheet.get_data_bounds().map_err(engine)? else {
+        return Ok(Vec::new());
+    };
+    let data = (data.min_row, data.min_col, data.max_row, data.max_col);
+    let Some(bounds) = intersect(scope, data) else {
+        return Ok(Vec::new());
+    };
+    let mut matches = find_matches(sheet, bounds, text, criteria)?;
+    if criteria.backwards {
+        matches.reverse();
+    }
+    Ok(matches)
+}
+
+/// Replace all matching values in a Worksheet or bounded Range.
+///
+/// The returned count is suitable for the top-level `ClientResult<number>`
+/// response.  Replacement is staged before mutation so scanning never mixes
+/// reads with writes. Formula cells are matched and replaced against their raw
+/// formula text; literal cells use their displayed value (which is also the
+/// raw stored value for the primitive cell types).
+pub(crate) fn replace_all(
+    sheet: &Sheet,
+    address: Option<&str>,
+    text: &str,
+    replacement: &str,
+    criteria: SearchCriteria,
+) -> Result<u32, RangeSearchError> {
+    if text.is_empty() {
+        return Err(invalid("replaceAll text cannot be empty"));
+    }
+
+    let parsed = address
+        .map(|raw| parse_range_address(sheet, raw).map_err(map_address_error))
+        .transpose()?;
+    let scope = parsed
+        .as_ref()
+        .map_or((0, 0, LAST_ROW, LAST_COLUMN), RangeAddress::bounds);
+    let Some(data) = sheet.get_data_bounds().map_err(engine)? else {
+        return Ok(0);
+    };
+    let data = (data.min_row, data.min_col, data.max_row, data.max_col);
+    let Some(bounds) = intersect(scope, data) else {
+        return Ok(0);
+    };
+
+    let values = values_in_bounds(sheet, bounds)?;
+    let mut changes = Vec::new();
+    let mut count = 0u32;
+    for (row_offset, row_values) in values.iter().enumerate() {
+        for (col_offset, value) in row_values.iter().enumerate() {
+            let row = bounds.0 + row_offset as u32;
+            let col = bounds.1 + col_offset as u32;
+            let raw = sheet.get_raw_value((row, col)).map_err(engine)?;
+            let display = value.to_string();
+            let candidate = if raw.starts_with('=') {
+                raw.as_str()
+            } else {
+                display.as_str()
+            };
+            if !matches_text(candidate, text, criteria) {
+                continue;
+            }
+            let (updated, occurrences) = replace_text(&raw, text, replacement, criteria);
+            if occurrences == 0 {
+                continue;
+            }
+            count = count.saturating_add(occurrences);
+            changes.push((row, col, updated));
+        }
+    }
+
+    for (row, col, value) in changes {
+        sheet
+            .set_cell((row, col), value)
+            .map_err(engine)
+            .map(|_| ())?;
+    }
+
+    Ok(count)
+}
+
+/// Discover bounded primitive special-cell areas.
+///
+/// Supported `cell_type` values are `Blanks`, `Constants`, and `Formulas`.
+/// The conditional-format, data-validation, same-format, and visibility
+/// families require engine indexes that are not currently exposed by the
+/// compute-api facade, so they return `UnsupportedOperation` explicitly.
+pub(crate) fn special_cells(
+    sheet: &Sheet,
+    address: &str,
+    cell_type: &str,
+    cell_value_type: Option<&str>,
+) -> Result<Vec<SearchArea>, RangeSearchError> {
+    let parsed = parse_range_address(sheet, address).map_err(map_address_error)?;
+    let bounds = match parsed {
+        RangeAddress::Cells {
+            start_row,
+            start_column,
+            end_row,
+            end_column,
+        } => (start_row, start_column, end_row, end_column),
+        RangeAddress::WholeSheet | RangeAddress::Rows { .. } | RangeAddress::Columns { .. } => {
+            return Err(unsupported("getSpecialCells requires a bounded cell range"));
+        }
+    };
+
+    let mode = match cell_type {
+        "Blanks" => SpecialCellMode::Blanks,
+        "Constants" => SpecialCellMode::Constants,
+        "Formulas" => SpecialCellMode::Formulas,
+        other => {
+            return Err(unsupported(format!(
+                "getSpecialCells cell type '{other}' is not supported by this host"
+            )));
+        }
+    };
+    let value_type = ValueType::parse(cell_value_type.unwrap_or("All"))?;
+    let values = values_in_bounds(sheet, bounds)?;
+    let formula_positions =
+        if matches!(mode, SpecialCellMode::Formulas | SpecialCellMode::Constants) {
+            sheet
+                .find_by_formula(".*")
+                .map_err(engine)?
+                .into_iter()
+                .filter(|&(row, col)| {
+                    row >= bounds.0 && row <= bounds.2 && col >= bounds.1 && col <= bounds.3
+                })
+                .collect::<HashSet<_>>()
+        } else {
+            HashSet::new()
+        };
+
+    let mut selected = Vec::new();
+    for (row_offset, row_values) in values.iter().enumerate() {
+        for (col_offset, value) in row_values.iter().enumerate() {
+            let row = bounds.0 + row_offset as u32;
+            let col = bounds.1 + col_offset as u32;
+            let has_formula = formula_positions.contains(&(row, col));
+            let include = match mode {
+                SpecialCellMode::Blanks => !has_formula && value.is_null(),
+                SpecialCellMode::Constants => {
+                    !has_formula && !value.is_null() && value_type.matches(value)
+                }
+                SpecialCellMode::Formulas => has_formula && value_type.matches(value),
+            };
+            if include {
+                selected.push((row, col));
+            }
+        }
+    }
+
+    Ok(matches_to_areas(&selected))
+}
+
+/// Coalesce row-major cell coordinates into deterministic rectangular areas.
+pub(crate) fn matches_to_areas(matches: &[(u32, u32)]) -> Vec<SearchArea> {
+    if matches.is_empty() {
+        return Vec::new();
+    }
+
+    let mut coordinates = matches.to_vec();
+    coordinates.sort_unstable();
+    coordinates.dedup();
+
+    // First build maximal horizontal runs for each row.
+    let mut runs = Vec::new();
+    let mut index = 0;
+    while index < coordinates.len() {
+        let row = coordinates[index].0;
+        let mut start_col = coordinates[index].1;
+        let mut end_col = start_col;
+        index += 1;
+        while index < coordinates.len() && coordinates[index].0 == row {
+            let col = coordinates[index].1;
+            if col == end_col + 1 {
+                end_col = col;
+            } else {
+                runs.push(SearchArea {
+                    start_row: row,
+                    start_col,
+                    end_row: row,
+                    end_col,
+                });
+                start_col = col;
+                end_col = col;
+            }
+            index += 1;
+        }
+        runs.push(SearchArea {
+            start_row: row,
+            start_col,
+            end_row: row,
+            end_col,
+        });
+    }
+
+    // Merge identical horizontal runs across adjacent rows.  This produces a
+    // compact, disjoint set while keeping the result stable for RangeAreas.
+    let mut merged = Vec::new();
+    for run in runs {
+        if let Some(previous) = merged.last_mut()
+            && previous.end_row + 1 == run.start_row
+            && previous.start_col == run.start_col
+            && previous.end_col == run.end_col
+        {
+            previous.end_row = run.end_row;
+        } else {
+            merged.push(run);
+        }
+    }
+    merged
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SpecialCellMode {
+    Blanks,
+    Constants,
+    Formulas,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ValueType {
+    All,
+    Errors,
+    ErrorsLogical,
+    ErrorsNumbers,
+    ErrorsText,
+    ErrorsLogicalNumber,
+    ErrorsLogicalText,
+    ErrorsNumberText,
+    Logical,
+    LogicalNumbers,
+    LogicalText,
+    LogicalNumbersText,
+    Numbers,
+    NumbersText,
+    Text,
+}
+
+impl ValueType {
+    fn parse(raw: &str) -> Result<Self, RangeSearchError> {
+        match raw {
+            "All" => Ok(Self::All),
+            "Errors" => Ok(Self::Errors),
+            "ErrorsLogical" => Ok(Self::ErrorsLogical),
+            "ErrorsNumbers" => Ok(Self::ErrorsNumbers),
+            "ErrorsText" => Ok(Self::ErrorsText),
+            "ErrorsLogicalNumber" => Ok(Self::ErrorsLogicalNumber),
+            "ErrorsLogicalText" => Ok(Self::ErrorsLogicalText),
+            "ErrorsNumberText" => Ok(Self::ErrorsNumberText),
+            "Logical" => Ok(Self::Logical),
+            "LogicalNumbers" => Ok(Self::LogicalNumbers),
+            "LogicalText" => Ok(Self::LogicalText),
+            "LogicalNumbersText" => Ok(Self::LogicalNumbersText),
+            "Numbers" => Ok(Self::Numbers),
+            "NumbersText" => Ok(Self::NumbersText),
+            "Text" => Ok(Self::Text),
+            other => Err(invalid(format!(
+                "getSpecialCells value type '{other}' is invalid"
+            ))),
+        }
+    }
+
+    fn matches(self, value: &CellValue) -> bool {
+        if self == Self::All {
+            return true;
+        }
+        let is_error = value.is_error();
+        let is_logical = value.is_boolean() || matches!(value, CellValue::Control(_));
+        let is_number = value.is_number();
+        let is_text = value.is_text();
+        match self {
+            Self::All => true,
+            Self::Errors => is_error,
+            Self::ErrorsLogical => is_error || is_logical,
+            Self::ErrorsNumbers => is_error || is_number,
+            Self::ErrorsText => is_error || is_text,
+            Self::ErrorsLogicalNumber => is_error || is_logical || is_number,
+            Self::ErrorsLogicalText => is_error || is_logical || is_text,
+            Self::ErrorsNumberText => is_error || is_number || is_text,
+            Self::Logical => is_logical,
+            Self::LogicalNumbers => is_logical || is_number,
+            Self::LogicalText => is_logical || is_text,
+            Self::LogicalNumbersText => is_logical || is_number || is_text,
+            Self::Numbers => is_number,
+            Self::NumbersText => is_number || is_text,
+            Self::Text => is_text,
+        }
+    }
+}
+
+fn find_matches(
+    sheet: &Sheet,
+    bounds: (u32, u32, u32, u32),
+    text: &str,
+    criteria: SearchCriteria,
+) -> Result<Vec<(u32, u32)>, RangeSearchError> {
+    // The engine's search primitive walks the sparse mirror rather than
+    // allocating a matrix.  Use it for the exact/case-sensitive form, which
+    // is also the common form used by callers that need a deterministic cell
+    // locator.  Partial and case-insensitive searches still need the value
+    // projection below because the primitive deliberately has no criteria
+    // arguments.
+    if criteria.complete_match && criteria.match_case {
+        return sheet
+            .find_by_value(
+                text,
+                Some(CellRange::Bounds(bounds.0, bounds.1, bounds.2, bounds.3)),
+            )
+            .map_err(engine);
+    }
+
+    let values = values_in_bounds(sheet, bounds)?;
+    let mut matches = Vec::new();
+    for (row_offset, row_values) in values.iter().enumerate() {
+        for (col_offset, value) in row_values.iter().enumerate() {
+            if matches_text(&value.to_string(), text, criteria) {
+                matches.push((bounds.0 + row_offset as u32, bounds.1 + col_offset as u32));
+            }
+        }
+    }
+    Ok(matches)
+}
+
+fn values_in_bounds(
+    sheet: &Sheet,
+    bounds: (u32, u32, u32, u32),
+) -> Result<Vec<Vec<CellValue>>, RangeSearchError> {
+    sheet
+        .get_range_values_2d(CellRange::Bounds(bounds.0, bounds.1, bounds.2, bounds.3))
+        .map_err(engine)
+}
+
+fn select_after_anchor(matches: &[(u32, u32)], anchor: (u32, u32), backwards: bool) -> (u32, u32) {
+    if backwards {
+        matches
+            .iter()
+            .rev()
+            .find(|&&(row, col)| (row, col) < anchor)
+            .copied()
+            .unwrap_or(*matches.last().expect("non-empty matches"))
+    } else {
+        matches
+            .iter()
+            .find(|&&(row, col)| (row, col) > anchor)
+            .copied()
+            .unwrap_or(matches[0])
+    }
+}
+
+fn matches_text(value: &str, text: &str, criteria: SearchCriteria) -> bool {
+    if criteria.complete_match {
+        if criteria.match_case {
+            value == text
+        } else {
+            value.to_lowercase() == text.to_lowercase()
+        }
+    } else if criteria.match_case {
+        value.contains(text)
+    } else {
+        value.to_lowercase().contains(&text.to_lowercase())
+    }
+}
+
+fn replace_text(
+    value: &str,
+    text: &str,
+    replacement: &str,
+    criteria: SearchCriteria,
+) -> (String, u32) {
+    if criteria.complete_match {
+        return (replacement.to_string(), 1);
+    }
+    if criteria.match_case {
+        let count = value.match_indices(text).count() as u32;
+        (value.replace(text, replacement), count)
+    } else {
+        replace_case_insensitive(value, text, replacement)
+    }
+}
+
+fn replace_case_insensitive(value: &str, text: &str, replacement: &str) -> (String, u32) {
+    if text.is_empty() {
+        return (value.to_string(), 0);
+    }
+    let lowered_value = value.to_lowercase();
+    let lowered_text = text.to_lowercase();
+    let mut output = String::with_capacity(value.len());
+    let mut cursor = 0;
+    let mut count = 0;
+    while let Some(relative) = lowered_value[cursor..].find(&lowered_text) {
+        let start = cursor + relative;
+        let end = start + lowered_text.len();
+        // `to_lowercase` can change byte lengths for a few Unicode code
+        // points.  The Office.js adapter's search contract is primarily
+        // ASCII-oriented; preserve a safe fallback for those boundaries.
+        if !value.is_char_boundary(start) || !value.is_char_boundary(end) || end > value.len() {
+            return (value.to_string(), 0);
+        }
+        output.push_str(&value[cursor..start]);
+        output.push_str(replacement);
+        cursor = end;
+        count += 1;
+    }
+    output.push_str(&value[cursor..]);
+    (output, count)
+}
+
+fn scope_bounds(
+    sheet: &Sheet,
+    address: Option<&str>,
+) -> Result<(u32, u32, u32, u32), RangeSearchError> {
+    address
+        .map(|raw| {
+            parse_range_address(sheet, raw)
+                .map(|range| range.bounds())
+                .map_err(map_address_error)
+        })
+        .transpose()
+        .map(|bounds| bounds.unwrap_or((0, 0, LAST_ROW, LAST_COLUMN)))
+}
+
+fn intersect(
+    left: (u32, u32, u32, u32),
+    right: (u32, u32, u32, u32),
+) -> Option<(u32, u32, u32, u32)> {
+    let bounds = (
+        left.0.max(right.0),
+        left.1.max(right.1),
+        left.2.min(right.2),
+        left.3.min(right.3),
+    );
+    (bounds.0 <= bounds.2 && bounds.1 <= bounds.3).then_some(bounds)
+}
+
+impl SearchArea {
+    fn from_bounds((start_row, start_col, end_row, end_col): (u32, u32, u32, u32)) -> Self {
+        Self {
+            start_row,
+            start_col,
+            end_row,
+            end_col,
+        }
+    }
+}
+
+fn cell_name(row: u32, column: u32) -> String {
+    format!("{}{}", column_name(column), row + 1)
+}
+
+fn column_name(mut column: u32) -> String {
+    let mut reversed = Vec::new();
+    loop {
+        reversed.push((b'A' + (column % 26) as u8) as char);
+        column /= 26;
+        if column == 0 {
+            break;
+        }
+        column -= 1;
+    }
+    reversed.into_iter().rev().collect()
+}
+
+fn map_address_error(error: RangeNavigationError) -> RangeSearchError {
+    RangeSearchError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn engine(error: impl std::fmt::Display) -> RangeSearchError {
+    RangeSearchError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn invalid(message: impl Into<String>) -> RangeSearchError {
+    RangeSearchError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn unsupported(message: impl Into<String>) -> RangeSearchError {
+    RangeSearchError {
+        code: "UnsupportedOperation",
+        message: message.into(),
+    }
+}

--- a/compute/officejs/src/range_structure.js
+++ b/compute/officejs/src/range_structure.js
@@ -1,0 +1,165 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+
+  function invalidArgument(message) {
+    var error = new OfficeExtension.Error({
+      code: "InvalidArgument",
+      message: message,
+    });
+    error.name = "RichApi.Error";
+    error.code = "InvalidArgument";
+    return error;
+  }
+
+  function propertyNotLoaded(name) {
+    var error = new OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function normalizeColumns(columns) {
+    if (!Array.isArray(columns) || columns.length === 0) {
+      throw invalidArgument(
+        "Range.removeDuplicates columns must be a non-empty number array"
+      );
+    }
+    var normalized = [];
+    for (var index = 0; index < columns.length; index++) {
+      var column = columns[index];
+      if (
+        typeof column !== "number" ||
+        !isFinite(column) ||
+        Math.floor(column) !== column ||
+        column < 0 ||
+        column > 4294967295
+      ) {
+        throw invalidArgument(
+          "Range.removeDuplicates columns[" + index + "] must be a non-negative integer"
+        );
+      }
+      normalized.push(column);
+    }
+    return normalized;
+  }
+
+  function normalizeBoolean(value, name) {
+    if (typeof value !== "boolean") {
+      throw invalidArgument("Range.removeDuplicates " + name + " must be a boolean");
+    }
+    return value;
+  }
+
+  function normalizeGroupOption(value, method) {
+    if (value !== "ByRows" && value !== "ByColumns") {
+      throw invalidArgument(
+        "Range." + method + " groupOption must be 'ByRows' or 'ByColumns'"
+      );
+    }
+    return value;
+  }
+
+  function RemoveDuplicatesResult(context) {
+    ClientObject.call(this, context);
+    this._scalarProperties = ["removed", "uniqueRemaining"];
+  }
+  RemoveDuplicatesResult.prototype = Object.create(ClientObject.prototype);
+  RemoveDuplicatesResult.prototype.constructor = RemoveDuplicatesResult;
+
+  ["removed", "uniqueRemaining"].forEach(function (name) {
+    Object.defineProperty(RemoveDuplicatesResult.prototype, name, {
+      configurable: true,
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+    });
+  });
+
+  RemoveDuplicatesResult.prototype.toJSON = function () {
+    var data = {};
+    ["removed", "uniqueRemaining"].forEach(function (name) {
+      if (this._loaded[name]) data[name] = this["_" + name];
+    }, this);
+    return data;
+  };
+
+  Excel.RemoveDuplicatesResult = RemoveDuplicatesResult;
+
+  // Structural operations stay deferred until context.sync(), matching the
+  // rest of the Office.js request model.  The host binds the Range returned by
+  // insert at the same address after the engine has created the blank space.
+  Excel.Range.prototype.insert = function (shift) {
+    var result = new Excel.Range(this.context, this._worksheet, this._address);
+    this.context._queue.push({
+      op: "rangeInsert",
+      id: result._id,
+      rangeId: this._id,
+      shift: shift,
+    });
+    return result;
+  };
+
+  Excel.Range.prototype.delete = function (shift) {
+    this.context._queue.push({
+      op: "rangeDelete",
+      id: this._id,
+      shift: shift,
+    });
+  };
+
+  Excel.Range.prototype.merge = function (across) {
+    this.context._queue.push({
+      op: "rangeMerge",
+      id: this._id,
+      across: across === true,
+    });
+  };
+
+  Excel.Range.prototype.unmerge = function () {
+    this.context._queue.push({
+      op: "rangeUnmerge",
+      id: this._id,
+    });
+  };
+
+  Excel.Range.prototype.removeDuplicates = function (columns, includesHeader) {
+    var normalizedColumns = normalizeColumns(columns);
+    var normalizedHeader = normalizeBoolean(includesHeader, "includesHeader");
+    var result = new RemoveDuplicatesResult(this.context);
+    this.context._queue.push({
+      op: "rangeRemoveDuplicates",
+      id: result._id,
+      rangeId: this._id,
+      columns: normalizedColumns,
+      includesHeader: normalizedHeader,
+    });
+    return result;
+  };
+
+  Excel.Range.prototype.group = function (groupOption) {
+    this.context._queue.push({
+      op: "rangeGroup",
+      id: this._id,
+      groupOption: normalizeGroupOption(groupOption, "group"),
+    });
+  };
+
+  Excel.Range.prototype.ungroup = function (groupOption) {
+    this.context._queue.push({
+      op: "rangeUngroup",
+      id: this._id,
+      groupOption: normalizeGroupOption(groupOption, "ungroup"),
+    });
+  };
+})(globalThis);

--- a/compute/officejs/src/range_structure.rs
+++ b/compute/officejs/src/range_structure.rs
@@ -1,0 +1,493 @@
+//! Office.js `Range` structural operations.
+//!
+//! This module is deliberately a translation boundary.  Range insert/delete
+//! operations must move the engine's existing cell identities so formulas,
+//! formats, and references follow the moved cells.  Merge operations must use
+//! the engine merge implementation as well: it retains the origin cell and
+//! applies Excel's child-cell data-loss behavior.  Copying values through the
+//! Office host would lose those semantics.
+
+use compute_api::{CellRange, ComputeApiError, Sheet};
+use serde::Deserialize;
+
+use crate::range_navigation::{parse_range_address, RangeNavigationError};
+
+/// Error returned by a Range structural operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RangeStructureError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+/// A bounded, validated range in zero-based worksheet coordinates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RangeBounds {
+    pub(crate) start_row: u32,
+    pub(crate) start_col: u32,
+    pub(crate) end_row: u32,
+    pub(crate) end_col: u32,
+}
+
+/// The two documented values accepted by `Excel.GroupOption`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GroupOption {
+    ByRows,
+    ByColumns,
+}
+
+impl GroupOption {
+    pub(crate) fn from_wire(value: &str) -> Result<Self, RangeStructureError> {
+        match value {
+            "ByRows" => Ok(Self::ByRows),
+            "ByColumns" => Ok(Self::ByColumns),
+            other => Err(invalid(format!(
+                "Range group option must be 'ByRows' or 'ByColumns', got '{other}'"
+            ))),
+        }
+    }
+}
+
+/// The scalar result exposed by `Excel.Range.removeDuplicates`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RemoveDuplicatesResult {
+    pub(crate) removed: u32,
+    pub(crate) unique_remaining: u32,
+}
+
+/// The compute-api result payload uses names from its lower-level operation.
+/// Keep that translation private so the Office.js result remains the exact
+/// `removed`/`uniqueRemaining` contract from the pinned declarations.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ComputeRemoveDuplicatesResult {
+    duplicates_removed: u32,
+    unique_values_remaining: u32,
+}
+
+impl RangeBounds {
+    fn row_count(self) -> Result<u32, RangeStructureError> {
+        self.end_row
+            .checked_sub(self.start_row)
+            .and_then(|span| span.checked_add(1))
+            .ok_or_else(|| invalid("Range row bounds are inverted"))
+    }
+
+    fn col_count(self) -> Result<u32, RangeStructureError> {
+        self.end_col
+            .checked_sub(self.start_col)
+            .and_then(|span| span.checked_add(1))
+            .ok_or_else(|| invalid("Range column bounds are inverted"))
+    }
+}
+
+/// The two documented values accepted by `Excel.Range.insert`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InsertShiftDirection {
+    Down,
+    Right,
+}
+
+impl InsertShiftDirection {
+    pub(crate) fn from_wire(value: &str) -> Result<Self, RangeStructureError> {
+        match value {
+            "Down" => Ok(Self::Down),
+            "Right" => Ok(Self::Right),
+            other => Err(invalid(format!(
+                "Range.insert shift must be 'Down' or 'Right', got '{other}'"
+            ))),
+        }
+    }
+
+    fn shifts_right(self) -> bool {
+        matches!(self, Self::Right)
+    }
+}
+
+/// The two documented values accepted by `Excel.Range.delete`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DeleteShiftDirection {
+    Up,
+    Left,
+}
+
+impl DeleteShiftDirection {
+    pub(crate) fn from_wire(value: &str) -> Result<Self, RangeStructureError> {
+        match value {
+            "Up" => Ok(Self::Up),
+            "Left" => Ok(Self::Left),
+            other => Err(invalid(format!(
+                "Range.delete shift must be 'Up' or 'Left', got '{other}'"
+            ))),
+        }
+    }
+
+    fn shifts_left(self) -> bool {
+        matches!(self, Self::Left)
+    }
+}
+
+/// Insert the current range and return the same bounded address.
+///
+/// The returned address is the blank space created by the insertion.  The
+/// caller uses it to bind the `Range` proxy returned by `Range.insert`; the
+/// engine mutation itself is performed by `SheetStructure`.
+pub(crate) fn insert(
+    sheet: &Sheet,
+    address: &str,
+    shift: &str,
+) -> Result<RangeBounds, RangeStructureError> {
+    let bounds = parse_bounds(address)?;
+    let direction = InsertShiftDirection::from_wire(shift)?;
+    let row_count = bounds.row_count()?;
+    let col_count = bounds.col_count()?;
+
+    sheet
+        .structure()
+        .insert_cells_with_shift(
+            bounds.start_row,
+            bounds.start_col,
+            row_count,
+            col_count,
+            direction.shifts_right(),
+        )
+        .map_err(engine)?;
+    Ok(bounds)
+}
+
+/// Delete the current range and shift adjacent cells in the requested
+/// direction.
+pub(crate) fn delete(sheet: &Sheet, address: &str, shift: &str) -> Result<(), RangeStructureError> {
+    let bounds = parse_bounds(address)?;
+    let direction = DeleteShiftDirection::from_wire(shift)?;
+    let row_count = bounds.row_count()?;
+    let col_count = bounds.col_count()?;
+
+    sheet
+        .structure()
+        .delete_cells_with_shift(
+            bounds.start_row,
+            bounds.start_col,
+            row_count,
+            col_count,
+            direction.shifts_left(),
+        )
+        .map_err(engine)?;
+    Ok(())
+}
+
+/// Merge the current range.  When `across` is true, the engine creates one
+/// merge per row, matching `Range.merge(true)`.
+pub(crate) fn merge(sheet: &Sheet, address: &str, across: bool) -> Result<(), RangeStructureError> {
+    let bounds = parse_bounds(address)?;
+    if across {
+        sheet
+            .structure()
+            .merge_across(
+                bounds.start_row,
+                bounds.start_col,
+                bounds.end_row,
+                bounds.end_col,
+            )
+            .map_err(engine)?;
+    } else {
+        sheet
+            .structure()
+            .merge_range(
+                bounds.start_row,
+                bounds.start_col,
+                bounds.end_row,
+                bounds.end_col,
+            )
+            .map_err(engine)?;
+    }
+    Ok(())
+}
+
+/// Unmerge merge regions whose origins are in the current range.
+pub(crate) fn unmerge(sheet: &Sheet, address: &str) -> Result<(), RangeStructureError> {
+    let bounds = parse_bounds(address)?;
+    sheet
+        .structure()
+        .unmerge_range(
+            bounds.start_row,
+            bounds.start_col,
+            bounds.end_row,
+            bounds.end_col,
+        )
+        .map_err(engine)?;
+    Ok(())
+}
+
+/// Remove duplicate rows from the current range through `SheetStructure`.
+///
+/// Office.js column indexes are relative to the range.  The compute-api
+/// primitive receives worksheet column indexes, so translate them after
+/// validating that every selected column is inside this range.  Passing an
+/// out-of-range index through would make the lower layer silently ignore the
+/// selection and report that no rows were removed.
+///
+/// The production primitive currently compacts authored values only; it does
+/// not carry formulas or cell properties along with a copied row. Keep that
+/// fidelity gap at the core boundary rather than reconstructing rows here,
+/// since a proxy-side copy would lose the engine's identity semantics.
+pub(crate) fn remove_duplicates(
+    sheet: &Sheet,
+    address: &str,
+    columns: &[u32],
+    includes_header: bool,
+) -> Result<RemoveDuplicatesResult, RangeStructureError> {
+    if columns.is_empty() {
+        return Err(invalid(
+            "Range.removeDuplicates requires at least one column",
+        ));
+    }
+
+    let bounds = parse_bounds(address)?;
+    let absolute_columns = columns
+        .iter()
+        .copied()
+        .map(|column| {
+            if column >= bounds.col_count()? {
+                return Err(invalid(format!(
+                    "Range.removeDuplicates column index {column} is outside the range"
+                )));
+            }
+            bounds
+                .start_col
+                .checked_add(column)
+                .ok_or_else(|| invalid("Range.removeDuplicates column index overflowed"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let result = sheet
+        .structure()
+        .remove_duplicates(
+            bounds.start_row,
+            bounds.start_col,
+            bounds.end_row,
+            bounds.end_col,
+            absolute_columns,
+            includes_header,
+        )
+        .map_err(engine)?;
+
+    let data = result
+        .extract_data::<ComputeRemoveDuplicatesResult>()
+        .ok_or_else(|| engine("SheetStructure.remove_duplicates returned no result data"))?;
+    Ok(RemoveDuplicatesResult {
+        removed: data.duplicates_removed,
+        unique_remaining: data.unique_values_remaining,
+    })
+}
+
+/// Group rows or columns in the current range through `SheetOutline`.
+///
+/// A full-row/full-column range rejects the opposite axis, matching the
+/// Office.js `groupOption` contract.  For a bounded cell range, the selected
+/// option chooses the corresponding row or column span, which also matches
+/// the Office.js ungroup examples that pass a rectangular range.
+pub(crate) fn group(
+    sheet: &Sheet,
+    address: &str,
+    group_option: &str,
+) -> Result<(), RangeStructureError> {
+    apply_grouping(sheet, address, group_option, false)
+}
+
+/// Remove the innermost row or column groups intersecting the current range.
+pub(crate) fn ungroup(
+    sheet: &Sheet,
+    address: &str,
+    group_option: &str,
+) -> Result<(), RangeStructureError> {
+    apply_grouping(sheet, address, group_option, true)
+}
+
+fn apply_grouping(
+    sheet: &Sheet,
+    address: &str,
+    group_option: &str,
+    ungroup: bool,
+) -> Result<(), RangeStructureError> {
+    let parsed = parse_range_address(sheet, address).map_err(map_navigation_error)?;
+    let option = GroupOption::from_wire(group_option)?;
+    if parsed.is_whole_sheet() {
+        return Err(invalid(
+            "Range group operations require a row, column, or bounded cell range",
+        ));
+    }
+    if parsed.is_entire_row() && matches!(option, GroupOption::ByColumns) {
+        return Err(invalid("A full-row range cannot be grouped by columns"));
+    }
+    if parsed.is_entire_column() && matches!(option, GroupOption::ByRows) {
+        return Err(invalid("A full-column range cannot be grouped by rows"));
+    }
+
+    let (start_row, start_col, end_row, end_col) = parsed.bounds();
+    let outline = sheet.outline();
+    match (option, ungroup) {
+        (GroupOption::ByRows, false) => outline
+            .group_rows(start_row, end_row)
+            .map_err(engine)
+            .map(|_| ()),
+        (GroupOption::ByRows, true) => outline
+            .ungroup_rows(start_row, end_row)
+            .map_err(engine)
+            .map(|_| ()),
+        (GroupOption::ByColumns, false) => outline
+            .group_columns(start_col, end_col)
+            .map_err(engine)
+            .map(|_| ()),
+        (GroupOption::ByColumns, true) => outline
+            .ungroup_columns(start_col, end_col)
+            .map_err(engine)
+            .map(|_| ()),
+    }
+}
+
+/// Parse a bounded A1 address for a structural operation.
+///
+/// Qualified addresses are accepted because `Worksheet.getRange` accepts
+/// them.  The host has already validated that a qualifier belongs to the
+/// current worksheet; this helper only removes it before handing the cell
+/// reference to `compute-api::CellRange`.
+pub(crate) fn parse_bounds(address: &str) -> Result<RangeBounds, RangeStructureError> {
+    let address = address.trim();
+    if address.is_empty() {
+        return Err(invalid("Range address cannot be empty"));
+    }
+
+    let reference = address
+        .rsplit_once('!')
+        .map(|(_, reference)| reference.trim())
+        .unwrap_or(address);
+    if reference.is_empty() {
+        return Err(invalid(format!("Invalid range address '{address}'")));
+    }
+
+    let (start_row, start_col, end_row, end_col) = CellRange::from(reference)
+        .resolve()
+        .map_err(map_address_error)?;
+    if start_row > end_row {
+        return Err(invalid(format!(
+            "Range '{address}' has start row {start_row} after end row {end_row}"
+        )));
+    }
+    if start_col > end_col {
+        return Err(invalid(format!(
+            "Range '{address}' has start column {start_col} after end column {end_col}"
+        )));
+    }
+
+    Ok(RangeBounds {
+        start_row,
+        start_col,
+        end_row,
+        end_col,
+    })
+}
+
+fn map_address_error(error: ComputeApiError) -> RangeStructureError {
+    match error {
+        ComputeApiError::InvalidAddress { address, reason } => {
+            invalid(format!("invalid address: {address} — {reason}"))
+        }
+        ComputeApiError::InvalidRange { range, reason } => {
+            invalid(format!("invalid range: {range} — {reason}"))
+        }
+        other => engine(other),
+    }
+}
+
+fn map_navigation_error(error: RangeNavigationError) -> RangeStructureError {
+    RangeStructureError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn invalid(message: impl Into<String>) -> RangeStructureError {
+    RangeStructureError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn engine(error: impl std::fmt::Display) -> RangeStructureError {
+    RangeStructureError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bounded_and_qualified_addresses() {
+        assert_eq!(
+            parse_bounds("'Sheet 1'!$B$2:$D$5").unwrap(),
+            RangeBounds {
+                start_row: 1,
+                start_col: 1,
+                end_row: 4,
+                end_col: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_inverted_and_unbounded_addresses() {
+        assert_eq!(parse_bounds("B2:A1").unwrap_err().code, "InvalidArgument");
+        assert_eq!(parse_bounds("1:1").unwrap_err().code, "InvalidArgument");
+        assert_eq!(parse_bounds("A:A").unwrap_err().code, "InvalidArgument");
+    }
+
+    #[test]
+    fn shift_directions_are_exact_wire_tokens() {
+        assert_eq!(
+            InsertShiftDirection::from_wire("Down").unwrap(),
+            InsertShiftDirection::Down
+        );
+        assert_eq!(
+            InsertShiftDirection::from_wire("Right").unwrap(),
+            InsertShiftDirection::Right
+        );
+        assert_eq!(
+            DeleteShiftDirection::from_wire("Up").unwrap(),
+            DeleteShiftDirection::Up
+        );
+        assert_eq!(
+            DeleteShiftDirection::from_wire("Left").unwrap(),
+            DeleteShiftDirection::Left
+        );
+        assert!(InsertShiftDirection::from_wire("down").is_err());
+        assert!(DeleteShiftDirection::from_wire("right").is_err());
+    }
+
+    #[test]
+    fn group_options_are_exact_wire_tokens() {
+        assert_eq!(
+            GroupOption::from_wire("ByRows").unwrap(),
+            GroupOption::ByRows
+        );
+        assert_eq!(
+            GroupOption::from_wire("ByColumns").unwrap(),
+            GroupOption::ByColumns
+        );
+        assert!(GroupOption::from_wire("Rows").is_err());
+        assert!(GroupOption::from_wire("byRows").is_err());
+    }
+
+    #[test]
+    fn remove_duplicates_result_uses_office_scalar_names() {
+        let json = serde_json::json!({
+            "duplicatesRemoved": 3,
+            "uniqueValuesRemaining": 5
+        });
+        let result: ComputeRemoveDuplicatesResult = serde_json::from_value(json).unwrap();
+        assert_eq!(result.duplicates_removed, 3);
+        assert_eq!(result.unique_values_remaining, 5);
+    }
+}

--- a/compute/officejs/src/range_structure_host.rs
+++ b/compute/officejs/src/range_structure_host.rs
@@ -1,0 +1,325 @@
+//! Host dispatch for the Office.js Range structural family.
+//!
+//! The JavaScript adapter emits structural operations into the normal
+//! request queue. This handler resolves the already-bound Range proxy and
+//! delegates the mutation to the range_structure module, which in turn calls
+//! the production SheetStructure/SheetOutline APIs. Keeping this bridge in
+//! its own family module lets the central host remain unaware of the Range
+//! operation payloads.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+
+use crate::dispatch::{ExtensionHandler, ExtensionObject, ExtensionRegistry, HostDispatchContext};
+use crate::host::{BatchError, RangeRef};
+use crate::range_structure::{self, RangeStructureError, RemoveDuplicatesResult};
+
+const OPERATIONS: &[&str] = &[
+    "rangeInsert",
+    "rangeDelete",
+    "rangeMerge",
+    "rangeUnmerge",
+    "rangeRemoveDuplicates",
+    "rangeGroup",
+    "rangeUngroup",
+];
+
+/// Register the Range structural family with the host extension registry.
+pub(crate) fn register(registry: &ExtensionRegistry) {
+    registry.register(RangeStructureHandler);
+}
+
+/// Dispatches Range.insert/delete/merge/unmerge/removeDuplicates/group/ungroup.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct RangeStructureHandler;
+
+impl ExtensionHandler for RangeStructureHandler {
+    fn can_handle(&self, operation: &str) -> bool {
+        OPERATIONS.contains(&operation)
+    }
+
+    fn handle(
+        &self,
+        operation: &Value,
+        context: &mut HostDispatchContext<'_>,
+    ) -> Result<bool, BatchError> {
+        match operation_name(operation)? {
+            "rangeInsert" => range_insert(operation, context)?,
+            "rangeDelete" => range_delete(operation, context)?,
+            "rangeMerge" => range_merge(operation, context)?,
+            "rangeUnmerge" => range_unmerge(operation, context)?,
+            "rangeRemoveDuplicates" => range_remove_duplicates(operation, context)?,
+            "rangeGroup" => range_group(operation, context, false)?,
+            "rangeUngroup" => range_group(operation, context, true)?,
+            _ => return Ok(false),
+        }
+        Ok(true)
+    }
+}
+
+/// The deferred Office.js result object returned by Range.removeDuplicates.
+#[derive(Clone)]
+struct RemoveDuplicatesObject {
+    result: RemoveDuplicatesResult,
+}
+
+impl ExtensionObject for RemoveDuplicatesObject {
+    fn object_type(&self) -> &'static str {
+        "RemoveDuplicatesResult"
+    }
+
+    fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, BatchError> {
+        let mut result = HashMap::new();
+        for property in properties {
+            match property.as_str() {
+                "removed" => {
+                    result.insert(property.clone(), json!(self.result.removed));
+                }
+                "uniqueRemaining" => {
+                    result.insert(property.clone(), json!(self.result.unique_remaining));
+                }
+                other => {
+                    return Err(invalid_argument(format!(
+                        "Unsupported RemoveDuplicatesResult property '{other}'"
+                    )));
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    fn set(&self, property: &str, _value: &Value) -> Result<(), BatchError> {
+        Err(invalid_argument(format!(
+            "RemoveDuplicatesResult.{property} is read-only"
+        )))
+    }
+}
+
+fn range_insert(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+) -> Result<(), BatchError> {
+    let result_id = required_string(operation, "id")?;
+    let range_id = required_string(operation, "rangeId")?;
+    let shift = required_string(operation, "shift")?;
+    let range = structural_range(context.range(range_id)?, "Range.insert")?;
+    range_structure::insert(
+        &range.sheet(),
+        range_address(&range, "Range.insert")?,
+        shift,
+    )
+    .map_err(range_structure_error)?;
+    // Range.insert returns a live Range proxy at the original address. The
+    // source RangeRef is already the exact worksheet/address binding needed
+    // for that result, so reuse it rather than copying cells or values.
+    context.bind_range(result_id, range);
+    Ok(())
+}
+
+fn range_delete(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+) -> Result<(), BatchError> {
+    let range_id = required_string(operation, "id")?;
+    let shift = required_string(operation, "shift")?;
+    let range = structural_range(context.range(range_id)?, "Range.delete")?;
+    range_structure::delete(
+        &range.sheet(),
+        range_address(&range, "Range.delete")?,
+        shift,
+    )
+    .map_err(range_structure_error)
+}
+
+fn range_merge(operation: &Value, context: &mut HostDispatchContext<'_>) -> Result<(), BatchError> {
+    let range_id = required_string(operation, "id")?;
+    let across = optional_bool(operation, "across", false)?;
+    let range = structural_range(context.range(range_id)?, "Range.merge")?;
+    range_structure::merge(
+        &range.sheet(),
+        range_address(&range, "Range.merge")?,
+        across,
+    )
+    .map_err(range_structure_error)
+}
+
+fn range_unmerge(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+) -> Result<(), BatchError> {
+    let range_id = required_string(operation, "id")?;
+    let range = structural_range(context.range(range_id)?, "Range.unmerge")?;
+    range_structure::unmerge(&range.sheet(), range_address(&range, "Range.unmerge")?)
+        .map_err(range_structure_error)
+}
+
+fn range_remove_duplicates(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+) -> Result<(), BatchError> {
+    let result_id = required_string(operation, "id")?;
+    let range_id = required_string(operation, "rangeId")?;
+    let columns = required_columns(operation)?;
+    let includes_header = required_bool(operation, "includesHeader")?;
+    let range = structural_range(context.range(range_id)?, "Range.removeDuplicates")?;
+    let result = range_structure::remove_duplicates(
+        &range.sheet(),
+        range_address(&range, "Range.removeDuplicates")?,
+        &columns,
+        includes_header,
+    )
+    .map_err(range_structure_error)?;
+
+    // This is intentionally an ExtensionObject binding, rather than a
+    // ClientResult response. The pinned Office.js declaration says that
+    // removeDuplicates returns a ClientObject with loadable scalar fields.
+    context.bind_object(result_id, Arc::new(RemoveDuplicatesObject { result }));
+    Ok(())
+}
+
+fn range_group(
+    operation: &Value,
+    context: &mut HostDispatchContext<'_>,
+    ungroup: bool,
+) -> Result<(), BatchError> {
+    let range_id = required_string(operation, "id")?;
+    let group_option = required_string(operation, "groupOption")?;
+    let label = if ungroup {
+        "Range.ungroup"
+    } else {
+        "Range.group"
+    };
+    let range = structural_range(context.range(range_id)?, label)?;
+    let address = range_address(&range, label)?;
+    let result = if ungroup {
+        range_structure::ungroup(&range.sheet(), address, group_option)
+    } else {
+        range_structure::group(&range.sheet(), address, group_option)
+    };
+    result.map_err(range_structure_error)
+}
+
+/// Structural mutations accept addressed ranges. Grouping additionally
+/// accepts full-row/full-column ranges; the range_structure grouping helper
+/// enforces the axis-specific groupOption contract after parsing them.
+fn structural_range(range: RangeRef, operation: &str) -> Result<RangeRef, BatchError> {
+    if range.is_null_object() {
+        return Err(batch_error(
+            "InvalidObjectPath",
+            format!("{operation} cannot use a null Range object"),
+        ));
+    }
+    if range.address().is_none() {
+        return Err(invalid_argument(format!(
+            "{operation} requires an addressed Range"
+        )));
+    }
+    Ok(range)
+}
+
+fn range_address<'a>(range: &'a RangeRef, operation: &str) -> Result<&'a str, BatchError> {
+    range
+        .address()
+        .ok_or_else(|| invalid_argument(format!("{operation} requires an addressed Range")))
+}
+
+fn required_columns(operation: &Value) -> Result<Vec<u32>, BatchError> {
+    let values = operation
+        .get("columns")
+        .and_then(Value::as_array)
+        .ok_or_else(|| invalid_argument("Range.removeDuplicates columns must be an array"))?;
+    values
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            value
+                .as_u64()
+                .and_then(|value| u32::try_from(value).ok())
+                .ok_or_else(|| {
+                    invalid_argument(format!(
+                        "Range.removeDuplicates columns[{index}] must be a non-negative integer"
+                    ))
+                })
+        })
+        .collect()
+}
+
+fn operation_name(operation: &Value) -> Result<&str, BatchError> {
+    operation
+        .get("op")
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid_argument("Range structural operation requires an op name"))
+}
+
+fn required_string<'a>(operation: &'a Value, field: &str) -> Result<&'a str, BatchError> {
+    operation.get(field).and_then(Value::as_str).ok_or_else(|| {
+        invalid_argument(format!(
+            "Range structural operation field '{field}' must be a string"
+        ))
+    })
+}
+
+fn required_bool(operation: &Value, field: &str) -> Result<bool, BatchError> {
+    operation
+        .get(field)
+        .and_then(Value::as_bool)
+        .ok_or_else(|| {
+            invalid_argument(format!(
+                "Range structural operation field '{field}' must be a boolean"
+            ))
+        })
+}
+
+fn optional_bool(operation: &Value, field: &str, default: bool) -> Result<bool, BatchError> {
+    match operation.get(field) {
+        None | Some(Value::Null) => Ok(default),
+        Some(Value::Bool(value)) => Ok(*value),
+        Some(_) => Err(invalid_argument(format!(
+            "Range structural operation field '{field}' must be a boolean"
+        ))),
+    }
+}
+
+fn batch_error(code: &'static str, message: impl Into<String>) -> BatchError {
+    BatchError {
+        code,
+        message: message.into(),
+    }
+}
+
+fn invalid_argument(message: impl Into<String>) -> BatchError {
+    batch_error("InvalidArgument", message)
+}
+
+fn range_structure_error(error: RangeStructureError) -> BatchError {
+    batch_error(error.code, error.message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claims_only_structure_operations() {
+        let handler = RangeStructureHandler;
+        assert!(handler.can_handle("rangeInsert"));
+        assert!(handler.can_handle("rangeRemoveDuplicates"));
+        assert!(handler.can_handle("rangeGroup"));
+        assert!(handler.can_handle("rangeUngroup"));
+        assert!(!handler.can_handle("rangeSort"));
+    }
+
+    #[test]
+    fn parses_non_negative_u32_column_indexes() {
+        let operation = json!({"columns": [0, 7, 4294967295u64]});
+        assert_eq!(required_columns(&operation).unwrap(), vec![0, 7, u32::MAX]);
+
+        let invalid = json!({"columns": [-1]});
+        assert_eq!(
+            required_columns(&invalid).unwrap_err().code,
+            "InvalidArgument"
+        );
+    }
+}

--- a/compute/officejs/src/runtime.rs
+++ b/compute/officejs/src/runtime.rs
@@ -10,14 +10,22 @@ use crate::error::OfficeJsError;
 use crate::host::Host;
 
 const BOOTSTRAP: &str = include_str!("bootstrap.js");
+const FORMAT_BOOTSTRAP: &str = include_str!("format.js");
+const ENUMS_BOOTSTRAP: &str = include_str!("enums.js");
+const TABLES_BOOTSTRAP: &str = include_str!("tables.js");
+const RANGE_CONTENT_BOOTSTRAP: &str = include_str!("range_content.js");
+const RANGE_NAVIGATION_BOOTSTRAP: &str = include_str!("range_navigation.js");
+const SORT_FILTER_BOOTSTRAP: &str = include_str!("sort_filter.js");
+const VALIDATION_BOOTSTRAP: &str = include_str!("validation.js");
+const WORKSHEETS_BOOTSTRAP: &str = include_str!("worksheets.js");
+const BORDERS_BOOTSTRAP: &str = include_str!("borders.js");
+const NAMES_BOOTSTRAP: &str = include_str!("names.js");
+const TABLE_COLLECTIONS_BOOTSTRAP: &str = include_str!("table_collections.js");
 
 const RUNNER: &str = r#"
 (async () => {
   try {
     const __result = await eval("(async () => {\n" + globalThis.__mogSource + "\n})()");
-    if (globalThis.__mogPendingRuns && globalThis.__mogPendingRuns.length) {
-      await Promise.all(globalThis.__mogPendingRuns);
-    }
     return JSON.stringify({
       ok: true,
       value: __result === undefined ? null : __result,
@@ -118,6 +126,62 @@ async fn eval_in_ctx(
         .eval(BOOTSTRAP)
         .catch(&ctx)
         .map_err(|e| OfficeJsError::runtime(format!("failed to load Office.js bootstrap: {e}")))?;
+
+    let _: () = ctx
+        .eval(ENUMS_BOOTSTRAP)
+        .catch(&ctx)
+        .map_err(|e| OfficeJsError::runtime(format!("failed to load Office.js enums: {e}")))?;
+
+    let _: () = ctx
+        .eval(FORMAT_BOOTSTRAP)
+        .catch(&ctx)
+        .map_err(|e| OfficeJsError::runtime(format!("failed to load Office.js formatting: {e}")))?;
+
+    let _: () = ctx
+        .eval(TABLES_BOOTSTRAP)
+        .catch(&ctx)
+        .map_err(|e| OfficeJsError::runtime(format!("failed to load Office.js tables: {e}")))?;
+
+    let _: () = ctx.eval(RANGE_CONTENT_BOOTSTRAP).catch(&ctx).map_err(|e| {
+        OfficeJsError::runtime(format!("failed to load Office.js range content: {e}"))
+    })?;
+
+    let _: () = ctx
+        .eval(RANGE_NAVIGATION_BOOTSTRAP)
+        .catch(&ctx)
+        .map_err(|e| {
+            OfficeJsError::runtime(format!("failed to load Office.js range navigation: {e}"))
+        })?;
+    let _: () = ctx.eval(SORT_FILTER_BOOTSTRAP).catch(&ctx).map_err(|e| {
+        OfficeJsError::runtime(format!(
+            "failed to load Office.js sorting and filtering: {e}"
+        ))
+    })?;
+
+    let _: () = ctx.eval(VALIDATION_BOOTSTRAP).catch(&ctx).map_err(|e| {
+        OfficeJsError::runtime(format!("failed to load Office.js data validation: {e}"))
+    })?;
+
+    let _: () = ctx
+        .eval(WORKSHEETS_BOOTSTRAP)
+        .catch(&ctx)
+        .map_err(|e| OfficeJsError::runtime(format!("failed to load Office.js worksheets: {e}")))?;
+
+    let _: () = ctx
+        .eval(BORDERS_BOOTSTRAP)
+        .catch(&ctx)
+        .map_err(|e| OfficeJsError::runtime(format!("failed to load Office.js borders: {e}")))?;
+
+    let _: () = ctx.eval(NAMES_BOOTSTRAP).catch(&ctx).map_err(|e| {
+        OfficeJsError::runtime(format!("failed to load Office.js named items: {e}"))
+    })?;
+
+    let _: () = ctx
+        .eval(TABLE_COLLECTIONS_BOOTSTRAP)
+        .catch(&ctx)
+        .map_err(|e| {
+            OfficeJsError::runtime(format!("failed to load Office.js table collections: {e}"))
+        })?;
 
     let console_src = r#"
       globalThis.console = {

--- a/compute/officejs/src/sheet_layout.js
+++ b/compute/officejs/src/sheet_layout.js
@@ -1,0 +1,642 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs;
+
+  var PAGE_LAYOUT_PROPERTIES = [
+    "alignMarginsHeaderFooter",
+    "blackAndWhite",
+    "bottomMargin",
+    "centerHorizontally",
+    "centerVertically",
+    "draftMode",
+    "firstPageNumber",
+    "footerMargin",
+    "headerMargin",
+    "leftMargin",
+    "orientation",
+    "paperSize",
+    "printComments",
+    "printErrors",
+    "printGridlines",
+    "printHeadings",
+    "printOrder",
+    "printQuality",
+    "rightMargin",
+    "topMargin",
+    "zoom",
+  ];
+
+  var BOOLEAN_PAGE_LAYOUT_PROPERTIES = {
+    alignMarginsHeaderFooter: true,
+    blackAndWhite: true,
+    centerHorizontally: true,
+    centerVertically: true,
+    draftMode: true,
+    printGridlines: true,
+    printHeadings: true,
+  };
+
+  var PAPER_TYPES = [
+    "Letter",
+    "LetterSmall",
+    "Tabloid",
+    "Ledger",
+    "Legal",
+    "Statement",
+    "Executive",
+    "A3",
+    "A4",
+    "A4Small",
+    "A5",
+    "B4",
+    "B5",
+    "Folio",
+    "Quatro",
+    "Paper10x14",
+    "Paper11x17",
+    "Note",
+    "Envelope9",
+    "Envelope10",
+    "Envelope11",
+    "Envelope12",
+    "Envelope14",
+    "Csheet",
+    "Dsheet",
+    "Esheet",
+    "EnvelopeDL",
+    "EnvelopeC5",
+    "EnvelopeC3",
+    "EnvelopeC4",
+    "EnvelopeC6",
+    "EnvelopeC65",
+    "EnvelopeB4",
+    "EnvelopeB5",
+    "EnvelopeB6",
+    "EnvelopeItaly",
+    "EnvelopeMonarch",
+    "EnvelopePersonal",
+    "FanfoldUS",
+    "FanfoldStdGerman",
+    "FanfoldLegalGerman",
+  ];
+
+  var PRINT_COMMENTS = ["NoComments", "EndSheet", "InPlace"];
+  var PRINT_ERRORS = ["AsDisplayed", "Blank", "Dash", "NotAvailable"];
+  var PRINT_ORDER = ["DownThenOver", "OverThenDown"];
+  var PRINT_MARGIN_UNITS = ["Points", "Inches", "Centimeters"];
+  var ZOOM_PROPERTIES = ["horizontalFitToPages", "scale", "verticalFitToPages"];
+  var MARGIN_PROPERTIES = ["bottom", "footer", "header", "left", "right", "top"];
+
+  function richApiError(code, message) {
+    var error = new OfficeExtension.Error({ code: code, message: message });
+    error.name = "RichApi.Error";
+    error.code = code;
+    return error;
+  }
+
+  function invalid(message) {
+    return richApiError("InvalidArgument", message);
+  }
+
+  function invalidContext() {
+    return richApiError(
+      "InvalidRequestContext",
+      "The object belongs to a different request context."
+    );
+  }
+
+  function unsupported(message) {
+    return richApiError("ApiNotFound", message);
+  }
+
+  function propertyNotLoaded(name) {
+    return richApiError(
+      "PropertyNotLoaded",
+      "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context."
+    );
+  }
+
+  function isPlainObject(value) {
+    if (value === null || typeof value !== "object") return false;
+    var prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  }
+
+  function own(object, name) {
+    return Object.prototype.hasOwnProperty.call(object, name);
+  }
+
+  function requireSameContext(value, context, property) {
+    if (value.context !== context) throw invalidContext();
+    if (property && value[property] === null) {
+      throw invalid(property + " cannot be an unbounded Range");
+    }
+  }
+
+  function requireFiniteNumber(value, property, integer) {
+    if (typeof value !== "number" || !isFinite(value)) {
+      throw invalid(property + " must be a finite number");
+    }
+    if (integer && Math.floor(value) !== value) {
+      throw invalid(property + " must be an integer");
+    }
+    return value;
+  }
+
+  function requireNonNegativeNumber(value, property, integer) {
+    requireFiniteNumber(value, property, integer);
+    if (value < 0) throw invalid(property + " must be non-negative");
+    return value;
+  }
+
+  function requireBoolean(value, property) {
+    if (typeof value !== "boolean") {
+      throw invalid(property + " must be a boolean");
+    }
+    return value;
+  }
+
+  function requireEnum(value, property, allowed) {
+    if (typeof value !== "string" || allowed.indexOf(value) < 0) {
+      throw invalid(property + " has an unsupported value");
+    }
+    return value;
+  }
+
+  function validateZoom(value) {
+    if (!isPlainObject(value)) throw invalid("PageLayout.zoom must be an object");
+    Object.keys(value).forEach(function (key) {
+      if (ZOOM_PROPERTIES.indexOf(key) < 0) {
+        throw invalid("Unsupported PageLayout.zoom property '" + key + "'");
+      }
+    });
+    ["horizontalFitToPages", "verticalFitToPages"].forEach(function (key) {
+      if (!own(value, key) || value[key] === null) return;
+      requireNonNegativeNumber(value[key], "PageLayout.zoom." + key, true);
+    });
+    if (own(value, "scale") && value.scale !== null) {
+      requireNonNegativeNumber(value.scale, "PageLayout.zoom.scale", true);
+      if (value.scale < 10 || value.scale > 400) {
+        throw invalid("PageLayout.zoom.scale must be between 10 and 400");
+      }
+    }
+  }
+
+  function validatePageLayoutValue(name, value) {
+    if (BOOLEAN_PAGE_LAYOUT_PROPERTIES[name]) {
+      requireBoolean(value, "PageLayout." + name);
+      return;
+    }
+    switch (name) {
+      case "bottomMargin":
+      case "footerMargin":
+      case "headerMargin":
+      case "leftMargin":
+      case "rightMargin":
+      case "topMargin":
+        requireNonNegativeNumber(value, "PageLayout." + name, false);
+        return;
+      case "firstPageNumber":
+        if (value === "") return;
+        requireNonNegativeNumber(value, "PageLayout.firstPageNumber", true);
+        return;
+      case "orientation":
+        requireEnum(value, "PageLayout.orientation", ["Portrait", "Landscape"]);
+        return;
+      case "paperSize":
+        requireEnum(value, "PageLayout.paperSize", PAPER_TYPES);
+        return;
+      case "printComments":
+        requireEnum(value, "PageLayout.printComments", PRINT_COMMENTS);
+        return;
+      case "printErrors":
+        requireEnum(value, "PageLayout.printErrors", PRINT_ERRORS);
+        return;
+      case "printOrder":
+        requireEnum(value, "PageLayout.printOrder", PRINT_ORDER);
+        return;
+      case "printQuality":
+        if (!Array.isArray(value) || value.length !== 2) {
+          throw invalid("PageLayout.printQuality must be a two-element number array");
+        }
+        value.forEach(function (entry, index) {
+          requireNonNegativeNumber(entry, "PageLayout.printQuality[" + index + "]", true);
+        });
+        return;
+      case "zoom":
+        validateZoom(value);
+        return;
+      default:
+        throw unsupported("PageLayout." + name + " is read-only or unsupported");
+    }
+  }
+
+  function defineScalarProperty(prototype, name) {
+    Object.defineProperty(prototype, name, {
+      configurable: true,
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        validatePageLayoutValue(name, value);
+        this["_" + name] = value;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: value,
+        });
+      },
+    });
+  }
+
+  function defineWorksheetScalarProperty(prototype, name) {
+    Object.defineProperty(prototype, name, {
+      configurable: true,
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        if (name === "showGridlines" || name === "showHeadings") {
+          requireBoolean(value, "Worksheet." + name);
+        } else if (typeof value !== "string") {
+          throw invalid("Worksheet.tabColor must be a string");
+        }
+        this["_" + name] = value;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: value,
+        });
+      },
+    });
+  }
+
+  function WorksheetFreezePanes(context, worksheet) {
+    ClientObject.call(this, context);
+    this._worksheet = worksheet;
+    this._scalarProperties = [];
+    this._navigationProperties = [];
+    context._queue.push({
+      op: "getWorksheetFreezePanes",
+      id: this._id,
+      worksheetId: worksheet._id,
+    });
+  }
+  WorksheetFreezePanes.prototype = Object.create(ClientObject.prototype);
+  WorksheetFreezePanes.prototype.constructor = WorksheetFreezePanes;
+
+  WorksheetFreezePanes.prototype.freezeAt = function (frozenRange) {
+    var operation = {
+      op: "worksheetFreezeAt",
+      id: this._id,
+      freezePanesId: this._id,
+      worksheetId: this._worksheet._id,
+    };
+    if (frozenRange === null) {
+      operation.clear = true;
+    } else if (frozenRange instanceof Excel.Range) {
+      requireSameContext(frozenRange, this.context);
+      operation.rangeId = frozenRange._id;
+    } else if (typeof frozenRange === "string") {
+      if (frozenRange.trim() === "") {
+        throw invalid("WorksheetFreezePanes.freezeAt requires a range address");
+      }
+      operation.address = frozenRange;
+    } else {
+      throw invalid("WorksheetFreezePanes.freezeAt requires a Range, string, or null");
+    }
+    this.context._queue.push(operation);
+  };
+
+  WorksheetFreezePanes.prototype.freezeColumns = function (count) {
+    if (count === undefined) count = 1;
+    requireNonNegativeNumber(count, "WorksheetFreezePanes.freezeColumns count", true);
+    this.context._queue.push({
+      op: "worksheetFreezeColumns",
+      id: this._id,
+      freezePanesId: this._id,
+      worksheetId: this._worksheet._id,
+      count: count,
+    });
+  };
+
+  WorksheetFreezePanes.prototype.freezeRows = function (count) {
+    if (count === undefined) count = 1;
+    requireNonNegativeNumber(count, "WorksheetFreezePanes.freezeRows count", true);
+    this.context._queue.push({
+      op: "worksheetFreezeRows",
+      id: this._id,
+      freezePanesId: this._id,
+      worksheetId: this._worksheet._id,
+      count: count,
+    });
+  };
+
+  function freezeLocation(freezePanes, orNullObject) {
+    var range = new Excel.Range(freezePanes.context, freezePanes._worksheet, null);
+    defineNullableRange(range);
+    freezePanes.context._queue.push({
+      op: "worksheetFreezeGetLocation",
+      id: range._id,
+      freezePanesId: freezePanes._id,
+      worksheetId: freezePanes._worksheet._id,
+      orNullObject: orNullObject === true,
+    });
+    return range;
+  }
+
+  // A range returned by an OrNullObject method needs an explicit scalar
+  // descriptor. The base Range proxy otherwise treats `isNullObject` as an
+  // ordinary inherited fallback and cannot distinguish a null host binding.
+  function defineNullableRange(range) {
+    if (range._scalarProperties.indexOf("isNullObject") < 0) {
+      range._scalarProperties.push("isNullObject");
+    }
+    range._isNullObject = false;
+    Object.defineProperty(range, "isNullObject", {
+      configurable: true,
+      get: function () {
+        if (!this._loaded.isNullObject) throw propertyNotLoaded("isNullObject");
+        return this._isNullObject;
+      },
+    });
+  }
+
+  WorksheetFreezePanes.prototype.getLocation = function () {
+    return freezeLocation(this, false);
+  };
+
+  WorksheetFreezePanes.prototype.getLocationOrNullObject = function () {
+    return freezeLocation(this, true);
+  };
+
+  WorksheetFreezePanes.prototype.unfreeze = function () {
+    this.context._queue.push({
+      op: "worksheetFreezeUnfreeze",
+      id: this._id,
+      freezePanesId: this._id,
+      worksheetId: this._worksheet._id,
+    });
+  };
+
+  WorksheetFreezePanes.prototype.toJSON = function () {
+    return {};
+  };
+
+  function PageLayout(context, worksheet) {
+    ClientObject.call(this, context);
+    this._worksheet = worksheet;
+    this._scalarProperties = PAGE_LAYOUT_PROPERTIES.slice();
+    this._navigationProperties = [];
+    context._queue.push({
+      op: "getWorksheetPageLayout",
+      id: this._id,
+      worksheetId: worksheet._id,
+    });
+  }
+  PageLayout.prototype = Object.create(ClientObject.prototype);
+  PageLayout.prototype.constructor = PageLayout;
+
+  PAGE_LAYOUT_PROPERTIES.forEach(function (name) {
+    defineScalarProperty(PageLayout.prototype, name);
+  });
+
+  PageLayout.prototype.set = function (source, options) {
+    if (source === null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+    var properties = source;
+    if (source instanceof ClientObject) {
+      if (Object.getPrototypeOf(source) !== Object.getPrototypeOf(this)) {
+        throw invalid("The object passed to set must have the same type.");
+      }
+      if (source.context !== this.context) throw invalidContext();
+      properties = source.toJSON();
+    } else if (!isPlainObject(source)) {
+      throw new TypeError("set requires a plain property object");
+    }
+    if (own(properties, "headersFooters") && properties.headersFooters !== undefined) {
+      throw unsupported("PageLayout.headersFooters is not supported by this Office.js host");
+    }
+    // `options` exists in the pinned overload. The scalar PageLayout surface
+    // has no read-only members, so there is no option-dependent branch here.
+    void options;
+    PAGE_LAYOUT_PROPERTIES.forEach(function (name) {
+      if (own(properties, name) && properties[name] !== undefined) {
+        this[name] = properties[name];
+      }
+    }, this);
+  };
+
+  PageLayout.prototype.toJSON = function () {
+    var result = {};
+    PAGE_LAYOUT_PROPERTIES.forEach(function (name) {
+      if (this._loaded[name]) result[name] = this["_" + name];
+    }, this);
+    return result;
+  };
+
+  Object.defineProperty(PageLayout.prototype, "headersFooters", {
+    configurable: true,
+    get: function () {
+      throw unsupported("PageLayout.headersFooters is not supported by this Office.js host");
+    },
+  });
+
+  function newRangeAreas(context, worksheet) {
+    if (typeof officeJs.createRangeAreas !== "function" || typeof Excel.RangeAreas !== "function") {
+      throw unsupported("PageLayout print-area methods require the RangeAreas adapter");
+    }
+    return officeJs.createRangeAreas(context, worksheet);
+  }
+
+  function printAreaResult(pageLayout, orNullObject) {
+    var result = newRangeAreas(pageLayout.context, pageLayout._worksheet);
+    pageLayout.context._queue.push({
+      op: "pageLayoutGetPrintArea",
+      id: result._id,
+      pageLayoutId: pageLayout._id,
+      worksheetId: pageLayout._worksheet._id,
+      orNullObject: orNullObject === true,
+    });
+    return result;
+  }
+
+  PageLayout.prototype.getPrintArea = function () {
+    return printAreaResult(this, false);
+  };
+
+  PageLayout.prototype.getPrintAreaOrNullObject = function () {
+    return printAreaResult(this, true);
+  };
+
+  function titleResult(pageLayout, axis, orNullObject) {
+    var range = new Excel.Range(pageLayout.context, pageLayout._worksheet, null);
+    defineNullableRange(range);
+    pageLayout.context._queue.push({
+      op: axis === "rows" ? "pageLayoutGetPrintTitleRows" : "pageLayoutGetPrintTitleColumns",
+      id: range._id,
+      pageLayoutId: pageLayout._id,
+      worksheetId: pageLayout._worksheet._id,
+      orNullObject: orNullObject === true,
+    });
+    return range;
+  }
+
+  PageLayout.prototype.getPrintTitleColumns = function () {
+    return titleResult(this, "columns", false);
+  };
+
+  PageLayout.prototype.getPrintTitleColumnsOrNullObject = function () {
+    return titleResult(this, "columns", true);
+  };
+
+  PageLayout.prototype.getPrintTitleRows = function () {
+    return titleResult(this, "rows", false);
+  };
+
+  PageLayout.prototype.getPrintTitleRowsOrNullObject = function () {
+    return titleResult(this, "rows", true);
+  };
+
+  PageLayout.prototype.setPrintArea = function (printArea) {
+    var operation = {
+      op: "pageLayoutSetPrintArea",
+      id: this._id,
+      pageLayoutId: this._id,
+      worksheetId: this._worksheet._id,
+    };
+    if (printArea instanceof Excel.Range) {
+      requireSameContext(printArea, this.context);
+      operation.rangeId = printArea._id;
+    } else if (typeof Excel.RangeAreas === "function" && printArea instanceof Excel.RangeAreas) {
+      requireSameContext(printArea, this.context);
+      operation.rangeAreasId = printArea._id;
+    } else if (typeof printArea === "string") {
+      if (printArea.trim() === "") {
+        throw invalid("PageLayout.setPrintArea requires a range address");
+      }
+      operation.address = printArea;
+    } else {
+      throw invalid("PageLayout.setPrintArea requires a Range, RangeAreas, or string");
+    }
+    this.context._queue.push(operation);
+  };
+
+  PageLayout.prototype.setPrintMargins = function (unit, marginOptions) {
+    requireEnum(unit, "PageLayout.setPrintMargins unit", PRINT_MARGIN_UNITS);
+    if (!isPlainObject(marginOptions)) {
+      throw invalid("PageLayout.setPrintMargins marginOptions must be an object");
+    }
+    Object.keys(marginOptions).forEach(function (name) {
+      if (MARGIN_PROPERTIES.indexOf(name) < 0) {
+        throw invalid("Unsupported PageLayout margin property '" + name + "'");
+      }
+      requireNonNegativeNumber(
+        marginOptions[name],
+        "PageLayout.setPrintMargins." + name,
+        false
+      );
+    });
+    this.context._queue.push({
+      op: "pageLayoutSetPrintMargins",
+      id: this._id,
+      pageLayoutId: this._id,
+      worksheetId: this._worksheet._id,
+      unit: unit,
+      options: marginOptions,
+    });
+  };
+
+  function queuePrintTitle(pageLayout, axis, value) {
+    var operation = {
+      op: axis === "rows" ? "pageLayoutSetPrintTitleRows" : "pageLayoutSetPrintTitleColumns",
+      id: pageLayout._id,
+      pageLayoutId: pageLayout._id,
+      worksheetId: pageLayout._worksheet._id,
+    };
+    if (value instanceof Excel.Range) {
+      requireSameContext(value, pageLayout.context);
+      operation.rangeId = value._id;
+    } else if (typeof value === "string") {
+      if (value.trim() === "") {
+        throw invalid("PageLayout print-title methods require a range address");
+      }
+      operation.address = value;
+    } else {
+      throw invalid("PageLayout print-title methods require a Range or string");
+    }
+    pageLayout.context._queue.push(operation);
+  }
+
+  PageLayout.prototype.setPrintTitleColumns = function (value) {
+    queuePrintTitle(this, "columns", value);
+  };
+
+  PageLayout.prototype.setPrintTitleRows = function (value) {
+    queuePrintTitle(this, "rows", value);
+  };
+
+  // Worksheet properties are additive to the lifecycle adapter. Keep the
+  // extra names on the shared scalar list so `$all` and normal load options
+  // reach the host's Worksheet projection.
+  officeJs.addScalarProperties(Excel.Worksheet.prototype, [
+    "showGridlines",
+    "showHeadings",
+    "tabColor",
+  ]);
+  officeJs.addNavigationProperties(Excel.Worksheet.prototype, [
+    "freezePanes",
+    "pageLayout",
+  ]);
+  ["showGridlines", "showHeadings", "tabColor"].forEach(function (name) {
+    defineWorksheetScalarProperty(Excel.Worksheet.prototype, name);
+  });
+
+  Object.defineProperty(Excel.Worksheet.prototype, "freezePanes", {
+    configurable: true,
+    get: function () {
+      if (!this._freezePanes) {
+        this._freezePanes = new WorksheetFreezePanes(this.context, this);
+      }
+      return this._freezePanes;
+    },
+  });
+
+  Object.defineProperty(Excel.Worksheet.prototype, "pageLayout", {
+    configurable: true,
+    get: function () {
+      if (!this._pageLayout) {
+        this._pageLayout = new PageLayout(this.context, this);
+      }
+      return this._pageLayout;
+    },
+  });
+
+  // The lifecycle adapter owns the base Worksheet.toJSON implementation.
+  // Extend it so loaded view properties survive serialization without
+  // replacing the lifecycle fields or inventing unloaded values.
+  var worksheetToJSON = Excel.Worksheet.prototype.toJSON;
+  Excel.Worksheet.prototype.toJSON = function () {
+    var result = worksheetToJSON ? worksheetToJSON.call(this) : {};
+    ["showGridlines", "showHeadings", "tabColor"].forEach(function (name) {
+      if (this._loaded[name]) result[name] = this["_" + name];
+    }, this);
+    return result;
+  };
+
+  Excel.WorksheetFreezePanes = WorksheetFreezePanes;
+  Excel.PageLayout = PageLayout;
+})(globalThis);

--- a/compute/officejs/src/sheet_layout.rs
+++ b/compute/officejs/src/sheet_layout.rs
@@ -1,0 +1,1134 @@
+//! Office.js worksheet view, frozen-pane, and page-layout adapters.
+//!
+//! The JavaScript side of this family owns Office object paths and batching.
+//! This module owns the translation from those paths to the existing typed
+//! compute-api layout/print primitives.  In particular, reads always query
+//! the engine at operation time; no worksheet view or page-layout state is
+//! cached in the Office.js host.
+
+use std::collections::HashMap;
+
+use compute_api::{ComputeApiError, Sheet, Workbook};
+use domain_types::domain::print::{HeaderFooter, PageMargins, PrintSettings};
+use domain_types::{FrozenPanes, PrintRange, PrintTitles};
+use serde_json::{Map, Value, json};
+
+use crate::range_navigation::{
+    EXCEL_MAX_COLUMNS, EXCEL_MAX_ROWS, RangeAddress, RangeNavigationError, parse_range_address,
+};
+
+/// Errors returned by the worksheet layout/page-layout translation layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SheetLayoutError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+impl From<ComputeApiError> for SheetLayoutError {
+    fn from(error: ComputeApiError) -> Self {
+        let code = match &error {
+            ComputeApiError::SheetNotFound { .. } => "ItemNotFound",
+            ComputeApiError::InvalidAddress { .. } | ComputeApiError::InvalidRange { .. } => {
+                "InvalidArgument"
+            }
+            ComputeApiError::InvalidOperation(_) => "InvalidOperation",
+            _ => "GeneralException",
+        };
+        Self {
+            code,
+            message: error.to_string(),
+        }
+    }
+}
+
+fn invalid(message: impl Into<String>) -> SheetLayoutError {
+    SheetLayoutError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn unsupported(message: impl Into<String>) -> SheetLayoutError {
+    SheetLayoutError {
+        code: "ApiNotFound",
+        message: message.into(),
+    }
+}
+
+fn navigation(error: RangeNavigationError) -> SheetLayoutError {
+    SheetLayoutError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worksheet view properties
+// ---------------------------------------------------------------------------
+
+/// A worksheet-backed view reference for `showGridlines`, `showHeadings`, and
+/// `tabColor`.
+///
+/// `showHeadings` is the Office.js aggregate of the engine's independent row
+/// and column header flags.  A write therefore updates both engine settings;
+/// a read is true only when both flags are true.
+#[derive(Clone)]
+pub(crate) struct WorksheetViewRef {
+    workbook: Workbook,
+    sheet: Sheet,
+}
+
+impl WorksheetViewRef {
+    pub(crate) fn new(workbook: Workbook, sheet: Sheet) -> Self {
+        Self { workbook, sheet }
+    }
+
+    /// Project the requested worksheet view properties from persisted state.
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, SheetLayoutError> {
+        let settings = self
+            .workbook
+            .sheets()
+            .get_sheet_settings(self.sheet.id())
+            .map_err(SheetLayoutError::from)?;
+        // `get_tab_color` is the typed read counterpart to the existing
+        // `set_tab_color` facade.  It intentionally remains a live query so a
+        // fresh Worksheet proxy sees a color written by an earlier batch.
+        let tab_color = self
+            .workbook
+            .sheets()
+            .get_tab_color(self.sheet.id())
+            .map_err(SheetLayoutError::from)?;
+        let visibility = self
+            .workbook
+            .sheets()
+            .get_sheet_visibility(self.sheet.id())
+            .map_err(SheetLayoutError::from)?;
+
+        let requested: Vec<&str> = if properties.is_empty() {
+            vec!["showGridlines", "showHeadings", "tabColor"]
+        } else {
+            properties.iter().map(String::as_str).collect()
+        };
+
+        let mut result = HashMap::new();
+        for property in requested {
+            let value = match property {
+                "showGridlines" => json!(settings.show_gridlines),
+                "showHeadings" => {
+                    json!(settings.show_row_headers && settings.show_column_headers)
+                }
+                "tabColor" => {
+                    if visibility != "visible" {
+                        Value::Null
+                    } else {
+                        Value::String(tab_color.clone().unwrap_or_default())
+                    }
+                }
+                "isNullObject" => Value::Bool(false),
+                other => {
+                    return Err(invalid(format!(
+                        "Unsupported Worksheet load property '{other}'"
+                    )));
+                }
+            };
+            result.insert(property.to_string(), value);
+        }
+        Ok(result)
+    }
+
+    /// Apply one Office.js worksheet view property through the persisted
+    /// sheet-settings/tab-color APIs.
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), SheetLayoutError> {
+        match property {
+            "showGridlines" => {
+                let value = value
+                    .as_bool()
+                    .ok_or_else(|| invalid("Worksheet.showGridlines must be a boolean"))?;
+                self.workbook
+                    .sheets()
+                    .set_sheet_setting(
+                        self.sheet.id(),
+                        "showGridlines",
+                        if value { "true" } else { "false" },
+                    )
+                    .map_err(SheetLayoutError::from)?;
+            }
+            "showHeadings" => {
+                let value = value
+                    .as_bool()
+                    .ok_or_else(|| invalid("Worksheet.showHeadings must be a boolean"))?;
+                let encoded = if value { "true" } else { "false" };
+                self.workbook
+                    .sheets()
+                    .set_sheet_setting(self.sheet.id(), "showRowHeaders", encoded)
+                    .map_err(SheetLayoutError::from)?;
+                self.workbook
+                    .sheets()
+                    .set_sheet_setting(self.sheet.id(), "showColumnHeaders", encoded)
+                    .map_err(SheetLayoutError::from)?;
+            }
+            "tabColor" => {
+                let value = value
+                    .as_str()
+                    .ok_or_else(|| invalid("Worksheet.tabColor must be a string"))?;
+                self.workbook
+                    .sheets()
+                    .set_tab_color(
+                        self.sheet.id(),
+                        if value.is_empty() { None } else { Some(value) },
+                    )
+                    .map_err(SheetLayoutError::from)?;
+            }
+            other => {
+                return Err(unsupported(format!(
+                    "Worksheet.{other} is read-only or unsupported"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Frozen panes
+// ---------------------------------------------------------------------------
+
+/// A worksheet-backed `WorksheetFreezePanes` reference.
+#[derive(Clone)]
+pub(crate) struct WorksheetFreezePanesRef {
+    sheet: Sheet,
+}
+
+impl WorksheetFreezePanesRef {
+    pub(crate) fn new(sheet: Sheet) -> Self {
+        Self { sheet }
+    }
+
+    pub(crate) fn freeze_at(&self, address: &str) -> Result<(), SheetLayoutError> {
+        let parsed = parse_range_address(&self.sheet, address).map_err(navigation)?;
+        let (rows, cols) = freeze_counts(&parsed, address)?;
+        self.sheet
+            .layout()
+            .set_frozen_panes(rows, cols)
+            .map(|_| ())
+            .map_err(SheetLayoutError::from)
+    }
+
+    pub(crate) fn freeze_rows(&self, count: u32) -> Result<(), SheetLayoutError> {
+        self.sheet
+            .layout()
+            .freeze_rows(count)
+            .map(|_| ())
+            .map_err(SheetLayoutError::from)
+    }
+
+    pub(crate) fn freeze_columns(&self, count: u32) -> Result<(), SheetLayoutError> {
+        self.sheet
+            .layout()
+            .freeze_columns(count)
+            .map(|_| ())
+            .map_err(SheetLayoutError::from)
+    }
+
+    pub(crate) fn unfreeze(&self) -> Result<(), SheetLayoutError> {
+        self.sheet
+            .layout()
+            .set_frozen_panes(0, 0)
+            .map(|_| ())
+            .map_err(SheetLayoutError::from)
+    }
+
+    /// Read the live frozen-pane counts from the compute engine.
+    pub(crate) fn get_frozen_panes(&self) -> Result<FrozenPanes, SheetLayoutError> {
+        self.sheet
+            .layout()
+            .get_frozen_panes()
+            .map_err(SheetLayoutError::from)
+    }
+
+    /// Return the unqualified Range address Office.js uses for the frozen
+    /// top-left pane.  A row-only or column-only freeze retains its unbounded
+    /// axis (`1:2` or `A:C`), while a two-axis freeze is a bounded rectangle.
+    pub(crate) fn get_location_address(&self) -> Result<Option<String>, SheetLayoutError> {
+        let panes = self.get_frozen_panes()?;
+        frozen_location_address(&panes)
+    }
+}
+
+fn freeze_counts(parsed: &RangeAddress, address: &str) -> Result<(u32, u32), SheetLayoutError> {
+    if parsed.is_whole_sheet() {
+        return Err(invalid(format!(
+            "WorksheetFreezePanes.freezeAt requires a non-empty range; '{address}' is the whole worksheet"
+        )));
+    }
+
+    let (start_row, start_col, end_row, end_col) = parsed.bounds();
+    if end_row >= EXCEL_MAX_ROWS || end_col >= EXCEL_MAX_COLUMNS {
+        return Err(invalid(format!(
+            "WorksheetFreezePanes.freezeAt range '{address}' exceeds the worksheet grid"
+        )));
+    }
+
+    // A single cell is the split point: Excel freezes the rows above it and
+    // columns to its left (B3 means two rows and one column).  A rectangular
+    // range describes the cells in the top-left frozen pane, so its bottom
+    // and right boundaries determine the persisted counts.  Entire-row and
+    // entire-column ranges retain their unbounded axis while contributing the
+    // bounded axis count.
+    let single_cell = !parsed.is_entire_row()
+        && !parsed.is_entire_column()
+        && start_row == end_row
+        && start_col == end_col;
+    let rows = if parsed.is_entire_column() {
+        0
+    } else if single_cell {
+        start_row
+    } else {
+        end_row
+            .checked_add(1)
+            .ok_or_else(|| invalid("WorksheetFreezePanes.freezeAt row boundary overflow"))?
+    };
+    let cols = if parsed.is_entire_row() {
+        0
+    } else if single_cell {
+        start_col
+    } else {
+        end_col
+            .checked_add(1)
+            .ok_or_else(|| invalid("WorksheetFreezePanes.freezeAt column boundary overflow"))?
+    };
+
+    // The range parser guarantees non-empty, ordered bounds. Keep the local
+    // checks explicit because this helper is also used by host integrations
+    // that may construct RangeAddress values directly in the future.
+    if start_row > end_row || start_col > end_col || (rows == 0 && cols == 0) {
+        return Err(invalid(format!(
+            "WorksheetFreezePanes.freezeAt range '{address}' is invalid"
+        )));
+    }
+    Ok((rows, cols))
+}
+
+/// Convert persisted frozen boundaries into the Range address returned by
+/// `getLocation`.
+pub(crate) fn frozen_location_address(
+    panes: &FrozenPanes,
+) -> Result<Option<String>, SheetLayoutError> {
+    if panes.rows == 0 && panes.cols == 0 {
+        return Ok(None);
+    }
+    if panes.rows > EXCEL_MAX_ROWS || panes.cols > EXCEL_MAX_COLUMNS {
+        return Err(invalid("Frozen pane boundaries exceed the worksheet grid"));
+    }
+    let address = match (panes.rows, panes.cols) {
+        (rows, 0) => format!("1:{rows}"),
+        (0, cols) => format!("A:{}", column_name(cols - 1)),
+        (rows, cols) => bounds_to_a1(0, 0, rows - 1, cols - 1),
+    };
+    Ok(Some(address))
+}
+
+// ---------------------------------------------------------------------------
+// PageLayout
+// ---------------------------------------------------------------------------
+
+/// A worksheet-backed `PageLayout` reference.
+#[derive(Clone)]
+pub(crate) struct PageLayoutRef {
+    sheet: Sheet,
+}
+
+impl PageLayoutRef {
+    pub(crate) fn new(sheet: Sheet) -> Self {
+        Self { sheet }
+    }
+
+    fn settings(&self) -> Result<PrintSettings, SheetLayoutError> {
+        self.sheet
+            .print()
+            .get_print_settings()
+            .map_err(SheetLayoutError::from)
+    }
+
+    /// Project PageLayout scalar fields from a fresh print-settings query.
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, SheetLayoutError> {
+        let settings = self.settings()?;
+        let requested: Vec<&str> = if properties.is_empty() {
+            PAGE_LAYOUT_PROPERTIES.to_vec()
+        } else {
+            properties.iter().map(String::as_str).collect()
+        };
+        let mut result = HashMap::new();
+        for property in requested {
+            let value = page_layout_value(&settings, property)?;
+            result.insert(property.to_string(), value);
+        }
+        Ok(result)
+    }
+
+    /// Apply one scalar PageLayout property. The current settings are read
+    /// immediately before the update so adjacent queued setters preserve one
+    /// another and fresh proxies observe persisted state.
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), SheetLayoutError> {
+        let mut settings = self.settings()?;
+        update_page_layout_value(&mut settings, property, value)?;
+        self.sheet
+            .print()
+            .set_print_settings(settings)
+            .map(|_| ())
+            .map_err(SheetLayoutError::from)
+    }
+
+    pub(crate) fn get_print_area(&self) -> Result<Option<PrintRange>, SheetLayoutError> {
+        self.sheet
+            .print()
+            .get_print_area()
+            .map_err(SheetLayoutError::from)
+    }
+
+    pub(crate) fn set_print_area(&self, area: Option<PrintRange>) -> Result<(), SheetLayoutError> {
+        self.sheet
+            .print()
+            .set_print_area(area)
+            .map(|_| ())
+            .map_err(SheetLayoutError::from)
+    }
+
+    pub(crate) fn get_print_titles(&self) -> Result<PrintTitles, SheetLayoutError> {
+        self.sheet
+            .print()
+            .get_print_titles()
+            .map_err(SheetLayoutError::from)
+    }
+
+    pub(crate) fn set_print_titles(&self, titles: PrintTitles) -> Result<(), SheetLayoutError> {
+        self.sheet
+            .print()
+            .set_print_titles(titles)
+            .map(|_| ())
+            .map_err(SheetLayoutError::from)
+    }
+
+    /// Update the requested print margins after converting Office.js units to
+    /// the persisted inch representation.  Values omitted from `options` are
+    /// retained by the fresh settings read above.
+    pub(crate) fn set_print_margins(
+        &self,
+        unit: &str,
+        options: &Map<String, Value>,
+    ) -> Result<(), SheetLayoutError> {
+        let multiplier = match unit {
+            "Points" => 1.0 / 72.0,
+            "Inches" => 1.0,
+            "Centimeters" => 1.0 / 2.54,
+            other => {
+                return Err(invalid(format!(
+                    "PageLayout.setPrintMargins has unsupported unit '{other}'"
+                )))
+            }
+        };
+        let mut settings = self.settings()?;
+        let margins = settings.margins.get_or_insert_with(PageMargins::default);
+        for (name, value) in options {
+            let value = points_value(value, &format!("PageLayout.setPrintMargins.{name}"))?;
+            let value = value * multiplier;
+            match name.as_str() {
+                "bottom" => margins.bottom = value,
+                "footer" => margins.footer = value,
+                "header" => margins.header = value,
+                "left" => margins.left = value,
+                "right" => margins.right = value,
+                "top" => margins.top = value,
+                other => {
+                    return Err(invalid(format!(
+                        "Unsupported PageLayout margin property '{other}'"
+                    )))
+                }
+            }
+        }
+        self.sheet
+            .print()
+            .set_print_settings(settings)
+            .map(|_| ())
+            .map_err(SheetLayoutError::from)
+    }
+
+    /// Set one title axis while preserving the other axis.
+    pub(crate) fn set_print_title_rows(
+        &self,
+        rows: Option<(u32, u32)>,
+    ) -> Result<(), SheetLayoutError> {
+        let mut titles = self.get_print_titles()?;
+        titles.repeat_rows = rows;
+        self.set_print_titles(titles)
+    }
+
+    pub(crate) fn set_print_title_columns(
+        &self,
+        cols: Option<(u32, u32)>,
+    ) -> Result<(), SheetLayoutError> {
+        let mut titles = self.get_print_titles()?;
+        titles.repeat_cols = cols;
+        self.set_print_titles(titles)
+    }
+}
+
+/// PageLayout scalar names from the pinned Office.js declaration. `zoom` is a
+/// structured scalar object; `headersFooters` is intentionally excluded until
+/// its dedicated HeaderFooterGroup adapter is available.
+pub(crate) const PAGE_LAYOUT_PROPERTIES: &[&str] = &[
+    "alignMarginsHeaderFooter",
+    "blackAndWhite",
+    "bottomMargin",
+    "centerHorizontally",
+    "centerVertically",
+    "draftMode",
+    "firstPageNumber",
+    "footerMargin",
+    "headerMargin",
+    "leftMargin",
+    "orientation",
+    "paperSize",
+    "printComments",
+    "printErrors",
+    "printGridlines",
+    "printHeadings",
+    "printOrder",
+    "printQuality",
+    "rightMargin",
+    "topMargin",
+    "zoom",
+];
+
+fn page_layout_value(settings: &PrintSettings, property: &str) -> Result<Value, SheetLayoutError> {
+    let margins = settings.margins.clone().unwrap_or_default();
+    let value = match property {
+        "alignMarginsHeaderFooter" => json!(
+            settings
+                .header_footer
+                .as_ref()
+                .and_then(|header_footer| header_footer.align_with_margins)
+                .unwrap_or(true)
+        ),
+        "blackAndWhite" => json!(settings.black_and_white),
+        "bottomMargin" => json!(inches_to_points(margins.bottom)),
+        "centerHorizontally" => json!(settings.h_centered),
+        "centerVertically" => json!(settings.v_centered),
+        "draftMode" => json!(settings.draft),
+        "firstPageNumber" => {
+            if settings.use_first_page_number {
+                settings
+                    .first_page_number
+                    .map(|number| json!(number))
+                    .unwrap_or_else(|| Value::String(String::new()))
+            } else {
+                Value::String(String::new())
+            }
+        }
+        "footerMargin" => json!(inches_to_points(margins.footer)),
+        "headerMargin" => json!(inches_to_points(margins.header)),
+        "leftMargin" => json!(inches_to_points(margins.left)),
+        "orientation" => Value::String(
+            match settings.orientation.as_deref() {
+                Some("landscape") | Some("Landscape") => "Landscape",
+                _ => "Portrait",
+            }
+            .to_string(),
+        ),
+        "paperSize" => Value::String(paper_type(settings.paper_size.unwrap_or(1))?.to_string()),
+        "printComments" => Value::String(print_comments_token(settings.cell_comments.as_deref())),
+        "printErrors" => Value::String(print_errors_token(settings.print_errors.as_deref())),
+        "printGridlines" => json!(settings.gridlines),
+        "printHeadings" => json!(settings.headings),
+        "printOrder" => Value::String(print_order_token(settings.page_order.as_deref())),
+        "printQuality" => json!([
+            settings.horizontal_dpi.unwrap_or(0),
+            settings.vertical_dpi.unwrap_or(0)
+        ]),
+        "rightMargin" => json!(inches_to_points(margins.right)),
+        "topMargin" => json!(inches_to_points(margins.top)),
+        "zoom" => json!({
+            "horizontalFitToPages": settings.fit_to_width,
+            "scale": settings.scale,
+            "verticalFitToPages": settings.fit_to_height,
+        }),
+        "headersFooters" => {
+            return Err(unsupported(
+                "PageLayout.headersFooters is not supported by this Office.js host",
+            ));
+        }
+        "isNullObject" => Value::Bool(false),
+        other => {
+            return Err(invalid(format!(
+                "Unsupported PageLayout load property '{other}'"
+            )));
+        }
+    };
+    Ok(value)
+}
+
+fn update_page_layout_value(
+    settings: &mut PrintSettings,
+    property: &str,
+    value: &Value,
+) -> Result<(), SheetLayoutError> {
+    match property {
+        "alignMarginsHeaderFooter" => {
+            let value = value
+                .as_bool()
+                .ok_or_else(|| invalid("PageLayout.alignMarginsHeaderFooter must be a boolean"))?;
+            settings
+                .header_footer
+                .get_or_insert_with(HeaderFooter::default)
+                .align_with_margins = Some(value);
+        }
+        "blackAndWhite" => {
+            settings.black_and_white = bool_value(value, "PageLayout.blackAndWhite")?;
+        }
+        "bottomMargin" => {
+            let value = points_value(value, "PageLayout.bottomMargin")?;
+            settings
+                .margins
+                .get_or_insert_with(PageMargins::default)
+                .bottom = points_to_inches(value);
+        }
+        "centerHorizontally" => {
+            settings.h_centered = bool_value(value, "PageLayout.centerHorizontally")?;
+        }
+        "centerVertically" => {
+            settings.v_centered = bool_value(value, "PageLayout.centerVertically")?;
+        }
+        "draftMode" => {
+            settings.draft = bool_value(value, "PageLayout.draftMode")?;
+        }
+        "firstPageNumber" => {
+            if value.as_str() == Some("") {
+                settings.first_page_number = None;
+                settings.use_first_page_number = false;
+            } else {
+                let number = required_u32(value, "PageLayout.firstPageNumber")?;
+                settings.first_page_number = Some(number);
+                settings.use_first_page_number = true;
+            }
+        }
+        "footerMargin" => {
+            let value = points_value(value, "PageLayout.footerMargin")?;
+            settings
+                .margins
+                .get_or_insert_with(PageMargins::default)
+                .footer = points_to_inches(value);
+        }
+        "headerMargin" => {
+            let value = points_value(value, "PageLayout.headerMargin")?;
+            settings
+                .margins
+                .get_or_insert_with(PageMargins::default)
+                .header = points_to_inches(value);
+        }
+        "leftMargin" => {
+            let value = points_value(value, "PageLayout.leftMargin")?;
+            settings
+                .margins
+                .get_or_insert_with(PageMargins::default)
+                .left = points_to_inches(value);
+        }
+        "orientation" => {
+            let value = value
+                .as_str()
+                .ok_or_else(|| invalid("PageLayout.orientation must be Portrait or Landscape"))?;
+            settings.orientation = Some(match value {
+                "Portrait" => "portrait".to_string(),
+                "Landscape" => "landscape".to_string(),
+                other => {
+                    return Err(invalid(format!(
+                        "PageLayout.orientation has unsupported value '{other}'"
+                    )));
+                }
+            });
+        }
+        "paperSize" => {
+            let value = value
+                .as_str()
+                .ok_or_else(|| invalid("PageLayout.paperSize must be a supported paper type"))?;
+            settings.paper_size = Some(paper_code(value)?);
+        }
+        "printComments" => {
+            let value = value.as_str().ok_or_else(|| {
+                invalid("PageLayout.printComments must be NoComments, EndSheet, or InPlace")
+            })?;
+            settings.cell_comments = Some(match value {
+                "NoComments" => "none".to_string(),
+                "EndSheet" => "atEnd".to_string(),
+                "InPlace" => "asDisplayed".to_string(),
+                other => {
+                    return Err(invalid(format!(
+                        "PageLayout.printComments has unsupported value '{other}'"
+                    )));
+                }
+            });
+        }
+        "printErrors" => {
+            let value = value.as_str().ok_or_else(|| {
+                invalid("PageLayout.printErrors must be AsDisplayed, Blank, Dash, or NotAvailable")
+            })?;
+            settings.print_errors = Some(match value {
+                "AsDisplayed" => "displayed".to_string(),
+                "Blank" => "blank".to_string(),
+                "Dash" => "dash".to_string(),
+                "NotAvailable" => "NA".to_string(),
+                other => {
+                    return Err(invalid(format!(
+                        "PageLayout.printErrors has unsupported value '{other}'"
+                    )));
+                }
+            });
+        }
+        "printGridlines" => {
+            settings.gridlines = bool_value(value, "PageLayout.printGridlines")?;
+        }
+        "printHeadings" => {
+            settings.headings = bool_value(value, "PageLayout.printHeadings")?;
+        }
+        "printOrder" => {
+            let value = value.as_str().ok_or_else(|| {
+                invalid("PageLayout.printOrder must be DownThenOver or OverThenDown")
+            })?;
+            settings.page_order = Some(match value {
+                "DownThenOver" => "downThenOver".to_string(),
+                "OverThenDown" => "overThenDown".to_string(),
+                other => {
+                    return Err(invalid(format!(
+                        "PageLayout.printOrder has unsupported value '{other}'"
+                    )));
+                }
+            });
+        }
+        "printQuality" => {
+            let values = value.as_array().ok_or_else(|| {
+                invalid("PageLayout.printQuality must be a two-element number array")
+            })?;
+            if values.len() != 2 {
+                return Err(invalid(
+                    "PageLayout.printQuality must be a two-element number array",
+                ));
+            }
+            settings.horizontal_dpi = Some(required_u32(&values[0], "PageLayout.printQuality[0]")?);
+            settings.vertical_dpi = Some(required_u32(&values[1], "PageLayout.printQuality[1]")?);
+        }
+        "rightMargin" => {
+            let value = points_value(value, "PageLayout.rightMargin")?;
+            settings
+                .margins
+                .get_or_insert_with(PageMargins::default)
+                .right = points_to_inches(value);
+        }
+        "topMargin" => {
+            let value = points_value(value, "PageLayout.topMargin")?;
+            settings
+                .margins
+                .get_or_insert_with(PageMargins::default)
+                .top = points_to_inches(value);
+        }
+        "zoom" => update_zoom(settings, value)?,
+        "headersFooters" => {
+            return Err(unsupported(
+                "PageLayout.headersFooters is not supported by this Office.js host",
+            ));
+        }
+        "isNullObject" => {
+            return Err(invalid("PageLayout.isNullObject is read-only"));
+        }
+        other => {
+            return Err(unsupported(format!(
+                "PageLayout.{other} is read-only or unsupported"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn update_zoom(settings: &mut PrintSettings, value: &Value) -> Result<(), SheetLayoutError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid("PageLayout.zoom must be an object"))?;
+    for key in object.keys() {
+        if !matches!(
+            key.as_str(),
+            "horizontalFitToPages" | "scale" | "verticalFitToPages"
+        ) {
+            return Err(invalid(format!(
+                "Unsupported PageLayout.zoom property '{key}'"
+            )));
+        }
+    }
+    if let Some(value) = object.get("horizontalFitToPages") {
+        settings.fit_to_width = optional_u32(value, "PageLayout.zoom.horizontalFitToPages")?;
+    }
+    if let Some(value) = object.get("scale") {
+        let scale = optional_u32(value, "PageLayout.zoom.scale")?;
+        if let Some(scale) = scale
+            && !(10..=400).contains(&scale)
+        {
+            return Err(invalid("PageLayout.zoom.scale must be between 10 and 400"));
+        }
+        settings.scale = scale;
+    }
+    if let Some(value) = object.get("verticalFitToPages") {
+        settings.fit_to_height = optional_u32(value, "PageLayout.zoom.verticalFitToPages")?;
+    }
+    Ok(())
+}
+
+fn bool_value(value: &Value, property: &str) -> Result<bool, SheetLayoutError> {
+    value
+        .as_bool()
+        .ok_or_else(|| invalid(format!("{property} must be a boolean")))
+}
+
+fn required_u32(value: &Value, property: &str) -> Result<u32, SheetLayoutError> {
+    value
+        .as_u64()
+        .and_then(|number| u32::try_from(number).ok())
+        .ok_or_else(|| invalid(format!("{property} must be a non-negative integer")))
+}
+
+fn optional_u32(value: &Value, property: &str) -> Result<Option<u32>, SheetLayoutError> {
+    if value.is_null() {
+        Ok(None)
+    } else {
+        required_u32(value, property).map(Some)
+    }
+}
+
+fn points_value(value: &Value, property: &str) -> Result<f64, SheetLayoutError> {
+    let number = value
+        .as_f64()
+        .ok_or_else(|| invalid(format!("{property} must be a finite non-negative number")))?;
+    if !number.is_finite() || number < 0.0 {
+        return Err(invalid(format!(
+            "{property} must be a finite non-negative number"
+        )));
+    }
+    Ok(number)
+}
+
+fn inches_to_points(value: f64) -> f64 {
+    value * 72.0
+}
+
+fn points_to_inches(value: f64) -> f64 {
+    value / 72.0
+}
+
+fn print_comments_token(value: Option<&str>) -> String {
+    match value {
+        Some("atEnd") => "EndSheet".to_string(),
+        Some("asDisplayed") => "InPlace".to_string(),
+        _ => "NoComments".to_string(),
+    }
+}
+
+fn print_errors_token(value: Option<&str>) -> String {
+    match value {
+        Some("blank") => "Blank".to_string(),
+        Some("dash") => "Dash".to_string(),
+        Some("NA") => "NotAvailable".to_string(),
+        _ => "AsDisplayed".to_string(),
+    }
+}
+
+fn print_order_token(value: Option<&str>) -> String {
+    match value {
+        Some("overThenDown") | Some("OverThenDown") => "OverThenDown".to_string(),
+        _ => "DownThenOver".to_string(),
+    }
+}
+
+fn paper_type(value: u32) -> Result<&'static str, SheetLayoutError> {
+    let token = match value {
+        1 => "Letter",
+        2 => "LetterSmall",
+        3 => "Tabloid",
+        4 => "Ledger",
+        5 => "Legal",
+        6 => "Statement",
+        7 => "Executive",
+        8 => "A3",
+        9 => "A4",
+        10 => "A4Small",
+        11 => "A5",
+        12 => "B4",
+        13 => "B5",
+        14 => "Folio",
+        // The pinned Excel.PaperType declaration spells this token Quatro.
+        15 => "Quatro",
+        16 => "Paper10x14",
+        17 => "Paper11x17",
+        18 => "Note",
+        19 => "Envelope9",
+        20 => "Envelope10",
+        21 => "Envelope11",
+        22 => "Envelope12",
+        23 => "Envelope14",
+        24 => "Csheet",
+        25 => "Dsheet",
+        26 => "Esheet",
+        27 => "EnvelopeDL",
+        28 => "EnvelopeC5",
+        29 => "EnvelopeC3",
+        30 => "EnvelopeC4",
+        31 => "EnvelopeC6",
+        32 => "EnvelopeC65",
+        33 => "EnvelopeB4",
+        34 => "EnvelopeB5",
+        35 => "EnvelopeB6",
+        36 => "EnvelopeItaly",
+        37 => "EnvelopeMonarch",
+        39 => "FanfoldUS",
+        40 => "FanfoldStdGerman",
+        41 => "FanfoldLegalGerman",
+        other => {
+            return Err(unsupported(format!(
+                "PageLayout.paperSize value {other} has no pinned Excel.PaperType token"
+            )));
+        }
+    };
+    Ok(token)
+}
+
+fn paper_code(value: &str) -> Result<u32, SheetLayoutError> {
+    let code = match value {
+        "Letter" => 1,
+        "LetterSmall" => 2,
+        "Tabloid" => 3,
+        "Ledger" => 4,
+        "Legal" => 5,
+        "Statement" => 6,
+        "Executive" => 7,
+        "A3" => 8,
+        "A4" => 9,
+        "A4Small" => 10,
+        "A5" => 11,
+        "B4" => 12,
+        "B5" => 13,
+        "Folio" => 14,
+        "Quatro" => 15,
+        "Paper10x14" => 16,
+        "Paper11x17" => 17,
+        "Note" => 18,
+        "Envelope9" => 19,
+        "Envelope10" => 20,
+        "Envelope11" => 21,
+        "Envelope12" => 22,
+        "Envelope14" => 23,
+        "Csheet" => 24,
+        "Dsheet" => 25,
+        "Esheet" => 26,
+        "EnvelopeDL" => 27,
+        "EnvelopeC5" => 28,
+        "EnvelopeC3" => 29,
+        "EnvelopeC4" => 30,
+        "EnvelopeC6" => 31,
+        "EnvelopeC65" => 32,
+        "EnvelopeB4" => 33,
+        "EnvelopeB5" => 34,
+        "EnvelopeB6" => 35,
+        "EnvelopeItaly" => 36,
+        "EnvelopeMonarch" => 37,
+        "FanfoldUS" => 39,
+        "FanfoldStdGerman" => 40,
+        "FanfoldLegalGerman" => 41,
+        other => {
+            return Err(invalid(format!(
+                "PageLayout.paperSize has unsupported value '{other}'"
+            )));
+        }
+    };
+    Ok(code)
+}
+
+// ---------------------------------------------------------------------------
+// Print area/title address translation
+// ---------------------------------------------------------------------------
+
+/// Parse one bounded print-area address into the domain's positional range.
+/// The persisted compute API currently models one rectangular print area;
+/// callers receiving a RangeAreas proxy must reject additional disjoint areas
+/// instead of silently dropping them.
+pub(crate) fn parse_print_area(
+    sheet: &Sheet,
+    address: &str,
+) -> Result<PrintRange, SheetLayoutError> {
+    let parsed = parse_range_address(sheet, address).map_err(navigation)?;
+    if parsed.is_whole_sheet() || parsed.is_entire_row() || parsed.is_entire_column() {
+        return Err(invalid(
+            "PageLayout.setPrintArea requires a bounded rectangular range",
+        ));
+    }
+    let (start_row, start_col, end_row, end_col) = parsed.bounds();
+    Ok(PrintRange {
+        start_row,
+        start_col,
+        end_row,
+        end_col,
+    })
+}
+
+pub(crate) fn print_area_address(area: &PrintRange) -> Result<String, SheetLayoutError> {
+    validate_print_range(area)?;
+    Ok(bounds_to_a1(
+        area.start_row,
+        area.start_col,
+        area.end_row,
+        area.end_col,
+    ))
+}
+
+pub(crate) fn parse_print_title_rows(
+    sheet: &Sheet,
+    address: &str,
+) -> Result<(u32, u32), SheetLayoutError> {
+    let parsed = parse_range_address(sheet, address).map_err(navigation)?;
+    if !parsed.is_entire_row() {
+        return Err(invalid(
+            "PageLayout.setPrintTitleRows requires a range spanning entire rows",
+        ));
+    }
+    Ok((parsed.bounds().0, parsed.bounds().2))
+}
+
+pub(crate) fn parse_print_title_columns(
+    sheet: &Sheet,
+    address: &str,
+) -> Result<(u32, u32), SheetLayoutError> {
+    let parsed = parse_range_address(sheet, address).map_err(navigation)?;
+    if !parsed.is_entire_column() {
+        return Err(invalid(
+            "PageLayout.setPrintTitleColumns requires a range spanning entire columns",
+        ));
+    }
+    Ok((parsed.bounds().1, parsed.bounds().3))
+}
+
+pub(crate) fn print_title_rows_address(rows: (u32, u32)) -> Result<String, SheetLayoutError> {
+    if rows.0 > rows.1 || rows.1 >= EXCEL_MAX_ROWS {
+        return Err(invalid("Print title row bounds exceed the worksheet grid"));
+    }
+    Ok(format!("{}:{}", rows.0 + 1, rows.1 + 1))
+}
+
+pub(crate) fn print_title_columns_address(cols: (u32, u32)) -> Result<String, SheetLayoutError> {
+    if cols.0 > cols.1 || cols.1 >= EXCEL_MAX_COLUMNS {
+        return Err(invalid(
+            "Print title column bounds exceed the worksheet grid",
+        ));
+    }
+    Ok(format!("{}:{}", column_name(cols.0), column_name(cols.1)))
+}
+
+fn validate_print_range(area: &PrintRange) -> Result<(), SheetLayoutError> {
+    if area.start_row > area.end_row
+        || area.start_col > area.end_col
+        || area.end_row >= EXCEL_MAX_ROWS
+        || area.end_col >= EXCEL_MAX_COLUMNS
+    {
+        return Err(invalid("Print area bounds exceed the worksheet grid"));
+    }
+    Ok(())
+}
+
+fn bounds_to_a1(start_row: u32, start_col: u32, end_row: u32, end_col: u32) -> String {
+    let start = format!("{}{}", column_name(start_col), start_row + 1);
+    let end = format!("{}{}", column_name(end_col), end_row + 1);
+    if start == end {
+        start
+    } else {
+        format!("{start}:{end}")
+    }
+}
+
+fn column_name(mut column: u32) -> String {
+    let mut name = String::new();
+    loop {
+        name.insert(0, (b'A' + (column % 26) as u8) as char);
+        if column < 26 {
+            break;
+        }
+        column = column / 26 - 1;
+    }
+    name
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frozen_location_shapes_follow_pane_boundaries() {
+        assert_eq!(
+            frozen_location_address(&FrozenPanes { rows: 2, cols: 3 }).unwrap(),
+            Some("A1:C2".to_string())
+        );
+        assert_eq!(
+            frozen_location_address(&FrozenPanes { rows: 2, cols: 0 }).unwrap(),
+            Some("1:2".to_string())
+        );
+        assert_eq!(
+            frozen_location_address(&FrozenPanes { rows: 0, cols: 3 }).unwrap(),
+            Some("A:C".to_string())
+        );
+        assert_eq!(
+            frozen_location_address(&FrozenPanes { rows: 0, cols: 0 }).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn freeze_at_single_cell_uses_the_split_point() {
+        let (workbook, _) = Workbook::blank().unwrap();
+        let sheet = workbook.sheet_by_name("Sheet1").unwrap();
+
+        let b3 = parse_range_address(&sheet, "B3").unwrap();
+        assert_eq!(freeze_counts(&b3, "B3").unwrap(), (2, 1));
+        let a1 = parse_range_address(&sheet, "A1").unwrap();
+        assert_eq!(freeze_counts(&a1, "A1").unwrap(), (0, 0));
+        let d1 = parse_range_address(&sheet, "D1").unwrap();
+        assert_eq!(freeze_counts(&d1, "D1").unwrap(), (0, 3));
+        let a5 = parse_range_address(&sheet, "A5").unwrap();
+        assert_eq!(freeze_counts(&a5, "A5").unwrap(), (4, 0));
+    }
+
+    #[test]
+    fn paper_tokens_cover_the_persisted_standard_ids() {
+        assert_eq!(paper_type(1).unwrap(), "Letter");
+        assert_eq!(paper_type(9).unwrap(), "A4");
+        assert_eq!(paper_type(41).unwrap(), "FanfoldLegalGerman");
+        assert_eq!(paper_code("A4").unwrap(), 9);
+        assert!(paper_code("EnvelopePersonal").is_err());
+    }
+
+    #[test]
+    fn title_and_print_area_addresses_are_canonical() {
+        assert_eq!(print_title_rows_address((0, 2)).unwrap(), "1:3".to_string());
+        assert_eq!(
+            print_title_columns_address((0, 27)).unwrap(),
+            "A:AB".to_string()
+        );
+        assert_eq!(
+            print_area_address(&PrintRange {
+                start_row: 1,
+                start_col: 2,
+                end_row: 3,
+                end_col: 4,
+            })
+            .unwrap(),
+            "C2:E4".to_string()
+        );
+    }
+}

--- a/compute/officejs/src/sort_filter.js
+++ b/compute/officejs/src/sort_filter.js
@@ -1,0 +1,246 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var ClientObject = global.OfficeExtension.ClientObject;
+
+  function richError(code, message) {
+    return new global.OfficeExtension.Error({
+      code: code,
+      message: message,
+    });
+  }
+
+  function propertyNotLoaded(name) {
+    var error = new global.OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function assertSameContext(object, context, message) {
+    if (object && object.context !== context) {
+      throw richError(
+        "InvalidRequestContext",
+        message || "The object belongs to a different request context."
+      );
+    }
+  }
+
+  function RangeSort(context, range) {
+    ClientObject.call(this, context);
+    this._range = range;
+  }
+  RangeSort.prototype = Object.create(ClientObject.prototype);
+  RangeSort.prototype.constructor = RangeSort;
+
+  RangeSort.prototype.apply = function (
+    fields,
+    matchCase,
+    hasHeaders,
+    orientation,
+    method
+  ) {
+    if (!Array.isArray(fields)) {
+      throw richError(
+        "InvalidArgument",
+        "Range.sort.apply requires an array of SortField objects."
+      );
+    }
+    if (matchCase !== undefined && typeof matchCase !== "boolean") {
+      throw richError("InvalidArgument", "Range.sort.apply matchCase must be a boolean.");
+    }
+    if (hasHeaders !== undefined && typeof hasHeaders !== "boolean") {
+      throw richError("InvalidArgument", "Range.sort.apply hasHeaders must be a boolean.");
+    }
+    if (orientation !== undefined && typeof orientation !== "string") {
+      throw richError("InvalidArgument", "Range.sort.apply orientation must be a string.");
+    }
+    if (method !== undefined && typeof method !== "string") {
+      throw richError("InvalidArgument", "Range.sort.apply method must be a string.");
+    }
+    var op = {
+      op: "rangeSort",
+      rangeId: this._range._id,
+      fields: fields,
+    };
+    if (matchCase !== undefined) op.matchCase = matchCase;
+    if (hasHeaders !== undefined) op.hasHeaders = hasHeaders;
+    if (orientation !== undefined) op.orientation = orientation;
+    if (method !== undefined) op.method = method;
+    this.context._queue.push(op);
+  };
+
+  RangeSort.prototype.toJSON = function () {
+    return {};
+  };
+
+  function addScalarProperty(object, name) {
+    Object.defineProperty(object, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+    });
+  }
+
+  function AutoFilter(context, worksheet) {
+    ClientObject.call(this, context);
+    this._worksheet = worksheet;
+    this._scalarProperties = ["criteria", "enabled", "isDataFiltered"];
+    this._navigationProperties = [];
+  }
+  AutoFilter.prototype = Object.create(ClientObject.prototype);
+  AutoFilter.prototype.constructor = AutoFilter;
+
+  ["criteria", "enabled", "isDataFiltered"].forEach(function (name) {
+    addScalarProperty(AutoFilter.prototype, name);
+  });
+
+  AutoFilter.prototype.apply = function (range, columnIndex, criteria) {
+    var op = {
+      op: "autoFilterApply",
+      id: this._id,
+      worksheetId: this._worksheet._id,
+    };
+    if (range instanceof Excel.Range) {
+      assertSameContext(range, this.context);
+      op.rangeId = range._id;
+    } else if (typeof range === "string") {
+      op.address = range;
+    } else {
+      throw richError(
+        "InvalidArgument",
+        "AutoFilter.apply requires a Range or range address string."
+      );
+    }
+    if (columnIndex !== undefined) {
+      if (
+        typeof columnIndex !== "number" ||
+        !Number.isFinite(columnIndex) ||
+        Math.floor(columnIndex) !== columnIndex
+      ) {
+        throw richError(
+          "InvalidArgument",
+          "AutoFilter.apply columnIndex must be a finite integer."
+        );
+      }
+      op.columnIndex = columnIndex;
+    }
+    if (criteria !== undefined) {
+      // `criteria` is an optional object in the Office.js contract.  Keeping
+      // null distinct from omission prevents a supplied null from silently
+      // becoming an unfiltered apply at the Rust/serde boundary.
+      if (criteria === null || typeof criteria !== "object" || Array.isArray(criteria)) {
+        throw richError(
+          "InvalidArgument",
+          "AutoFilter.apply criteria must be a FilterCriteria object."
+        );
+      }
+      op.criteria = criteria;
+    }
+    this.context._queue.push(op);
+  };
+
+  AutoFilter.prototype.clearColumnCriteria = function (columnIndex) {
+    this.context._queue.push({
+      op: "autoFilterClearColumnCriteria",
+      id: this._id,
+      columnIndex: columnIndex,
+    });
+  };
+
+  AutoFilter.prototype.clearCriteria = function () {
+    this.context._queue.push({
+      op: "autoFilterClearCriteria",
+      id: this._id,
+    });
+  };
+
+  function autoFilterRange(autoFilter, nullObject) {
+    var range = new Excel.Range(autoFilter.context, autoFilter._worksheet, null);
+    // Range is defined in bootstrap.js.  The null-object scalar is attached
+    // here so this module remains a separately loaded Office.js surface.
+    if (range._scalarProperties.indexOf("isNullObject") < 0) {
+      range._scalarProperties.push("isNullObject");
+    }
+    range._isNullObject = false;
+    Object.defineProperty(range, "isNullObject", {
+      get: function () {
+        if (!this._loaded.isNullObject) throw propertyNotLoaded("isNullObject");
+        return this._isNullObject;
+      },
+    });
+    autoFilter.context._queue.push({
+      op: "autoFilterGetRange",
+      id: range._id,
+      autoFilterId: autoFilter._id,
+      worksheetId: autoFilter._worksheet._id,
+      nullObject: nullObject === true,
+    });
+    return range;
+  }
+
+  AutoFilter.prototype.getRange = function () {
+    return autoFilterRange(this, false);
+  };
+
+  AutoFilter.prototype.getRangeOrNullObject = function () {
+    return autoFilterRange(this, true);
+  };
+
+  AutoFilter.prototype.reapply = function () {
+    this.context._queue.push({
+      op: "autoFilterReapply",
+      id: this._id,
+    });
+  };
+
+  AutoFilter.prototype.remove = function () {
+    this.context._queue.push({
+      op: "autoFilterRemove",
+      id: this._id,
+    });
+  };
+
+  AutoFilter.prototype.toJSON = function () {
+    var data = {};
+    if (this._loaded.criteria) data.criteria = this._criteria;
+    if (this._loaded.enabled) data.enabled = this._enabled;
+    if (this._loaded.isDataFiltered) data.isDataFiltered = this._isDataFiltered;
+    return data;
+  };
+
+  Object.defineProperty(Excel.Range.prototype, "sort", {
+    get: function () {
+      if (!this._sort) this._sort = new RangeSort(this.context, this);
+      return this._sort;
+    },
+  });
+
+  Object.defineProperty(Excel.Worksheet.prototype, "autoFilter", {
+    get: function () {
+      if (!this._autoFilter) {
+        this._autoFilter = new AutoFilter(this.context, this);
+        // Worksheet.autoFilter is a navigational object.  Bind it eagerly so
+        // loading enabled/criteria before the first apply resolves against
+        // the correct worksheet (including the disabled/no-filter state).
+        this.context._queue.push({
+          op: "getAutoFilter",
+          id: this._autoFilter._id,
+          worksheetId: this._id,
+        });
+      }
+      return this._autoFilter;
+    },
+  });
+
+  Excel.RangeSort = RangeSort;
+  Excel.AutoFilter = AutoFilter;
+})(globalThis);

--- a/compute/officejs/src/sort_filter.rs
+++ b/compute/officejs/src/sort_filter.rs
@@ -1,0 +1,1342 @@
+//! Office.js range sorting and worksheet AutoFilter integration.
+//!
+//! The Office.js bootstrap intentionally keeps request objects thin.  This
+//! module is the typed boundary behind those objects: it parses the public
+//! Office.js descriptors, delegates sorting/filtering to the production
+//! `compute-api` facades, and converts the engine's durable filter state back
+//! to Office.js-shaped values.
+
+use std::collections::{BTreeMap, HashMap};
+use std::fmt;
+
+use compute_api::{CellRange, ComputeApiError, Sheet};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use value_types::Color;
+
+/// Error returned by the Office.js sort/filter boundary.
+///
+/// `Host` maps this directly to a Rich API batch error.  Keeping the Office
+/// error code here prevents unsupported descriptors from becoming silent
+/// no-ops at the JS boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SortFilterError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+impl SortFilterError {
+    fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            code: "InvalidArgument",
+            message: message.into(),
+        }
+    }
+
+    fn unsupported(message: impl Into<String>) -> Self {
+        Self {
+            code: "UnsupportedOperation",
+            message: message.into(),
+        }
+    }
+
+    fn item_not_found(message: impl Into<String>) -> Self {
+        Self {
+            code: "ItemNotFound",
+            message: message.into(),
+        }
+    }
+
+    fn general(message: impl Into<String>) -> Self {
+        Self {
+            code: "GeneralException",
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for SortFilterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for SortFilterError {}
+
+impl From<ComputeApiError> for SortFilterError {
+    fn from(error: ComputeApiError) -> Self {
+        match error {
+            ComputeApiError::InvalidAddress { .. }
+            | ComputeApiError::InvalidRange { .. }
+            | ComputeApiError::InvalidOperation(_) => Self::invalid(error.to_string()),
+            ComputeApiError::SheetNotFound { .. } => Self::item_not_found(error.to_string()),
+            ComputeApiError::Compute(value_types::ComputeError::SheetNotFound { .. }) => {
+                Self::item_not_found(error.to_string())
+            }
+            ComputeApiError::Compute(value_types::ComputeError::InvalidInput { .. }) => {
+                Self::invalid(error.to_string())
+            }
+            other => Self::general(other.to_string()),
+        }
+    }
+}
+
+/// Inputs to `Range.sort.apply` after the JS request has been decoded.
+#[derive(Debug, Clone)]
+pub(crate) struct RangeSortRequest {
+    pub(crate) fields: Value,
+    pub(crate) match_case: Option<bool>,
+    pub(crate) has_headers: Option<bool>,
+    pub(crate) orientation: Option<String>,
+    pub(crate) method: Option<String>,
+}
+
+/// Inputs to `AutoFilter.apply` after the JS request has been decoded.
+#[derive(Debug, Clone)]
+pub(crate) struct AutoFilterApplyRequest {
+    pub(crate) range: String,
+    pub(crate) column_index: Option<i64>,
+    pub(crate) criteria: Option<Value>,
+}
+
+/// A serializable view of a worksheet AutoFilter.
+///
+/// `range` is an unqualified A1 range (`A1:C6`); the host adds the worksheet
+/// qualifier when it hydrates a returned `Range` object's `address` property.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AutoFilterSnapshot {
+    pub(crate) filter_id: Option<String>,
+    pub(crate) range: Option<String>,
+    pub(crate) criteria: Vec<Value>,
+    pub(crate) enabled: bool,
+    pub(crate) is_data_filtered: bool,
+}
+
+/// A worksheet AutoFilter proxy anchored to the engine's stable filter ID.
+///
+/// The JS object can be created before a filter exists (`Worksheet.autoFilter`
+/// is always an object), so `filter_id` and `range` are optional until the
+/// first `apply`.  `known_criteria` preserves exact Office.js descriptors for
+/// filters created through this request context; imported filters are rebuilt
+/// from the durable typed filter state when possible.
+#[derive(Clone)]
+pub(crate) struct AutoFilterRef {
+    sheet: Sheet,
+    filter_id: Option<String>,
+    range: Option<String>,
+    known_criteria: BTreeMap<u32, Value>,
+}
+
+impl AutoFilterRef {
+    pub(crate) fn new(sheet: Sheet) -> Self {
+        Self {
+            sheet,
+            filter_id: None,
+            range: None,
+            known_criteria: BTreeMap::new(),
+        }
+    }
+
+    /// Apply or create a worksheet AutoFilter and optionally set one column's
+    /// criteria.  The range and column index are validated before any engine
+    /// mutation occurs, so an invalid descriptor cannot partially mutate the
+    /// workbook.
+    pub(crate) fn apply(&mut self, request: AutoFilterApplyRequest) -> Result<(), SortFilterError> {
+        let bounds = resolve_range(&request.range)?;
+        let (start_row, start_col, end_row, end_col) = bounds;
+        let width = end_col
+            .checked_sub(start_col)
+            .and_then(|span| span.checked_add(1))
+            .ok_or_else(|| SortFilterError::invalid("AutoFilter range has invalid columns"))?;
+
+        let relative_column = match request.column_index {
+            Some(index) => {
+                if index < 0 {
+                    return Err(SortFilterError::invalid(
+                        "AutoFilter columnIndex must be a non-negative integer",
+                    ));
+                }
+                let index = u32::try_from(index).map_err(|_| {
+                    SortFilterError::invalid("AutoFilter columnIndex is outside the worksheet")
+                })?;
+                if index >= width {
+                    return Err(SortFilterError::invalid(format!(
+                        "AutoFilter columnIndex {index} is outside the range's {width} columns"
+                    )));
+                }
+                Some(index)
+            }
+            None => None,
+        };
+
+        let typed_criteria = match request.criteria.as_ref() {
+            Some(criteria) => Some(parse_filter_criteria(criteria)?),
+            None => None,
+        };
+        if relative_column.is_none() && typed_criteria.is_some() {
+            return Err(SortFilterError::invalid(
+                "AutoFilter criteria requires columnIndex",
+            ));
+        }
+
+        // A worksheet has one AutoFilter surface.  Reuse an exact existing
+        // range; when the requested range changes, delete old worksheet-level
+        // AutoFilters while leaving table filters intact.
+        let records = filter_records(&self.sheet)?;
+        let existing = records
+            .iter()
+            .find(|record| record.is_auto_filter() && record.bounds() == Some(bounds))
+            .cloned();
+
+        let filter_id = if let Some(record) = existing.as_ref() {
+            record.id.clone()
+        } else {
+            for record in records.iter().filter(|record| record.is_auto_filter()) {
+                self.sheet
+                    .filters()
+                    .delete(&record.id)
+                    .map_err(SortFilterError::from)?;
+            }
+
+            let result = self
+                .sheet
+                .filters()
+                .create(json!({
+                    "startRow": start_row,
+                    "startCol": start_col,
+                    "endRow": end_row,
+                    "endCol": end_col,
+                    "filterType": "autoFilter",
+                }))
+                .map_err(SortFilterError::from)?;
+            result
+                .data
+                .as_ref()
+                .and_then(|data| data.get("id"))
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| {
+                    SortFilterError::general(
+                        "The compute engine did not return the created AutoFilter ID",
+                    )
+                })?
+        };
+
+        // A proxy can be reused for a different worksheet filter range.  Its
+        // request-context criteria cache is valid only for the filter ID that
+        // populated it; discard it before hydrating the new filter.
+        if self.filter_id.as_deref() != Some(filter_id.as_str()) {
+            self.known_criteria.clear();
+        }
+
+        if let (Some(relative_column), Some(criteria)) = (relative_column, typed_criteria) {
+            let absolute_column = start_col.checked_add(relative_column).ok_or_else(|| {
+                SortFilterError::invalid("AutoFilter columnIndex exceeds the worksheet")
+            })?;
+            let original_criteria = request.criteria.clone().ok_or_else(|| {
+                SortFilterError::general("AutoFilter criteria disappeared while applying")
+            })?;
+            set_column_filter_json(&self.sheet, &filter_id, absolute_column, criteria)?;
+            self.known_criteria
+                .insert(relative_column, original_criteria);
+        }
+
+        self.filter_id = Some(filter_id);
+        self.range = Some(request.range);
+        // Keep the local proxy's range synchronized with the canonical
+        // position even when it was supplied with `$` markers.
+        if let Some(record) = filter_records(&self.sheet)?
+            .into_iter()
+            .find(|record| record.id == self.filter_id.as_deref().unwrap_or_default())
+        {
+            self.range = record.bounds().map(range_address);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn clear_column_criteria(
+        &mut self,
+        column_index: i64,
+    ) -> Result<(), SortFilterError> {
+        let Some(record) = self.resolve_current()? else {
+            return Err(SortFilterError::item_not_found(
+                "The worksheet has no AutoFilter",
+            ));
+        };
+        let bounds = record.bounds().ok_or_else(|| {
+            SortFilterError::general("The AutoFilter range could not be resolved")
+        })?;
+        let relative_column = validate_relative_column(column_index, bounds)?;
+        let absolute_column = bounds.1.checked_add(relative_column).ok_or_else(|| {
+            SortFilterError::invalid("AutoFilter columnIndex exceeds the worksheet")
+        })?;
+        self.sheet
+            .filters()
+            .clear_column_filter(&record.id, absolute_column)
+            .map_err(SortFilterError::from)?;
+        self.known_criteria.remove(&relative_column);
+        self.filter_id = Some(record.id);
+        self.range = Some(range_address(bounds));
+        Ok(())
+    }
+
+    pub(crate) fn clear_criteria(&mut self) -> Result<(), SortFilterError> {
+        let Some(record) = self.resolve_current()? else {
+            self.known_criteria.clear();
+            return Ok(());
+        };
+        self.sheet
+            .filters()
+            .clear_all_column_filters(&record.id)
+            .map_err(SortFilterError::from)?;
+        let filter_id = record.id.clone();
+        let range = record.bounds().map(range_address);
+        self.known_criteria.clear();
+        self.filter_id = Some(filter_id);
+        self.range = range;
+        Ok(())
+    }
+
+    pub(crate) fn reapply(&mut self) -> Result<(), SortFilterError> {
+        let Some(record) = self.resolve_current()? else {
+            return Ok(());
+        };
+        self.sheet
+            .filters()
+            .reapply(&record.id)
+            .map_err(SortFilterError::from)?;
+        let filter_id = record.id.clone();
+        let range = record.bounds().map(range_address);
+        self.filter_id = Some(filter_id);
+        self.range = range;
+        Ok(())
+    }
+
+    pub(crate) fn remove(&mut self) -> Result<(), SortFilterError> {
+        let Some(record) = self.resolve_current()? else {
+            self.filter_id = None;
+            self.range = None;
+            self.known_criteria.clear();
+            return Ok(());
+        };
+        self.sheet
+            .filters()
+            .delete(&record.id)
+            .map_err(SortFilterError::from)?;
+        self.filter_id = None;
+        self.range = None;
+        self.known_criteria.clear();
+        Ok(())
+    }
+
+    /// Return the Office.js state for `criteria`, `enabled`, and
+    /// `isDataFiltered` loads.
+    pub(crate) fn snapshot(&self) -> Result<AutoFilterSnapshot, SortFilterError> {
+        let Some(record) = self.resolve_current()? else {
+            return Ok(AutoFilterSnapshot {
+                filter_id: None,
+                range: None,
+                criteria: Vec::new(),
+                enabled: false,
+                is_data_filtered: false,
+            });
+        };
+        let bounds = record.bounds().ok_or_else(|| {
+            SortFilterError::general("The AutoFilter range could not be resolved")
+        })?;
+        let criteria = criteria_array(&self.sheet, &record, bounds, &self.known_criteria)?;
+        Ok(AutoFilterSnapshot {
+            filter_id: Some(record.id.clone()),
+            range: Some(range_address(bounds)),
+            is_data_filtered: criteria.iter().any(|value| !value.is_null()),
+            enabled: true,
+            criteria,
+        })
+    }
+
+    /// Resolve the current range for `getRange`.
+    pub(crate) fn range_address(&self) -> Result<String, SortFilterError> {
+        let Some(record) = self.resolve_current()? else {
+            return Err(SortFilterError::item_not_found(
+                "The worksheet has no AutoFilter range",
+            ));
+        };
+        let bounds = record.bounds().ok_or_else(|| {
+            SortFilterError::general("The AutoFilter range could not be resolved")
+        })?;
+        Ok(range_address(bounds))
+    }
+
+    fn resolve_current(&self) -> Result<Option<FilterRecord>, SortFilterError> {
+        let records = filter_records(&self.sheet)?;
+        if let Some(id) = self.filter_id.as_deref() {
+            return Ok(records
+                .into_iter()
+                .find(|record| record.is_auto_filter() && record.id == id));
+        }
+        if let Some(range) = self.range.as_deref() {
+            let bounds = resolve_range(range)?;
+            return Ok(records
+                .into_iter()
+                .find(|record| record.is_auto_filter() && record.bounds() == Some(bounds)));
+        }
+        Ok(records.into_iter().find(FilterRecord::is_auto_filter))
+    }
+}
+
+/// Apply `Range.sort.apply` through the production sort mutation.
+pub(crate) fn apply_range_sort(
+    sheet: &Sheet,
+    address: &str,
+    request: RangeSortRequest,
+) -> Result<(), SortFilterError> {
+    let bounds = resolve_range(address)?;
+    let (start_row, start_col, end_row, end_col) = bounds;
+    let match_case = request.match_case.unwrap_or(false);
+    let has_headers = request.has_headers.unwrap_or(false);
+
+    let orientation = request.orientation.as_deref().unwrap_or("Rows");
+    match orientation {
+        "Rows" => {}
+        "Columns" => {
+            return Err(SortFilterError::unsupported(
+                "Range.sort.apply with orientation 'Columns' is not supported by the compute engine",
+            ));
+        }
+        other => {
+            return Err(SortFilterError::invalid(format!(
+                "Unsupported SortOrientation '{other}'"
+            )));
+        }
+    }
+
+    if let Some(method) = request.method.as_deref() {
+        match method {
+            "PinYin" | "StrokeCount" => {
+                return Err(SortFilterError::unsupported(format!(
+                    "Range.sort.apply method '{method}' is not supported by the compute engine"
+                )));
+            }
+            other => {
+                return Err(SortFilterError::invalid(format!(
+                    "Unsupported SortMethod '{other}'"
+                )));
+            }
+        }
+    }
+
+    let fields = request.fields.as_array().ok_or_else(|| {
+        SortFilterError::invalid("Range.sort.apply fields must be an array of SortField objects")
+    })?;
+    if fields.is_empty() {
+        return Err(SortFilterError::invalid(
+            "Range.sort.apply fields must contain at least one SortField",
+        ));
+    }
+    let width = end_col
+        .checked_sub(start_col)
+        .and_then(|span| span.checked_add(1))
+        .ok_or_else(|| SortFilterError::invalid("Range has invalid column bounds"))?;
+
+    let mut criteria = Vec::with_capacity(fields.len());
+    for (field_index, field) in fields.iter().enumerate() {
+        let object = field.as_object().ok_or_else(|| {
+            SortFilterError::invalid(format!(
+                "Range.sort.apply fields[{field_index}] must be a SortField object"
+            ))
+        })?;
+        let key = required_u32(object, "key", &format!("fields[{field_index}]"))?;
+        if key >= width {
+            return Err(SortFilterError::invalid(format!(
+                "Range.sort.apply fields[{field_index}].key {key} is outside the range's {width} columns"
+            )));
+        }
+        let column = start_col.checked_add(key).ok_or_else(|| {
+            SortFilterError::invalid(format!(
+                "Range.sort.apply fields[{field_index}].key exceeds the worksheet"
+            ))
+        })?;
+        let ascending = optional_bool(object, "ascending")?.unwrap_or(true);
+        let sort_on = optional_string(object, "sortOn")?.unwrap_or("Value".to_string());
+        let mode = match sort_on.as_str() {
+            "Value" => {
+                if let Some(data_option) = optional_string(object, "dataOption")? {
+                    match data_option.as_str() {
+                        "Normal" => {}
+                        "TextAsNumber" => {
+                            return Err(SortFilterError::unsupported(
+                                "SortDataOption 'TextAsNumber' is not supported by the compute engine",
+                            ));
+                        }
+                        other => {
+                            return Err(SortFilterError::invalid(format!(
+                                "Unsupported SortDataOption '{other}'"
+                            )));
+                        }
+                    }
+                }
+                json!({"kind":"value"})
+            }
+            "CellColor" | "FontColor" => {
+                let color = required_string(object, "color", &format!("fields[{field_index}]"))?;
+                if !is_engine_color_token(&color) {
+                    return Err(SortFilterError::invalid(format!(
+                        "fields[{field_index}].color must be a valid color string"
+                    )));
+                }
+                if let Some(data_option) = optional_string(object, "dataOption")? {
+                    if data_option == "TextAsNumber" {
+                        return Err(SortFilterError::unsupported(
+                            "SortDataOption 'TextAsNumber' is not supported for color sorting",
+                        ));
+                    }
+                    if data_option != "Normal" {
+                        return Err(SortFilterError::invalid(format!(
+                            "Unsupported SortDataOption '{data_option}'"
+                        )));
+                    }
+                }
+                json!({
+                    "kind": if sort_on == "CellColor" { "cellColor" } else { "fontColor" },
+                    "target": color,
+                    "position": "top",
+                })
+            }
+            "Icon" => {
+                return Err(SortFilterError::unsupported(
+                    "SortOn 'Icon' requires conditional-format icon context and is not supported by the compute engine",
+                ));
+            }
+            other => {
+                return Err(SortFilterError::invalid(format!(
+                    "Unsupported SortOn '{other}'"
+                )));
+            }
+        };
+        if let Some(sub_field) = object.get("subField")
+            && !sub_field.is_null()
+        {
+            return Err(SortFilterError::unsupported(
+                "SortField.subField is not supported by the compute engine",
+            ));
+        }
+        criteria.push(json!({
+            "column": column,
+            "direction": if ascending { "asc" } else { "desc" },
+            "caseSensitive": match_case,
+            "mode": mode,
+        }));
+    }
+
+    let options: compute_api::mutation::BridgeSortOptions = serde_json::from_value(json!({
+        "criteria": criteria,
+        "hasHeaders": has_headers,
+        "visibleRowsOnly": false,
+    }))
+    .map_err(|error| SortFilterError::general(format!("failed to build sort options: {error}")))?;
+    sheet
+        .sort_range(
+            CellRange::Bounds(start_row, start_col, end_row, end_col),
+            options,
+        )
+        .map_err(SortFilterError::from)?;
+    Ok(())
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FilterRecord {
+    id: String,
+    #[serde(rename = "type")]
+    filter_type: String,
+    #[serde(default)]
+    column_filters: HashMap<String, Value>,
+    #[serde(default)]
+    start_row: Option<u32>,
+    #[serde(default)]
+    start_col: Option<u32>,
+    #[serde(default)]
+    end_row: Option<u32>,
+    #[serde(default)]
+    end_col: Option<u32>,
+}
+
+impl FilterRecord {
+    fn is_auto_filter(&self) -> bool {
+        self.filter_type == "autoFilter"
+    }
+
+    fn bounds(&self) -> Option<(u32, u32, u32, u32)> {
+        let bounds = (
+            self.start_row?,
+            self.start_col?,
+            self.end_row?,
+            self.end_col?,
+        );
+        (bounds.0 <= bounds.2 && bounds.1 <= bounds.3).then_some(bounds)
+    }
+}
+
+fn filter_records(sheet: &Sheet) -> Result<Vec<FilterRecord>, SortFilterError> {
+    let states = sheet.filters().get_all().map_err(SortFilterError::from)?;
+    let value = serde_json::to_value(states).map_err(|error| {
+        SortFilterError::general(format!("failed to encode AutoFilter state: {error}"))
+    })?;
+    serde_json::from_value(value).map_err(|error| {
+        SortFilterError::general(format!("failed to decode AutoFilter state: {error}"))
+    })
+}
+
+fn resolve_range(address: &str) -> Result<(u32, u32, u32, u32), SortFilterError> {
+    let bounds = CellRange::from(address)
+        .resolve()
+        .map_err(SortFilterError::from)?;
+    if bounds.0 > bounds.2 || bounds.1 > bounds.3 {
+        return Err(SortFilterError::invalid(format!(
+            "Range '{address}' has its start after its end"
+        )));
+    }
+    Ok(bounds)
+}
+
+fn range_address((start_row, start_col, end_row, end_col): (u32, u32, u32, u32)) -> String {
+    let start = format!("{}{}", column_name(start_col), start_row + 1);
+    let end = format!("{}{}", column_name(end_col), end_row + 1);
+    if start == end {
+        start
+    } else {
+        format!("{start}:{end}")
+    }
+}
+
+fn column_name(mut column: u32) -> String {
+    let mut reversed = Vec::new();
+    loop {
+        reversed.push((b'A' + (column % 26) as u8) as char);
+        column /= 26;
+        if column == 0 {
+            break;
+        }
+        column -= 1;
+    }
+    reversed.into_iter().rev().collect()
+}
+
+fn required_u32(
+    object: &Map<String, Value>,
+    name: &str,
+    location: &str,
+) -> Result<u32, SortFilterError> {
+    let value = object
+        .get(name)
+        .ok_or_else(|| SortFilterError::invalid(format!("{location}.{name} is required")))?;
+    value
+        .as_u64()
+        .and_then(|value| u32::try_from(value).ok())
+        .ok_or_else(|| {
+            SortFilterError::invalid(format!("{location}.{name} must be a non-negative integer"))
+        })
+}
+
+fn required_string(
+    object: &Map<String, Value>,
+    name: &str,
+    location: &str,
+) -> Result<String, SortFilterError> {
+    let value = object
+        .get(name)
+        .ok_or_else(|| SortFilterError::invalid(format!("{location}.{name} is required")))?;
+    let string = value
+        .as_str()
+        .ok_or_else(|| SortFilterError::invalid(format!("{location}.{name} must be a string")))?;
+    if string.is_empty() {
+        return Err(SortFilterError::invalid(format!(
+            "{location}.{name} must not be empty"
+        )));
+    }
+    Ok(string.to_string())
+}
+
+fn optional_string(
+    object: &Map<String, Value>,
+    name: &str,
+) -> Result<Option<String>, SortFilterError> {
+    match object.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value
+            .as_str()
+            .map(ToOwned::to_owned)
+            .map(Some)
+            .ok_or_else(|| SortFilterError::invalid(format!("{name} must be a string"))),
+    }
+}
+
+fn optional_bool(object: &Map<String, Value>, name: &str) -> Result<Option<bool>, SortFilterError> {
+    match object.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value
+            .as_bool()
+            .map(Some)
+            .ok_or_else(|| SortFilterError::invalid(format!("{name} must be a boolean"))),
+    }
+}
+
+fn is_engine_color_token(color: &str) -> bool {
+    Color::from_hex(color).is_ok()
+        || color.starts_with("theme:")
+        || color.starts_with("rgb(")
+        || color.starts_with("rgba(")
+}
+
+fn validate_relative_column(
+    column_index: i64,
+    bounds: (u32, u32, u32, u32),
+) -> Result<u32, SortFilterError> {
+    if column_index < 0 {
+        return Err(SortFilterError::invalid(
+            "AutoFilter columnIndex must be a non-negative integer",
+        ));
+    }
+    let index = u32::try_from(column_index)
+        .map_err(|_| SortFilterError::invalid("AutoFilter columnIndex is outside the worksheet"))?;
+    let width = bounds.3 - bounds.1 + 1;
+    if index >= width {
+        return Err(SortFilterError::invalid(format!(
+            "AutoFilter columnIndex {index} is outside the range's {width} columns"
+        )));
+    }
+    Ok(index)
+}
+
+fn set_column_filter_json(
+    sheet: &Sheet,
+    filter_id: &str,
+    absolute_column: u32,
+    criteria: Value,
+) -> Result<(), SortFilterError> {
+    // The target type is inferred from SheetFilters::set_column_filter's
+    // typed argument.  This keeps officejs independent from the domain-types
+    // crate while still crossing the production typed API.
+    let typed = serde_json::from_value(criteria).map_err(|error| {
+        SortFilterError::general(format!("failed to build typed filter criteria: {error}"))
+    })?;
+    sheet
+        .filters()
+        .set_column_filter(filter_id, absolute_column, typed)
+        .map_err(SortFilterError::from)?;
+    Ok(())
+}
+
+fn parse_filter_criteria(criteria: &Value) -> Result<Value, SortFilterError> {
+    let object = criteria.as_object().ok_or_else(|| {
+        SortFilterError::invalid("AutoFilter criteria must be a FilterCriteria object")
+    })?;
+    if let Some(sub_field) = object.get("subField")
+        && !sub_field.is_null()
+    {
+        return Err(SortFilterError::unsupported(
+            "FilterCriteria.subField is not supported by the compute engine",
+        ));
+    }
+    let filter_on = object
+        .get("filterOn")
+        .and_then(Value::as_str)
+        .ok_or_else(|| SortFilterError::invalid("FilterCriteria.filterOn is required"))?;
+
+    match filter_on {
+        "Values" => {
+            let values = object
+                .get("values")
+                .and_then(Value::as_array)
+                .ok_or_else(|| SortFilterError::invalid("Values filtering requires values[]"))?;
+            for (index, value) in values.iter().enumerate() {
+                match value {
+                    Value::String(_) | Value::Number(_) | Value::Bool(_) => {}
+                    Value::Object(_) => {
+                        return Err(SortFilterError::unsupported(format!(
+                            "Values filter value at index {index} is a FilterDatetime/rich value, which the compute engine cannot evaluate"
+                        )));
+                    }
+                    Value::Null | Value::Array(_) => {
+                        return Err(SortFilterError::invalid(format!(
+                            "Values filter value at index {index} must be a scalar"
+                        )));
+                    }
+                }
+            }
+            Ok(json!({
+                "type": "values",
+                "values": values,
+                "includeBlanks": false,
+            }))
+        }
+        "Custom" => parse_custom_filter(object),
+        "TopItems" | "BottomItems" | "TopPercent" | "BottomPercent" => {
+            let count = parse_count(object.get("criterion1"), "criterion1")?;
+            if filter_on.ends_with("Items") && count.fract() != 0.0 {
+                return Err(SortFilterError::invalid(
+                    "Top/bottom item count must be an integer",
+                ));
+            }
+            if filter_on.ends_with("Percent") && count > 100.0 {
+                return Err(SortFilterError::invalid(
+                    "Top/bottom percent must be between 0 and 100",
+                ));
+            }
+            let direction = if filter_on.starts_with("Top") {
+                "top"
+            } else {
+                "bottom"
+            };
+            let by = if filter_on.ends_with("Percent") {
+                "percent"
+            } else {
+                "items"
+            };
+            Ok(json!({
+                "type": "topBottom",
+                "direction": direction,
+                "count": count,
+                "by": by,
+            }))
+        }
+        "Dynamic" => {
+            let dynamic = object
+                .get("dynamicCriteria")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    SortFilterError::invalid("Dynamic filtering requires dynamicCriteria")
+                })?;
+            let rule = dynamic_rule(dynamic)?;
+            Ok(json!({"type":"dynamic", "rule":rule}))
+        }
+        "CellColor" | "FontColor" => {
+            let color = object
+                .get("color")
+                .and_then(Value::as_str)
+                .filter(|color| !color.is_empty())
+                .ok_or_else(|| SortFilterError::invalid("Color filtering requires color"))?;
+            if Color::from_hex(color).is_err() {
+                return Err(SortFilterError::invalid(
+                    "Color filtering requires a hexadecimal color string",
+                ));
+            }
+            Ok(json!({
+                "type": "color",
+                "color": color,
+                "byFont": filter_on == "FontColor",
+            }))
+        }
+        "Icon" => Err(SortFilterError::unsupported(
+            "FilterOn 'Icon' requires conditional-format icon context and is not supported by the compute engine",
+        )),
+        other => Err(SortFilterError::invalid(format!(
+            "Unsupported FilterOn '{other}'"
+        ))),
+    }
+}
+
+fn parse_custom_filter(object: &Map<String, Value>) -> Result<Value, SortFilterError> {
+    let criterion1 = object
+        .get("criterion1")
+        .and_then(Value::as_str)
+        .ok_or_else(|| SortFilterError::invalid("Custom filtering requires criterion1"))?;
+    let criterion2 = match object.get("criterion2") {
+        None | Some(Value::Null) => None,
+        Some(value) => Some(value.as_str().ok_or_else(|| {
+            SortFilterError::invalid("Custom filtering criterion2 must be a string")
+        })?),
+    };
+    let logic = match object.get("operator") {
+        None | Some(Value::Null) => "and",
+        Some(Value::String(value)) if value == "And" => "and",
+        Some(Value::String(value)) if value == "Or" => "or",
+        Some(Value::String(value)) => {
+            return Err(SortFilterError::invalid(format!(
+                "Unsupported FilterOperator '{value}'"
+            )));
+        }
+        Some(_) => {
+            return Err(SortFilterError::invalid(
+                "FilterCriteria.operator must be 'And' or 'Or'",
+            ));
+        }
+    };
+    let first = parse_condition(criterion1)?;
+    let second = criterion2.map(parse_condition).transpose()?;
+
+    // Above/BelowAverage have dedicated dynamic filter semantics and cannot
+    // be represented as custom criteria; reject them explicitly if a caller
+    // attempts to smuggle them through a string descriptor.
+    let mut conditions = vec![first];
+    if let Some(second) = second {
+        conditions.push(second);
+    }
+    Ok(json!({
+        "type": "condition",
+        "conditions": conditions,
+        "logic": logic,
+    }))
+}
+
+fn parse_condition(raw: &str) -> Result<Value, SortFilterError> {
+    let (operator, operand) = if let Some(rest) = raw.strip_prefix(">=") {
+        ("greaterThanOrEqual", rest)
+    } else if let Some(rest) = raw.strip_prefix("<=") {
+        ("lessThanOrEqual", rest)
+    } else if let Some(rest) = raw.strip_prefix("<>") {
+        ("notEquals", rest)
+    } else if let Some(rest) = raw.strip_prefix('>') {
+        ("greaterThan", rest)
+    } else if let Some(rest) = raw.strip_prefix('<') {
+        ("lessThan", rest)
+    } else if let Some(rest) = raw.strip_prefix('=') {
+        ("equals", rest)
+    } else {
+        ("equals", raw)
+    };
+
+    let (operator, operand) = wildcard_condition(operator, operand)?;
+    if operand.is_empty() {
+        return match operator {
+            "equals" => Ok(json!({"operator": "isBlank"})),
+            "notEquals" => Ok(json!({"operator": "isNotBlank"})),
+            other => Err(SortFilterError::invalid(format!(
+                "Custom filter operator '{other}' requires a criterion value"
+            ))),
+        };
+    }
+    Ok(json!({
+        "operator": operator,
+        "value": parse_operand(operand),
+    }))
+}
+
+fn wildcard_condition<'a>(
+    operator: &'static str,
+    operand: &'a str,
+) -> Result<(&'static str, &'a str), SortFilterError> {
+    let has_wildcard = operand.contains('*') || operand.contains('?');
+    if !has_wildcard {
+        return Ok((operator, operand));
+    }
+    if operand.contains('?') {
+        return Err(SortFilterError::unsupported(
+            "Custom filter wildcard '?' is not supported by the compute engine",
+        ));
+    }
+    if operator != "equals" && operator != "notEquals" {
+        return Err(SortFilterError::unsupported(
+            "Custom filter wildcards are supported only with equals/notEquals",
+        ));
+    }
+    let leading = operand.starts_with('*');
+    let trailing = operand.ends_with('*');
+    let core = match (leading, trailing) {
+        (true, true) => &operand[1..operand.len() - 1],
+        (true, false) => &operand[1..],
+        (false, true) => &operand[..operand.len() - 1],
+        (false, false) => operand,
+    };
+    if core.contains('*') || core.contains('~') {
+        return Err(SortFilterError::unsupported(
+            "Custom filter wildcard patterns with interior escapes are not supported by the compute engine",
+        ));
+    }
+    if operator == "notEquals" && (leading != trailing) {
+        return Err(SortFilterError::unsupported(
+            "Custom filter exclusion wildcards are supported only for contains/notContains patterns",
+        ));
+    }
+    let mapped = match (operator, leading, trailing) {
+        ("equals", true, true) => "contains",
+        ("notEquals", true, true) => "notContains",
+        ("equals", true, false) => "endsWith",
+        ("equals", false, true) => "beginsWith",
+        _ => operator,
+    };
+    Ok((mapped, core))
+}
+
+fn parse_operand(operand: &str) -> Value {
+    if operand.eq_ignore_ascii_case("TRUE") {
+        return Value::Bool(true);
+    }
+    if operand.eq_ignore_ascii_case("FALSE") {
+        return Value::Bool(false);
+    }
+    if let Ok(number) = operand.parse::<f64>()
+        && number.is_finite()
+    {
+        return json!(number);
+    }
+    Value::String(operand.to_string())
+}
+
+fn parse_count(value: Option<&Value>, name: &str) -> Result<f64, SortFilterError> {
+    let value = value.ok_or_else(|| SortFilterError::invalid(format!("{name} is required")))?;
+    let number = match value {
+        Value::Number(number) => number.as_f64(),
+        Value::String(string) => string.parse::<f64>().ok(),
+        _ => None,
+    }
+    .filter(|number| number.is_finite() && *number >= 0.0)
+    .ok_or_else(|| {
+        SortFilterError::invalid(format!("{name} must be a finite non-negative number"))
+    })?;
+    Ok(number)
+}
+
+fn dynamic_rule(value: &str) -> Result<&'static str, SortFilterError> {
+    let rule = match value {
+        "AboveAverage" => "aboveAverage",
+        "BelowAverage" => "belowAverage",
+        "Today" => "today",
+        "Yesterday" => "yesterday",
+        "Tomorrow" => "tomorrow",
+        "ThisWeek" => "thisWeek",
+        "LastWeek" => "lastWeek",
+        "NextWeek" => "nextWeek",
+        "ThisMonth" => "thisMonth",
+        "LastMonth" => "lastMonth",
+        "NextMonth" => "nextMonth",
+        "ThisQuarter" => "thisQuarter",
+        "LastQuarter" => "lastQuarter",
+        "NextQuarter" => "nextQuarter",
+        "ThisYear" => "thisYear",
+        "LastYear" => "lastYear",
+        "NextYear" => "nextYear",
+        other => {
+            return Err(SortFilterError::unsupported(format!(
+                "DynamicFilterCriteria '{other}' is not supported by the compute engine"
+            )));
+        }
+    };
+    Ok(rule)
+}
+
+fn criteria_array(
+    sheet: &Sheet,
+    record: &FilterRecord,
+    bounds: (u32, u32, u32, u32),
+    known: &BTreeMap<u32, Value>,
+) -> Result<Vec<Value>, SortFilterError> {
+    let width = (bounds.3 - bounds.1 + 1) as usize;
+    let mut result = vec![Value::Null; width];
+    let mut resolved_ids: HashMap<String, u32> = HashMap::new();
+
+    // For regular headers, `get_cell_data` exposes the stable CellId used as
+    // the filter map key.  Identity-only blank headers are covered by the
+    // local request-context cache (`known`) when the filter was applied here.
+    for relative in 0..width as u32 {
+        let absolute_col = bounds.1 + relative;
+        if let Some(data) = sheet
+            .get_cell_data((bounds.0, absolute_col))
+            .map_err(SortFilterError::from)?
+            && let Some(cell_id) = data.get("cell_id").and_then(Value::as_str)
+        {
+            resolved_ids.insert(cell_id.to_string(), relative);
+        }
+    }
+
+    if !record.column_filters.is_empty() {
+        for (relative, criterion) in known {
+            if (*relative as usize) < result.len() {
+                result[*relative as usize] = criterion.clone();
+            }
+        }
+    }
+    let unresolved_count = record
+        .column_filters
+        .keys()
+        .filter(|cell_id| !resolved_ids.contains_key(*cell_id))
+        .count();
+    if unresolved_count > 0 && known.len() != record.column_filters.len() {
+        let unresolved = record
+            .column_filters
+            .keys()
+            .find(|cell_id| !resolved_ids.contains_key(*cell_id))
+            .cloned()
+            .unwrap_or_default();
+        return Err(SortFilterError::unsupported(format!(
+            "AutoFilter criterion for column CellId '{unresolved}' could not be resolved"
+        )));
+    }
+    for (cell_id, criterion) in &record.column_filters {
+        if let Some(relative) = resolved_ids.get(cell_id) {
+            // Keep the exact descriptor supplied by this request context
+            // when available (for example `>50`, rather than the typed
+            // engine value's `>50.0`).  Imported criteria are rebuilt from
+            // the durable domain representation below.
+            if !known.contains_key(relative) {
+                result[*relative as usize] = office_criteria_from_domain(criterion)?;
+            }
+        }
+    }
+    Ok(result)
+}
+
+fn office_criteria_from_domain(value: &Value) -> Result<Value, SortFilterError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| SortFilterError::general("stored AutoFilter criterion is not an object"))?;
+    let kind = object
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| SortFilterError::general("stored AutoFilter criterion has no type"))?;
+    match kind {
+        "values" => Ok(json!({
+            "filterOn": "Values",
+            "values": object.get("values").cloned().unwrap_or_else(|| json!([])),
+        })),
+        "condition" => domain_condition_to_office(object),
+        "topBottom" => {
+            let direction = object
+                .get("direction")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    SortFilterError::general("stored top/bottom criterion has no direction")
+                })?;
+            let by = object.get("by").and_then(Value::as_str).ok_or_else(|| {
+                SortFilterError::general("stored top/bottom criterion has no basis")
+            })?;
+            let count = object
+                .get("count")
+                .map(value_to_criterion_text)
+                .unwrap_or_default();
+            let filter_on = match (direction, by) {
+                ("top", "items") => "TopItems",
+                ("bottom", "items") => "BottomItems",
+                ("top", "percent") => "TopPercent",
+                ("bottom", "percent") => "BottomPercent",
+                _ => {
+                    return Err(SortFilterError::unsupported(
+                        "stored top/bottom filter basis is not supported by Office.js AutoFilter",
+                    ));
+                }
+            };
+            Ok(json!({"filterOn":filter_on,"criterion1":count}))
+        }
+        "dynamic" => {
+            let rule = object
+                .get("rule")
+                .and_then(Value::as_str)
+                .ok_or_else(|| SortFilterError::general("stored dynamic criterion has no rule"))?;
+            let office = dynamic_rule_to_office(rule)?;
+            Ok(json!({"filterOn":"Dynamic","dynamicCriteria":office}))
+        }
+        "color" => {
+            let color = object
+                .get("color")
+                .and_then(Value::as_str)
+                .ok_or_else(|| SortFilterError::general("stored color criterion has no color"))?;
+            let by_font = object
+                .get("byFont")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            Ok(json!({
+                "filterOn": if by_font { "FontColor" } else { "CellColor" },
+                "color": color,
+            }))
+        }
+        "icon" => Err(SortFilterError::unsupported(
+            "stored icon filter criteria cannot be evaluated by the compute engine",
+        )),
+        other => Err(SortFilterError::unsupported(format!(
+            "stored AutoFilter criterion type '{other}' is unsupported"
+        ))),
+    }
+}
+
+fn domain_condition_to_office(object: &Map<String, Value>) -> Result<Value, SortFilterError> {
+    let conditions = object
+        .get("conditions")
+        .and_then(Value::as_array)
+        .ok_or_else(|| SortFilterError::general("stored condition criterion has no conditions"))?;
+    if conditions.is_empty() || conditions.len() > 2 {
+        return Err(SortFilterError::unsupported(
+            "stored AutoFilter condition count cannot be represented by Office.js",
+        ));
+    }
+    let logic = match object.get("logic").and_then(Value::as_str) {
+        Some("or") => "Or",
+        _ => "And",
+    };
+    let first = condition_to_office(conditions[0].as_object().ok_or_else(|| {
+        SortFilterError::general("stored AutoFilter condition is not an object")
+    })?)?;
+    let second = if conditions.len() == 2 {
+        Some(condition_to_office(conditions[1].as_object().ok_or_else(
+            || SortFilterError::general("stored AutoFilter condition is not an object"),
+        )?)?)
+    } else {
+        None
+    };
+    let mut result = Map::new();
+    result.insert("filterOn".into(), Value::String("Custom".into()));
+    result.insert("criterion1".into(), Value::String(first));
+    if let Some(second) = second {
+        result.insert("criterion2".into(), Value::String(second));
+        result.insert("operator".into(), Value::String(logic.into()));
+    }
+    Ok(Value::Object(result))
+}
+
+fn condition_to_office(object: &Map<String, Value>) -> Result<String, SortFilterError> {
+    let operator = object
+        .get("operator")
+        .and_then(Value::as_str)
+        .ok_or_else(|| SortFilterError::general("stored AutoFilter condition has no operator"))?;
+    if matches!(operator, "isBlank" | "isNotBlank") {
+        return Ok(if operator == "isBlank" {
+            "=".into()
+        } else {
+            "<>".into()
+        });
+    }
+    let value = object.get("value").cloned().unwrap_or(Value::Null);
+    let text = value_to_criterion_text(&value);
+    let prefix = match operator {
+        "equals" => "=",
+        "notEquals" => "<>",
+        "greaterThan" => ">",
+        "greaterThanOrEqual" => ">=",
+        "lessThan" => "<",
+        "lessThanOrEqual" => "<=",
+        "beginsWith" => "=",
+        "endsWith" => "=",
+        "contains" => "=",
+        "notContains" => "<>",
+        other => {
+            return Err(SortFilterError::unsupported(format!(
+                "stored AutoFilter condition operator '{other}' cannot be represented"
+            )));
+        }
+    };
+    let wildcard = match operator {
+        // Excel's custom criteria use a leading `*` for suffix matches and a
+        // trailing `*` for prefix matches.  Keeping these positions exact is
+        // necessary for criteria read after an imported filter is hydrated.
+        "beginsWith" => format!("{text}*"),
+        "endsWith" => format!("*{text}"),
+        "contains" | "notContains" => format!("*{text}*"),
+        _ => text,
+    };
+    Ok(format!("{prefix}{wildcard}"))
+}
+
+fn value_to_criterion_text(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::String(value) => value.clone(),
+        Value::Bool(value) => {
+            if *value {
+                "TRUE".into()
+            } else {
+                "FALSE".into()
+            }
+        }
+        Value::Number(value) => {
+            let number = value.as_f64().unwrap_or(0.0);
+            if number == 0.0 {
+                "0".into()
+            } else if number.is_finite() && number.fract() == 0.0 && number.abs() < 1e21 {
+                format!("{number:.0}")
+            } else {
+                value.to_string()
+            }
+        }
+        other => other.to_string(),
+    }
+}
+
+fn dynamic_rule_to_office(rule: &str) -> Result<&'static str, SortFilterError> {
+    let office = match rule {
+        "aboveAverage" => "AboveAverage",
+        "belowAverage" => "BelowAverage",
+        "today" => "Today",
+        "yesterday" => "Yesterday",
+        "tomorrow" => "Tomorrow",
+        "thisWeek" => "ThisWeek",
+        "lastWeek" => "LastWeek",
+        "nextWeek" => "NextWeek",
+        "thisMonth" => "ThisMonth",
+        "lastMonth" => "LastMonth",
+        "nextMonth" => "NextMonth",
+        "thisQuarter" => "ThisQuarter",
+        "lastQuarter" => "LastQuarter",
+        "nextQuarter" => "NextQuarter",
+        "thisYear" => "ThisYear",
+        "lastYear" => "LastYear",
+        "nextYear" => "NextYear",
+        other => {
+            return Err(SortFilterError::unsupported(format!(
+                "stored dynamic filter rule '{other}' is unsupported"
+            )));
+        }
+    };
+    Ok(office)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_numeric_custom_threshold_as_number() {
+        let parsed = parse_filter_criteria(&json!({
+            "filterOn": "Custom",
+            "criterion1": ">50"
+        }))
+        .expect("custom criterion");
+        assert_eq!(
+            parsed,
+            json!({
+                "type":"condition",
+                "conditions":[{"operator":"greaterThan","value":50.0}],
+                "logic":"and"
+            })
+        );
+    }
+
+    #[test]
+    fn parses_values_and_custom_two_condition_logic() {
+        assert_eq!(
+            parse_filter_criteria(&json!({
+                "filterOn":"Values",
+                "values":["Open", "Closed"]
+            }))
+            .unwrap(),
+            json!({"type":"values","values":["Open","Closed"],"includeBlanks":false})
+        );
+        assert_eq!(
+            parse_filter_criteria(&json!({
+                "filterOn":"Custom",
+                "criterion1":">=10",
+                "criterion2":"<=20",
+                "operator":"And"
+            }))
+            .unwrap(),
+            json!({
+                "type":"condition",
+                "conditions":[
+                    {"operator":"greaterThanOrEqual","value":10.0},
+                    {"operator":"lessThanOrEqual","value":20.0}
+                ],
+                "logic":"and"
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_icon_and_column_orientation() {
+        let error = parse_filter_criteria(&json!({
+            "filterOn":"Icon",
+            "icon":{"set":"ThreeArrows","index":0}
+        }))
+        .unwrap_err();
+        assert_eq!(error.code, "UnsupportedOperation");
+        assert!(error.message.contains("Icon"));
+    }
+}

--- a/compute/officejs/src/table_collections.js
+++ b/compute/officejs/src/table_collections.js
@@ -1,0 +1,611 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var ClientObject = global.OfficeExtension.ClientObject;
+
+  function propertyNotLoaded(name) {
+    var error = new global.OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function invalidArgument(message) {
+    return new global.OfficeExtension.Error({
+      code: "InvalidArgument",
+      message: message,
+    });
+  }
+
+  function invalidRequestContext() {
+    return new global.OfficeExtension.Error({
+      code: "InvalidRequestContext",
+      message: "The object belongs to a different request context.",
+    });
+  }
+
+  function integerArgument(value, property, allowNull) {
+    if (allowNull && (value === null || value === undefined)) return value;
+    if (typeof value !== "number" || !isFinite(value) || Math.floor(value) !== value) {
+      throw invalidArgument(property + " must be an integer");
+    }
+    return value;
+  }
+
+  function normalizeLoad(props, defaults) {
+    if (props === undefined || props === null) return defaults.slice();
+    if (typeof props === "string") {
+      return props
+        .split(",")
+        .map(function (entry) { return entry.trim(); })
+        .filter(Boolean);
+    }
+    if (Array.isArray(props)) {
+      return props.reduce(function (all, entry) {
+        return all.concat(normalizeLoad(entry, defaults));
+      }, []);
+    }
+    if (typeof props === "object") {
+      var result = props.$all === true ? defaults.slice() : [];
+      if (props.select != null) result = result.concat(normalizeLoad(props.select, []));
+      if (props.expand != null) result = result.concat(normalizeLoad(props.expand, []));
+      Object.keys(props).forEach(function (key) {
+        if (key === "$all" || key === "select" || key === "expand" || key === "top" || key === "skip") return;
+        var value = props[key];
+        if (value === true) result.push(key);
+        else if (value && typeof value === "object") {
+          if (value.$all === true) result.push(key);
+          normalizeLoad(value, []).forEach(function (path) {
+            result.push(key + "/" + path);
+          });
+        }
+      });
+      return result;
+    }
+    return [String(props)];
+  }
+
+  function seedLoaded(object, properties) {
+    if (!properties || typeof properties !== "object") return;
+    Object.keys(properties).forEach(function (name) {
+      object._loaded[name] = true;
+      object[name === "id" ? "_idValue" : "_" + name] = properties[name];
+    });
+  }
+
+  function toJSONScalars(object) {
+    var result = {};
+    (object._scalarProperties || []).forEach(function (name) {
+      if (object._loaded[name]) {
+        result[name] = name === "id" ? object._idValue : object["_" + name];
+      }
+    });
+    return result;
+  }
+
+  function queueRange(object, kind) {
+    var range = new Excel.Range(object.context, object._table._worksheet, null);
+    object.context._queue.push({
+      op: "tableColumnGetRange",
+      id: range._id,
+      columnId: object._id,
+      kind: kind,
+    });
+    return range;
+  }
+
+  function queueRowRange(object) {
+    var range = new Excel.Range(object.context, object._table._worksheet, null);
+    object.context._queue.push({
+      op: "tableRowGetRange",
+      id: range._id,
+      rowId: object._id,
+    });
+    return range;
+  }
+
+  function queueChildBinding(object, table, kind, key, orNullObject, byIndex) {
+    object._table = table;
+    object._tableId = table._id;
+    object._key = key;
+    if (kind === "column") {
+      var columnOperation = {
+        op: "tableColumnGetItem",
+        id: object._id,
+        tableId: table._id,
+        key: key,
+      };
+      if (byIndex === true) columnOperation.byIndex = true;
+      if (orNullObject === true) columnOperation.orNullObject = true;
+      object.context._queue.push(columnOperation);
+    } else {
+      var rowOperation = {
+        op: "tableRowGetItem",
+        id: object._id,
+        tableId: table._id,
+        index: Number(key),
+      };
+      if (orNullObject === true) rowOperation.orNullObject = true;
+      object.context._queue.push(rowOperation);
+    }
+  }
+
+  function cacheKey(key) {
+    return typeof key + ":" + String(key);
+  }
+
+  function childCollection(context, table, kind) {
+    ClientObject.call(this, context);
+    this._table = table;
+    this._tableId = table._id;
+    this._kind = kind;
+    this._scalarProperties = ["items", "count"];
+    this._navigationProperties = ["items"];
+    this._itemCache = Object.create(null);
+
+    // Register the collection's table reference with the host. The shared
+    // collection hook only owns descriptor hydration; it does not carry the
+    // table selector or collection kind, so the host needs this one binding
+    // operation before generic `load` can resolve the collection ID.
+    context._queue.push({
+      op: "tableCollectionGet",
+      id: this._id,
+      tableId: table._id,
+      kind: kind,
+    });
+
+    // The shared runtime hook registers the descriptor factory used when a
+    // collection load returns [{key, properties}]. The factory enters the
+    // same binding path as an explicit lookup so every hydrated child is a
+    // normal request-context object. Rows have only the declared getItemAt
+    // API, so their private helper is used for hydration.
+    var hooks = global.__mogOfficeJs;
+    if (hooks && typeof hooks.configureCollection === "function") {
+      hooks.configureCollection(this, function (key) {
+        return this._kind === "columns"
+          ? this.getItem(key)
+          : this._getItem(Number(key));
+      });
+    } else {
+      // Keep the extension loadable with an older bootstrap. Production uses
+      // the shared hook above; this fallback mirrors its descriptor contract.
+      this._hydrateItems = function (descriptors) {
+        if (!Array.isArray(descriptors)) {
+          throw new global.OfficeExtension.Error({
+            code: "GeneralException",
+            message: "The host returned an invalid collection result.",
+          });
+        }
+        return descriptors.map(function (descriptor, index) {
+          var key = descriptor && descriptor.key !== undefined
+            ? descriptor.key
+            : index;
+          var item = this._kind === "columns"
+            ? this.getItem(key)
+            : this._getItem(Number(key));
+          seedLoaded(item, descriptor && descriptor.properties);
+          return item;
+        }, this);
+      };
+    }
+  }
+  childCollection.prototype = Object.create(ClientObject.prototype);
+  childCollection.prototype.constructor = childCollection;
+
+  childCollection.prototype._newItem = function (key, bind, orNullObject, byIndex) {
+    var item;
+    if (this._kind === "columns") {
+      item = new Excel.TableColumn(this.context, this._table, key, false);
+      if (bind) queueChildBinding(item, this._table, "column", key, orNullObject, byIndex);
+    } else {
+      item = new Excel.TableRow(this.context, this._table, Number(key), false);
+      if (bind) queueChildBinding(item, this._table, "row", Number(key), orNullObject);
+    }
+    return item;
+  };
+
+  childCollection.prototype._getItem = function (key, orNullObject, byIndex) {
+    var normalized = this._kind === "rows" ? Number(key) : key;
+    var lookup = cacheKey(normalized) + (byIndex === true ? ":index" : ":key");
+    var item = this._itemCache[lookup];
+    if (!item) {
+      item = this._newItem(normalized, true, orNullObject, byIndex);
+      this._itemCache[lookup] = item;
+    }
+    return item;
+  };
+
+  Object.defineProperty(childCollection.prototype, "items", {
+    get: function () {
+      if (!this._loaded.items) throw propertyNotLoaded("items");
+      return this._items || [];
+    },
+  });
+
+  Object.defineProperty(childCollection.prototype, "count", {
+    get: function () {
+      if (!this._loaded.count) throw propertyNotLoaded("count");
+      return this._count;
+    },
+  });
+
+  childCollection.prototype.load = function (props) {
+    // Office's generated collection load options name child scalar fields
+    // directly (`columns.load({ select: "name" })`), while the host wire
+    // contract represents the same projection as `items/name`. Preserve
+    // already-qualified paths for callers that use the explicit form.
+    var itemProperties = this._kind === "columns"
+      ? ["id", "index", "name", "values"]
+      : ["index", "values"];
+    var paths = normalizeLoad(props, this._scalarProperties).map(function (path) {
+      if (path === "items" || path === "count" || path.indexOf("items/") === 0) {
+        return path;
+      }
+      return itemProperties.indexOf(path) >= 0 ? "items/" + path : path;
+    });
+    if (paths.length) {
+      this.context._queue.push({
+        op: "load",
+        id: this._id,
+        properties: paths,
+      });
+    }
+    return this;
+  };
+
+  childCollection.prototype.toJSON = function () {
+    if (!this._loaded.items) return {};
+    return {
+      items: this.items.map(function (item) { return item.toJSON(); }),
+    };
+  };
+
+  childCollection.prototype.getCount = function () {
+    var hooks = global.__mogOfficeJs;
+    var result = hooks && typeof hooks.createClientResult === "function"
+      ? hooks.createClientResult(this.context)
+      : new (global.OfficeExtension.ClientResult || ClientResult)(this.context);
+    this.context._queue.push({
+      op: "tableCollectionGetCount",
+      collectionId: this._id,
+      resultId: result._id,
+    });
+    return result;
+  };
+
+  childCollection.prototype._getItemAt = function (index) {
+    return this._getItem(index);
+  };
+
+  function ClientResult(context) {
+    this.context = context;
+    this._id = "result_" + Math.random().toString(36).slice(2);
+    this._loaded = false;
+    this._value = undefined;
+    if (context && context._results) context._results[this._id] = this;
+  }
+  Object.defineProperty(ClientResult.prototype, "value", {
+    get: function () {
+      if (!this._loaded) throw propertyNotLoaded("value");
+      return this._value;
+    },
+  });
+
+  function TableColumnCollection(context, table) {
+    childCollection.call(this, context, table, "columns");
+  }
+  TableColumnCollection.prototype = Object.create(childCollection.prototype);
+  TableColumnCollection.prototype.constructor = TableColumnCollection;
+
+  TableColumnCollection.prototype.getItem = function (key) {
+    if (typeof key !== "string" && typeof key !== "number") {
+      throw invalidArgument("TableColumnCollection.getItem requires a column name or ID");
+    }
+    if (typeof key === "number") {
+      integerArgument(key, "TableColumnCollection.getItem key", false);
+    }
+    return this._getItem(key);
+  };
+
+  TableColumnCollection.prototype.getItemAt = function (index) {
+    integerArgument(index, "TableColumnCollection.getItemAt index", false);
+    return this._getItem(index, false, true);
+  };
+
+  TableColumnCollection.prototype.getItemOrNullObject = function (key) {
+    if (typeof key !== "string" && typeof key !== "number") {
+      throw invalidArgument("TableColumnCollection.getItemOrNullObject requires a column name or ID");
+    }
+    if (typeof key === "number") {
+      integerArgument(key, "TableColumnCollection.getItemOrNullObject key", false);
+    }
+    return this._getItem(key, true);
+  };
+
+  TableColumnCollection.prototype.add = function (index, values, name) {
+    integerArgument(index, "TableColumnCollection.add index", true);
+    var column = new Excel.TableColumn(this.context, this._table, null, false);
+    var operation = {
+      op: "tableColumnAdd",
+      id: column._id,
+      tableId: this._table._id,
+    };
+    if (arguments.length >= 1) operation.index = index;
+    if (arguments.length >= 2) operation.values = values;
+    if (arguments.length >= 3) operation.name = name;
+    this.context._queue.push(operation);
+    return column;
+  };
+
+  function TableColumn(context, table, key, bind) {
+    ClientObject.call(this, context);
+    this._table = table;
+    this._tableId = table._id;
+    this._key = key;
+    this._scalarProperties = ["id", "index", "name", "values"];
+    if (bind) queueChildBinding(this, table, "column", key);
+  }
+  TableColumn.prototype = Object.create(ClientObject.prototype);
+  TableColumn.prototype.constructor = TableColumn;
+
+  Object.defineProperty(TableColumn.prototype, "id", {
+    get: function () {
+      if (!this._loaded.id) throw propertyNotLoaded("id");
+      return this._idValue;
+    },
+  });
+
+  Object.defineProperty(TableColumn.prototype, "index", {
+    get: function () {
+      if (!this._loaded.index) throw propertyNotLoaded("index");
+      return this._index;
+    },
+  });
+
+  ["name", "values"].forEach(function (name) {
+    Object.defineProperty(TableColumn.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        this["_" + name] = value;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: value,
+        });
+      },
+    });
+  });
+
+  TableColumn.prototype.set = function (source, options) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+    var isClientObject = source instanceof ClientObject;
+    if (isClientObject && source.context !== this.context) {
+      throw invalidRequestContext();
+    }
+    if (isClientObject && Object.getPrototypeOf(source) !== Object.getPrototypeOf(this)) {
+      throw invalidArgument("The object passed to set must have the same type.");
+    }
+    if (!isClientObject && (Object.prototype.hasOwnProperty.call(source, "id") ||
+        Object.prototype.hasOwnProperty.call(source, "index")) &&
+        (!options || options.throwOnReadOnly !== false)) {
+      throw invalidArgument("The properties 'id' and 'index' are read-only.");
+    }
+    ["name", "values"].forEach(function (name) {
+      if (isClientObject) {
+        if (source._loaded[name]) this[name] = source[name];
+      } else if (Object.prototype.hasOwnProperty.call(source, name)) {
+        this[name] = source[name];
+      }
+    }, this);
+  };
+
+  TableColumn.prototype.delete = function () {
+    this.context._queue.push({ op: "tableColumnDelete", id: this._id });
+  };
+
+  ["full", "header", "dataBody", "total"].forEach(function (kind) {
+    var method = kind === "full" ? "getRange" :
+      kind === "header" ? "getHeaderRowRange" :
+      kind === "dataBody" ? "getDataBodyRange" : "getTotalRowRange";
+    TableColumn.prototype[method] = function () {
+      return queueRange(this, kind);
+    };
+  });
+
+  TableColumn.prototype.toJSON = function () {
+    return toJSONScalars(this);
+  };
+
+  function TableRowCollection(context, table) {
+    childCollection.call(this, context, table, "rows");
+  }
+  TableRowCollection.prototype = Object.create(childCollection.prototype);
+  TableRowCollection.prototype.constructor = TableRowCollection;
+
+  TableRowCollection.prototype.getItemAt = function (index) {
+    integerArgument(index, "TableRowCollection.getItemAt index", false);
+    return this._getItem(index, false, true);
+  };
+
+  TableRowCollection.prototype.add = function (index, values, alwaysInsert) {
+    integerArgument(index, "TableRowCollection.add index", true);
+    if (alwaysInsert !== undefined && alwaysInsert !== null && typeof alwaysInsert !== "boolean") {
+      throw invalidArgument("TableRowCollection.add alwaysInsert must be a boolean");
+    }
+    var row = new Excel.TableRow(this.context, this._table, null, false);
+    // An explicit insertion index is already the returned row's positional
+    // selector. For append, use a loaded count when available; the host also
+    // hydrates `index` for an unknown append position before later operations.
+    if (alwaysInsert !== false && typeof index === "number" && index >= 0) {
+      row._key = index;
+    } else if (alwaysInsert !== false && this._loaded.count) {
+      row._key = this._count;
+    }
+    var operation = {
+      op: "tableRowAdd",
+      id: row._id,
+      tableId: this._table._id,
+    };
+    if (arguments.length >= 1) operation.index = index;
+    if (arguments.length >= 2) operation.values = values;
+    if (arguments.length >= 3) operation.alwaysInsert = alwaysInsert;
+    this.context._queue.push(operation);
+    return row;
+  };
+
+  TableRowCollection.prototype.deleteRows = function (rows) {
+    if (!Array.isArray(rows)) throw invalidArgument("deleteRows requires an array");
+    var encoded = rows.map(function (row) {
+      if (row instanceof Excel.TableRow) {
+        if (row.context !== this.context) throw invalidArgument("Object belongs to a different request context");
+        var key = row._key;
+        if ((key === null || key === undefined) && row._loaded.index) key = row._index;
+        integerArgument(key, "TableRowCollection.deleteRows row", false);
+        return key;
+      }
+      integerArgument(row, "TableRowCollection.deleteRows row", false);
+      return row;
+    }, this);
+    this.context._queue.push({
+      op: "tableRowDeleteMany",
+      tableId: this._table._id,
+      rows: encoded,
+    });
+  };
+
+  TableRowCollection.prototype.deleteRowsAt = function (index, count) {
+    integerArgument(index, "TableRowCollection.deleteRowsAt index", false);
+    if (count !== undefined && count !== null) {
+      integerArgument(count, "TableRowCollection.deleteRowsAt count", false);
+    }
+    this.context._queue.push({
+      op: "tableRowDeleteAt",
+      tableId: this._table._id,
+      index: index,
+      count: count === undefined || count === null ? 1 : count,
+    });
+  };
+
+  function TableRow(context, table, index, bind) {
+    ClientObject.call(this, context);
+    this._table = table;
+    this._tableId = table._id;
+    this._key = index;
+    this._scalarProperties = ["index", "values"];
+    if (bind) queueChildBinding(this, table, "row", index);
+  }
+  TableRow.prototype = Object.create(ClientObject.prototype);
+  TableRow.prototype.constructor = TableRow;
+
+  Object.defineProperty(TableRow.prototype, "index", {
+    get: function () {
+      if (!this._loaded.index) throw propertyNotLoaded("index");
+      return this._index;
+    },
+  });
+
+  ["values"].forEach(function (name) {
+    Object.defineProperty(TableRow.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        this["_" + name] = value;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: value,
+        });
+      },
+    });
+  });
+
+  TableRow.prototype.set = function (source, options) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+    var isClientObject = source instanceof ClientObject;
+    if (isClientObject && source.context !== this.context) {
+      throw invalidRequestContext();
+    }
+    if (isClientObject && Object.getPrototypeOf(source) !== Object.getPrototypeOf(this)) {
+      throw invalidArgument("The object passed to set must have the same type.");
+    }
+    if (!isClientObject && Object.prototype.hasOwnProperty.call(source, "index") &&
+        (!options || options.throwOnReadOnly !== false)) {
+      throw invalidArgument("The property 'index' is read-only.");
+    }
+    if (isClientObject) {
+      if (source._loaded.values) this.values = source.values;
+    } else if (Object.prototype.hasOwnProperty.call(source, "values")) {
+      this.values = source.values;
+    }
+  };
+
+  TableRow.prototype.delete = function () {
+    this.context._queue.push({ op: "tableRowDelete", id: this._id });
+  };
+
+  TableRow.prototype.getRange = function () {
+    return queueRowRange(this);
+  };
+
+  TableRow.prototype.toJSON = function () {
+    return toJSONScalars(this);
+  };
+
+  function installTableNavigation() {
+    if (!Excel.Table) return;
+    Excel.Table.prototype._navigationProperties = ["rows", "columns"];
+    Object.defineProperty(Excel.Table.prototype, "columns", {
+      configurable: true,
+      get: function () {
+        if (!this._columns) this._columns = new TableColumnCollection(this.context, this);
+        return this._columns;
+      },
+    });
+    Object.defineProperty(Excel.Table.prototype, "rows", {
+      configurable: true,
+      get: function () {
+        if (!this._rows) this._rows = new TableRowCollection(this.context, this);
+        return this._rows;
+      },
+    });
+
+    var oldToJSON = Excel.Table.prototype.toJSON;
+    Excel.Table.prototype.toJSON = function () {
+      var result = oldToJSON.call(this);
+      if (this._columns && this._columns._loaded.items) {
+        result.columns = this._columns.items.map(function (item) { return item.toJSON(); });
+      }
+      if (this._rows && this._rows._loaded.items) {
+        result.rows = this._rows.items.map(function (item) { return item.toJSON(); });
+      }
+      return result;
+    };
+  }
+
+  installTableNavigation();
+
+  Excel.TableColumnCollection = TableColumnCollection;
+  Excel.TableColumn = TableColumn;
+  Excel.TableRowCollection = TableRowCollection;
+  Excel.TableRow = TableRow;
+})(globalThis);

--- a/compute/officejs/src/table_collections.rs
+++ b/compute/officejs/src/table_collections.rs
@@ -1,0 +1,1438 @@
+//! Office.js table row and column collections.
+//!
+//! The table object itself lives in [`crate::tables`].  This module keeps the
+//! collection and child-object adapters separate so that a child proxy can be
+//! bound to a stable table-column id or to a positional table-row index.  All
+//! range and mutation work is delegated to `compute-api`; this module only
+//! translates the Office.js object model to the sheet/table API.
+
+use std::collections::HashMap;
+
+use compute_api::{CellAddress, CellRange, Sheet, mutation::CellInput};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use value_types::CellValue;
+
+use crate::tables::{TableError, TableRangeKind, TableRef};
+
+/// Errors returned by the collection adapters and mapped to Rich API errors
+/// by the Office host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TableCollectionError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+/// The two child collections exposed by `Excel.Table`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TableCollectionKind {
+    Rows,
+    Columns,
+}
+
+impl TableCollectionKind {
+    pub(crate) fn from_wire(value: &str) -> Result<Self, TableCollectionError> {
+        match value {
+            "rows" => Ok(Self::Rows),
+            "columns" => Ok(Self::Columns),
+            _ => Err(invalid(format!(
+                "Unsupported table collection kind '{value}'"
+            ))),
+        }
+    }
+}
+
+/// The table ranges reachable from a column object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TableColumnRangeKind {
+    Full,
+    Header,
+    DataBody,
+    Total,
+}
+
+impl TableColumnRangeKind {
+    pub(crate) fn from_wire(value: &str) -> Result<Self, TableCollectionError> {
+        match value {
+            "full" => Ok(Self::Full),
+            "header" => Ok(Self::Header),
+            "dataBody" => Ok(Self::DataBody),
+            "total" | "totals" => Ok(Self::Total),
+            _ => Err(invalid(format!(
+                "Unsupported table column range kind '{value}'"
+            ))),
+        }
+    }
+}
+
+/// One item in a collection-load response.
+///
+/// The Office.js bootstrap owns client proxy allocation.  The host sends a
+/// stable selector plus the properties requested for that item; the bootstrap
+/// calls the normal child `getItem` binding path and seeds those properties.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct CollectionItem {
+    pub(crate) key: String,
+    pub(crate) properties: HashMap<String, Value>,
+}
+
+#[derive(Clone)]
+pub(crate) struct TableRowAddResult {
+    pub(crate) row: TableRowRef,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TableCollectionState {
+    id: String,
+    name: String,
+    range: TableCollectionRange,
+    has_header_row: bool,
+    has_totals_row: bool,
+    #[serde(default)]
+    columns: Vec<TableCollectionColumn>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct TableCollectionRange {
+    start_row: u32,
+    start_col: u32,
+    end_row: u32,
+    end_col: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TableCollectionColumn {
+    id: String,
+    name: String,
+    index: u32,
+    #[serde(default)]
+    calculated_formula: Option<String>,
+    #[serde(default)]
+    ooxml_column_id: Option<u32>,
+}
+
+/// A column child proxy bound to the canonical column id.
+#[derive(Clone)]
+pub(crate) struct TableColumnRef {
+    table: TableRef,
+    column_id: String,
+}
+
+impl TableColumnRef {
+    pub(crate) fn new(table: TableRef, column_id: String) -> Self {
+        Self { table, column_id }
+    }
+
+    pub(crate) fn key(&self) -> &str {
+        &self.column_id
+    }
+
+    pub(crate) fn table(&self) -> TableRef {
+        self.table.clone()
+    }
+
+    pub(crate) fn sheet(&self) -> Sheet {
+        self.table.sheet()
+    }
+
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, TableCollectionError> {
+        let table = resolve_table(&self.table)?;
+        let column = resolve_column_by_id(&table, &self.column_id)?;
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                "isNullObject" => Value::Bool(false),
+                "id" => json!(public_column_id(column)),
+                "index" => json!(column.index),
+                "name" => Value::String(column.name.clone()),
+                "values" => column_values(&self.sheet(), &table, column.index)?,
+                "valuesAsJson" | "valuesAsJsonLocal" => {
+                    return Err(unsupported(property, "TableColumn"));
+                }
+                other => return Err(unsupported(other, "TableColumn")),
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), TableCollectionError> {
+        let table = resolve_table(&self.table)?;
+        let column = resolve_column_by_id(&table, &self.column_id)?;
+        match property {
+            "name" => {
+                let name = required_name(value, "TableColumn.name")?;
+                self.sheet()
+                    .tables()
+                    .rename_column(&table.name, column.index, name)
+                    .map_err(engine)?;
+            }
+            "values" => {
+                let (row_count, _) = data_dimensions(&table);
+                let grid = table_value_grid(value, row_count as usize, 1, "TableColumn.values")?;
+                if row_count > 0 {
+                    let range =
+                        range_for_column(&table, column.index, TableColumnRangeKind::DataBody)?;
+                    self.sheet()
+                        .set_range_typed(range.as_str(), &grid)
+                        .map_err(engine)?;
+                }
+            }
+            "id" | "index" => return Err(read_only(property, "TableColumn")),
+            "valuesAsJson" | "valuesAsJsonLocal" => {
+                return Err(unsupported(property, "TableColumn"));
+            }
+            other => return Err(unsupported(other, "TableColumn")),
+        }
+        Ok(())
+    }
+
+    pub(crate) fn delete(&self) -> Result<(), TableCollectionError> {
+        let table = resolve_table(&self.table)?;
+        let column = resolve_column_by_id(&table, &self.column_id)?;
+        if table.columns.len() <= 1 {
+            return Err(invalid(
+                "A table must retain at least one column".to_string(),
+            ));
+        }
+        let deleted_column = table.range.start_col + column.index;
+        // Remove the physical worksheet column first. The structural metadata
+        // pass then keeps the table alive and moves its range with the cells;
+        // doing the metadata contraction first would make a first-column
+        // delete look like the entire (already contracted) table was deleted.
+        self.sheet()
+            .structure()
+            .delete_columns(deleted_column, 1)
+            .map_err(engine)?;
+        self.sheet()
+            .tables()
+            .remove_column(&table.name, column.index)
+            .map_err(engine)?;
+        // The table metadata API contracts the table definition but leaves
+        // worksheet cells in place. The structural delete above moved cells,
+        // formulas, and neighboring columns together; resize restores the
+        // intended range after the metadata contraction.
+        self.sheet()
+            .tables()
+            .resize(
+                &table.name,
+                table.range.start_row,
+                table.range.start_col,
+                table.range.end_row,
+                table.range.end_col - 1,
+            )
+            .map_err(engine)?;
+        Ok(())
+    }
+
+    pub(crate) fn range_address(
+        &self,
+        kind: TableColumnRangeKind,
+    ) -> Result<String, TableCollectionError> {
+        let table = resolve_table(&self.table)?;
+        let column = resolve_column_by_id(&table, &self.column_id)?;
+        range_for_column(&table, column.index, kind)
+    }
+}
+
+/// A row child proxy bound to a physical table-row position.
+///
+/// `relative_index` intentionally remains positional.  Inserting a row before
+/// this proxy changes the data at that position, matching the Office.js
+/// contract that a `TableRow` represents a physical location rather than a
+/// logical record.
+#[derive(Clone)]
+pub(crate) struct TableRowRef {
+    table: TableRef,
+    relative_index: u32,
+    /// Rows created with `alwaysInsert:false` are written below the table and
+    /// therefore do not participate in the table's data-body range.
+    fixed_row: Option<u32>,
+}
+
+impl TableRowRef {
+    pub(crate) fn new(table: TableRef, relative_index: u32) -> Self {
+        Self {
+            table,
+            relative_index,
+            fixed_row: None,
+        }
+    }
+
+    fn fixed(table: TableRef, relative_index: u32, absolute_row: u32) -> Self {
+        Self {
+            table,
+            relative_index,
+            fixed_row: Some(absolute_row),
+        }
+    }
+
+    pub(crate) fn index(&self) -> u32 {
+        self.relative_index
+    }
+
+    pub(crate) fn table(&self) -> TableRef {
+        self.table.clone()
+    }
+
+    pub(crate) fn sheet(&self) -> Sheet {
+        self.table.sheet()
+    }
+
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, TableCollectionError> {
+        let table = resolve_table(&self.table)?;
+        let mut result = HashMap::new();
+        let bounds = self.row_bounds(&table)?;
+        for property in properties {
+            let value = match property.as_str() {
+                "isNullObject" => Value::Bool(false),
+                "index" => json!(self.relative_index),
+                "values" => range_values(&self.sheet(), bounds)?,
+                "valuesAsJson" | "valuesAsJsonLocal" => {
+                    return Err(unsupported(property, "TableRow"));
+                }
+                other => return Err(unsupported(other, "TableRow")),
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), TableCollectionError> {
+        let table = resolve_table(&self.table)?;
+        let bounds = self.row_bounds(&table)?;
+        match property {
+            "values" => {
+                let row_width = bounds.3 - bounds.1 + 1;
+                let grid = table_value_grid(value, 1, row_width as usize, "TableRow.values")?;
+                self.sheet()
+                    .set_range_typed(
+                        a1_range(bounds.0, bounds.1, bounds.2, bounds.3).as_str(),
+                        &grid,
+                    )
+                    .map_err(engine)?;
+            }
+            "index" => return Err(read_only(property, "TableRow")),
+            "valuesAsJson" | "valuesAsJsonLocal" => {
+                return Err(unsupported(property, "TableRow"));
+            }
+            other => return Err(unsupported(other, "TableRow")),
+        }
+        Ok(())
+    }
+
+    pub(crate) fn delete(&self) -> Result<(), TableCollectionError> {
+        if self.fixed_row.is_some() {
+            return Err(invalid(
+                "A row created with alwaysInsert=false is outside the table and cannot be deleted through TableRow.delete()".to_string(),
+            ));
+        }
+        let table = resolve_table(&self.table)?;
+        ensure_rows_not_filtered(&self.table, &table)?;
+        let (data_start, data_end) = data_row_bounds(&table)
+            .ok_or_else(|| item_not_found_error("The table does not have a data body range"))?;
+        let data_count = data_end - data_start + 1;
+        if self.relative_index >= data_count {
+            return item_not_found(format!("Table row index {}", self.relative_index));
+        }
+        if data_count <= 1 {
+            return invalid_result("A table must retain at least one data row");
+        }
+        delete_table_row(&self.table, &table, data_start + self.relative_index)
+    }
+
+    pub(crate) fn range_address(&self) -> Result<String, TableCollectionError> {
+        let table = resolve_table(&self.table)?;
+        let bounds = self.row_bounds(&table)?;
+        Ok(a1_range(bounds.0, bounds.1, bounds.2, bounds.3))
+    }
+
+    fn row_bounds(
+        &self,
+        table: &TableCollectionState,
+    ) -> Result<(u32, u32, u32, u32), TableCollectionError> {
+        let row = match self.fixed_row {
+            Some(row) => row,
+            None => {
+                let (start, end) = data_row_bounds(table).ok_or_else(|| {
+                    item_not_found_error("The table does not have a data body range")
+                })?;
+                if self.relative_index > end - start {
+                    return item_not_found(format!("Table row index {}", self.relative_index));
+                }
+                start + self.relative_index
+            }
+        };
+        Ok((row, table.range.start_col, row, table.range.end_col))
+    }
+}
+
+/// Load a table's rows or columns collection.
+///
+/// `properties` accepts the normal Office load paths (`count`, `items`, and
+/// `items/<property>`).  The returned map is ready to merge into the host's
+/// generic `loaded[objectId]` response.
+pub(crate) fn load_collection(
+    table_ref: &TableRef,
+    kind: TableCollectionKind,
+    properties: &[String],
+) -> Result<HashMap<String, Value>, TableCollectionError> {
+    let table = resolve_table(table_ref)?;
+    let mut result = HashMap::new();
+    let mut item_properties = Vec::new();
+    let mut load_items = false;
+    let mut load_default_items = false;
+
+    for property in properties {
+        match property.as_str() {
+            // Collections are ordinary, non-nullable client objects.  Keep
+            // the inherited ClientObject null-object probe loadable even
+            // though it is not part of the collection's toJSON data shape.
+            "isNullObject" => {
+                result.insert(property.clone(), Value::Bool(false));
+            }
+            "count" => {
+                result.insert("count".to_string(), json!(collection_count(&table, kind)));
+            }
+            "items" => {
+                load_items = true;
+                load_default_items = true;
+            }
+            path if path.starts_with("items/") => {
+                load_items = true;
+                let child = path.trim_start_matches("items/");
+                if child == "$all" {
+                    load_default_items = true;
+                    continue;
+                }
+                if child.is_empty() || child.contains('/') {
+                    return Err(invalid(format!("Invalid collection load path '{path}'")));
+                }
+                if !item_properties.iter().any(|existing| existing == child) {
+                    item_properties.push(child.to_string());
+                }
+            }
+            other => return Err(unsupported(other, "Table collection")),
+        }
+    }
+
+    if load_items {
+        if load_default_items {
+            let defaults: &[&str] = match kind {
+                TableCollectionKind::Columns => &["id", "index", "name", "values"],
+                TableCollectionKind::Rows => &["index", "values"],
+            };
+            item_properties = defaults.iter().map(|name| (*name).to_string()).collect();
+        }
+        let items = match kind {
+            TableCollectionKind::Columns => table
+                .columns
+                .iter()
+                .map(|column| {
+                    let properties = load_column_properties(
+                        table_ref.sheet(),
+                        &table,
+                        column,
+                        &item_properties,
+                    )?;
+                    Ok(CollectionItem {
+                        key: column.id.clone(),
+                        properties,
+                    })
+                })
+                .collect::<Result<Vec<_>, TableCollectionError>>()?,
+            TableCollectionKind::Rows => {
+                let count = collection_count(&table, kind);
+                (0..count)
+                    .map(|index| {
+                        let row = TableRowRef::new(table_ref.clone(), index);
+                        let properties = load_row_properties(&row, &table, &item_properties)?;
+                        Ok(CollectionItem {
+                            key: index.to_string(),
+                            properties,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, TableCollectionError>>()?
+            }
+        };
+        result.insert(
+            "items".to_string(),
+            serde_json::to_value(items).map_err(encoding)?,
+        );
+    }
+    Ok(result)
+}
+
+/// Bind a column by its Office `getItem` key (name, canonical id, or numeric
+/// imported/legacy id).
+pub(crate) fn get_column(
+    table_ref: &TableRef,
+    key: &Value,
+) -> Result<TableColumnRef, TableCollectionError> {
+    let table = resolve_table(table_ref)?;
+    let column = if let Some(number) = key.as_u64() {
+        let text = number.to_string();
+        let legacy_id = u32::try_from(number).ok();
+        table.columns.iter().find(|column| {
+            column.id == text
+                || column.ooxml_column_id == legacy_id
+                || public_column_id(column) == number
+        })
+    } else if let Some(text) = key.as_str() {
+        let numeric_id = text.parse::<u64>().ok();
+        table.columns.iter().find(|column| {
+            column.id == text
+                || column.name.eq_ignore_ascii_case(text)
+                || numeric_id.is_some_and(|id| public_column_id(column) == id)
+        })
+    } else {
+        None
+    };
+    let column = column.ok_or_else(|| item_not_found_error(format!("Table column key {key}")))?;
+    Ok(TableColumnRef::new(table_ref.clone(), column.id.clone()))
+}
+
+pub(crate) fn get_column_at(
+    table_ref: &TableRef,
+    index: i64,
+) -> Result<TableColumnRef, TableCollectionError> {
+    let table = resolve_table(table_ref)?;
+    let index = checked_index(index, table.columns.len(), "column")?;
+    Ok(TableColumnRef::new(
+        table_ref.clone(),
+        table.columns[index].id.clone(),
+    ))
+}
+
+pub(crate) fn get_row_at(
+    table_ref: &TableRef,
+    index: i64,
+) -> Result<TableRowRef, TableCollectionError> {
+    let table = resolve_table(table_ref)?;
+    let count = collection_count(&table, TableCollectionKind::Rows);
+    let index = checked_index(index, count as usize, "row")?;
+    Ok(TableRowRef::new(table_ref.clone(), index as u32))
+}
+
+/// Add a column and optionally populate its data body.
+pub(crate) fn add_column(
+    table_ref: &TableRef,
+    index: Option<i64>,
+    values: Option<&Value>,
+    name: Option<&Value>,
+) -> Result<TableColumnRef, TableCollectionError> {
+    let table = resolve_table(table_ref)?;
+    let position = insertion_index(index, table.columns.len(), "column")?;
+    let column_name = match name {
+        None | Some(Value::Null) => generated_column_name(&table),
+        Some(value) => required_name(value, "TableColumn.name")?.to_string(),
+    };
+    if table
+        .columns
+        .iter()
+        .any(|column| column.name.eq_ignore_ascii_case(&column_name))
+    {
+        return Err(invalid(format!(
+            "A table column named '{column_name}' already exists"
+        )));
+    }
+
+    let (row_count, _) = data_dimensions(&table);
+    let parsed_values = values
+        .filter(|value| !value.is_null())
+        .map(|value| table_value_grid(value, row_count as usize, 1, "TableColumn.values"))
+        .transpose()?;
+
+    let sheet = table_ref.sheet();
+    // A worksheet column insertion at the table's left edge is the only
+    // prepend path that lets the engine move formulas and neighboring cells
+    // with their identities intact. The table metadata is repaired below so
+    // the newly-created column remains at the original start position.
+    let old_header_values = if position == 0 && table.has_header_row {
+        Some(snapshot_range_inputs(
+            &sheet,
+            &TableCollectionRange {
+                start_row: table.range.start_row,
+                start_col: table.range.start_col,
+                end_row: table.range.start_row,
+                end_col: table.range.end_col,
+            },
+        )?)
+    } else {
+        None
+    };
+
+    // Reserve worksheet space before changing the table definition. Inserting
+    // at an interior position lets the engine adjust formulas and neighboring
+    // cells in one structural operation. Appending reserves a blank column at
+    // the right edge; prepending inserts at the table's left edge and repairs
+    // the metadata range after the table API adds its column definition.
+    let reserved_column = if position == 0 {
+        table.range.start_col
+    } else {
+        table.range.start_col + position as u32
+    };
+    sheet
+        .structure()
+        .insert_columns(reserved_column, 1)
+        .map_err(engine)?;
+
+    sheet
+        .tables()
+        .add_column(&table.name, &column_name, position as u32)
+        .map_err(engine)?;
+
+    if position == 0 {
+        let expanded_end = table.range.end_col.checked_add(1).ok_or_else(|| {
+            invalid("The added column would exceed the worksheet column limit".to_string())
+        })?;
+        // The left-edge worksheet insertion shifted the table to the right;
+        // put its start back while retaining the new column definition.
+        sheet
+            .tables()
+            .resize(
+                &table.name,
+                table.range.start_row,
+                table.range.start_col,
+                table.range.end_row,
+                expanded_end,
+            )
+            .map_err(engine)?;
+
+        if let Some(old_header_values) = old_header_values {
+            let shifted_start = table.range.start_col + 1;
+            let shifted_end = table.range.end_col.checked_add(1).ok_or_else(|| {
+                invalid("The added column would exceed the worksheet column limit".to_string())
+            })?;
+            sheet
+                .set_range_typed(
+                    a1_range(
+                        table.range.start_row,
+                        shifted_start,
+                        table.range.start_row,
+                        shifted_end,
+                    )
+                    .as_str(),
+                    &old_header_values,
+                )
+                .map_err(engine)?;
+            let new_header = vec![vec![Some(CellInput::Literal {
+                text: column_name.clone(),
+            })]];
+            sheet
+                .set_range_typed(
+                    a1_range(
+                        table.range.start_row,
+                        table.range.start_col,
+                        table.range.start_row,
+                        table.range.start_col,
+                    )
+                    .as_str(),
+                    &new_header,
+                )
+                .map_err(engine)?;
+        }
+    } else if position < table.columns.len() {
+        // The structural insert already grew the table range by one column;
+        // add_column grows it once more while adding metadata. Restore the
+        // intended width without changing its start position.
+        sheet
+            .tables()
+            .resize(
+                &table.name,
+                table.range.start_row,
+                table.range.start_col,
+                table.range.end_row,
+                table.range.end_col + 1,
+            )
+            .map_err(engine)?;
+    }
+    if let Some(grid) = parsed_values.as_ref()
+        && row_count > 0
+    {
+        let updated = resolve_table(table_ref)?;
+        let range = range_for_column(&updated, position as u32, TableColumnRangeKind::DataBody)?;
+        table_ref
+            .sheet()
+            .set_range_typed(range.as_str(), grid)
+            .map_err(engine)?;
+    }
+    let updated = resolve_table(table_ref)?;
+    let column = updated.columns.get(position).ok_or_else(|| {
+        encoding_message("the engine did not return the newly-added table column")
+    })?;
+    Ok(TableColumnRef::new(table_ref.clone(), column.id.clone()))
+}
+
+/// Add one or more rows.  The return reference points at the first newly
+/// added row, matching `TableRowCollection.add`.
+pub(crate) fn add_rows(
+    table_ref: &TableRef,
+    index: Option<i64>,
+    values: Option<&Value>,
+    always_insert: Option<bool>,
+) -> Result<TableRowAddResult, TableCollectionError> {
+    let table = resolve_table(table_ref)?;
+    let width = table.range.end_col - table.range.start_col + 1;
+    let data_count = collection_count(&table, TableCollectionKind::Rows);
+    let requested_index = insertion_index(index, data_count as usize, "row")? as u32;
+    let parsed_values = values
+        .filter(|value| !value.is_null())
+        .map(|value| table_row_values(value, width as usize))
+        .transpose()?;
+    let row_count = parsed_values.as_ref().map_or(1, |grid| grid.len() as u32);
+    let insert_in_table = always_insert.unwrap_or(true);
+    let sheet = table_ref.sheet();
+
+    if !insert_in_table {
+        let absolute = table.range.end_row.checked_add(1).ok_or_else(|| {
+            invalid("The added rows would exceed the worksheet row limit".to_string())
+        })?;
+        let end = absolute.checked_add(row_count - 1).ok_or_else(|| {
+            invalid("The added rows would exceed the worksheet row limit".to_string())
+        })?;
+        // `alwaysInsert:false` writes into the first rows below the table when
+        // they are empty. If occupied cells exist below the table, preserve
+        // them by shifting the used sheet region down before writing.
+        if sheet_has_rows_at_or_below(&sheet, absolute)? {
+            insert_sheet_rows(&sheet, absolute, row_count, table.range.end_col)?;
+        }
+        let grid = parsed_values.as_ref();
+        if let Some(grid) = grid {
+            sheet
+                .set_range_typed(
+                    a1_range(absolute, table.range.start_col, end, table.range.end_col).as_str(),
+                    grid,
+                )
+                .map_err(engine)?;
+        }
+        return Ok(TableRowAddResult {
+            row: TableRowRef::fixed(table_ref.clone(), data_count, absolute),
+        });
+    }
+
+    let insert_row = data_insert_row(&table, requested_index)?;
+    insert_sheet_rows(&sheet, insert_row, row_count, table.range.end_col)?;
+    let new_end = table.range.end_row.checked_add(row_count).ok_or_else(|| {
+        invalid("The added rows would exceed the worksheet row limit".to_string())
+    })?;
+    sheet
+        .tables()
+        .resize(
+            &table.name,
+            table.range.start_row,
+            table.range.start_col,
+            new_end,
+            table.range.end_col,
+        )
+        .map_err(engine)?;
+
+    let mut grid =
+        parsed_values.unwrap_or_else(|| vec![vec![None; width as usize]; row_count as usize]);
+    fill_calculated_formulas(&table, &mut grid);
+    if grid.iter().any(|row| row.iter().any(Option::is_some)) {
+        let end = insert_row.checked_add(row_count - 1).ok_or_else(|| {
+            invalid("The added rows would exceed the worksheet row limit".to_string())
+        })?;
+        sheet
+            .set_range_typed(
+                a1_range(insert_row, table.range.start_col, end, table.range.end_col).as_str(),
+                &grid,
+            )
+            .map_err(engine)?;
+    }
+
+    Ok(TableRowAddResult {
+        row: TableRowRef::new(table_ref.clone(), requested_index),
+    })
+}
+
+/// Delete rows by relative index.  The indices are interpreted against the
+/// collection before the operation, as Office's batch delete API specifies.
+pub(crate) fn delete_rows(
+    table_ref: &TableRef,
+    indices: &[u32],
+) -> Result<(), TableCollectionError> {
+    if indices.is_empty() {
+        return Ok(());
+    }
+    let table = resolve_table(table_ref)?;
+    ensure_rows_not_filtered(table_ref, &table)?;
+    let (start, end) = data_row_bounds(&table)
+        .ok_or_else(|| item_not_found_error("The table does not have a data body range"))?;
+    let count = end - start + 1;
+    let mut sorted = indices.to_vec();
+    sorted.sort_unstable();
+    if sorted.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(invalid(
+            "A requested table row appears more than once".to_string(),
+        ));
+    }
+    if sorted.iter().any(|index| *index >= count) {
+        return Err(invalid("A requested table row does not exist".to_string()));
+    }
+    if sorted.len() as u32 >= count {
+        return Err(invalid(
+            "A table must retain at least one data row".to_string(),
+        ));
+    }
+    // Delete from the bottom so all indices retain their pre-operation
+    // meaning and each structure operation remains a normal engine mutation.
+    for index in sorted.into_iter().rev() {
+        let current = resolve_table(table_ref)?;
+        let (current_start, _) = data_row_bounds(&current)
+            .ok_or_else(|| item_not_found_error("The table does not have a data body range"))?;
+        delete_table_row(table_ref, &current, current_start + index)?;
+    }
+    Ok(())
+}
+
+/// Delete a contiguous run of data rows using Office's `deleteRowsAt` shape.
+pub(crate) fn delete_rows_at(
+    table_ref: &TableRef,
+    index: i64,
+    count: i64,
+) -> Result<(), TableCollectionError> {
+    if index < 0 || count <= 0 {
+        return Err(invalid(
+            "TableRowCollection.deleteRowsAt requires a non-negative index and a positive count"
+                .to_string(),
+        ));
+    }
+    let end = index.checked_add(count).ok_or_else(|| {
+        invalid("TableRowCollection.deleteRowsAt exceeds the row index range".to_string())
+    })?;
+    let table = resolve_table(table_ref)?;
+    let rows = collection_count(&table, TableCollectionKind::Rows) as i64;
+    if end > rows {
+        return Err(invalid(
+            "TableRowCollection.deleteRowsAt exceeds the data-row count".to_string(),
+        ));
+    }
+    let indices = (index..end)
+        .map(|row| {
+            u32::try_from(row).map_err(|_| {
+                invalid("TableRowCollection.deleteRowsAt exceeds the row index range".to_string())
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    delete_rows(table_ref, &indices)
+}
+
+/// Delete one physical table row while preserving cells outside the table.
+///
+/// The partial-shift API remaps cell identities and deliberately skips the
+/// metadata-shift pass used by worksheet-wide row operations. Resize the
+/// table explicitly after the remap so its data-body range follows the cells.
+fn delete_table_row(
+    table_ref: &TableRef,
+    table: &TableCollectionState,
+    absolute_row: u32,
+) -> Result<(), TableCollectionError> {
+    let (data_start, data_end) = data_row_bounds(table)
+        .ok_or_else(|| item_not_found_error("The table does not have a data body range"))?;
+    if absolute_row < data_start || absolute_row > data_end {
+        return item_not_found(format!("Table row position {absolute_row}"));
+    }
+    let data_count = data_end - data_start + 1;
+    if data_count <= 1 {
+        return invalid_result("A table must retain at least one data row");
+    }
+
+    let sheet = table_ref.sheet();
+    let column_count = sheet_shift_column_count(&sheet, table.range.end_col)?;
+    sheet
+        .structure()
+        .delete_cells_with_shift(absolute_row, 0, 1, column_count, false)
+        .map_err(engine)?;
+
+    let new_end = table.range.end_row.checked_sub(1).ok_or_else(|| {
+        invalid("Deleting the table row would exceed the worksheet row limit".to_string())
+    })?;
+    sheet
+        .tables()
+        .resize(
+            &table.name,
+            table.range.start_row,
+            table.range.start_col,
+            new_end,
+            table.range.end_col,
+        )
+        .map_err(engine)?;
+    Ok(())
+}
+
+/// Add worksheet rows by remapping the used cell region from `at` downward.
+///
+/// The range width includes the table and every currently used neighboring
+/// column. This preserves adjacent values/formulas while keeping table
+/// metadata under explicit control at the call site.
+fn insert_sheet_rows(
+    sheet: &Sheet,
+    at: u32,
+    count: u32,
+    table_end_col: u32,
+) -> Result<(), TableCollectionError> {
+    let column_count = sheet_shift_column_count(sheet, table_end_col)?;
+    sheet
+        .structure()
+        .insert_cells_with_shift(at, 0, count, column_count, false)
+        .map_err(engine)?;
+    Ok(())
+}
+
+fn sheet_shift_column_count(
+    sheet: &Sheet,
+    table_end_col: u32,
+) -> Result<u32, TableCollectionError> {
+    let table_width = table_end_col
+        .checked_add(1)
+        .ok_or_else(|| invalid("The table exceeds the worksheet column limit".to_string()))?;
+    let used_width = sheet
+        .get_data_bounds()
+        .map_err(engine)?
+        .and_then(|bounds| bounds.max_col.checked_add(1))
+        .unwrap_or(0);
+    Ok(table_width.max(used_width))
+}
+
+fn sheet_has_rows_at_or_below(sheet: &Sheet, row: u32) -> Result<bool, TableCollectionError> {
+    Ok(sheet
+        .get_data_bounds()
+        .map_err(engine)?
+        .is_some_and(|bounds| bounds.max_row >= row))
+}
+
+fn ensure_rows_not_filtered(
+    table_ref: &TableRef,
+    table: &TableCollectionState,
+) -> Result<(), TableCollectionError> {
+    let filtered = table_ref
+        .sheet()
+        .filters()
+        .get_all()
+        .map_err(engine)?
+        .into_iter()
+        .any(|filter| {
+            filter.table_id.as_deref() == Some(table.id.as_str())
+                && (!filter.column_filters.is_empty() || filter.advanced_filter.is_some())
+        });
+    if filtered {
+        return Err(TableCollectionError {
+            code: "InsertDeleteConflict",
+            message: "Cannot insert or delete rows in a filtered table".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn load_column_properties(
+    sheet: Sheet,
+    table: &TableCollectionState,
+    column: &TableCollectionColumn,
+    requested: &[String],
+) -> Result<HashMap<String, Value>, TableCollectionError> {
+    let mut properties = HashMap::new();
+    for property in requested {
+        let value = match property.as_str() {
+            "id" => json!(public_column_id(column)),
+            "index" => json!(column.index),
+            "name" => Value::String(column.name.clone()),
+            "values" => column_values(&sheet, table, column.index)?,
+            "valuesAsJson" | "valuesAsJsonLocal" => {
+                return Err(unsupported(property, "TableColumn"));
+            }
+            other => return Err(unsupported(other, "TableColumn")),
+        };
+        properties.insert(property.clone(), value);
+    }
+    Ok(properties)
+}
+
+fn load_row_properties(
+    row: &TableRowRef,
+    table: &TableCollectionState,
+    requested: &[String],
+) -> Result<HashMap<String, Value>, TableCollectionError> {
+    let mut properties = HashMap::new();
+    for property in requested {
+        let value = match property.as_str() {
+            "index" => json!(row.relative_index),
+            "values" => range_values(&row.sheet(), row.row_bounds(table)?)?,
+            "valuesAsJson" | "valuesAsJsonLocal" => {
+                return Err(unsupported(property, "TableRow"));
+            }
+            other => return Err(unsupported(other, "TableRow")),
+        };
+        properties.insert(property.clone(), value);
+    }
+    Ok(properties)
+}
+
+fn resolve_table(table_ref: &TableRef) -> Result<TableCollectionState, TableCollectionError> {
+    let full = table_ref
+        .range_address(TableRangeKind::Full)
+        .map_err(table_error)?;
+    let bounds = CellRange::from(full.as_str()).resolve().map_err(engine)?;
+    let sheet = table_ref.sheet();
+    for table in sheet.tables().get_all().map_err(engine)? {
+        let table = decode_table(table)?;
+        let candidate = (
+            table.range.start_row,
+            table.range.start_col,
+            table.range.end_row,
+            table.range.end_col,
+        );
+        if candidate == bounds {
+            return Ok(table);
+        }
+    }
+    item_not_found("The requested table no longer exists".to_string())
+}
+
+fn resolve_column_by_id<'a>(
+    table: &'a TableCollectionState,
+    id: &str,
+) -> Result<&'a TableCollectionColumn, TableCollectionError> {
+    table
+        .columns
+        .iter()
+        .find(|column| column.id == id)
+        .ok_or_else(|| item_not_found_error(format!("Table column id {id}")))
+}
+
+/// Convert Mog's stable string identity to Office's numeric `TableColumn.id`.
+/// Imported workbooks retain the OOXML numeric id; runtime-created columns do
+/// not, so use a deterministic 53-bit value derived from the stable id. This
+/// keeps the public id stable when columns are inserted or reordered while
+/// remaining exactly representable by a JavaScript number.
+fn public_column_id(column: &TableCollectionColumn) -> u64 {
+    if let Some(id) = column.ooxml_column_id {
+        return u64::from(id);
+    }
+
+    const FNV_OFFSET: u64 = 14_695_981_039_346_656_037;
+    const FNV_PRIME: u64 = 1_099_511_628_211;
+    const JS_SAFE_INTEGER: u64 = (1 << 53) - 1;
+    let mut hash = FNV_OFFSET;
+    for byte in column.id.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    let value = hash & JS_SAFE_INTEGER;
+    if value == 0 { 1 } else { value }
+}
+
+fn collection_count(table: &TableCollectionState, kind: TableCollectionKind) -> u32 {
+    match kind {
+        TableCollectionKind::Columns => table.columns.len() as u32,
+        TableCollectionKind::Rows => data_dimensions(table).0,
+    }
+}
+
+fn data_dimensions(table: &TableCollectionState) -> (u32, u32) {
+    let count = data_row_bounds(table).map_or(0, |(start, end)| end - start + 1);
+    (count, table.range.end_col - table.range.start_col + 1)
+}
+
+fn data_row_bounds(table: &TableCollectionState) -> Option<(u32, u32)> {
+    let start = table
+        .range
+        .start_row
+        .checked_add(u32::from(table.has_header_row))?;
+    let end = table
+        .range
+        .end_row
+        .checked_sub(u32::from(table.has_totals_row))?;
+    (start <= end).then_some((start, end))
+}
+
+fn data_insert_row(
+    table: &TableCollectionState,
+    relative_index: u32,
+) -> Result<u32, TableCollectionError> {
+    let start = table
+        .range
+        .start_row
+        .checked_add(u32::from(table.has_header_row))
+        .ok_or_else(|| invalid("The added row would exceed the worksheet row limit".to_string()))?;
+    let count = collection_count(table, TableCollectionKind::Rows);
+    start
+        .checked_add(relative_index.min(count))
+        .ok_or_else(|| invalid("The added row would exceed the worksheet row limit".to_string()))
+}
+
+fn range_for_column(
+    table: &TableCollectionState,
+    index: u32,
+    kind: TableColumnRangeKind,
+) -> Result<String, TableCollectionError> {
+    if index as usize >= table.columns.len() {
+        return item_not_found(format!("Table column index {index}"));
+    }
+    let column = table.range.start_col + index;
+    let (start, end) = match kind {
+        TableColumnRangeKind::Full => (table.range.start_row, table.range.end_row),
+        TableColumnRangeKind::Header if table.has_header_row => {
+            (table.range.start_row, table.range.start_row)
+        }
+        TableColumnRangeKind::Header => {
+            return item_not_found("The table does not have a header row".to_string());
+        }
+        TableColumnRangeKind::DataBody => data_row_bounds(table)
+            .ok_or_else(|| item_not_found_error("The table does not have a data body range"))?,
+        TableColumnRangeKind::Total if table.has_totals_row => {
+            (table.range.end_row, table.range.end_row)
+        }
+        TableColumnRangeKind::Total => {
+            return item_not_found("The table does not have a totals row".to_string());
+        }
+    };
+    Ok(a1_range(start, column, end, column))
+}
+
+fn column_values(
+    sheet: &Sheet,
+    table: &TableCollectionState,
+    index: u32,
+) -> Result<Value, TableCollectionError> {
+    let Some((start, end)) = data_row_bounds(table) else {
+        return Ok(Value::Array(Vec::new()));
+    };
+    range_values(
+        sheet,
+        (
+            start,
+            table.range.start_col + index,
+            end,
+            table.range.start_col + index,
+        ),
+    )
+}
+
+fn range_values(
+    sheet: &Sheet,
+    (start_row, start_col, end_row, end_col): (u32, u32, u32, u32),
+) -> Result<Value, TableCollectionError> {
+    let values = sheet
+        .get_range_values_2d(CellRange::Bounds(start_row, start_col, end_row, end_col))
+        .map_err(engine)?;
+    Ok(Value::Array(
+        values
+            .into_iter()
+            .map(|row| Value::Array(row.into_iter().map(cell_to_json).collect()))
+            .collect(),
+    ))
+}
+
+/// Snapshot a table range as typed cell inputs before a structural operation.
+///
+/// The prepend-column path inserts a worksheet column at the table's left
+/// edge.  Header cells are restored after the table metadata mutation, so a
+/// typed snapshot keeps literals, values, and formulas intact while the new
+/// first header is populated by the caller.
+fn snapshot_range_inputs(
+    sheet: &Sheet,
+    range: &TableCollectionRange,
+) -> Result<Vec<Vec<Option<CellInput>>>, TableCollectionError> {
+    let mut grid = Vec::new();
+    for row in range.start_row..=range.end_row {
+        let mut cells = Vec::new();
+        for col in range.start_col..=range.end_col {
+            let address = CellAddress::Position(row, col);
+            let input = if let Some(formula) = sheet.get_formula(address.clone()).map_err(engine)? {
+                CellInput::formula(&formula)
+            } else {
+                CellInput::from_cell_value(&sheet.get_cell_value(address).map_err(engine)?)
+            };
+            cells.push(Some(input));
+        }
+        grid.push(cells);
+    }
+    Ok(grid)
+}
+
+fn table_row_values(
+    value: &Value,
+    width: usize,
+) -> Result<Vec<Vec<Option<CellInput>>>, TableCollectionError> {
+    if !value.is_array() {
+        if width == 1 {
+            return Ok(vec![vec![table_cell_input(value, "values")?]]);
+        }
+        return invalid_result(
+            "TableRowCollection.add values require one scalar per one-column table or a 2-dimensional array",
+        );
+    }
+    let rows = value.as_array().ok_or_else(|| {
+        invalid("TableRowCollection.add values require a 2-dimensional array or scalar".to_string())
+    })?;
+    if rows.is_empty() {
+        return invalid_result("TableRowCollection.add values cannot be empty");
+    }
+    let mut grid = Vec::with_capacity(rows.len());
+    for row in rows {
+        let cells = row.as_array().ok_or_else(|| {
+            invalid("TableRowCollection.add values require a 2-dimensional array".to_string())
+        })?;
+        if cells.len() != width {
+            return invalid_result(format!(
+                "TableRowCollection.add values has {} columns; table requires {width}",
+                cells.len()
+            ));
+        }
+        grid.push(
+            cells
+                .iter()
+                .map(|cell| table_cell_input(cell, "values"))
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+    }
+    Ok(grid)
+}
+
+fn table_value_grid(
+    value: &Value,
+    expected_rows: usize,
+    expected_cols: usize,
+    property: &str,
+) -> Result<Vec<Vec<Option<CellInput>>>, TableCollectionError> {
+    if !value.is_array() {
+        if expected_rows == 1 && expected_cols == 1 {
+            return Ok(vec![vec![table_cell_input(value, property)?]]);
+        }
+        return invalid_result(format!(
+            "{property} requires a {expected_rows}x{expected_cols} 2-dimensional array"
+        ));
+    }
+    let rows = value.as_array().expect("array checked");
+    if rows.len() != expected_rows {
+        return invalid_result(format!(
+            "{property} has {} rows; target requires {expected_rows}",
+            rows.len()
+        ));
+    }
+    let mut grid = Vec::with_capacity(rows.len());
+    for (row_index, row) in rows.iter().enumerate() {
+        let cells = row
+            .as_array()
+            .ok_or_else(|| invalid(format!("{property} requires a 2-dimensional array")))?;
+        if cells.len() != expected_cols {
+            return invalid_result(format!(
+                "{property} row {row_index} has {} columns; target requires {expected_cols}",
+                cells.len()
+            ));
+        }
+        grid.push(
+            cells
+                .iter()
+                .map(|cell| table_cell_input(cell, property))
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+    }
+    Ok(grid)
+}
+
+fn table_cell_input(
+    value: &Value,
+    property: &str,
+) -> Result<Option<CellInput>, TableCollectionError> {
+    match value {
+        Value::Null => Ok(None),
+        Value::Bool(value) => Ok(Some(CellInput::Value {
+            value: CellValue::Boolean(*value),
+        })),
+        Value::Number(value) => value
+            .as_f64()
+            .map(CellValue::from)
+            .map(|value| Some(CellInput::Value { value }))
+            .ok_or_else(|| invalid(format!("{property} must contain finite numbers"))),
+        Value::String(value) if value.is_empty() => Ok(Some(CellInput::Clear)),
+        Value::String(value)
+            if value.starts_with('+') || value.starts_with('-') || value.starts_with('=') =>
+        {
+            Ok(Some(CellInput::formula(value)))
+        }
+        Value::String(value) => Ok(Some(CellInput::Literal {
+            text: value.clone(),
+        })),
+        _ => invalid_result(format!(
+            "{property} must contain only strings, numbers, booleans, or null"
+        )),
+    }
+}
+
+fn fill_calculated_formulas(table: &TableCollectionState, grid: &mut [Vec<Option<CellInput>>]) {
+    for row in grid {
+        for (index, cell) in row.iter_mut().enumerate() {
+            if cell.is_none()
+                && let Some(formula) = table
+                    .columns
+                    .get(index)
+                    .and_then(|column| column.calculated_formula.as_deref())
+            {
+                *cell = Some(CellInput::formula(formula));
+            }
+        }
+    }
+}
+
+fn generated_column_name(table: &TableCollectionState) -> String {
+    for index in 1..100_000 {
+        let candidate = format!("Column{index}");
+        if table
+            .columns
+            .iter()
+            .all(|column| !column.name.eq_ignore_ascii_case(&candidate))
+        {
+            return candidate;
+        }
+    }
+    "Column".to_string()
+}
+
+fn insertion_index(
+    index: Option<i64>,
+    length: usize,
+    object: &str,
+) -> Result<usize, TableCollectionError> {
+    match index {
+        None | Some(-1) => Ok(length),
+        Some(value) if value >= 0 && (value as usize) <= length => Ok(value as usize),
+        Some(value) => invalid_result(format!(
+            "The {object} insertion index {value} is outside 0..={length}"
+        )),
+    }
+}
+
+fn checked_index(index: i64, length: usize, object: &str) -> Result<usize, TableCollectionError> {
+    if index >= 0 && (index as usize) < length {
+        Ok(index as usize)
+    } else {
+        item_not_found(format!("Table {object} index {index}"))
+    }
+}
+
+fn required_name<'a>(value: &'a Value, property: &str) -> Result<&'a str, TableCollectionError> {
+    value
+        .as_str()
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| invalid(format!("{property} must be a non-empty string")))
+}
+
+fn cell_to_json(value: CellValue) -> Value {
+    match value {
+        CellValue::Null => Value::String(String::new()),
+        CellValue::Boolean(value) => Value::Bool(value),
+        CellValue::Number(_) => value
+            .as_number()
+            .map(|number| json!(number))
+            .unwrap_or(Value::Null),
+        CellValue::Text(value) => Value::String(value.to_string()),
+        CellValue::Error(error, _) => Value::String(error.to_string()),
+        other => Value::String(other.to_string()),
+    }
+}
+
+fn decode_table(
+    table: impl serde::Serialize,
+) -> Result<TableCollectionState, TableCollectionError> {
+    let value = serde_json::to_value(table).map_err(encoding)?;
+    serde_json::from_value(value).map_err(encoding)
+}
+
+fn a1_range(start_row: u32, start_col: u32, end_row: u32, end_col: u32) -> String {
+    let start = format!("{}{}", column_name(start_col), start_row + 1);
+    let end = format!("{}{}", column_name(end_col), end_row + 1);
+    if start == end {
+        start
+    } else {
+        format!("{start}:{end}")
+    }
+}
+
+fn column_name(mut column: u32) -> String {
+    let mut reversed = Vec::new();
+    loop {
+        reversed.push((b'A' + (column % 26) as u8) as char);
+        column /= 26;
+        if column == 0 {
+            break;
+        }
+        column -= 1;
+    }
+    reversed.into_iter().rev().collect()
+}
+
+fn table_error(error: TableError) -> TableCollectionError {
+    TableCollectionError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn engine(error: impl std::fmt::Display) -> TableCollectionError {
+    TableCollectionError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn encoding(error: serde_json::Error) -> TableCollectionError {
+    TableCollectionError {
+        code: "GeneralException",
+        message: format!("Failed to encode table collection state: {error}"),
+    }
+}
+
+fn encoding_message(message: &str) -> TableCollectionError {
+    TableCollectionError {
+        code: "GeneralException",
+        message: message.to_string(),
+    }
+}
+
+fn unsupported(property: &str, object: &str) -> TableCollectionError {
+    TableCollectionError {
+        code: "InvalidArgument",
+        message: format!("Unsupported {object} property '{property}'"),
+    }
+}
+
+fn read_only(property: &str, object: &str) -> TableCollectionError {
+    TableCollectionError {
+        code: "InvalidArgument",
+        message: format!("{object}.{property} is read-only"),
+    }
+}
+
+fn invalid(message: String) -> TableCollectionError {
+    TableCollectionError {
+        code: "InvalidArgument",
+        message,
+    }
+}
+
+fn invalid_result<T>(message: impl Into<String>) -> Result<T, TableCollectionError> {
+    Err(invalid(message.into()))
+}
+
+fn item_not_found_error(message: impl Into<String>) -> TableCollectionError {
+    TableCollectionError {
+        code: "ItemNotFound",
+        message: message.into(),
+    }
+}
+
+fn item_not_found<T>(message: impl Into<String>) -> Result<T, TableCollectionError> {
+    Err(item_not_found_error(message))
+}

--- a/compute/officejs/src/table_filters.js
+++ b/compute/officejs/src/table_filters.js
@@ -1,0 +1,373 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var hooks = global.__mogOfficeJs || {};
+
+  function error(code, message) {
+    var value = new OfficeExtension.Error({
+      code: code,
+      message: message,
+    });
+    value.name = "RichApi.Error";
+    value.code = code;
+    return value;
+  }
+
+  function propertyNotLoaded(name) {
+    return error(
+      "PropertyNotLoaded",
+      "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context."
+    );
+  }
+
+  function invalid(message) {
+    return error("InvalidArgument", message);
+  }
+
+  function unsupported(message) {
+    return error("ApiNotFound", message);
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object";
+  }
+
+  function isPlainObject(value) {
+    if (!isObject(value)) return false;
+    var prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  }
+
+  function requirePlainObject(value, property) {
+    if (!isPlainObject(value)) throw invalid(property + " must be an object");
+    return value;
+  }
+
+  function requireString(value, property) {
+    if (typeof value !== "string") throw invalid(property + " must be a string");
+    return value;
+  }
+
+  function requireFiniteNumber(value, property) {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      throw invalid(property + " must be a finite number");
+    }
+    return value;
+  }
+
+  function requireNonNegativeNumber(value, property) {
+    value = requireFiniteNumber(value, property);
+    if (value < 0) throw invalid(property + " must be non-negative");
+    return value;
+  }
+
+  function requireInteger(value, property) {
+    value = requireFiniteNumber(value, property);
+    if (Math.floor(value) !== value) throw invalid(property + " must be an integer");
+    return value;
+  }
+
+  function assertSameContext(object, context) {
+    if (object && object.context !== context) {
+      throw error(
+        "InvalidRequestContext",
+        "The object belongs to a different request context."
+      );
+    }
+  }
+
+  function addReadOnlyScalar(prototype, name) {
+    Object.defineProperty(prototype, name, {
+      configurable: true,
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+    });
+  }
+
+  function TableSort(context, table) {
+    ClientObject.call(this, context);
+    this._table = table;
+    this._tableId = table._id;
+    this._scalarProperties = ["fields", "matchCase", "method"];
+    this._lastSort = null;
+    this._bindingQueued = false;
+  }
+  TableSort.prototype = Object.create(ClientObject.prototype);
+  TableSort.prototype.constructor = TableSort;
+
+  ["fields", "matchCase", "method"].forEach(function (name) {
+    addReadOnlyScalar(TableSort.prototype, name);
+  });
+
+  TableSort.prototype._ensureBinding = function () {
+    if (this._bindingQueued) return;
+    this.context._queue.push({
+      op: "getTableSort",
+      id: this._id,
+      tableId: this._tableId,
+    });
+    this._bindingQueued = true;
+  };
+
+  TableSort.prototype.apply = function (fields, matchCase, method) {
+    if (!Array.isArray(fields)) {
+      throw invalid("Table.sort.apply requires an array of SortField objects");
+    }
+    if (matchCase !== undefined && typeof matchCase !== "boolean") {
+      throw invalid("Table.sort.apply matchCase must be a boolean");
+    }
+    if (method !== undefined && typeof method !== "string") {
+      throw invalid("Table.sort.apply method must be a string");
+    }
+    var descriptor = {
+      fields: fields.slice(),
+      matchCase: matchCase === undefined ? false : matchCase,
+      method: method === undefined ? "PinYin" : method,
+    };
+    this._lastSort = descriptor;
+    this.context._queue.push({
+      op: "tableSortApply",
+      id: this._id,
+      tableId: this._tableId,
+      fields: descriptor.fields,
+      matchCase: matchCase,
+      method: method,
+    });
+  };
+
+  TableSort.prototype.clear = function () {
+    this._lastSort = null;
+    this.context._queue.push({
+      op: "tableSortClear",
+      id: this._id,
+      tableId: this._tableId,
+    });
+  };
+
+  TableSort.prototype.reapply = function () {
+    var op = {
+      op: "tableSortReapply",
+      id: this._id,
+      tableId: this._tableId,
+    };
+    // Including the request-context descriptor makes reapply deterministic
+    // for a proxy whose first apply and reapply share a batch. The host's
+    // bound descriptor wins when it has one, so fresh proxies still use the
+    // durable/imported projection.
+    if (this._lastSort) {
+      op.fields = this._lastSort.fields;
+      op.matchCase = this._lastSort.matchCase;
+      op.method = this._lastSort.method;
+    }
+    this.context._queue.push(op);
+  };
+
+  TableSort.prototype.load = function (props) {
+    this._ensureBinding();
+    return ClientObject.prototype.load.call(this, props);
+  };
+
+  TableSort.prototype.toJSON = function () {
+    var result = {};
+    if (this._loaded.fields) result.fields = this._fields;
+    if (this._loaded.matchCase) result.matchCase = this._matchCase;
+    if (this._loaded.method) result.method = this._method;
+    return result;
+  };
+
+  function Filter(context, column) {
+    ClientObject.call(this, context);
+    this._column = column;
+    this._table = column._table;
+    this._columnId = column._id;
+    this._scalarProperties = ["criteria"];
+    this._bindingQueued = false;
+  }
+  Filter.prototype = Object.create(ClientObject.prototype);
+  Filter.prototype.constructor = Filter;
+
+  addReadOnlyScalar(Filter.prototype, "criteria");
+
+  Filter.prototype._ensureBinding = function () {
+    if (this._bindingQueued) return;
+    this.context._queue.push({
+      op: "getTableColumnFilter",
+      id: this._id,
+      columnId: this._columnId,
+    });
+    this._bindingQueued = true;
+  };
+
+  Filter.prototype.apply = function (criteria) {
+    requirePlainObject(criteria, "Filter.apply criteria");
+    this.context._queue.push({
+      op: "tableFilterApply",
+      id: this._id,
+      columnId: this._columnId,
+      criteria: criteria,
+    });
+  };
+
+  Filter.prototype.applyBottomItemsFilter = function (count) {
+    count = requireInteger(count, "Filter.applyBottomItemsFilter count");
+    if (count < 0) throw invalid("Filter.applyBottomItemsFilter count must be non-negative");
+    this._queueTopBottom("BottomItems", count);
+  };
+
+  Filter.prototype.applyBottomPercentFilter = function (percent) {
+    percent = requireNonNegativeNumber(percent, "Filter.applyBottomPercentFilter percent");
+    if (percent > 100) throw invalid("Filter.applyBottomPercentFilter percent must be at most 100");
+    this._queueTopBottom("BottomPercent", percent);
+  };
+
+  Filter.prototype.applyCellColorFilter = function (color) {
+    this._queueColor("CellColor", color);
+  };
+
+  Filter.prototype.applyCustomFilter = function (criteria1, criteria2, oper) {
+    requireString(criteria1, "Filter.applyCustomFilter criteria1");
+    if (criteria2 !== undefined && typeof criteria2 !== "string") {
+      throw invalid("Filter.applyCustomFilter criteria2 must be a string");
+    }
+    if (oper !== undefined && oper !== "And" && oper !== "Or") {
+      throw invalid("Filter.applyCustomFilter oper must be 'And' or 'Or'");
+    }
+    var criteria = {
+      filterOn: "Custom",
+      criterion1: criteria1,
+    };
+    if (criteria2 !== undefined) criteria.criterion2 = criteria2;
+    if (oper !== undefined) criteria.operator = oper;
+    this._queueCriteria(criteria);
+  };
+
+  Filter.prototype.applyDynamicFilter = function (criteria) {
+    requireString(criteria, "Filter.applyDynamicFilter criteria");
+    this._queueCriteria({
+      filterOn: "Dynamic",
+      dynamicCriteria: criteria,
+    });
+  };
+
+  Filter.prototype.applyFontColorFilter = function (color) {
+    this._queueColor("FontColor", color);
+  };
+
+  Filter.prototype.applyIconFilter = function (icon) {
+    requirePlainObject(icon, "Filter.applyIconFilter icon");
+    if (typeof icon.set !== "string" || icon.set.length === 0) {
+      throw invalid("Filter.applyIconFilter icon.set must be a non-empty string");
+    }
+    requireInteger(icon.index, "Filter.applyIconFilter icon.index");
+    if (icon.index < 0) throw invalid("Filter.applyIconFilter icon.index must be non-negative");
+    this._queueCriteria({
+      filterOn: "Icon",
+      icon: { set: icon.set, index: icon.index },
+    });
+  };
+
+  Filter.prototype.applyTopItemsFilter = function (count) {
+    count = requireInteger(count, "Filter.applyTopItemsFilter count");
+    if (count < 0) throw invalid("Filter.applyTopItemsFilter count must be non-negative");
+    this._queueTopBottom("TopItems", count);
+  };
+
+  Filter.prototype.applyTopPercentFilter = function (percent) {
+    percent = requireNonNegativeNumber(percent, "Filter.applyTopPercentFilter percent");
+    if (percent > 100) throw invalid("Filter.applyTopPercentFilter percent must be at most 100");
+    this._queueTopBottom("TopPercent", percent);
+  };
+
+  Filter.prototype.applyValuesFilter = function (values) {
+    if (!Array.isArray(values)) {
+      throw invalid("Filter.applyValuesFilter values must be an array");
+    }
+    this._queueCriteria({
+      filterOn: "Values",
+      values: values.slice(),
+    });
+  };
+
+  Filter.prototype.clear = function () {
+    this.context._queue.push({
+      op: "tableFilterClear",
+      id: this._id,
+      columnId: this._columnId,
+    });
+  };
+
+  Filter.prototype._queueCriteria = function (criteria) {
+    this.context._queue.push({
+      op: "tableFilterApply",
+      id: this._id,
+      columnId: this._columnId,
+      criteria: criteria,
+    });
+  };
+
+  Filter.prototype._queueTopBottom = function (filterOn, count) {
+    this._queueCriteria({
+      filterOn: filterOn,
+      criterion1: String(count),
+    });
+  };
+
+  Filter.prototype._queueColor = function (filterOn, color) {
+    requireString(color, "Filter color");
+    if (color.length === 0) throw invalid("Filter color must not be empty");
+    this._queueCriteria({
+      filterOn: filterOn,
+      color: color,
+    });
+  };
+
+  Filter.prototype.load = function (props) {
+    this._ensureBinding();
+    return ClientObject.prototype.load.call(this, props);
+  };
+
+  Filter.prototype.toJSON = function () {
+    return this._loaded.criteria ? { criteria: this._criteria } : {};
+  };
+
+  if (hooks.addNavigationProperties) {
+    if (Excel.Table) {
+      hooks.addNavigationProperties(Excel.Table.prototype, ["sort"]);
+    }
+    if (Excel.TableColumn) {
+      hooks.addNavigationProperties(Excel.TableColumn.prototype, ["filter"]);
+    }
+  }
+
+  if (Excel.Table) {
+    Object.defineProperty(Excel.Table.prototype, "sort", {
+      configurable: true,
+      get: function () {
+        if (!this._sort) this._sort = new TableSort(this.context, this);
+        this._sort._ensureBinding();
+        return this._sort;
+      },
+    });
+  }
+
+  if (Excel.TableColumn) {
+    Object.defineProperty(Excel.TableColumn.prototype, "filter", {
+      configurable: true,
+      get: function () {
+        if (!this._filter) this._filter = new Filter(this.context, this);
+        this._filter._ensureBinding();
+        return this._filter;
+      },
+    });
+  }
+
+  Excel.TableSort = TableSort;
+  Excel.Filter = Filter;
+})(globalThis);

--- a/compute/officejs/src/table_filters.rs
+++ b/compute/officejs/src/table_filters.rs
@@ -1,0 +1,1378 @@
+//! Office.js table sorting and column filtering.
+//!
+//! The Office object model exposes TableSort and Filter as children of a
+//! table and table column. This module is the translation boundary for those
+//! children. It resolves the existing TableRef/TableColumnRef handles on
+//! every operation and delegates mutations to the production compute-api
+//! range-sort and SheetFilters facades. No workbook state is kept in this
+//! adapter.
+//!
+//! Host wire contract:
+//!
+//! * getTableSort { id, tableId } binds id to the existing table handle.
+//! * tableSortApply { tableId, fields, matchCase?, method? } calls
+//!   apply_table_sort and stores the returned descriptor in the host's
+//!   TableSort proxy map for load, clear, and reapply.
+//! * tableSortClear { tableId } validates the table and clears the host
+//!   descriptor. The current public compute-api has no table-sort metadata
+//!   mutation; clearing therefore has no cell effect, as Office specifies.
+//! * tableSortReapply { tableId, fields, matchCase, method } calls
+//!   reapply_table_sort with the descriptor retained by that map.
+//! * getTableColumnFilter { id, columnId } binds id to an existing column
+//!   handle.
+//! * tableFilterApply { columnId, criteria } and tableFilterClear
+//!   { columnId } call the corresponding helpers below. Filter.criteria
+//!   is loaded through load_table_filter.
+//!
+//! The Rust API deliberately accepts the already-bound TableRef and
+//! TableColumnRef rather than host map IDs. This keeps stable table and
+//! column identity in the existing table modules and prevents a second host
+//! implementation from resolving names or columns differently.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use compute_api::{CellRange, ComputeApiError, Sheet};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use value_types::Color;
+
+use crate::sort_filter::{RangeSortRequest, apply_range_sort};
+use crate::table_collections::TableColumnRef;
+use crate::tables::{TableError, TableRef};
+
+/// Error returned by a table sort/filter host operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TableFilterError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+impl TableFilterError {
+    fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            code: "InvalidArgument",
+            message: message.into(),
+        }
+    }
+
+    fn unsupported(message: impl Into<String>) -> Self {
+        Self {
+            code: "UnsupportedOperation",
+            message: message.into(),
+        }
+    }
+
+    fn item_not_found(message: impl Into<String>) -> Self {
+        Self {
+            code: "ItemNotFound",
+            message: message.into(),
+        }
+    }
+
+    fn general(message: impl Into<String>) -> Self {
+        Self {
+            code: "GeneralException",
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for TableFilterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for TableFilterError {}
+
+impl From<ComputeApiError> for TableFilterError {
+    fn from(error: ComputeApiError) -> Self {
+        let message = error.to_string();
+        match error {
+            ComputeApiError::InvalidAddress { .. }
+            | ComputeApiError::InvalidRange { .. }
+            | ComputeApiError::InvalidOperation(_) => Self::invalid(message),
+            ComputeApiError::SheetNotFound { .. }
+            | ComputeApiError::Compute(value_types::ComputeError::SheetNotFound { .. }) => {
+                Self::item_not_found(message)
+            }
+            ComputeApiError::Compute(value_types::ComputeError::InvalidInput { .. }) => {
+                Self::invalid(message)
+            }
+            _ => Self::general(message),
+        }
+    }
+}
+
+impl From<TableError> for TableFilterError {
+    fn from(error: TableError) -> Self {
+        Self {
+            code: error.code,
+            message: error.message,
+        }
+    }
+}
+
+/// Inputs to Table.sort.apply after the JS request has been decoded.
+#[derive(Debug, Clone)]
+pub(crate) struct TableSortRequest {
+    pub(crate) fields: Value,
+    pub(crate) match_case: Option<bool>,
+    pub(crate) method: Option<String>,
+}
+
+/// The Office-shaped descriptor for a table's last sort.
+///
+/// A host keeps this descriptor alongside its TableSort proxy so that
+/// reapply() can issue the same request after an edit. Imported OOXML table
+/// sort state is projected into the same shape by load_table_sort.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TableSortSnapshot {
+    pub(crate) fields: Vec<Value>,
+    pub(crate) match_case: bool,
+    pub(crate) method: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TableView {
+    id: String,
+    name: String,
+    range: TableRangeView,
+    #[serde(default)]
+    has_header_row: bool,
+    #[serde(default)]
+    has_totals_row: bool,
+    #[serde(default)]
+    columns: Vec<TableColumnView>,
+    #[serde(default)]
+    sort_state: Option<TableSortStateView>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TableRangeView {
+    start_row: u32,
+    start_col: u32,
+    end_row: u32,
+    end_col: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TableColumnView {
+    id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    index: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TableSortStateView {
+    #[serde(default)]
+    case_sensitive: bool,
+    #[serde(default)]
+    sort_method: String,
+    #[serde(default)]
+    conditions: Vec<TableSortConditionView>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TableSortConditionView {
+    ref_range: String,
+    #[serde(default)]
+    descending: bool,
+    #[serde(default)]
+    sort_by: String,
+    #[serde(default)]
+    color: Option<String>,
+    #[serde(default)]
+    icon_set: Option<Value>,
+    #[serde(default)]
+    icon_id: Option<u32>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FilterView {
+    id: String,
+    #[serde(rename = "type")]
+    #[allow(dead_code)]
+    filter_type: String,
+    #[serde(default)]
+    table_id: Option<String>,
+    #[serde(default)]
+    column_filters: HashMap<String, Value>,
+}
+
+/// Apply Table.sort.apply to the table data body.
+///
+/// SortField.key is a table-relative column offset. The production range
+/// sorter receives the corresponding absolute worksheet columns and the
+/// already-resolved data-body range, so headers and totals are excluded.
+/// Empty data bodies are valid table state and produce no cell mutation while
+/// still returning the requested last-sort descriptor.
+pub(crate) fn apply_table_sort(
+    table: &TableRef,
+    request: TableSortRequest,
+) -> Result<TableSortSnapshot, TableFilterError> {
+    let table_view = resolve_table(table)?;
+    let snapshot = sort_snapshot_from_request(&table_view, &request)?;
+
+    let Some(data_bounds) = data_body_bounds(&table_view) else {
+        return Ok(snapshot);
+    };
+    let address = a1_range(data_bounds.0, data_bounds.1, data_bounds.2, data_bounds.3);
+
+    // Range.sort's parser performs the one authoritative conversion to
+    // BridgeSortOptions, including color validation and unsupported icon /
+    // TextAsNumber diagnostics. It receives hasHeaders=false because the
+    // address is the table data body itself.
+    apply_range_sort(
+        &table.sheet(),
+        &address,
+        RangeSortRequest {
+            fields: request.fields,
+            match_case: request.match_case,
+            has_headers: Some(false),
+            orientation: Some("Rows".to_string()),
+            method: request.method,
+        },
+    )
+    .map_err(|error| TableFilterError {
+        code: error.code,
+        message: error.message,
+    })?;
+    Ok(snapshot)
+}
+
+/// Reapply a descriptor previously returned by apply_table_sort or
+/// load_table_sort.
+pub(crate) fn reapply_table_sort(
+    table: &TableRef,
+    snapshot: &TableSortSnapshot,
+) -> Result<(), TableFilterError> {
+    let request = TableSortRequest {
+        fields: Value::Array(snapshot.fields.clone()),
+        match_case: Some(snapshot.match_case),
+        // PinYin is the Office-facing default used when no CJK override was
+        // supplied. Passing it to the bridge would incorrectly turn the
+        // default into an unsupported explicit override.
+        method: (snapshot.method != "PinYin").then(|| snapshot.method.clone()),
+    };
+    apply_table_sort(table, request).map(|_| ())
+}
+
+/// Validate a table for TableSort.clear.
+///
+/// clear only clears header-button state in Office.js and leaves row order
+/// unchanged. The current public compute-api exposes no table-level sort
+/// metadata setter/clearer, so the host must drop its proxy descriptor after
+/// this validation succeeds. Imported table metadata is intentionally not
+/// rewritten by a no-op mutation.
+pub(crate) fn clear_table_sort(table: &TableRef) -> Result<(), TableFilterError> {
+    resolve_table(table).map(|_| ())
+}
+
+/// Load requested TableSort scalar properties.
+pub(crate) fn load_table_sort(
+    table: &TableRef,
+    properties: &[String],
+) -> Result<HashMap<String, Value>, TableFilterError> {
+    let table_view = resolve_table(table)?;
+    let snapshot = sort_snapshot_from_table(&table_view)?;
+    let requested: Vec<&str> = if properties.is_empty() {
+        vec!["fields", "matchCase", "method"]
+    } else {
+        properties.iter().map(String::as_str).collect()
+    };
+    let mut result = HashMap::new();
+    for property in requested {
+        let value = match property {
+            "fields" => Value::Array(snapshot.fields.clone()),
+            "matchCase" => Value::Bool(snapshot.match_case),
+            "method" => Value::String(snapshot.method.clone()),
+            other => {
+                return Err(TableFilterError::invalid(format!(
+                    "TableSort.{other} is not supported by this Office.js host"
+                )));
+            }
+        };
+        result.insert(property.to_string(), value);
+    }
+    Ok(result)
+}
+
+/// Apply a FilterCriteria to a bound table column.
+///
+/// Table creation/import creates a durable TableFilter record. If an
+/// imported workbook omitted that record, this helper creates one from the
+/// current table bounds before setting the column criterion. The
+/// SheetFilters::set_column_filter facade performs the actual evaluation and
+/// row visibility mutation as part of the same production operation.
+pub(crate) fn apply_table_filter(
+    column: &TableColumnRef,
+    criteria: &Value,
+) -> Result<(), TableFilterError> {
+    let table = column.table();
+    let table_view = resolve_table(&table)?;
+    let table_column = resolve_table_column(&table_view, column.key())?;
+    let filter = ensure_table_filter(&table.sheet(), &table_view)?;
+    let absolute_column = table_view
+        .range
+        .start_col
+        .checked_add(table_column.index)
+        .ok_or_else(|| TableFilterError::invalid("Table column exceeds worksheet bounds"))?;
+    let typed = parse_filter_criteria(criteria)?;
+    table
+        .sheet()
+        .filters()
+        .set_column_filter(&filter.id, absolute_column, typed)
+        .map_err(TableFilterError::from)?;
+    Ok(())
+}
+
+/// Clear one table-column criterion while retaining the table filter object.
+pub(crate) fn clear_table_filter(column: &TableColumnRef) -> Result<(), TableFilterError> {
+    let table = column.table();
+    let table_view = resolve_table(&table)?;
+    let table_column = resolve_table_column(&table_view, column.key())?;
+    let filter = table_filter(&table.sheet(), &table_view)?;
+    let absolute_column = table_view
+        .range
+        .start_col
+        .checked_add(table_column.index)
+        .ok_or_else(|| TableFilterError::invalid("Table column exceeds worksheet bounds"))?;
+    table
+        .sheet()
+        .filters()
+        .clear_column_filter(&filter.id, absolute_column)
+        .map_err(TableFilterError::from)?;
+    Ok(())
+}
+
+/// Load requested Filter scalar properties for one table column.
+pub(crate) fn load_table_filter(
+    column: &TableColumnRef,
+    properties: &[String],
+) -> Result<HashMap<String, Value>, TableFilterError> {
+    let table = column.table();
+    let table_view = resolve_table(&table)?;
+    let table_column = resolve_table_column(&table_view, column.key())?;
+    let filter = table_filter(&table.sheet(), &table_view)?;
+    let criteria =
+        office_criteria_for_column(&table.sheet(), &table_view, table_column.index, &filter)?;
+    let requested: Vec<&str> = if properties.is_empty() {
+        vec!["criteria"]
+    } else {
+        properties.iter().map(String::as_str).collect()
+    };
+    let mut result = HashMap::new();
+    for property in requested {
+        match property {
+            "criteria" => {
+                result.insert("criteria".to_string(), criteria.clone());
+            }
+            other => {
+                return Err(TableFilterError::invalid(format!(
+                    "Filter.{other} is not supported by this Office.js host"
+                )));
+            }
+        }
+    }
+    Ok(result)
+}
+
+fn resolve_table(table: &TableRef) -> Result<TableView, TableFilterError> {
+    let properties = table
+        .load(&["id".to_string()])
+        .map_err(TableFilterError::from)?;
+    let id = properties
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| TableFilterError::general("The table did not return its stable ID"))?;
+    let serialized = table
+        .sheet()
+        .tables()
+        .get_all()
+        .map_err(TableFilterError::from)?
+        .into_iter()
+        .find_map(|candidate| {
+            let value = serde_json::to_value(candidate).ok()?;
+            (value.get("id").and_then(Value::as_str) == Some(id)).then_some(value)
+        })
+        .ok_or_else(|| {
+            TableFilterError::item_not_found(format!("The table '{id}' no longer exists"))
+        })?;
+    serde_json::from_value(serialized).map_err(|error| {
+        TableFilterError::general(format!("Failed to decode table state: {error}"))
+    })
+}
+
+fn resolve_table_column<'a>(
+    table: &'a TableView,
+    key: &str,
+) -> Result<&'a TableColumnView, TableFilterError> {
+    if let Some(column) = table.columns.iter().find(|column| column.id == key) {
+        return Ok(column);
+    }
+    if let Ok(index) = key.parse::<u32>()
+        && let Some(column) = table.columns.iter().find(|column| column.index == index)
+    {
+        return Ok(column);
+    }
+    table
+        .columns
+        .iter()
+        .find(|column| column.name.eq_ignore_ascii_case(key))
+        .ok_or_else(|| {
+            TableFilterError::item_not_found(format!("The table column '{key}' no longer exists"))
+        })
+}
+
+fn data_body_bounds(table: &TableView) -> Option<(u32, u32, u32, u32)> {
+    let start_row = table
+        .range
+        .start_row
+        .checked_add(u32::from(table.has_header_row))?;
+    let end_row = table
+        .range
+        .end_row
+        .checked_sub(u32::from(table.has_totals_row))?;
+    (start_row <= end_row).then_some((
+        start_row,
+        table.range.start_col,
+        end_row,
+        table.range.end_col,
+    ))
+}
+
+fn sort_snapshot_from_request(
+    table: &TableView,
+    request: &TableSortRequest,
+) -> Result<TableSortSnapshot, TableFilterError> {
+    let fields = request.fields.as_array().ok_or_else(|| {
+        TableFilterError::invalid("Table.sort.apply fields must be an array of SortField objects")
+    })?;
+    if fields.is_empty() {
+        return Err(TableFilterError::invalid(
+            "Table.sort.apply fields must contain at least one SortField",
+        ));
+    }
+    let method = request
+        .method
+        .clone()
+        .unwrap_or_else(|| "PinYin".to_string());
+    if request.method.is_some() {
+        validate_sort_method(&method)?;
+    }
+    let width = table
+        .range
+        .end_col
+        .checked_sub(table.range.start_col)
+        .and_then(|span| span.checked_add(1))
+        .ok_or_else(|| TableFilterError::invalid("Table range has invalid column bounds"))?;
+    for (index, field) in fields.iter().enumerate() {
+        validate_table_sort_field(field, index, width)?;
+    }
+    Ok(TableSortSnapshot {
+        fields: fields.clone(),
+        match_case: request.match_case.unwrap_or(false),
+        method,
+    })
+}
+
+fn validate_sort_method(method: &str) -> Result<(), TableFilterError> {
+    match method {
+        // The bridge sorter uses the workbook's normal locale ordering. The
+        // CJK method is retained in the Office descriptor but is not
+        // silently treated as a different comparator.
+        "PinYin" | "StrokeCount" => Err(TableFilterError::unsupported(format!(
+            "Table.sort.apply method '{method}' is not supported by the compute engine"
+        ))),
+        other => Err(TableFilterError::invalid(format!(
+            "Unsupported SortMethod '{other}'"
+        ))),
+    }
+}
+
+fn validate_table_sort_field(
+    field: &Value,
+    field_index: usize,
+    width: u32,
+) -> Result<(), TableFilterError> {
+    let object = field.as_object().ok_or_else(|| {
+        TableFilterError::invalid(format!(
+            "Table.sort.apply fields[{field_index}] must be a SortField object"
+        ))
+    })?;
+    let key = required_u32(object, "key", &format!("fields[{field_index}]"))?;
+    if key >= width {
+        return Err(TableFilterError::invalid(format!(
+            "Table.sort.apply fields[{field_index}].key {key} is outside the table's {width} columns"
+        )));
+    }
+    if let Some(ascending) = object.get("ascending")
+        && !ascending.is_null()
+        && !ascending.is_boolean()
+    {
+        return Err(TableFilterError::invalid(format!(
+            "fields[{field_index}].ascending must be a boolean"
+        )));
+    }
+    let sort_on = optional_string(object, "sortOn")?.unwrap_or_else(|| "Value".to_string());
+    match sort_on.as_str() {
+        "Value" | "CellColor" | "FontColor" | "Icon" => {}
+        other => {
+            return Err(TableFilterError::invalid(format!(
+                "Unsupported SortOn '{other}'"
+            )));
+        }
+    }
+    if let Some(data_option) = optional_string(object, "dataOption")? {
+        match data_option.as_str() {
+            "Normal" => {}
+            "TextAsNumber" => {
+                return Err(TableFilterError::unsupported(
+                    "SortDataOption 'TextAsNumber' is not supported by the compute engine",
+                ));
+            }
+            other => {
+                return Err(TableFilterError::invalid(format!(
+                    "Unsupported SortDataOption '{other}'"
+                )));
+            }
+        }
+    }
+    if let Some(sub_field) = object.get("subField")
+        && !sub_field.is_null()
+    {
+        return Err(TableFilterError::unsupported(
+            "SortField.subField is not supported by the compute engine",
+        ));
+    }
+    match sort_on.as_str() {
+        "CellColor" | "FontColor" => {
+            let color = required_string(object, "color", &format!("fields[{field_index}]"))?;
+            if !is_engine_color_token(&color) {
+                return Err(TableFilterError::invalid(format!(
+                    "fields[{field_index}].color must be a valid color string"
+                )));
+            }
+        }
+        "Icon" => {
+            return Err(TableFilterError::unsupported(
+                "SortOn 'Icon' requires conditional-format icon context and is not supported by the compute engine",
+            ));
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn sort_snapshot_from_table(table: &TableView) -> Result<TableSortSnapshot, TableFilterError> {
+    let Some(state) = table.sort_state.as_ref() else {
+        return Ok(TableSortSnapshot {
+            fields: Vec::new(),
+            match_case: false,
+            method: "PinYin".to_string(),
+        });
+    };
+    let method = match state.sort_method.as_str() {
+        "stroke" | "Stroke" | "StrokeCount" => "StrokeCount",
+        "pinYin" | "PinYin" => "PinYin",
+        // OOXML's none is the absence of a CJK override. Office's public
+        // SortMethod enum has no None; PinYin is the host's stable default.
+        "" | "none" | "None" => "PinYin",
+        other => {
+            return Err(TableFilterError::unsupported(format!(
+                "Stored table sort method '{other}' is unsupported"
+            )));
+        }
+    }
+    .to_string();
+    let mut fields = Vec::with_capacity(state.conditions.len());
+    for (index, condition) in state.conditions.iter().enumerate() {
+        let (start_row, start_col, _, end_col) = CellRange::from(condition.ref_range.as_str())
+            .resolve()
+            .map_err(TableFilterError::from)?;
+        let table_width = table
+            .range
+            .end_col
+            .checked_sub(table.range.start_col)
+            .and_then(|span| span.checked_add(1))
+            .ok_or_else(|| TableFilterError::invalid("Table range has invalid columns"))?;
+        let table_end_col = table
+            .range
+            .start_col
+            .checked_add(table_width - 1)
+            .ok_or_else(|| TableFilterError::invalid("Table range exceeds worksheet bounds"))?;
+        if start_col < table.range.start_col || start_col > table_end_col {
+            return Err(TableFilterError::unsupported(format!(
+                "Stored table sort condition {index} is outside the table"
+            )));
+        }
+        if end_col < start_col || start_row > table.range.end_row {
+            return Err(TableFilterError::unsupported(format!(
+                "Stored table sort condition {index} has an invalid range"
+            )));
+        }
+        let key = start_col - table.range.start_col;
+        let sort_on = match condition.sort_by.as_str() {
+            "value" | "Value" | "" => "Value",
+            "cellColor" | "CellColor" => "CellColor",
+            "fontColor" | "FontColor" => "FontColor",
+            "icon" | "Icon" => "Icon",
+            other => {
+                return Err(TableFilterError::unsupported(format!(
+                    "Stored table sort condition kind '{other}' is unsupported"
+                )));
+            }
+        };
+        let mut field = Map::new();
+        field.insert("key".to_string(), json!(key));
+        field.insert("ascending".to_string(), json!(!condition.descending));
+        field.insert("sortOn".to_string(), json!(sort_on));
+        if let Some(color) = condition.color.as_ref() {
+            field.insert("color".to_string(), Value::String(color.clone()));
+        }
+        if sort_on == "Icon"
+            && let (Some(set), Some(icon_id)) = (condition.icon_set.as_ref(), condition.icon_id)
+        {
+            field.insert("icon".to_string(), json!({"set": set, "index": icon_id}));
+        }
+        fields.push(Value::Object(field));
+    }
+    Ok(TableSortSnapshot {
+        fields,
+        match_case: state.case_sensitive,
+        method,
+    })
+}
+
+fn table_filter(sheet: &Sheet, table: &TableView) -> Result<FilterView, TableFilterError> {
+    let states = sheet.filters().get_all().map_err(TableFilterError::from)?;
+    let value = serde_json::to_value(states).map_err(|error| {
+        TableFilterError::general(format!("Failed to encode table filter state: {error}"))
+    })?;
+    let records: Vec<FilterView> = serde_json::from_value(value).map_err(|error| {
+        TableFilterError::general(format!("Failed to decode table filter state: {error}"))
+    })?;
+    records
+        .into_iter()
+        .find(|record| record.table_id.as_deref() == Some(table.id.as_str()))
+        .ok_or_else(|| {
+            TableFilterError::item_not_found(format!(
+                "The table '{}' has no table filter",
+                table.name
+            ))
+        })
+}
+
+fn ensure_table_filter(sheet: &Sheet, table: &TableView) -> Result<FilterView, TableFilterError> {
+    match table_filter(sheet, table) {
+        Ok(filter) => Ok(filter),
+        Err(error) if error.code == "ItemNotFound" => {
+            let data_end_row = table
+                .range
+                .end_row
+                .checked_sub(u32::from(table.has_totals_row))
+                .unwrap_or(table.range.start_row);
+            let result = sheet
+                .filters()
+                .create(json!({
+                    "startRow": table.range.start_row,
+                    "startCol": table.range.start_col,
+                    "endRow": data_end_row,
+                    "endCol": table.range.end_col,
+                    "filterType": "tableFilter",
+                    "tableId": table.id,
+                }))
+                .map_err(TableFilterError::from)?;
+            let id = result
+                .data
+                .as_ref()
+                .and_then(|data| data.get("id"))
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    TableFilterError::general(
+                        "The compute engine did not return the created table filter ID",
+                    )
+                })?
+                .to_string();
+            table_filter(sheet, table).or_else(|_| {
+                Ok(FilterView {
+                    id,
+                    filter_type: "tableFilter".to_string(),
+                    table_id: Some(table.id.clone()),
+                    column_filters: HashMap::new(),
+                })
+            })
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn office_criteria_for_column(
+    sheet: &Sheet,
+    table: &TableView,
+    column_index: u32,
+    filter: &FilterView,
+) -> Result<Value, TableFilterError> {
+    let absolute_column = table
+        .range
+        .start_col
+        .checked_add(column_index)
+        .ok_or_else(|| TableFilterError::invalid("Table column exceeds worksheet bounds"))?;
+    let header_cell_id = sheet
+        .get_cell_data((table.range.start_row, absolute_column))
+        .map_err(TableFilterError::from)?
+        .and_then(|data| {
+            data.get("cell_id")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        });
+    let Some(header_cell_id) = header_cell_id else {
+        return Err(TableFilterError::unsupported(
+            "The table filter header cell has no resolvable identity",
+        ));
+    };
+    let Some(stored) = filter.column_filters.get(&header_cell_id) else {
+        // Office returns a valid FilterCriteria-shaped value for an unfiltered
+        // table column. An empty Values selection is the stable projection
+        // and keeps criteria.filterOn readable by clients.
+        return Ok(json!({"filterOn":"Values", "values":[]}));
+    };
+    office_criteria_from_domain(stored)
+}
+
+fn parse_filter_criteria(criteria: &Value) -> Result<Value, TableFilterError> {
+    let object = criteria.as_object().ok_or_else(|| {
+        TableFilterError::invalid("Filter criteria must be a FilterCriteria object")
+    })?;
+    if let Some(sub_field) = object.get("subField")
+        && !sub_field.is_null()
+    {
+        return Err(TableFilterError::unsupported(
+            "FilterCriteria.subField is not supported by the compute engine",
+        ));
+    }
+    let filter_on = object
+        .get("filterOn")
+        .and_then(Value::as_str)
+        .ok_or_else(|| TableFilterError::invalid("FilterCriteria.filterOn is required"))?;
+    match filter_on {
+        "Values" => {
+            let values = object
+                .get("values")
+                .and_then(Value::as_array)
+                .ok_or_else(|| TableFilterError::invalid("Values filtering requires values[]"))?;
+            for (index, value) in values.iter().enumerate() {
+                match value {
+                    Value::String(_) | Value::Number(_) | Value::Bool(_) => {}
+                    Value::Object(_) => {
+                        return Err(TableFilterError::unsupported(format!(
+                            "Values filter value at index {index} is a FilterDatetime/rich value, which the compute engine cannot evaluate"
+                        )));
+                    }
+                    Value::Null | Value::Array(_) => {
+                        return Err(TableFilterError::invalid(format!(
+                            "Values filter value at index {index} must be a scalar"
+                        )));
+                    }
+                }
+            }
+            Ok(json!({
+                "type":"values",
+                "values":values,
+                "includeBlanks":false,
+            }))
+        }
+        "Custom" => parse_custom_filter(object),
+        "TopItems" | "BottomItems" | "TopPercent" | "BottomPercent" => {
+            let count = parse_count(object.get("criterion1"), "criterion1")?;
+            if filter_on.ends_with("Items") && count.fract() != 0.0 {
+                return Err(TableFilterError::invalid(
+                    "Top/bottom item count must be an integer",
+                ));
+            }
+            if filter_on.ends_with("Percent") && count > 100.0 {
+                return Err(TableFilterError::invalid(
+                    "Top/bottom percent must be between 0 and 100",
+                ));
+            }
+            Ok(json!({
+                "type":"topBottom",
+                "direction":if filter_on.starts_with("Top") { "top" } else { "bottom" },
+                "count":count,
+                "by":if filter_on.ends_with("Percent") { "percent" } else { "items" },
+            }))
+        }
+        "Dynamic" => {
+            let dynamic = object
+                .get("dynamicCriteria")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    TableFilterError::invalid("Dynamic filtering requires dynamicCriteria")
+                })?;
+            Ok(json!({"type":"dynamic", "rule":dynamic_rule(dynamic)?}))
+        }
+        "CellColor" | "FontColor" => {
+            let color = object
+                .get("color")
+                .and_then(Value::as_str)
+                .filter(|color| !color.is_empty())
+                .ok_or_else(|| TableFilterError::invalid("Color filtering requires color"))?;
+            if Color::from_hex(color).is_err() {
+                return Err(TableFilterError::invalid(
+                    "Color filtering requires a hexadecimal color string",
+                ));
+            }
+            Ok(json!({
+                "type":"color",
+                "color":color,
+                "byFont":filter_on == "FontColor",
+            }))
+        }
+        "Icon" => Err(TableFilterError::unsupported(
+            "FilterOn 'Icon' requires conditional-format icon context and is not supported by the compute engine",
+        )),
+        other => Err(TableFilterError::invalid(format!(
+            "Unsupported FilterOn '{other}'"
+        ))),
+    }
+}
+
+fn parse_custom_filter(object: &Map<String, Value>) -> Result<Value, TableFilterError> {
+    let criterion1 = object
+        .get("criterion1")
+        .and_then(Value::as_str)
+        .ok_or_else(|| TableFilterError::invalid("Custom filtering requires criterion1"))?;
+    let criterion2 = match object.get("criterion2") {
+        None | Some(Value::Null) => None,
+        Some(value) => Some(value.as_str().ok_or_else(|| {
+            TableFilterError::invalid("Custom filtering criterion2 must be a string")
+        })?),
+    };
+    let logic = match object.get("operator") {
+        None | Some(Value::Null) => "and",
+        Some(Value::String(value)) if value == "And" => "and",
+        Some(Value::String(value)) if value == "Or" => "or",
+        Some(Value::String(value)) => {
+            return Err(TableFilterError::invalid(format!(
+                "Unsupported FilterOperator '{value}'"
+            )));
+        }
+        Some(_) => {
+            return Err(TableFilterError::invalid(
+                "FilterCriteria.operator must be 'And' or 'Or'",
+            ));
+        }
+    };
+    let first = parse_condition(criterion1)?;
+    let second = criterion2.map(parse_condition).transpose()?;
+    let mut conditions = vec![first];
+    if let Some(second) = second {
+        conditions.push(second);
+    }
+    Ok(json!({
+        "type":"condition",
+        "conditions":conditions,
+        "logic":logic,
+    }))
+}
+
+fn parse_condition(raw: &str) -> Result<Value, TableFilterError> {
+    let (operator, operand) = if let Some(rest) = raw.strip_prefix(">=") {
+        ("greaterThanOrEqual", rest)
+    } else if let Some(rest) = raw.strip_prefix("<=") {
+        ("lessThanOrEqual", rest)
+    } else if let Some(rest) = raw.strip_prefix("<>") {
+        ("notEquals", rest)
+    } else if let Some(rest) = raw.strip_prefix('>') {
+        ("greaterThan", rest)
+    } else if let Some(rest) = raw.strip_prefix('<') {
+        ("lessThan", rest)
+    } else if let Some(rest) = raw.strip_prefix('=') {
+        ("equals", rest)
+    } else {
+        ("equals", raw)
+    };
+    let (operator, operand) = wildcard_condition(operator, operand)?;
+    if operand.is_empty() {
+        return match operator {
+            "equals" => Ok(json!({"operator":"isBlank"})),
+            "notEquals" => Ok(json!({"operator":"isNotBlank"})),
+            other => Err(TableFilterError::invalid(format!(
+                "Custom filter operator '{other}' requires a criterion value"
+            ))),
+        };
+    }
+    Ok(json!({"operator":operator, "value":parse_operand(operand)}))
+}
+
+fn wildcard_condition<'a>(
+    operator: &'static str,
+    operand: &'a str,
+) -> Result<(&'static str, &'a str), TableFilterError> {
+    let has_wildcard = operand.contains('*') || operand.contains('?');
+    if !has_wildcard {
+        return Ok((operator, operand));
+    }
+    if operand.contains('?') {
+        return Err(TableFilterError::unsupported(
+            "Custom filter wildcard '?' is not supported by the compute engine",
+        ));
+    }
+    if operator != "equals" && operator != "notEquals" {
+        return Err(TableFilterError::unsupported(
+            "Custom filter wildcards are supported only with equals/notEquals",
+        ));
+    }
+    let leading = operand.starts_with('*');
+    let trailing = operand.ends_with('*');
+    let core = match (leading, trailing) {
+        (true, true) => &operand[1..operand.len() - 1],
+        (true, false) => &operand[1..],
+        (false, true) => &operand[..operand.len() - 1],
+        (false, false) => operand,
+    };
+    if core.contains('*') || core.contains('~') {
+        return Err(TableFilterError::unsupported(
+            "Custom filter wildcard patterns with interior escapes are not supported by the compute engine",
+        ));
+    }
+    if operator == "notEquals" && (leading != trailing) {
+        return Err(TableFilterError::unsupported(
+            "Custom filter exclusion wildcards are supported only for contains/notContains patterns",
+        ));
+    }
+    let mapped = match (operator, leading, trailing) {
+        ("equals", true, true) => "contains",
+        ("notEquals", true, true) => "notContains",
+        ("equals", true, false) => "endsWith",
+        ("equals", false, true) => "beginsWith",
+        _ => operator,
+    };
+    Ok((mapped, core))
+}
+
+fn parse_operand(operand: &str) -> Value {
+    if operand.eq_ignore_ascii_case("TRUE") {
+        return Value::Bool(true);
+    }
+    if operand.eq_ignore_ascii_case("FALSE") {
+        return Value::Bool(false);
+    }
+    if let Ok(number) = operand.parse::<f64>()
+        && number.is_finite()
+    {
+        return json!(number);
+    }
+    Value::String(operand.to_string())
+}
+
+fn parse_count(value: Option<&Value>, name: &str) -> Result<f64, TableFilterError> {
+    let value = value.ok_or_else(|| TableFilterError::invalid(format!("{name} is required")))?;
+    let number = match value {
+        Value::Number(number) => number.as_f64(),
+        Value::String(string) => string.parse::<f64>().ok(),
+        _ => None,
+    }
+    .filter(|number| number.is_finite() && *number >= 0.0)
+    .ok_or_else(|| {
+        TableFilterError::invalid(format!("{name} must be a finite non-negative number"))
+    })?;
+    Ok(number)
+}
+
+fn dynamic_rule(value: &str) -> Result<&'static str, TableFilterError> {
+    let rule = match value {
+        "AboveAverage" => "aboveAverage",
+        "BelowAverage" => "belowAverage",
+        "Today" => "today",
+        "Yesterday" => "yesterday",
+        "Tomorrow" => "tomorrow",
+        "ThisWeek" => "thisWeek",
+        "LastWeek" => "lastWeek",
+        "NextWeek" => "nextWeek",
+        "ThisMonth" => "thisMonth",
+        "LastMonth" => "lastMonth",
+        "NextMonth" => "nextMonth",
+        "ThisQuarter" => "thisQuarter",
+        "LastQuarter" => "lastQuarter",
+        "NextQuarter" => "nextQuarter",
+        "ThisYear" => "thisYear",
+        "LastYear" => "lastYear",
+        "NextYear" => "nextYear",
+        other => {
+            return Err(TableFilterError::unsupported(format!(
+                "DynamicFilterCriteria '{other}' is not supported by the compute engine"
+            )));
+        }
+    };
+    Ok(rule)
+}
+
+fn office_criteria_from_domain(value: &Value) -> Result<Value, TableFilterError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| TableFilterError::general("Stored table criterion is not an object"))?;
+    let kind = object
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| TableFilterError::general("Stored table criterion has no type"))?;
+    match kind {
+        "values" => Ok(json!({
+            "filterOn":"Values",
+            "values":object.get("values").cloned().unwrap_or_else(|| json!([])),
+        })),
+        "condition" => domain_condition_to_office(object),
+        "topBottom" => {
+            let direction = object
+                .get("direction")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    TableFilterError::general("Stored top/bottom criterion has no direction")
+                })?;
+            let by = object.get("by").and_then(Value::as_str).ok_or_else(|| {
+                TableFilterError::general("Stored top/bottom criterion has no basis")
+            })?;
+            let count = object
+                .get("count")
+                .map(value_to_criterion_text)
+                .unwrap_or_default();
+            let filter_on = match (direction, by) {
+                ("top", "items") => "TopItems",
+                ("bottom", "items") => "BottomItems",
+                ("top", "percent") => "TopPercent",
+                ("bottom", "percent") => "BottomPercent",
+                _ => {
+                    return Err(TableFilterError::unsupported(
+                        "Stored top/bottom filter basis is not supported by Office.js",
+                    ));
+                }
+            };
+            Ok(json!({"filterOn":filter_on,"criterion1":count}))
+        }
+        "dynamic" => {
+            let rule = object
+                .get("rule")
+                .and_then(Value::as_str)
+                .ok_or_else(|| TableFilterError::general("Stored dynamic criterion has no rule"))?;
+            Ok(json!({
+                "filterOn":"Dynamic",
+                "dynamicCriteria":dynamic_rule_to_office(rule)?,
+            }))
+        }
+        "color" => {
+            let color = object
+                .get("color")
+                .and_then(Value::as_str)
+                .ok_or_else(|| TableFilterError::general("Stored color criterion has no color"))?;
+            let by_font = object
+                .get("byFont")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            Ok(json!({
+                "filterOn":if by_font { "FontColor" } else { "CellColor" },
+                "color":color,
+            }))
+        }
+        "icon" => Err(TableFilterError::unsupported(
+            "Stored icon filter criteria cannot be evaluated by the compute engine",
+        )),
+        other => Err(TableFilterError::unsupported(format!(
+            "Stored table criterion type '{other}' is unsupported"
+        ))),
+    }
+}
+
+fn domain_condition_to_office(object: &Map<String, Value>) -> Result<Value, TableFilterError> {
+    let conditions = object
+        .get("conditions")
+        .and_then(Value::as_array)
+        .ok_or_else(|| TableFilterError::general("Stored condition criterion has no conditions"))?;
+    if conditions.is_empty() || conditions.len() > 2 {
+        return Err(TableFilterError::unsupported(
+            "Stored table condition count cannot be represented by Office.js",
+        ));
+    }
+    let logic = match object.get("logic").and_then(Value::as_str) {
+        Some("or") => "Or",
+        _ => "And",
+    };
+    let first =
+        condition_to_office(conditions[0].as_object().ok_or_else(|| {
+            TableFilterError::general("Stored table condition is not an object")
+        })?)?;
+    let second = if conditions.len() == 2 {
+        Some(condition_to_office(conditions[1].as_object().ok_or_else(
+            || TableFilterError::general("Stored table condition is not an object"),
+        )?)?)
+    } else {
+        None
+    };
+    let mut result = Map::new();
+    result.insert("filterOn".to_string(), Value::String("Custom".to_string()));
+    result.insert("criterion1".to_string(), Value::String(first));
+    if let Some(second) = second {
+        result.insert("criterion2".to_string(), Value::String(second));
+        result.insert("operator".to_string(), Value::String(logic.to_string()));
+    }
+    Ok(Value::Object(result))
+}
+
+fn condition_to_office(object: &Map<String, Value>) -> Result<String, TableFilterError> {
+    let operator = object
+        .get("operator")
+        .and_then(Value::as_str)
+        .ok_or_else(|| TableFilterError::general("Stored table condition has no operator"))?;
+    if matches!(operator, "isBlank" | "isNotBlank") {
+        return Ok(if operator == "isBlank" {
+            "=".to_string()
+        } else {
+            "<>".to_string()
+        });
+    }
+    let value = object.get("value").cloned().unwrap_or(Value::Null);
+    let text = value_to_criterion_text(&value);
+    let prefix = match operator {
+        "equals" => "=",
+        "notEquals" => "<>",
+        "greaterThan" => ">",
+        "greaterThanOrEqual" => ">=",
+        "lessThan" => "<",
+        "lessThanOrEqual" => "<=",
+        "beginsWith" | "endsWith" | "contains" => "=",
+        "notContains" => "<>",
+        other => {
+            return Err(TableFilterError::unsupported(format!(
+                "Stored table condition operator '{other}' cannot be represented"
+            )));
+        }
+    };
+    let wildcard = match operator {
+        "beginsWith" => format!("{text}*"),
+        "endsWith" => format!("*{text}"),
+        "contains" | "notContains" => format!("*{text}*"),
+        _ => text,
+    };
+    Ok(format!("{prefix}{wildcard}"))
+}
+
+fn value_to_criterion_text(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::String(value) => value.clone(),
+        Value::Bool(value) => {
+            if *value {
+                "TRUE".to_string()
+            } else {
+                "FALSE".to_string()
+            }
+        }
+        Value::Number(value) => {
+            let number = value.as_f64().unwrap_or(0.0);
+            if number == 0.0 {
+                "0".to_string()
+            } else if number.is_finite() && number.fract() == 0.0 && number.abs() < 1e21 {
+                format!("{number:.0}")
+            } else {
+                value.to_string()
+            }
+        }
+        other => other.to_string(),
+    }
+}
+
+fn dynamic_rule_to_office(rule: &str) -> Result<&'static str, TableFilterError> {
+    let office = match rule {
+        "aboveAverage" => "AboveAverage",
+        "belowAverage" => "BelowAverage",
+        "today" => "Today",
+        "yesterday" => "Yesterday",
+        "tomorrow" => "Tomorrow",
+        "thisWeek" => "ThisWeek",
+        "lastWeek" => "LastWeek",
+        "nextWeek" => "NextWeek",
+        "thisMonth" => "ThisMonth",
+        "lastMonth" => "LastMonth",
+        "nextMonth" => "NextMonth",
+        "thisQuarter" => "ThisQuarter",
+        "lastQuarter" => "LastQuarter",
+        "nextQuarter" => "NextQuarter",
+        "thisYear" => "ThisYear",
+        "lastYear" => "LastYear",
+        "nextYear" => "NextYear",
+        other => {
+            return Err(TableFilterError::unsupported(format!(
+                "Stored dynamic filter rule '{other}' is unsupported"
+            )));
+        }
+    };
+    Ok(office)
+}
+
+fn required_u32(
+    object: &Map<String, Value>,
+    name: &str,
+    location: &str,
+) -> Result<u32, TableFilterError> {
+    let value = object
+        .get(name)
+        .ok_or_else(|| TableFilterError::invalid(format!("{location}.{name} is required")))?;
+    value
+        .as_u64()
+        .and_then(|value| u32::try_from(value).ok())
+        .ok_or_else(|| {
+            TableFilterError::invalid(format!("{location}.{name} must be a non-negative integer"))
+        })
+}
+
+fn required_string(
+    object: &Map<String, Value>,
+    name: &str,
+    location: &str,
+) -> Result<String, TableFilterError> {
+    let value = object
+        .get(name)
+        .ok_or_else(|| TableFilterError::invalid(format!("{location}.{name} is required")))?;
+    let string = value
+        .as_str()
+        .ok_or_else(|| TableFilterError::invalid(format!("{location}.{name} must be a string")))?;
+    if string.is_empty() {
+        return Err(TableFilterError::invalid(format!(
+            "{location}.{name} must not be empty"
+        )));
+    }
+    Ok(string.to_string())
+}
+
+fn optional_string(
+    object: &Map<String, Value>,
+    name: &str,
+) -> Result<Option<String>, TableFilterError> {
+    match object.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value
+            .as_str()
+            .map(ToOwned::to_owned)
+            .map(Some)
+            .ok_or_else(|| TableFilterError::invalid(format!("{name} must be a string"))),
+    }
+}
+
+fn is_engine_color_token(color: &str) -> bool {
+    Color::from_hex(color).is_ok()
+        || color.starts_with("theme:")
+        || color.starts_with("rgb(")
+        || color.starts_with("rgba(")
+}
+
+fn a1_range(start_row: u32, start_col: u32, end_row: u32, end_col: u32) -> String {
+    let start = format!("{}{}", column_name(start_col), start_row + 1);
+    let end = format!("{}{}", column_name(end_col), end_row + 1);
+    if start == end {
+        start
+    } else {
+        format!("{start}:{end}")
+    }
+}
+
+fn column_name(mut column: u32) -> String {
+    let mut reversed = Vec::new();
+    loop {
+        reversed.push((b'A' + (column % 26) as u8) as char);
+        column /= 26;
+        if column == 0 {
+            break;
+        }
+        column -= 1;
+    }
+    reversed.into_iter().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_table_values_filter_into_domain_shape() {
+        assert_eq!(
+            parse_filter_criteria(&json!({
+                "filterOn":"Values",
+                "values":["Open", "Closed"]
+            }))
+            .unwrap(),
+            json!({
+                "type":"values",
+                "values":["Open", "Closed"],
+                "includeBlanks":false
+            })
+        );
+    }
+
+    #[test]
+    fn parses_custom_filter_wildcards_and_numbers() {
+        assert_eq!(
+            parse_filter_criteria(&json!({
+                "filterOn":"Custom",
+                "criterion1":">=10",
+                "criterion2":"<=20",
+                "operator":"And"
+            }))
+            .unwrap(),
+            json!({
+                "type":"condition",
+                "conditions":[
+                    {"operator":"greaterThanOrEqual", "value":10.0},
+                    {"operator":"lessThanOrEqual", "value":20.0}
+                ],
+                "logic":"and"
+            })
+        );
+        assert_eq!(
+            parse_filter_criteria(&json!({
+                "filterOn":"Custom",
+                "criterion1":"=*needle*"
+            }))
+            .unwrap(),
+            json!({
+                "type":"condition",
+                "conditions":[{"operator":"contains", "value":"needle"}],
+                "logic":"and"
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_date_icon_and_dynamic_shapes_explicitly() {
+        let date = parse_filter_criteria(&json!({
+            "filterOn":"Values",
+            "values":[{"date":"2024-01-01", "specificity":"Day"}]
+        }))
+        .unwrap_err();
+        assert_eq!(date.code, "UnsupportedOperation");
+
+        let icon = parse_filter_criteria(&json!({
+            "filterOn":"Icon",
+            "icon":{"set":"ThreeArrows", "index":0}
+        }))
+        .unwrap_err();
+        assert_eq!(icon.code, "UnsupportedOperation");
+
+        let dynamic = parse_filter_criteria(&json!({
+            "filterOn":"Dynamic",
+            "dynamicCriteria":"AllDatesInPeriodJanuary"
+        }))
+        .unwrap_err();
+        assert_eq!(dynamic.code, "UnsupportedOperation");
+    }
+}

--- a/compute/officejs/src/tables.js
+++ b/compute/officejs/src/tables.js
@@ -1,0 +1,424 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var ClientObject = OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs;
+
+  function propertyNotLoaded(name) {
+    var error = new OfficeExtension.Error({
+      code: "PropertyNotLoaded",
+      message:
+        "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context.",
+    });
+    error.name = "RichApi.Error";
+    error.code = "PropertyNotLoaded";
+    return error;
+  }
+
+  function invalidArgument(message) {
+    return new OfficeExtension.Error({
+      code: "InvalidArgument",
+      message: message,
+    });
+  }
+
+  function requirePropertyObject(source) {
+    if (source == null || typeof source !== "object") {
+      throw new TypeError("set requires a property object");
+    }
+  }
+
+  function invalidRequestContext() {
+    return new OfficeExtension.Error({
+      code: "InvalidRequestContext",
+      message: "The object belongs to a different request context.",
+    });
+  }
+
+  function integerArgument(value, property) {
+    if (typeof value !== "number" || !isFinite(value) || Math.floor(value) !== value) {
+      throw invalidArgument(property + " must be an integer");
+    }
+    return value;
+  }
+
+  function newClientResult(context) {
+    if (officeJs && typeof officeJs.createClientResult === "function") {
+      return officeJs.createClientResult(context);
+    }
+    return new OfficeExtension.ClientResult(context);
+  }
+
+  function queueTableItem(table, collection, key, orNullObject, byIndex) {
+    table._collection = collection;
+    table._tableCollectionId = collection ? collection._id : null;
+    var operation = {
+      op: "tableGetItem",
+      id: table._id,
+      key: String(key),
+    };
+    if (collection && collection._worksheet) {
+      operation.worksheetId = collection._worksheet._id;
+    } else if (collection) {
+      // Workbook-scoped lookup is resolved by the collection on the host.
+      operation.collectionId = collection._id;
+    }
+    if (orNullObject === true) operation.orNullObject = true;
+    if (byIndex === true) operation.byIndex = true;
+    table.context._queue.push(operation);
+    return table;
+  }
+
+  function TableCollection(context, worksheet, workbook) {
+    ClientObject.call(this, context);
+    this._worksheet = worksheet || null;
+    this._workbook = workbook || null;
+    this._scalarProperties = ["items", "count"];
+    this._navigationProperties = ["items"];
+    this._itemCache = Object.create(null);
+    this._bindingQueued = false;
+
+    if (officeJs && typeof officeJs.configureCollection === "function") {
+      officeJs.configureCollection(this, function (key) {
+        return this.getItem(key);
+      });
+    } else {
+      // Production uses the shared bootstrap collection hook. This fallback
+      // keeps the module usable with a compatible older bootstrap.
+      this._hydrateItems = function (descriptors) {
+        if (!Array.isArray(descriptors)) {
+          throw new OfficeExtension.Error({
+            code: "GeneralException",
+            message: "The host returned an invalid collection result.",
+          });
+        }
+        return descriptors.map(function (descriptor) {
+          var item = this.getItem(descriptor && descriptor.key);
+          var properties = descriptor && descriptor.properties;
+          if (properties && typeof properties === "object") {
+            Object.keys(properties).forEach(function (name) {
+              item._loaded[name] = true;
+              item[name === "id" ? "_idValue" : "_" + name] = properties[name];
+            });
+          }
+          return item;
+        }, this);
+      };
+    }
+  }
+  TableCollection.prototype = Object.create(ClientObject.prototype);
+  TableCollection.prototype.constructor = TableCollection;
+
+  Object.defineProperty(TableCollection.prototype, "items", {
+    get: function () {
+      if (!this._loaded.items) throw propertyNotLoaded("items");
+      return this._items || [];
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(TableCollection.prototype, "count", {
+    get: function () {
+      if (!this._loaded.count) throw propertyNotLoaded("count");
+      return this._count;
+    },
+    configurable: true,
+  });
+
+  TableCollection.prototype._ensureBinding = function () {
+    if (this._bindingQueued) return;
+    var binding = {
+      op: "getTableCollection",
+      id: this._id,
+    };
+    if (this._worksheet) binding.worksheetId = this._worksheet._id;
+    this.context._queue.push(binding);
+    this._bindingQueued = true;
+  };
+
+  TableCollection.prototype._newTable = function (key) {
+    var table = new Table(this.context, this._worksheet, this);
+    table._key = key;
+    return table;
+  };
+
+  TableCollection.prototype.add = function (address, hasHeaders) {
+    if (typeof hasHeaders !== "boolean") {
+      throw invalidArgument("TableCollection.add hasHeaders must be a boolean");
+    }
+    if (address instanceof Excel.Range && address.context !== this.context) {
+      throw invalidRequestContext();
+    }
+    if (!(address instanceof Excel.Range) && typeof address !== "string") {
+      throw invalidArgument("TableCollection.add requires a Range or range address");
+    }
+    var table = this._newTable(null);
+    var op = {
+      op: "tableAdd",
+      id: table._id,
+      hasHeaders: hasHeaders,
+    };
+    if (this._worksheet) op.worksheetId = this._worksheet._id;
+    if (address instanceof Excel.Range) {
+      op.rangeId = address._id;
+    } else {
+      op.address = address;
+    }
+    this.context._queue.push(op);
+    return table;
+  };
+
+  TableCollection.prototype.getItem = function (key) {
+    if (typeof key !== "string") {
+      throw invalidArgument("TableCollection.getItem requires a table name or ID");
+    }
+    this._ensureBinding();
+    var cacheKey = "key:" + key.toLowerCase();
+    var table = this._itemCache[cacheKey];
+    if (!table) {
+      table = this._newTable(key);
+      this._itemCache[cacheKey] = table;
+      queueTableItem(table, this, key, false, false);
+    }
+    return table;
+  };
+
+  TableCollection.prototype.getItemAt = function (index) {
+    integerArgument(index, "TableCollection.getItemAt index");
+    this._ensureBinding();
+    var cacheKey = "index:" + index;
+    var table = this._itemCache[cacheKey];
+    if (!table) {
+      table = this._newTable(index);
+      this._itemCache[cacheKey] = table;
+      queueTableItem(table, this, index, false, true);
+    }
+    return table;
+  };
+
+  TableCollection.prototype.getItemOrNullObject = function (key) {
+    if (typeof key !== "string") {
+      throw invalidArgument("TableCollection.getItemOrNullObject requires a table name or ID");
+    }
+    this._ensureBinding();
+    var cacheKey = "null:" + key.toLowerCase();
+    var table = this._itemCache[cacheKey];
+    if (!table) {
+      table = this._newTable(key);
+      this._itemCache[cacheKey] = table;
+      queueTableItem(table, this, key, true, false);
+    }
+    return table;
+  };
+
+  TableCollection.prototype.getCount = function () {
+    this._ensureBinding();
+    var result = newClientResult(this.context);
+    this.context._queue.push({
+      op: "tableCollectionGetCount",
+      collectionId: this._id,
+      resultId: result._id,
+    });
+    return result;
+  };
+
+  TableCollection.prototype.load = function (props) {
+    this._ensureBinding();
+    return ClientObject.prototype.load.call(this, props);
+  };
+
+  TableCollection.prototype.toJSON = function () {
+    if (!this._loaded.items) return {};
+    return {
+      items: this.items.map(function (item) {
+        return item && typeof item.toJSON === "function" ? item.toJSON() : item;
+      }),
+    };
+  };
+
+  function Table(context, worksheet, collection) {
+    ClientObject.call(this, context);
+    this._worksheet = worksheet || null;
+    this._collection = collection || null;
+    this._scalarProperties = [
+      "id",
+      "name",
+      "style",
+      "showHeaders",
+      "showTotals",
+      "highlightFirstColumn",
+      "highlightLastColumn",
+      "showBandedRows",
+      "showBandedColumns",
+      "showFilterButton",
+    ];
+  }
+  Table.prototype = Object.create(ClientObject.prototype);
+  Table.prototype.constructor = Table;
+
+  Object.defineProperty(Table.prototype, "id", {
+    get: function () {
+      if (!this._loaded.id) throw propertyNotLoaded("id");
+      return this._idValue;
+    },
+  });
+
+  [
+    "name",
+    "style",
+    "showHeaders",
+    "showTotals",
+    "highlightFirstColumn",
+    "highlightLastColumn",
+    "showBandedRows",
+    "showBandedColumns",
+    "showFilterButton",
+  ].forEach(function (name) {
+    Object.defineProperty(Table.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        this["_" + name] = value;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: value,
+        });
+      },
+      configurable: true,
+    });
+  });
+
+  Table.prototype.set = function (source) {
+    requirePropertyObject(source);
+    var names = [
+      "name",
+      "style",
+      "showHeaders",
+      "showTotals",
+      "highlightFirstColumn",
+      "highlightLastColumn",
+      "showBandedRows",
+      "showBandedColumns",
+      "showFilterButton",
+    ];
+    for (var i = 0; i < names.length; i++) {
+      var name = names[i];
+      if (source instanceof ClientObject) {
+        if (source._loaded[name]) this[name] = source[name];
+      } else if (Object.prototype.hasOwnProperty.call(source, name)) {
+        this[name] = source[name];
+      }
+    }
+  };
+
+  Table.prototype.toJSON = function () {
+    var data = {};
+    for (var i = 0; i < this._scalarProperties.length; i++) {
+      var name = this._scalarProperties[i];
+      if (!this._loaded[name]) continue;
+      data[name] = name === "id" ? this._idValue : this["_" + name];
+    }
+    return data;
+  };
+
+  function tableRange(table, kind) {
+    var range = new Excel.Range(table.context, table._worksheet, null);
+    table.context._queue.push({
+      op: "tableGetRange",
+      id: range._id,
+      tableId: table._id,
+      kind: kind,
+    });
+    return range;
+  }
+
+  Table.prototype.getRange = function () {
+    return tableRange(this, "full");
+  };
+
+  Table.prototype.getHeaderRowRange = function () {
+    return tableRange(this, "header");
+  };
+
+  Table.prototype.getDataBodyRange = function () {
+    return tableRange(this, "dataBody");
+  };
+
+  Table.prototype.getTotalRowRange = function () {
+    return tableRange(this, "total");
+  };
+
+  Table.prototype.delete = function () {
+    this.context._queue.push({ op: "tableDelete", id: this._id });
+  };
+
+  Table.prototype.convertToRange = function () {
+    var range = new Excel.Range(this.context, this._worksheet, null);
+    this.context._queue.push({
+      op: "tableConvertToRange",
+      id: range._id,
+      tableId: this._id,
+    });
+    return range;
+  };
+
+  Table.prototype.resize = function (newRange) {
+    if (newRange instanceof Excel.Range) {
+      if (newRange.context !== this.context) throw invalidRequestContext();
+      this.context._queue.push({
+        op: "tableResize",
+        tableId: this._id,
+        rangeId: newRange._id,
+      });
+      return;
+    }
+    if (typeof newRange !== "string") {
+      throw invalidArgument("Table.resize requires a Range or range address");
+    }
+    this.context._queue.push({
+      op: "tableResize",
+      tableId: this._id,
+      address: newRange,
+    });
+  };
+
+  function worksheetTables(worksheet) {
+    if (!worksheet._tables) {
+      worksheet._tables = new TableCollection(worksheet.context, worksheet, null);
+    }
+    return worksheet._tables;
+  }
+
+  function workbookTables(workbook) {
+    if (!workbook._tables) {
+      workbook._tables = new TableCollection(workbook.context, null, workbook);
+    }
+    return workbook._tables;
+  }
+
+  Object.defineProperty(Excel.Worksheet.prototype, "tables", {
+    get: function () {
+      return worksheetTables(this);
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(Excel.Workbook.prototype, "tables", {
+    get: function () {
+      return workbookTables(this);
+    },
+    configurable: true,
+  });
+
+  Excel.TableCollection = TableCollection;
+  Excel.Table = Table;
+})(globalThis);

--- a/compute/officejs/src/tables.rs
+++ b/compute/officejs/src/tables.rs
@@ -1,0 +1,752 @@
+use std::collections::HashMap;
+
+use compute_api::{Sheet, SheetId, Workbook};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{range_navigation::parse_range_address, worksheets};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TableError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TableRangeKind {
+    Full,
+    Header,
+    DataBody,
+    Total,
+}
+
+impl TableRangeKind {
+    pub(crate) fn from_wire(value: &str) -> Result<Self, TableError> {
+        match value {
+            "full" => Ok(Self::Full),
+            "header" => Ok(Self::Header),
+            "dataBody" => Ok(Self::DataBody),
+            "total" | "totals" => Ok(Self::Total),
+            _ => Err(invalid(format!("Unsupported table range kind '{value}'"))),
+        }
+    }
+}
+
+/// A host proxy anchored to the engine's stable table ID.
+///
+/// Names are deliberately not cached: every operation resolves the current
+/// canonical table by ID, so a proxy remains usable after `Table.name` changes.
+#[derive(Clone)]
+pub(crate) struct TableRef {
+    sheet: Sheet,
+    stable_id: String,
+}
+
+/// One table item in a `TableCollection` hydration response.
+///
+/// The JavaScript collection adapter uses `key` to enter the normal
+/// `TableCollection.getItem` path.  The worksheet ID is descriptor metadata
+/// for workbook-scoped collections; it is intentionally not exposed as a
+/// table property.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TableCollectionItem {
+    pub(crate) key: String,
+    pub(crate) worksheet_id: String,
+    pub(crate) properties: HashMap<String, Value>,
+}
+
+/// Resolve the worksheet used by `TableCollection.add` and validate its source
+/// address.  A worksheet-scoped collection takes precedence over every address
+/// qualifier.  For workbook-scoped string addresses, a quoted or unquoted
+/// worksheet qualifier selects that worksheet; an unqualified address uses the
+/// persisted active worksheet.  A workbook-scoped Range overload supplies its
+/// originating worksheet through `range_sheet`.
+pub(crate) fn resolve_table_add_source(
+    workbook: &Workbook,
+    worksheet_scope: Option<Sheet>,
+    range_sheet: Option<Sheet>,
+    address: &str,
+) -> Result<Sheet, TableError> {
+    let sheet = if let Some(sheet) = worksheet_scope {
+        sheet
+    } else if let Some(sheet) = range_sheet {
+        sheet
+    } else if let Some(name) = qualified_sheet_name(address)? {
+        worksheets::get_item(workbook, &name)
+            .map_err(worksheet_error)?
+            .sheet()
+    } else {
+        worksheets::active(workbook)
+            .map_err(worksheet_error)?
+            .sheet()
+    };
+
+    parse_range_address(&sheet, address).map_err(range_navigation)?;
+    Ok(sheet)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TableState {
+    id: String,
+    name: String,
+    range: TableRangeState,
+    has_header_row: bool,
+    has_totals_row: bool,
+    style: String,
+    #[serde(default)]
+    banded_rows: bool,
+    #[serde(default)]
+    banded_columns: bool,
+    #[serde(default)]
+    emphasize_first_column: bool,
+    #[serde(default)]
+    emphasize_last_column: bool,
+    #[serde(default)]
+    show_filter_buttons: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TableRangeState {
+    start_row: u32,
+    start_col: u32,
+    end_row: u32,
+    end_col: u32,
+}
+
+impl TableRef {
+    pub(crate) fn add(
+        workbook: &Workbook,
+        sheet: Sheet,
+        address: &str,
+        has_headers: bool,
+    ) -> Result<Self, TableError> {
+        let range = parse_range_address(&sheet, address).map_err(range_navigation)?;
+        if range.is_whole_sheet() || range.is_entire_row() || range.is_entire_column() {
+            return Err(invalid(format!(
+                "Table.add requires a bounded range: '{address}'"
+            )));
+        }
+        let (start_row, start_col, end_row, end_col) = range.bounds();
+
+        for existing in sheet.tables().get_all().map_err(engine)? {
+            let existing = decode_table(existing)?;
+            if ranges_overlap(start_row, start_col, end_row, end_col, &existing.range) {
+                return Err(invalid(format!(
+                    "A table cannot overlap the existing table '{}'.",
+                    existing.name
+                )));
+            }
+        }
+
+        let name = unique_table_name(workbook)?;
+        let (effective_end_row, effective_has_headers, columns) = if has_headers {
+            (end_row, true, Vec::new())
+        } else {
+            let effective_end_row = end_row.checked_add(1).ok_or_else(|| {
+                invalid("A generated table header would exceed the worksheet row limit".to_string())
+            })?;
+            if effective_end_row >= 1_048_576 {
+                return Err(invalid(
+                    "A generated table header would exceed the worksheet row limit".to_string(),
+                ));
+            }
+            let column_count = end_col - start_col + 1;
+            let columns: Vec<String> = (1..=column_count)
+                .map(|index| format!("Column{index}"))
+                .collect();
+
+            // `hasHeaders` describes the source data, not the resulting table's
+            // header visibility. Excel inserts a worksheet row, moves the source
+            // data down, and creates visible ColumnN headings.
+            sheet
+                .structure()
+                .insert_rows(start_row, 1)
+                .map_err(engine)?;
+            let header_address = a1_range(start_row, start_col, start_row, end_col);
+            sheet
+                .set_range(header_address.as_str(), &[columns.clone()])
+                .map_err(engine)?;
+            (effective_end_row, true, columns)
+        };
+        sheet
+            .tables()
+            .create(
+                &name,
+                start_row,
+                start_col,
+                effective_end_row,
+                end_col,
+                columns,
+                effective_has_headers,
+            )
+            .map_err(engine)?;
+        Self::get_item(sheet, &name)
+    }
+
+    pub(crate) fn get_item(sheet: Sheet, key: &str) -> Result<Self, TableError> {
+        let table = sheet
+            .tables()
+            .get_all()
+            .map_err(engine)?
+            .into_iter()
+            .find(|table| {
+                table.id.eq_ignore_ascii_case(key) || table.name.eq_ignore_ascii_case(key)
+            })
+            .ok_or_else(|| item_not_found(key))?;
+        Ok(Self {
+            sheet,
+            stable_id: table.id,
+        })
+    }
+
+    /// Resolve a table by name or stable ID across all worksheets.
+    pub(crate) fn get_item_in_workbook(workbook: &Workbook, key: &str) -> Result<Self, TableError> {
+        let table = workbook
+            .get_all_tables()
+            .map_err(engine)?
+            .into_iter()
+            .find(|entry| {
+                entry.table.id.eq_ignore_ascii_case(key)
+                    || entry.table.name.eq_ignore_ascii_case(key)
+            })
+            .ok_or_else(|| item_not_found(key))?;
+        let sheet_id = SheetId::from_uuid_str(&table.sheet_id).map_err(engine)?;
+        let sheet = workbook.sheet(&sheet_id).map_err(engine)?;
+        Ok(Self {
+            sheet,
+            stable_id: table.table.id,
+        })
+    }
+
+    /// Resolve a table by zero-based position in a worksheet collection.
+    pub(crate) fn get_item_at(sheet: Sheet, index: i64) -> Result<Self, TableError> {
+        let tables = sheet.tables().get_all().map_err(engine)?;
+        let index = checked_collection_index(index, tables.len(), "table")?;
+        Ok(Self {
+            sheet,
+            stable_id: tables[index].id.clone(),
+        })
+    }
+
+    /// Resolve a table by zero-based position in a workbook collection.
+    pub(crate) fn get_item_at_in_workbook(
+        workbook: &Workbook,
+        index: i64,
+    ) -> Result<Self, TableError> {
+        let tables = workbook.get_all_tables().map_err(engine)?;
+        let index = checked_collection_index(index, tables.len(), "table")?;
+        let table = &tables[index];
+        let sheet_id = SheetId::from_uuid_str(&table.sheet_id).map_err(engine)?;
+        Ok(Self {
+            sheet: workbook.sheet(&sheet_id).map_err(engine)?,
+            stable_id: table.table.id.clone(),
+        })
+    }
+
+    pub(crate) fn load(&self, properties: &[String]) -> Result<HashMap<String, Value>, TableError> {
+        let table = self.resolve()?;
+        load_table_properties(&table, properties)
+    }
+
+    /// Delete the table while preserving its cell contents as normal cells.
+    pub(crate) fn delete(&self) -> Result<(), TableError> {
+        let table = self.resolve()?;
+        self.sheet.tables().delete(&table.name).map_err(engine)?;
+        Ok(())
+    }
+
+    /// Convert the table to a normal range and return its former full range.
+    pub(crate) fn convert_to_range(&self) -> Result<String, TableError> {
+        let address = self.range_address(TableRangeKind::Full)?;
+        let table = self.resolve()?;
+        self.sheet
+            .tables()
+            .convert_to_range(&table.name)
+            .map_err(engine)?;
+        Ok(address)
+    }
+
+    /// Resize the table from an A1 address on its worksheet.
+    pub(crate) fn resize(&self, address: &str) -> Result<(), TableError> {
+        let range = parse_range_address(&self.sheet, address).map_err(range_navigation)?;
+        if range.is_whole_sheet() || range.is_entire_row() || range.is_entire_column() {
+            return Err(invalid(
+                "Table.resize requires a bounded range address".to_string(),
+            ));
+        }
+        let (start_row, start_col, end_row, end_col) = range.bounds();
+        self.resize_bounds(start_row, start_col, end_row, end_col)
+    }
+
+    /// Resize the table to already-resolved zero-based bounds.
+    ///
+    /// The Office.js contract requires the new range to overlap the old
+    /// range and to keep its top row fixed.  Validate those constraints here,
+    /// before delegating the persisted mutation to compute-api.
+    pub(crate) fn resize_bounds(
+        &self,
+        start_row: u32,
+        start_col: u32,
+        end_row: u32,
+        end_col: u32,
+    ) -> Result<(), TableError> {
+        if start_row > end_row || start_col > end_col {
+            return Err(invalid(
+                "Table.resize requires a non-empty range".to_string(),
+            ));
+        }
+
+        let table = self.resolve()?;
+        if start_row != table.range.start_row
+            || !ranges_overlap(start_row, start_col, end_row, end_col, &table.range)
+        {
+            return Err(invalid(
+                "The new table range must overlap the existing range and keep the same top row"
+                    .to_string(),
+            ));
+        }
+
+        for existing in self.sheet.tables().get_all().map_err(engine)? {
+            let existing = decode_table(existing)?;
+            if existing.id != table.id
+                && ranges_overlap(start_row, start_col, end_row, end_col, &existing.range)
+            {
+                return Err(invalid(format!(
+                    "A table cannot overlap the existing table '{}'.",
+                    existing.name
+                )));
+            }
+        }
+
+        self.sheet
+            .tables()
+            .resize(&table.name, start_row, start_col, end_row, end_col)
+            .map_err(engine)?;
+        Ok(())
+    }
+
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), TableError> {
+        let table = self.resolve()?;
+        match property {
+            "name" => {
+                let name = required_string(value, "Table.name")?;
+                self.sheet
+                    .tables()
+                    .rename(&table.name, name)
+                    .map_err(engine)?;
+            }
+            "style" => {
+                let style = value
+                    .as_str()
+                    .ok_or_else(|| invalid("Table.style must be a string".to_string()))?;
+                self.sheet
+                    .tables()
+                    .set_style(&table.name, style)
+                    .map_err(engine)?;
+            }
+            "showHeaders" => {
+                let requested = required_bool(value, "Table.showHeaders")?;
+                if requested != table.has_header_row {
+                    self.sheet
+                        .tables()
+                        .toggle_header_row(&table.name)
+                        .map_err(engine)?;
+                }
+            }
+            "showTotals" => {
+                let requested = required_bool(value, "Table.showTotals")?;
+                if requested != table.has_totals_row {
+                    self.sheet
+                        .tables()
+                        .toggle_totals_row(&table.name)
+                        .map_err(engine)?;
+                }
+            }
+            "showBandedRows" => {
+                let requested = required_bool(value, "Table.showBandedRows")?;
+                if requested != table.banded_rows {
+                    self.sheet
+                        .tables()
+                        .set_bool_option(&table.name, "bandedRows", requested)
+                        .map_err(engine)?;
+                }
+            }
+            "showBandedColumns" => {
+                let requested = required_bool(value, "Table.showBandedColumns")?;
+                if requested != table.banded_columns {
+                    self.sheet
+                        .tables()
+                        .set_bool_option(&table.name, "bandedColumns", requested)
+                        .map_err(engine)?;
+                }
+            }
+            "highlightFirstColumn" => {
+                let requested = required_bool(value, "Table.highlightFirstColumn")?;
+                if requested != table.emphasize_first_column {
+                    self.sheet
+                        .tables()
+                        .set_bool_option(&table.name, "emphasizeFirstColumn", requested)
+                        .map_err(engine)?;
+                }
+            }
+            "highlightLastColumn" => {
+                let requested = required_bool(value, "Table.highlightLastColumn")?;
+                if requested != table.emphasize_last_column {
+                    self.sheet
+                        .tables()
+                        .set_bool_option(&table.name, "emphasizeLastColumn", requested)
+                        .map_err(engine)?;
+                }
+            }
+            "showFilterButton" => {
+                let requested = required_bool(value, "Table.showFilterButton")?;
+                if !table.has_header_row {
+                    return Err(invalid(
+                        "Table.showFilterButton requires a table header row".to_string(),
+                    ));
+                }
+                if requested != table.show_filter_buttons {
+                    self.sheet
+                        .tables()
+                        .set_bool_option(&table.name, "showFilterButtons", requested)
+                        .map_err(engine)?;
+                }
+            }
+            other => {
+                return Err(TableError {
+                    code: "InvalidArgument",
+                    message: format!("Table.{other} is read-only or unsupported"),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn range_address(&self, kind: TableRangeKind) -> Result<String, TableError> {
+        let table = self.resolve()?;
+        let (start_row, start_col, end_row, end_col) = match kind {
+            TableRangeKind::Full => (
+                table.range.start_row,
+                table.range.start_col,
+                table.range.end_row,
+                table.range.end_col,
+            ),
+            TableRangeKind::Header if table.has_header_row => (
+                table.range.start_row,
+                table.range.start_col,
+                table.range.start_row,
+                table.range.end_col,
+            ),
+            TableRangeKind::Header => {
+                return Err(TableError {
+                    code: "ItemNotFound",
+                    message: "The table does not have a header row.".to_string(),
+                });
+            }
+            TableRangeKind::Total if table.has_totals_row => (
+                table.range.end_row,
+                table.range.start_col,
+                table.range.end_row,
+                table.range.end_col,
+            ),
+            TableRangeKind::Total => {
+                return Err(TableError {
+                    code: "ItemNotFound",
+                    message: "The table does not have a totals row.".to_string(),
+                });
+            }
+            TableRangeKind::DataBody => {
+                let start_row = table.range.start_row + u32::from(table.has_header_row);
+                let Some(end_row) = table
+                    .range
+                    .end_row
+                    .checked_sub(u32::from(table.has_totals_row))
+                else {
+                    return Err(TableError {
+                        code: "ItemNotFound",
+                        message: "The table does not have a data body range.".to_string(),
+                    });
+                };
+                if start_row > end_row {
+                    return Err(TableError {
+                        code: "ItemNotFound",
+                        message: "The table does not have a data body range.".to_string(),
+                    });
+                }
+                (
+                    start_row,
+                    table.range.start_col,
+                    end_row,
+                    table.range.end_col,
+                )
+            }
+        };
+        Ok(a1_range(start_row, start_col, end_row, end_col))
+    }
+
+    pub(crate) fn sheet(&self) -> Sheet {
+        self.sheet.clone()
+    }
+
+    fn resolve(&self) -> Result<TableState, TableError> {
+        let table = self
+            .sheet
+            .tables()
+            .get_all()
+            .map_err(engine)?
+            .into_iter()
+            .find(|table| table.id == self.stable_id)
+            .ok_or_else(|| item_not_found(&self.stable_id))?;
+        decode_table(table)
+    }
+}
+
+/// Load the scalar properties supported by the Office.js table adapter.
+pub(crate) fn load_table_properties(
+    table: &TableState,
+    properties: &[String],
+) -> Result<HashMap<String, Value>, TableError> {
+    let defaults = [
+        "id",
+        "name",
+        "style",
+        "showHeaders",
+        "showTotals",
+        "highlightFirstColumn",
+        "highlightLastColumn",
+        "showBandedRows",
+        "showBandedColumns",
+        "showFilterButton",
+    ];
+    let properties: Vec<&str> = if properties.is_empty() {
+        defaults.to_vec()
+    } else {
+        properties.iter().map(String::as_str).collect()
+    };
+    let mut result = HashMap::new();
+    for property in properties {
+        let value = match property {
+            "id" => Value::String(table.id.clone()),
+            "name" => Value::String(table.name.clone()),
+            "style" => Value::String(table.style.clone()),
+            "showHeaders" => Value::Bool(table.has_header_row),
+            "showTotals" => Value::Bool(table.has_totals_row),
+            "highlightFirstColumn" => Value::Bool(table.emphasize_first_column),
+            "highlightLastColumn" => Value::Bool(table.emphasize_last_column),
+            "showBandedRows" => Value::Bool(table.banded_rows),
+            "showBandedColumns" => Value::Bool(table.banded_columns),
+            "showFilterButton" => Value::Bool(table.show_filter_buttons),
+            "isNullObject" => Value::Bool(false),
+            other => {
+                return Err(TableError {
+                    code: "InvalidArgument",
+                    message: format!("Table.{other} is not supported by this Office.js host"),
+                });
+            }
+        };
+        result.insert(property.to_string(), value);
+    }
+    Ok(result)
+}
+
+/// Return table collection items for a worksheet or for the whole workbook.
+///
+/// `properties` contains scalar properties requested for each item.  An empty
+/// list uses the collection's default scalar projection.
+pub(crate) fn collection_items(
+    workbook: &Workbook,
+    worksheet: Option<&Sheet>,
+    properties: &[String],
+) -> Result<Vec<TableCollectionItem>, TableError> {
+    let mut result = Vec::new();
+    if let Some(sheet) = worksheet {
+        for table in sheet.tables().get_all().map_err(engine)? {
+            let state = decode_table(table)?;
+            result.push(TableCollectionItem {
+                key: state.id.clone(),
+                worksheet_id: sheet.id().to_uuid_string(),
+                properties: load_table_properties(&state, properties)?,
+            });
+        }
+        return Ok(result);
+    }
+
+    for entry in workbook.get_all_tables().map_err(engine)? {
+        let sheet_id = entry.sheet_id.clone();
+        let state = decode_table(entry.table)?;
+        result.push(TableCollectionItem {
+            key: state.id.clone(),
+            worksheet_id: sheet_id,
+            properties: load_table_properties(&state, properties)?,
+        });
+    }
+    Ok(result)
+}
+
+fn unique_table_name(workbook: &Workbook) -> Result<String, TableError> {
+    let existing = workbook.get_all_tables().map_err(engine)?;
+    for suffix in 1..10_000 {
+        let candidate = format!("Table{suffix}");
+        if existing
+            .iter()
+            .all(|entry| !entry.table.name.eq_ignore_ascii_case(&candidate))
+        {
+            return Ok(candidate);
+        }
+    }
+    Err(TableError {
+        code: "GeneralException",
+        message: "Unable to generate a unique table name".to_string(),
+    })
+}
+
+fn required_string<'a>(value: &'a Value, property: &str) -> Result<&'a str, TableError> {
+    value
+        .as_str()
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| invalid(format!("{property} must be a non-empty string")))
+}
+
+fn required_bool(value: &Value, property: &str) -> Result<bool, TableError> {
+    value
+        .as_bool()
+        .ok_or_else(|| invalid(format!("{property} must be a boolean")))
+}
+
+fn checked_collection_index(index: i64, length: usize, kind: &str) -> Result<usize, TableError> {
+    if index < 0 {
+        return Err(invalid(format!(
+            "TableCollection.getItemAt {kind} index must be non-negative"
+        )));
+    }
+    let index = usize::try_from(index).map_err(|_| {
+        invalid(format!(
+            "TableCollection.getItemAt {kind} index is outside the supported range"
+        ))
+    })?;
+    if index >= length {
+        return Err(item_not_found(&format!("{kind} index {index}")));
+    }
+    Ok(index)
+}
+
+fn item_not_found(key: &str) -> TableError {
+    TableError {
+        code: "ItemNotFound",
+        message: format!("The requested table doesn't exist. Name or ID: {key}"),
+    }
+}
+
+fn invalid(message: String) -> TableError {
+    TableError {
+        code: "InvalidArgument",
+        message,
+    }
+}
+
+fn engine(error: impl std::fmt::Display) -> TableError {
+    TableError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn range_navigation(error: crate::range_navigation::RangeNavigationError) -> TableError {
+    TableError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn worksheet_error(error: crate::worksheets::WorksheetError) -> TableError {
+    TableError {
+        code: error.code,
+        message: error.message,
+    }
+}
+
+fn qualified_sheet_name(raw: &str) -> Result<Option<String>, TableError> {
+    let raw = raw.trim();
+    let Some(separator) = raw.rfind('!') else {
+        return Ok(None);
+    };
+
+    let qualifier = raw[..separator].trim();
+    let reference = raw[separator + 1..].trim();
+    if qualifier.is_empty() || reference.is_empty() {
+        return Err(invalid(format!(
+            "Invalid sheet-qualified range address '{raw}'"
+        )));
+    }
+
+    let name = if qualifier.len() >= 2 && qualifier.starts_with('\'') && qualifier.ends_with('\'') {
+        qualifier[1..qualifier.len() - 1].replace("''", "'")
+    } else if qualifier
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || character == '_' || character == '.')
+    {
+        qualifier.to_string()
+    } else {
+        return Err(invalid(format!(
+            "Invalid worksheet qualifier in range address '{raw}'"
+        )));
+    };
+
+    if name.is_empty() {
+        return Err(invalid(format!(
+            "Invalid worksheet qualifier in range address '{raw}'"
+        )));
+    }
+    Ok(Some(name))
+}
+
+fn encoding(error: serde_json::Error) -> TableError {
+    TableError {
+        code: "GeneralException",
+        message: format!("Failed to encode table state: {error}"),
+    }
+}
+
+fn decode_table(table: impl serde::Serialize) -> Result<TableState, TableError> {
+    let value = serde_json::to_value(table).map_err(encoding)?;
+    serde_json::from_value(value).map_err(encoding)
+}
+
+fn ranges_overlap(
+    start_row: u32,
+    start_col: u32,
+    end_row: u32,
+    end_col: u32,
+    existing: &TableRangeState,
+) -> bool {
+    start_row <= existing.end_row
+        && end_row >= existing.start_row
+        && start_col <= existing.end_col
+        && end_col >= existing.start_col
+}
+
+fn a1_range(start_row: u32, start_col: u32, end_row: u32, end_col: u32) -> String {
+    let start = format!("{}{}", column_name(start_col), start_row + 1);
+    let end = format!("{}{}", column_name(end_col), end_row + 1);
+    if start == end {
+        start
+    } else {
+        format!("{start}:{end}")
+    }
+}
+
+fn column_name(mut column: u32) -> String {
+    let mut reversed = Vec::new();
+    loop {
+        reversed.push((b'A' + (column % 26) as u8) as char);
+        column /= 26;
+        if column == 0 {
+            break;
+        }
+        column -= 1;
+    }
+    reversed.into_iter().rev().collect()
+}

--- a/compute/officejs/src/validation.js
+++ b/compute/officejs/src/validation.js
@@ -1,0 +1,506 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var ClientObject = global.OfficeExtension.ClientObject;
+  var officeJs = global.__mogOfficeJs;
+
+  function richApiError(code, message) {
+    var error = new global.OfficeExtension.Error({
+      code: code,
+      message: message,
+    });
+    error.name = "RichApi.Error";
+    error.code = code;
+    return error;
+  }
+
+  function propertyNotLoaded(name) {
+    return richApiError(
+      "PropertyNotLoaded",
+      "The property '" +
+        name +
+        "' is not available. Before reading the property's value, call the load method on the containing object and call \"context.sync()\" on the associated request context."
+    );
+  }
+
+  function invalid(message) {
+    return richApiError("InvalidArgument", message);
+  }
+
+  function invalidContext() {
+    return richApiError(
+      "InvalidRequestContext",
+      "The object belongs to a different request context."
+    );
+  }
+
+  function unsupported(message) {
+    return richApiError("ApiNotFound", message);
+  }
+
+  function createRangeAreas(context, worksheet) {
+    if (officeJs && typeof officeJs.createRangeAreas === "function") {
+      return officeJs.createRangeAreas(context, worksheet || null);
+    }
+    if (typeof Excel.RangeAreas !== "function") {
+      throw unsupported(
+        "DataValidation.getInvalidCells requires the RangeAreas adapter"
+      );
+    }
+    return new Excel.RangeAreas(context, worksheet || null);
+  }
+
+  function queueRangeAreasOperation(result, operation) {
+    if (
+      officeJs &&
+      typeof officeJs.queueRangeAreasOperation === "function"
+    ) {
+      return officeJs.queueRangeAreasOperation(result, operation);
+    }
+    operation.id = result._id;
+    result.context._queue.push(operation);
+    return result;
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object";
+  }
+
+  function isPlainObject(value) {
+    if (!isObject(value)) return false;
+    var prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  }
+
+  function own(object, name) {
+    return Object.prototype.hasOwnProperty.call(object, name);
+  }
+
+  function requirePlainObject(value, property) {
+    if (!isPlainObject(value)) {
+      throw invalid(property + " must be an object");
+    }
+    return value;
+  }
+
+  function normalizeFormula(value, context, property, allowDate) {
+    if (value instanceof Excel.Range) {
+      if (value.context !== context) throw invalidContext();
+      if (value._address == null || value._address === "") {
+        throw invalid(property + " cannot use an unbounded Range");
+      }
+      return "=" + value._address;
+    }
+    if (value instanceof Date) {
+      if (!allowDate) {
+        throw invalid(property + " must be a number, Range, or formula string");
+      }
+      if (isNaN(value.getTime())) throw invalid(property + " must be a valid date");
+      return value.toISOString();
+    }
+    if (typeof value === "number") {
+      if (!isFinite(value)) throw invalid(property + " must be finite");
+      return value;
+    }
+    if (typeof value === "string") {
+      if (value.length === 0) throw invalid(property + " cannot be empty");
+      return value;
+    }
+    var allowed = allowDate
+      ? "a Date, Range, or formula string"
+      : "a number, Range, or formula string";
+    throw invalid(property + " must be " + allowed);
+  }
+
+  var validationKinds = [
+    "wholeNumber",
+    "decimal",
+    "date",
+    "time",
+    "textLength",
+    "list",
+    "custom",
+  ];
+
+  var operators = [
+    "Between",
+    "NotBetween",
+    "EqualTo",
+    "NotEqualTo",
+    "GreaterThan",
+    "LessThan",
+    "GreaterThanOrEqualTo",
+    "LessThanOrEqualTo",
+  ];
+
+  function normalizeBasicRule(value, context, kind) {
+    var source = requirePlainObject(value, "DataValidation.rule." + kind);
+    Object.keys(source).forEach(function (key) {
+      if (key !== "formula1" && key !== "formula2" && key !== "operator") {
+        throw invalid(
+          "Unsupported DataValidation.rule." + kind + " property '" + key + "'"
+        );
+      }
+    });
+    if (!own(source, "formula1")) {
+      throw invalid("DataValidation.rule." + kind + " requires formula1");
+    }
+    if (!own(source, "operator") || operators.indexOf(source.operator) < 0) {
+      throw invalid(
+        "DataValidation.rule." + kind + ".operator must be a supported enum value"
+      );
+    }
+    var output = {
+      formula1: normalizeFormula(
+        source.formula1,
+        context,
+        "DataValidation.rule." + kind + ".formula1",
+        kind === "date" || kind === "time"
+      ),
+      operator: source.operator,
+    };
+    if (own(source, "formula2")) {
+      if (
+        source.operator !== "Between" &&
+        source.operator !== "NotBetween"
+      ) {
+        throw invalid(
+          "formula2 is only valid with Between or NotBetween operators"
+        );
+      }
+      output.formula2 = normalizeFormula(
+        source.formula2,
+        context,
+        "DataValidation.rule." + kind + ".formula2",
+        kind === "date" || kind === "time"
+      );
+    } else if (
+      source.operator === "Between" ||
+      source.operator === "NotBetween"
+    ) {
+      throw invalid(source.operator + " requires formula2");
+    }
+    return output;
+  }
+
+  function normalizeListRule(value, context) {
+    var source = requirePlainObject(value, "DataValidation.rule.list");
+    Object.keys(source).forEach(function (key) {
+      if (key !== "source" && key !== "inCellDropDown") {
+        throw invalid(
+          "Unsupported DataValidation.rule.list property '" + key + "'"
+        );
+      }
+    });
+    if (!own(source, "source")) {
+      throw invalid("DataValidation.rule.list requires source");
+    }
+    var list = source.source;
+    if (list instanceof Excel.Range) {
+      list = normalizeFormula(
+        list,
+        context,
+        "DataValidation.rule.list.source",
+        false
+      );
+    } else if (typeof list !== "string" || list.length === 0) {
+      throw invalid("DataValidation.rule.list.source must be a non-empty string or Range");
+    }
+    if (!own(source, "inCellDropDown") || typeof source.inCellDropDown !== "boolean") {
+      throw invalid(
+        "DataValidation.rule.list.inCellDropDown must be a boolean"
+      );
+    }
+    return {
+      source: list,
+      inCellDropDown: source.inCellDropDown,
+    };
+  }
+
+  function normalizeRule(value, context) {
+    var source = requirePlainObject(value, "DataValidation.rule");
+    var keys = Object.keys(source);
+    if (keys.length === 0) return {};
+    if (keys.length !== 1) {
+      throw invalid("DataValidation.rule must contain exactly one validation type");
+    }
+    var kind = keys[0];
+    if (validationKinds.indexOf(kind) < 0) {
+      throw invalid("Unsupported DataValidation.rule property '" + kind + "'");
+    }
+    var normalized;
+    if (kind === "list") normalized = normalizeListRule(source[kind], context);
+    else if (kind === "custom") {
+      var custom = requirePlainObject(source[kind], "DataValidation.rule.custom");
+      Object.keys(custom).forEach(function (key) {
+        if (key !== "formula") {
+          throw invalid(
+            "Unsupported DataValidation.rule.custom property '" + key + "'"
+          );
+        }
+      });
+      if (typeof custom.formula !== "string" || custom.formula.length === 0) {
+        throw invalid("DataValidation.rule.custom.formula must be a non-empty string");
+      }
+      normalized = { formula: custom.formula };
+    } else {
+      normalized = normalizeBasicRule(source[kind], context, kind);
+    }
+    var result = {};
+    result[kind] = normalized;
+    return result;
+  }
+
+  function normalizeErrorAlert(value) {
+    var source = requirePlainObject(value, "DataValidation.errorAlert");
+    ["message", "showAlert", "style", "title"].forEach(function (key) {
+      if (!own(source, key)) {
+        throw invalid("DataValidation.errorAlert requires " + key);
+      }
+    });
+    Object.keys(source).forEach(function (key) {
+      if (["message", "showAlert", "style", "title"].indexOf(key) < 0) {
+        throw invalid(
+          "Unsupported DataValidation.errorAlert property '" + key + "'"
+        );
+      }
+    });
+    if (typeof source.message !== "string") {
+      throw invalid("DataValidation.errorAlert.message must be a string");
+    }
+    if (typeof source.title !== "string") {
+      throw invalid("DataValidation.errorAlert.title must be a string");
+    }
+    if (typeof source.showAlert !== "boolean") {
+      throw invalid("DataValidation.errorAlert.showAlert must be a boolean");
+    }
+    if (["Stop", "Warning", "Information"].indexOf(source.style) < 0) {
+      throw invalid("DataValidation.errorAlert.style must be a supported enum value");
+    }
+    return {
+      message: source.message,
+      showAlert: source.showAlert,
+      style: source.style,
+      title: source.title,
+    };
+  }
+
+  function normalizePrompt(value) {
+    var source = requirePlainObject(value, "DataValidation.prompt");
+    ["message", "showPrompt", "title"].forEach(function (key) {
+      if (!own(source, key)) {
+        throw invalid("DataValidation.prompt requires " + key);
+      }
+    });
+    Object.keys(source).forEach(function (key) {
+      if (["message", "showPrompt", "title"].indexOf(key) < 0) {
+        throw invalid("Unsupported DataValidation.prompt property '" + key + "'");
+      }
+    });
+    if (typeof source.message !== "string") {
+      throw invalid("DataValidation.prompt.message must be a string");
+    }
+    if (typeof source.title !== "string") {
+      throw invalid("DataValidation.prompt.title must be a string");
+    }
+    if (typeof source.showPrompt !== "boolean") {
+      throw invalid("DataValidation.prompt.showPrompt must be a boolean");
+    }
+    return {
+      message: source.message,
+      showPrompt: source.showPrompt,
+      title: source.title,
+    };
+  }
+
+  function normalizeScalar(name, value, context) {
+    switch (name) {
+      case "rule":
+        return normalizeRule(value, context);
+      case "errorAlert":
+        return normalizeErrorAlert(value);
+      case "ignoreBlanks":
+        if (typeof value !== "boolean") {
+          throw invalid("DataValidation.ignoreBlanks must be a boolean");
+        }
+        return value;
+      case "prompt":
+        return normalizePrompt(value);
+      default:
+        return value;
+    }
+  }
+
+  function queueScalar(object, name, value) {
+    object["_" + name] = value;
+    object._loaded[name] = true;
+    object.context._queue.push({
+      op: "set",
+      id: object._id,
+      property: name,
+      value: value,
+    });
+  }
+
+  function setProperties(source) {
+    var isClientObject = source instanceof ClientObject;
+    if (isClientObject) {
+      if (Object.getPrototypeOf(this) !== Object.getPrototypeOf(source)) {
+        throw invalid("The object passed to set must have the same type");
+      }
+      if (source.context !== this.context) throw invalidContext();
+      var loaded = {};
+      for (var k = 0; k < this._scalarProperties.length; k++) {
+        var loadedName = this._scalarProperties[k];
+        if (source._loaded[loadedName]) {
+          loaded[loadedName] = source["_" + loadedName];
+        }
+      }
+      source = loaded;
+    } else if (!isPlainObject(source)) {
+      throw new TypeError("set requires a property object");
+    }
+    var names = this._scalarProperties;
+    Object.keys(source).forEach(function (name) {
+      if (names.indexOf(name) < 0) {
+        throw invalid("Unsupported DataValidation property '" + name + "'");
+      }
+      if (name === "type" || name === "valid") {
+        throw invalid("DataValidation." + name + " is read-only");
+      }
+    });
+    var normalized = {};
+    for (var i = 0; i < names.length; i++) {
+      var name = names[i];
+      if (!own(source, name) || source[name] === undefined) continue;
+      normalized[name] = normalizeScalar(name, source[name], this.context);
+    }
+    for (var j = 0; j < names.length; j++) {
+      var property = names[j];
+      if (own(normalized, property)) queueScalar(this, property, normalized[property]);
+    }
+  }
+
+  function toJSON() {
+    var result = {};
+    for (var i = 0; i < this._scalarProperties.length; i++) {
+      var name = this._scalarProperties[i];
+      if (this._loaded[name]) result[name] = this["_" + name];
+    }
+    return result;
+  }
+
+  function defineScalar(proto, name, normalizer) {
+    Object.defineProperty(proto, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+      set: function (value) {
+        var normalized = normalizer ? normalizer.call(this, value) : value;
+        queueScalar(this, name, normalized);
+      },
+    });
+  }
+
+  function DataValidation(context, range) {
+    ClientObject.call(this, context);
+    this._range = range;
+    this._rangeId = range._id;
+    this._scalarProperties = [
+      "rule",
+      "errorAlert",
+      "ignoreBlanks",
+      "prompt",
+      "type",
+      "valid",
+    ];
+    this._navigationProperties = [];
+    this.context._queue.push({
+      op: "getRangeDataValidation",
+      id: this._id,
+      rangeId: range._id,
+    });
+  }
+  DataValidation.prototype = Object.create(ClientObject.prototype);
+  DataValidation.prototype.constructor = DataValidation;
+
+  defineScalar(DataValidation.prototype, "rule", function (value) {
+    return normalizeRule(value, this.context);
+  });
+  defineScalar(DataValidation.prototype, "errorAlert", function (value) {
+    return normalizeErrorAlert(value);
+  });
+  defineScalar(DataValidation.prototype, "ignoreBlanks", function (value) {
+    if (typeof value !== "boolean") {
+      throw invalid("DataValidation.ignoreBlanks must be a boolean");
+    }
+    return value;
+  });
+  defineScalar(DataValidation.prototype, "prompt", function (value) {
+    return normalizePrompt(value);
+  });
+  ["type", "valid"].forEach(function (name) {
+    Object.defineProperty(DataValidation.prototype, name, {
+      get: function () {
+        if (!this._loaded[name]) throw propertyNotLoaded(name);
+        return this["_" + name];
+      },
+    });
+  });
+
+  DataValidation.prototype.set = setProperties;
+  DataValidation.prototype.toJSON = toJSON;
+  DataValidation.prototype.clear = function () {
+    this.context._queue.push({
+      op: "set",
+      id: this._id,
+      property: "clear",
+      value: null,
+    });
+  };
+  DataValidation.prototype.getInvalidCells = function () {
+    var result = createRangeAreas(this.context, this._range._worksheet);
+    return queueRangeAreasOperation(result, {
+      op: "dataValidationGetInvalidCells",
+      validationId: this._id,
+      rangeId: this._rangeId,
+      orNullObject: false,
+    });
+  };
+  DataValidation.prototype.getInvalidCellsOrNullObject = function () {
+    var result = createRangeAreas(this.context, this._range._worksheet);
+    return queueRangeAreasOperation(result, {
+      op: "dataValidationGetInvalidCells",
+      validationId: this._id,
+      rangeId: this._rangeId,
+      orNullObject: true,
+    });
+  };
+
+  Object.defineProperty(Excel.Range.prototype, "dataValidation", {
+    get: function () {
+      if (!this._dataValidation) {
+        this._dataValidation = new DataValidation(this.context, this);
+      }
+      return this._dataValidation;
+    },
+  });
+
+  // Newer bootstrap revisions expose declarative navigation hooks. Keep the
+  // fallback for the current bootstrap so this module remains loadable during
+  // the transition, while allowing the foundation to own the canonical list.
+  var hooks = global.__mogOfficeJs;
+  if (hooks && hooks.addNavigationProperties) {
+    hooks.addNavigationProperties(Excel.Range.prototype, ["dataValidation"]);
+  } else {
+    Excel.Range.prototype._navigationProperties =
+      Excel.Range.prototype._navigationProperties || [];
+    if (Excel.Range.prototype._navigationProperties.indexOf("dataValidation") < 0) {
+      Excel.Range.prototype._navigationProperties.push("dataValidation");
+    }
+  }
+
+  Excel.DataValidation = DataValidation;
+})(globalThis);

--- a/compute/officejs/src/validation.rs
+++ b/compute/officejs/src/validation.rs
@@ -1,0 +1,1393 @@
+//! Office.js Range.dataValidation backed by the durable sheet validation API.
+//!
+//! The Office object model exposes one data-validation object for a range while
+//! the compute engine stores a RangeSchema. This module is the translation
+//! boundary between those two representations. It deliberately keeps the
+//! wire-facing representation in serde_json::Value: the Office.js host only
+//! needs the public compute_api::SheetValidation methods and does not need to
+//! duplicate the domain type hierarchy.
+
+use std::collections::{HashMap, HashSet};
+
+use compute_api::{CellRange, ComputeApiError, Sheet};
+use serde_json::{Map, Value, json};
+use value_types::CellValue;
+
+/// Error returned by an Office.js data-validation host operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ValidationError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+/// A data-validation proxy anchored to one bounded worksheet range.
+///
+/// The range itself remains the source of truth for the object path. Every
+/// read resolves the current durable range schemas, so a fresh proxy sees
+/// validation mutations made by an earlier request context.
+#[derive(Clone)]
+pub(crate) struct ValidationRef {
+    sheet: Sheet,
+    address: String,
+}
+
+#[derive(Clone)]
+struct SchemaCandidate {
+    id: String,
+    value: Value,
+    ranges: Vec<Bounds>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Bounds {
+    start_row: u32,
+    start_col: u32,
+    end_row: u32,
+    end_col: u32,
+}
+
+impl ValidationRef {
+    /// Create a validation proxy for a bounded A1 range.
+    pub(crate) fn new(sheet: Sheet, address: impl Into<String>) -> Result<Self, ValidationError> {
+        let address = address.into();
+        CellRange::from(address.as_str())
+            .resolve()
+            .map_err(|error| invalid(error.to_string()))?;
+        Ok(Self { sheet, address })
+    }
+
+    /// Load Office-shaped scalar properties.
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, ValidationError> {
+        let candidates = self.candidates()?;
+        let selected = select_candidate(&candidates, self.bounds()?);
+        let mut result = HashMap::new();
+
+        for property in properties {
+            let value = match property.as_str() {
+                "errorAlert" => office_error_alert(selected)?,
+                "ignoreBlanks" => office_ignore_blanks(selected),
+                "prompt" => office_prompt(selected)?,
+                "rule" => office_rule(selected)?,
+                "type" => office_type(selected)?,
+                "valid" => self.office_valid(selected)?,
+                other => {
+                    return Err(unsupported(format!(
+                        "Unsupported DataValidation load property '{other}'"
+                    )));
+                }
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    /// Apply one Office.js scalar property.
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), ValidationError> {
+        if property == "clear" {
+            if !value.is_null() {
+                return Err(invalid("DataValidation.clear does not accept a value"));
+            }
+            return self.clear();
+        }
+
+        let bounds = self.bounds()?;
+        let candidates = self.candidates()?;
+        let selected = select_candidate(&candidates, bounds);
+        if selected.is_some_and(|candidate| candidate.ranges.len() != 1) {
+            return Err(invalid(
+                "DataValidation cannot update a schema shared by multiple ranges",
+            ));
+        }
+
+        let mut state = match selected.as_ref() {
+            Some(candidate) => office_state_from_schema(&candidate.value)?,
+            None => default_office_state(),
+        };
+
+        match property {
+            "rule" => {
+                let normalized = normalize_rule_value(value)?;
+                if normalized
+                    .as_object()
+                    .is_some_and(|object| object.is_empty())
+                {
+                    return self.clear();
+                }
+                state.insert("rule".to_string(), normalized);
+            }
+            "ignoreBlanks" => {
+                state.insert(
+                    "ignoreBlanks".to_string(),
+                    value
+                        .as_bool()
+                        .map(Value::Bool)
+                        .ok_or_else(|| invalid("DataValidation.ignoreBlanks must be a boolean"))?,
+                );
+            }
+            "errorAlert" => {
+                state.insert("errorAlert".to_string(), normalize_error_alert(value)?);
+            }
+            "prompt" => {
+                state.insert("prompt".to_string(), normalize_prompt(value)?);
+            }
+            "type" | "valid" => {
+                return Err(invalid(format!("DataValidation.{property} is read-only")));
+            }
+            other => {
+                return Err(unsupported(format!(
+                    "Unsupported DataValidation property '{other}'"
+                )));
+            }
+        }
+
+        let schema_id = selected
+            .as_ref()
+            .map(|candidate| candidate.id.clone())
+            .unwrap_or_else(|| schema_id_for(bounds));
+
+        // The canonical range-backed engine cannot split a larger existing
+        // validation rule when Office.js targets only a subset of it. Refuse
+        // that ambiguous update rather than leaving the requested property
+        // apparently applied while a different rule still wins evaluation.
+        if let Some(candidate) = selected.as_ref()
+            && !candidate.ranges.iter().any(|range| *range == bounds)
+        {
+            return Err(invalid(
+                "DataValidation cannot replace only part of an existing validation range",
+            ));
+        }
+
+        let schema_value = office_state_to_schema(&schema_id, bounds, &state)?;
+        let schema = serde_json::from_value(schema_value).map_err(encoding)?;
+        self.sheet
+            .validation()
+            .set_range_schema(schema)
+            .map_err(engine)?;
+        Ok(())
+    }
+
+    /// Remove the validation rule(s) that exactly cover this range.
+    pub(crate) fn clear(&self) -> Result<(), ValidationError> {
+        let bounds = self.bounds()?;
+        let candidates = self.candidates()?;
+        let mut exact_ids = Vec::new();
+        for candidate in candidates {
+            if candidate.ranges.iter().any(|range| *range == bounds) {
+                if candidate.ranges.len() != 1 {
+                    return Err(invalid(
+                        "DataValidation cannot clear a schema shared by multiple ranges",
+                    ));
+                }
+                exact_ids.push(candidate.id);
+            } else if candidate.ranges.iter().any(|range| range.contains(bounds)) {
+                return Err(invalid(
+                    "DataValidation cannot clear only part of an existing validation range",
+                ));
+            }
+        }
+
+        let mut seen = HashSet::new();
+        for id in exact_ids {
+            if seen.insert(id.clone()) {
+                self.sheet
+                    .validation()
+                    .delete_range_schema(&id)
+                    .map_err(engine)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn bounds(&self) -> Result<Bounds, ValidationError> {
+        let (start_row, start_col, end_row, end_col) = CellRange::from(self.address.as_str())
+            .resolve()
+            .map_err(|error| invalid(error.to_string()))?;
+        Ok(Bounds {
+            start_row,
+            start_col,
+            end_row,
+            end_col,
+        })
+    }
+
+    fn candidates(&self) -> Result<Vec<SchemaCandidate>, ValidationError> {
+        self.sheet
+            .validation()
+            .get_range_schemas()
+            .map_err(engine)?
+            .into_iter()
+            .map(|schema| {
+                let value = serde_json::to_value(schema).map_err(encoding)?;
+                let id = value
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .filter(|id| !id.is_empty())
+                    .ok_or_else(|| encoding_message("range schema has no id"))?
+                    .to_string();
+                let ranges = parse_schema_ranges(&value)?;
+                Ok(SchemaCandidate { id, value, ranges })
+            })
+            .collect()
+    }
+
+    fn office_valid(&self, selected: Option<&SchemaCandidate>) -> Result<Value, ValidationError> {
+        let Some(_selected) = selected else {
+            return Ok(Value::Bool(true));
+        };
+        let invalid_cells = self.invalid_cells_for_selected()?;
+        if invalid_cells.is_empty() {
+            return Ok(Value::Bool(true));
+        }
+
+        let bounds = self.bounds()?;
+        let cell_count = (bounds.end_row - bounds.start_row + 1) as usize
+            * (bounds.end_col - bounds.start_col + 1) as usize;
+        if invalid_cells.len() == cell_count {
+            return Ok(Value::Bool(false));
+        }
+
+        Ok(Value::Null)
+    }
+
+    /// Return the coordinates whose current values fail the durable
+    /// validation engine for this DataValidation range.
+    ///
+    /// This deliberately asks the engine to validate every cell instead of
+    /// decoding the stored rule in the Office.js adapter. In particular, the
+    /// engine owns blank handling, list membership, custom formulas, and
+    /// relative formula references.
+    pub(crate) fn invalid_cells(&self) -> Result<Vec<(u32, u32)>, ValidationError> {
+        let bounds = self.bounds()?;
+        let candidates = self.candidates()?;
+        let selected = select_candidate(&candidates, bounds);
+        let Some(selected) = selected else {
+            return Ok(Vec::new());
+        };
+        self.invalid_cells_for_selected()
+    }
+
+    fn invalid_cells_for_selected(&self) -> Result<Vec<(u32, u32)>, ValidationError> {
+        let bounds = self.bounds()?;
+        let values = self
+            .sheet
+            .get_range_values_2d(CellRange::Bounds(
+                bounds.start_row,
+                bounds.start_col,
+                bounds.end_row,
+                bounds.end_col,
+            ))
+            .map_err(engine)?;
+        let mut invalid_cells = Vec::new();
+        for (row_offset, row_values) in values.into_iter().enumerate() {
+            for (col_offset, value) in row_values.into_iter().enumerate() {
+                let row = bounds.start_row + row_offset as u32;
+                let col = bounds.start_col + col_offset as u32;
+                let text = validation_text(&value);
+                let result = self
+                    .sheet
+                    .validation()
+                    .validate_cell_value(row, col, &text)
+                    .map_err(engine)?;
+                if !result.valid {
+                    invalid_cells.push((row, col));
+                }
+            }
+        }
+        Ok(invalid_cells)
+    }
+}
+
+fn default_office_state() -> Map<String, Value> {
+    Map::from_iter([
+        (
+            "errorAlert".to_string(),
+            json!({
+                "message": "",
+                "showAlert": true,
+                "style": "Stop",
+                "title": ""
+            }),
+        ),
+        ("ignoreBlanks".to_string(), Value::Bool(true)),
+        (
+            "prompt".to_string(),
+            json!({"message": "", "showPrompt": false, "title": ""}),
+        ),
+        ("rule".to_string(), json!({})),
+    ])
+}
+
+fn office_error_alert(selected: Option<&SchemaCandidate>) -> Result<Value, ValidationError> {
+    let Some(selected) = selected else {
+        return Ok(default_office_state()["errorAlert"].clone());
+    };
+    Ok(office_state_from_schema(&selected.value)?["errorAlert"].clone())
+}
+
+fn office_ignore_blanks(selected: Option<&SchemaCandidate>) -> Value {
+    selected
+        .and_then(|candidate| candidate.value.pointer("/schema/constraints/allowBlank"))
+        .and_then(Value::as_bool)
+        .map(Value::Bool)
+        .unwrap_or(Value::Bool(true))
+}
+
+fn office_prompt(selected: Option<&SchemaCandidate>) -> Result<Value, ValidationError> {
+    let Some(selected) = selected else {
+        return Ok(default_office_state()["prompt"].clone());
+    };
+    Ok(office_state_from_schema(&selected.value)?["prompt"].clone())
+}
+
+fn office_rule(selected: Option<&SchemaCandidate>) -> Result<Value, ValidationError> {
+    let Some(selected) = selected else {
+        return Ok(json!({}));
+    };
+    Ok(office_state_from_schema(&selected.value)?["rule"].clone())
+}
+
+fn office_type(selected: Option<&SchemaCandidate>) -> Result<Value, ValidationError> {
+    let Some(selected) = selected else {
+        return Ok(json!("None"));
+    };
+    let Some((kind, _)) = schema_type_to_office(
+        selected.value.pointer("/schema/type"),
+        selected.value.pointer("/schema/constraints"),
+    ) else {
+        if selected.value.pointer("/schema/type").is_none() {
+            return Ok(json!("None"));
+        }
+        return Err(invalid(
+            "The stored validation schema type is not supported by Office.js",
+        ));
+    };
+    Ok(json!(kind))
+}
+
+fn select_candidate<'a>(
+    candidates: &'a [SchemaCandidate],
+    target: Bounds,
+) -> Option<&'a SchemaCandidate> {
+    candidates
+        .iter()
+        .find(|candidate| candidate.ranges.iter().any(|range| *range == target))
+        .or_else(|| {
+            candidates
+                .iter()
+                .find(|candidate| candidate.ranges.iter().any(|range| range.contains(target)))
+        })
+}
+
+fn parse_schema_ranges(value: &Value) -> Result<Vec<Bounds>, ValidationError> {
+    let ranges = value
+        .get("ranges")
+        .and_then(Value::as_array)
+        .ok_or_else(|| encoding_message("range schema has no ranges"))?;
+    ranges.iter().map(parse_identity_range).collect()
+}
+
+fn parse_identity_range(value: &Value) -> Result<Bounds, ValidationError> {
+    let start = value
+        .get("startId")
+        .and_then(Value::as_str)
+        .ok_or_else(|| encoding_message("range schema range has no startId"))?;
+    let end = value
+        .get("endId")
+        .and_then(Value::as_str)
+        .ok_or_else(|| encoding_message("range schema range has no endId"))?;
+    let (start_row, start_col) = parse_identity_cell(start)?;
+    let (end_row, end_col) = parse_identity_cell(end)?;
+    Ok(Bounds {
+        start_row: start_row.min(end_row),
+        start_col: start_col.min(end_col),
+        end_row: start_row.max(end_row),
+        end_col: start_col.max(end_col),
+    })
+}
+
+fn parse_identity_cell(value: &str) -> Result<(u32, u32), ValidationError> {
+    let (row, col) = value
+        .split_once(':')
+        .ok_or_else(|| encoding_message(format!("invalid identity cell '{value}'")))?;
+    let row = row
+        .parse::<u32>()
+        .map_err(|_| encoding_message(format!("invalid identity row '{row}'")))?;
+    let col = col
+        .parse::<u32>()
+        .map_err(|_| encoding_message(format!("invalid identity column '{col}'")))?;
+    Ok((row, col))
+}
+
+impl Bounds {
+    fn contains(self, other: Self) -> bool {
+        self.start_row <= other.start_row
+            && self.start_col <= other.start_col
+            && self.end_row >= other.end_row
+            && self.end_col >= other.end_col
+    }
+}
+
+fn office_state_from_schema(value: &Value) -> Result<Map<String, Value>, ValidationError> {
+    let mut state = default_office_state();
+    state.insert(
+        "ignoreBlanks".to_string(),
+        value
+            .pointer("/schema/constraints/allowBlank")
+            .filter(|value| !value.is_null())
+            .cloned()
+            .unwrap_or(Value::Bool(true)),
+    );
+
+    let style = match value.pointer("/enforcement").and_then(Value::as_str) {
+        Some("warning") | Some("Warning") => "Warning",
+        Some("info") | Some("Info") => "Information",
+        Some("none") | Some("None") => "Information",
+        _ => "Stop",
+    };
+    let error = value.pointer("/ui/errorMessage");
+    // RangeSchema's durable conversion currently represents a missing
+    // message as the engine's default `show_error=true`; the schema has no
+    // independent false bit. Treat absent UI text as that default so a later
+    // property update does not accidentally fail on a fabricated false flag.
+    let show_alert = true;
+    state.insert(
+        "errorAlert".to_string(),
+        json!({
+            "message": error.and_then(|v| v.get("message")).and_then(Value::as_str).unwrap_or(""),
+            "showAlert": show_alert,
+            "style": style,
+            "title": error.and_then(|v| v.get("title")).and_then(Value::as_str).unwrap_or(""),
+        }),
+    );
+
+    let prompt = value.pointer("/ui/inputMessage");
+    state.insert(
+        "prompt".to_string(),
+        json!({
+            "message": prompt.and_then(|v| v.get("message")).and_then(Value::as_str).unwrap_or(""),
+            "showPrompt": prompt.is_some(),
+            "title": prompt.and_then(|v| v.get("title")).and_then(Value::as_str).unwrap_or(""),
+        }),
+    );
+
+    let constraints = value.pointer("/schema/constraints");
+    let Some((kind, rule)) = schema_type_to_office(value.pointer("/schema/type"), constraints)
+    else {
+        let is_empty_rule = value.pointer("/schema/type").is_none()
+            && constraints
+                .and_then(Value::as_object)
+                .is_none_or(|constraints| constraints.keys().all(|key| key == "allowBlank"));
+        if is_empty_rule {
+            state.insert("rule".to_string(), json!({}));
+            return Ok(state);
+        }
+        return Err(invalid(
+            "The stored validation rule is not supported by Office.js",
+        ));
+    };
+    let _ = kind;
+    state.insert("rule".to_string(), rule);
+
+    if let Some(list) = state
+        .get_mut("rule")
+        .and_then(Value::as_object_mut)
+        .and_then(|rule| rule.get_mut("list"))
+        .and_then(Value::as_object_mut)
+    {
+        let dropdown = value
+            .pointer("/ui/showDropdown")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+        list.insert("inCellDropDown".to_string(), Value::Bool(dropdown));
+    }
+    Ok(state)
+}
+
+fn schema_type_to_office(
+    schema_type: Option<&Value>,
+    constraints: Option<&Value>,
+) -> Option<(&'static str, Value)> {
+    let constraints = constraints.and_then(Value::as_object);
+    if let Some(values) = constraints
+        .and_then(|c| c.get("enum"))
+        .and_then(Value::as_array)
+    {
+        let source = values
+            .iter()
+            .map(|value| value.as_str().unwrap_or_default())
+            .collect::<Vec<_>>()
+            .join(",");
+        return Some((
+            "List",
+            json!({
+                "list": {
+                    "inCellDropDown": true,
+                    "source": source,
+                }
+            }),
+        ));
+    }
+    if let Some(source) = constraints
+        .and_then(|c| c.get("enumSource"))
+        .and_then(identity_range_to_a1)
+    {
+        return Some((
+            "List",
+            json!({
+                "list": {"inCellDropDown": true, "source": format!("={source}")}
+            }),
+        ));
+    }
+    if let Some(source) = constraints
+        .and_then(|c| c.get("enumSourceFormula"))
+        .and_then(Value::as_str)
+    {
+        return Some((
+            "List",
+            json!({
+                "list": {"inCellDropDown": true, "source": source}
+            }),
+        ));
+    }
+    if let Some(formula) = constraints
+        .and_then(|c| c.get("formula"))
+        .and_then(Value::as_str)
+    {
+        return Some(("Custom", json!({"custom": {"formula": formula}})));
+    }
+
+    let schema_type = schema_type?.as_str()?;
+    match schema_type {
+        "integer" | "Integer" => numeric_rule("WholeNumber", constraints),
+        "number" | "currency" | "percentage" | "Number" | "Currency" | "Percentage" => {
+            numeric_rule("Decimal", constraints)
+        }
+        "date" | "Date" => numeric_rule("Date", constraints),
+        "time" | "Time" => numeric_rule("Time", constraints),
+        "string" | "String" => length_rule(constraints),
+        _ => None,
+    }
+}
+
+fn numeric_rule(
+    kind: &'static str,
+    constraints: Option<&Map<String, Value>>,
+) -> Option<(&'static str, Value)> {
+    let (operator, formula1, formula2) = numeric_operator(constraints)?;
+    let key = match kind {
+        "WholeNumber" => "wholeNumber",
+        "Decimal" => "decimal",
+        "Date" => "date",
+        "Time" => "time",
+        _ => return None,
+    };
+    let mut rule = Map::new();
+    rule.insert("operator".to_string(), json!(operator));
+    rule.insert("formula1".to_string(), json!(formula1));
+    if let Some(formula2) = formula2 {
+        rule.insert("formula2".to_string(), json!(formula2));
+    }
+    Some((
+        kind,
+        Value::Object(Map::from_iter([(key.to_string(), Value::Object(rule))])),
+    ))
+}
+
+fn length_rule(constraints: Option<&Map<String, Value>>) -> Option<(&'static str, Value)> {
+    let (operator, formula1, formula2) = length_operator(constraints)?;
+    let mut rule = Map::new();
+    rule.insert("operator".to_string(), json!(operator));
+    rule.insert("formula1".to_string(), json!(formula1));
+    if let Some(formula2) = formula2 {
+        rule.insert("formula2".to_string(), json!(formula2));
+    }
+    Some(("TextLength", json!({"textLength": rule})))
+}
+
+fn numeric_operator(
+    constraints: Option<&Map<String, Value>>,
+) -> Option<(&'static str, String, Option<String>)> {
+    let c = constraints?;
+    if let Some(value) = office_formula_bound(c, "equal") {
+        return Some(("EqualTo", value, None));
+    }
+    if let Some(value) = office_formula_bound(c, "notEqual") {
+        return Some(("NotEqualTo", value, None));
+    }
+    if let (Some(lo), Some(hi)) = (
+        office_formula_bound(c, "notBetweenMin"),
+        office_formula_bound(c, "notBetweenMax"),
+    ) {
+        return Some(("NotBetween", lo, Some(hi)));
+    }
+    if let (Some(lo), Some(hi)) = (
+        office_formula_bound(c, "min"),
+        office_formula_bound(c, "max"),
+    ) {
+        return Some(("Between", lo, Some(hi)));
+    }
+    if let Some(value) = office_formula_bound(c, "exclusiveMin") {
+        return Some(("GreaterThan", value, None));
+    }
+    if let Some(value) = office_formula_bound(c, "min") {
+        return Some(("GreaterThanOrEqualTo", value, None));
+    }
+    if let Some(value) = office_formula_bound(c, "exclusiveMax") {
+        return Some(("LessThan", value, None));
+    }
+    if let Some(value) = office_formula_bound(c, "max") {
+        return Some(("LessThanOrEqualTo", value, None));
+    }
+    None
+}
+
+fn length_operator(
+    constraints: Option<&Map<String, Value>>,
+) -> Option<(&'static str, String, Option<String>)> {
+    let c = constraints?;
+    if let (Some(lo), Some(hi)) = (
+        office_formula_bound(c, "minLength"),
+        office_formula_bound(c, "maxLength"),
+    ) {
+        return Some(("Between", lo, Some(hi)));
+    }
+    if let Some(value) = office_formula_bound(c, "minLength") {
+        return Some(("GreaterThanOrEqualTo", value, None));
+    }
+    if let Some(value) = office_formula_bound(c, "maxLength") {
+        return Some(("LessThanOrEqualTo", value, None));
+    }
+    None
+}
+
+fn formula_number(value: &Value) -> Option<String> {
+    value
+        .as_f64()
+        .filter(|value| value.is_finite())
+        .map(|value| format!("={value}"))
+}
+
+fn office_formula_bound(constraints: &Map<String, Value>, key: &str) -> Option<String> {
+    constraints
+        .get("formulaBounds")
+        .and_then(Value::as_object)
+        .and_then(|bounds| bounds.get(key))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .or_else(|| constraints.get(key).and_then(formula_number))
+}
+
+fn identity_range_to_a1(value: &Value) -> Option<String> {
+    let start = value.get("startId")?.as_str()?;
+    let end = value.get("endId")?.as_str()?;
+    let (sr, sc) = parse_identity_cell(start).ok()?;
+    let (er, ec) = parse_identity_cell(end).ok()?;
+    let start = a1_cell(sr, sc);
+    let end = a1_cell(er, ec);
+    Some(if start == end {
+        start
+    } else {
+        format!("{start}:{end}")
+    })
+}
+
+fn a1_cell(row: u32, col: u32) -> String {
+    let mut col = col + 1;
+    let mut letters = Vec::new();
+    while col > 0 {
+        let rem = ((col - 1) % 26) as u8;
+        letters.push((b'A' + rem) as char);
+        col = (col - 1) / 26;
+    }
+    letters.reverse();
+    format!("{}{}", letters.into_iter().collect::<String>(), row + 1)
+}
+
+fn office_state_to_schema(
+    id: &str,
+    bounds: Bounds,
+    state: &Map<String, Value>,
+) -> Result<Value, ValidationError> {
+    let rule = state
+        .get("rule")
+        .and_then(Value::as_object)
+        .ok_or_else(|| invalid("DataValidation.rule must be an object"))?;
+    if rule.is_empty() {
+        return Err(invalid(
+            "DataValidation.rule must contain one validation type",
+        ));
+    }
+
+    let (schema_type, constraints) = rule_to_schema(rule)?;
+    let allow_blank = state
+        .get("ignoreBlanks")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| invalid("DataValidation.ignoreBlanks must be a boolean"))?;
+    let error = state
+        .get("errorAlert")
+        .ok_or_else(|| invalid("DataValidation.errorAlert must be an object"))?;
+    let error = normalize_error_alert(error)?;
+    let show_alert = error
+        .get("showAlert")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    if !show_alert {
+        // RangeSchema currently has no show-error bit. Rejecting this state is
+        // preferable to silently changing it to an enabled alert on reload.
+        return Err(invalid(
+            "DataValidation.errorAlert.showAlert=false cannot be persisted by the validation engine",
+        ));
+    }
+    let style = error
+        .get("style")
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid("DataValidation.errorAlert.style must be a string enum value"))?;
+    let enforcement = match style {
+        "Stop" => "strict",
+        "Warning" => "warning",
+        "Information" => "info",
+        other => {
+            return Err(invalid(format!(
+                "Unsupported DataValidation alert style '{other}'"
+            )));
+        }
+    };
+    let prompt = state
+        .get("prompt")
+        .ok_or_else(|| invalid("DataValidation.prompt must be an object"))?;
+    let prompt = normalize_prompt(prompt)?;
+    let show_prompt = prompt
+        .get("showPrompt")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !show_prompt
+        && (prompt
+            .get("message")
+            .and_then(Value::as_str)
+            .is_some_and(|message| !message.is_empty())
+            || prompt
+                .get("title")
+                .and_then(Value::as_str)
+                .is_some_and(|title| !title.is_empty()))
+    {
+        return Err(invalid(
+            "DataValidation.prompt.message/title cannot be persisted when showPrompt=false",
+        ));
+    }
+
+    let mut constraint_map = constraints.unwrap_or_default();
+    constraint_map.insert("allowBlank".to_string(), Value::Bool(allow_blank));
+    let mut ui = Map::new();
+    ui.insert(
+        "errorMessage".to_string(),
+        json!({
+            "title": error.get("title").and_then(Value::as_str).unwrap_or(""),
+            "message": error.get("message").and_then(Value::as_str).unwrap_or(""),
+        }),
+    );
+    if show_prompt {
+        ui.insert(
+            "inputMessage".to_string(),
+            json!({
+                "title": prompt.get("title").and_then(Value::as_str).unwrap_or(""),
+                "message": prompt.get("message").and_then(Value::as_str).unwrap_or(""),
+            }),
+        );
+    }
+    if let Some(list) = rule.get("list").and_then(Value::as_object) {
+        let dropdown = list
+            .get("inCellDropDown")
+            .and_then(Value::as_bool)
+            .ok_or_else(|| invalid("DataValidation.list.inCellDropDown must be a boolean"))?;
+        ui.insert("showDropdown".to_string(), Value::Bool(dropdown));
+    }
+
+    Ok(json!({
+        "id": id,
+        "createdAt": 0,
+        "ranges": [{
+            "startId": format!("{}:{}", bounds.start_row, bounds.start_col),
+            "endId": format!("{}:{}", bounds.end_row, bounds.end_col),
+        }],
+        "schema": {
+            "type": schema_type,
+            "constraints": constraint_map,
+        },
+        "enforcement": enforcement,
+        "ui": ui,
+    }))
+}
+
+fn rule_to_schema(
+    rule: &Map<String, Value>,
+) -> Result<(Value, Option<Map<String, Value>>), ValidationError> {
+    let allowed = [
+        "wholeNumber",
+        "decimal",
+        "date",
+        "time",
+        "textLength",
+        "list",
+        "custom",
+    ];
+    let unknown = rule.keys().find(|key| !allowed.contains(&key.as_str()));
+    if let Some(unknown) = unknown {
+        return Err(invalid(format!(
+            "Unsupported DataValidation.rule property '{unknown}'"
+        )));
+    }
+    if rule.len() != 1 {
+        return Err(invalid(
+            "DataValidation.rule must contain exactly one validation type",
+        ));
+    }
+    if let Some(value) = rule.get("wholeNumber") {
+        return basic_rule_to_schema("integer", value);
+    }
+    if let Some(value) = rule.get("decimal") {
+        return basic_rule_to_schema("number", value);
+    }
+    if let Some(value) = rule.get("date") {
+        return basic_rule_to_schema("date", value);
+    }
+    if let Some(value) = rule.get("time") {
+        return basic_rule_to_schema("time", value);
+    }
+    if let Some(value) = rule.get("textLength") {
+        return basic_rule_to_schema("string", value);
+    }
+    if let Some(value) = rule.get("list") {
+        return list_rule_to_schema(value);
+    }
+    let custom = rule
+        .get("custom")
+        .and_then(Value::as_object)
+        .ok_or_else(|| invalid("DataValidation.custom must be an object"))?;
+    let formula = required_string(custom, "formula", "DataValidation.custom.formula")?;
+    Ok((
+        Value::Null,
+        Some(Map::from_iter([(
+            "formula".to_string(),
+            Value::String(formula),
+        )])),
+    ))
+}
+
+fn basic_rule_to_schema(
+    schema_type: &'static str,
+    value: &Value,
+) -> Result<(Value, Option<Map<String, Value>>), ValidationError> {
+    let object = value.as_object().ok_or_else(|| {
+        invalid(format!(
+            "DataValidation rule '{schema_type}' must be an object"
+        ))
+    })?;
+    let allowed = ["formula1", "formula2", "operator"];
+    for key in object.keys() {
+        if !allowed.contains(&key.as_str()) {
+            return Err(invalid(format!(
+                "Unsupported DataValidation rule property '{key}'"
+            )));
+        }
+    }
+    let operator = required_string(object, "operator", "DataValidation rule operator")?;
+    let formula1 = object
+        .get("formula1")
+        .ok_or_else(|| invalid("DataValidation rule requires formula1"))?;
+    let formula2 = object.get("formula2");
+    let constraints = match schema_type {
+        "string" => length_constraints(&operator, formula1, formula2)?,
+        "date" => numeric_constraints(&operator, formula1, formula2, DateKind::Date)?,
+        "time" => numeric_constraints(&operator, formula1, formula2, DateKind::Time)?,
+        _ => numeric_constraints(&operator, formula1, formula2, DateKind::Number)?,
+    };
+    Ok((json!(schema_type), Some(constraints)))
+}
+
+fn list_rule_to_schema(
+    value: &Value,
+) -> Result<(Value, Option<Map<String, Value>>), ValidationError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid("DataValidation.list must be an object"))?;
+    for key in object.keys() {
+        if key != "source" && key != "inCellDropDown" {
+            return Err(invalid(format!(
+                "Unsupported DataValidation.list property '{key}'"
+            )));
+        }
+    }
+    object
+        .get("inCellDropDown")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| invalid("DataValidation.list.inCellDropDown must be a boolean"))?;
+    let source = object
+        .get("source")
+        .ok_or_else(|| invalid("DataValidation.list requires source"))?;
+    let source = source
+        .as_str()
+        .ok_or_else(|| invalid("DataValidation.list.source must be a string"))?;
+    if source.is_empty() {
+        return Err(invalid("DataValidation.list.source cannot be empty"));
+    }
+
+    let mut constraints = Map::new();
+    if let Some(range) = source.strip_prefix('=')
+        && let Ok((sr, sc, er, ec)) = CellRange::from(range).resolve()
+    {
+        constraints.insert(
+            "enumSource".to_string(),
+            json!({
+                "startId": format!("{sr}:{sc}"),
+                "endId": format!("{er}:{ec}"),
+            }),
+        );
+    } else if source.starts_with('=') {
+        constraints.insert(
+            "enumSourceFormula".to_string(),
+            Value::String(source.to_string()),
+        );
+    } else {
+        constraints.insert(
+            "enum".to_string(),
+            Value::Array(
+                source
+                    .split(',')
+                    .map(|item| Value::String(item.to_string()))
+                    .collect(),
+            ),
+        );
+    }
+    Ok((Value::Null, Some(constraints)))
+}
+
+#[derive(Clone, Copy)]
+enum DateKind {
+    Number,
+    Date,
+    Time,
+}
+
+enum ParsedBound {
+    Literal(f64),
+    Formula(String),
+}
+
+fn parse_bound(
+    value: &Value,
+    date_kind: DateKind,
+    _property: &str,
+) -> Result<ParsedBound, ValidationError> {
+    if let Some(number) = value.as_f64() {
+        if number.is_finite() {
+            return Ok(ParsedBound::Literal(number));
+        }
+        return Err(invalid("DataValidation bound must be finite"));
+    }
+
+    let Some(raw) = value.as_str() else {
+        return Err(invalid(
+            "DataValidation bound must be a finite number or formula string",
+        ));
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(invalid("DataValidation bound cannot be empty"));
+    }
+
+    let has_formula_prefix = trimmed.starts_with('=');
+    let raw = trimmed.strip_prefix('=').unwrap_or(trimmed).trim();
+    // An ISO date/time without `=` is a literal accepted by the DateTime
+    // contract. Once the caller supplies `=`, retain the expression so
+    // arithmetic such as `=2024-01-01` is evaluated by the production engine
+    // instead of being mistaken for the literal date 2024-01-01.
+    let parsed = if has_formula_prefix {
+        None
+    } else {
+        match date_kind {
+            DateKind::Number => raw.parse::<f64>().ok().filter(|number| number.is_finite()),
+            DateKind::Date => parse_date_bound(raw),
+            DateKind::Time => parse_time_bound(raw),
+        }
+    };
+    Ok(parsed.map_or_else(
+        || ParsedBound::Formula(formula_text(trimmed)),
+        ParsedBound::Literal,
+    ))
+}
+
+fn formula_text(value: &str) -> String {
+    let value = value.trim();
+    if value.starts_with('=') {
+        value.to_string()
+    } else {
+        format!("={value}")
+    }
+}
+
+fn parse_date_bound(raw: &str) -> Option<f64> {
+    // JavaScript Date values arrive as ISO UTC strings. The durable date
+    // parser intentionally accepts Excel-style date text, so preserve the
+    // calendar date and discard the transport-only time suffix.
+    let date_text = raw.split_once('T').map_or(raw, |(date, _)| date);
+    value_types::date_serial::try_parse_date(date_text)
+        .ok()
+        .or_else(|| {
+            let normalized = raw
+                .trim_end_matches('Z')
+                .split_once('.')
+                .map_or(raw, |(value, _)| value)
+                .replace('T', " ");
+            value_types::date_serial::try_parse_datetime(&normalized)
+                .ok()
+                .map(f64::floor)
+        })
+}
+
+fn parse_time_bound(raw: &str) -> Option<f64> {
+    // JavaScript Date values carry a full date. For time validation only the
+    // clock component participates in the constraint.
+    let time_text = raw
+        .split_once('T')
+        .map(|(_, time)| time)
+        .or_else(|| raw.split_once(' ').map(|(_, time)| time))
+        .unwrap_or(raw)
+        .trim_end_matches('Z');
+    let time_text = time_text
+        .split_once('.')
+        .map_or(time_text, |(value, _)| value);
+    let time_text = time_text
+        .find(|character| matches!(character, '+' | '-'))
+        .map_or(time_text, |offset| &time_text[..offset]);
+    value_types::date_serial::try_parse_time(time_text).ok()
+}
+
+fn non_negative_integer(value: f64, property: &str) -> Result<usize, ValidationError> {
+    if !value.is_finite() || value < 0.0 || value.fract() != 0.0 {
+        return Err(invalid(format!(
+            "DataValidation.{property} must be a non-negative integer"
+        )));
+    }
+    if value > usize::MAX as f64 {
+        return Err(invalid(format!("DataValidation.{property} is too large")));
+    }
+    Ok(value as usize)
+}
+
+fn numeric_constraints(
+    operator: &str,
+    formula1: &Value,
+    formula2: Option<&Value>,
+    date_kind: DateKind,
+) -> Result<Map<String, Value>, ValidationError> {
+    if formula2.is_some() && !matches!(operator, "Between" | "NotBetween") {
+        return Err(invalid(
+            "formula2 is only valid with Between or NotBetween operators",
+        ));
+    }
+    let first = parse_bound(formula1, date_kind, "formula1")?;
+    let second = formula2
+        .map(|value| parse_bound(value, date_kind, "formula2"))
+        .transpose()?;
+    let mut constraints = Map::new();
+    match operator {
+        "Between" => {
+            let second = second.ok_or_else(|| invalid("Between requires formula2"))?;
+            insert_bound(&mut constraints, "min", first);
+            insert_bound(&mut constraints, "max", second);
+        }
+        "NotBetween" => {
+            let second = second.ok_or_else(|| invalid("NotBetween requires formula2"))?;
+            insert_bound(&mut constraints, "notBetweenMin", first);
+            insert_bound(&mut constraints, "notBetweenMax", second);
+        }
+        "EqualTo" => {
+            insert_bound(&mut constraints, "equal", first);
+        }
+        "NotEqualTo" => {
+            insert_bound(&mut constraints, "notEqual", first);
+        }
+        "GreaterThan" => {
+            insert_bound(&mut constraints, "exclusiveMin", first);
+        }
+        "GreaterThanOrEqualTo" => {
+            insert_bound(&mut constraints, "min", first);
+        }
+        "LessThan" => {
+            insert_bound(&mut constraints, "exclusiveMax", first);
+        }
+        "LessThanOrEqualTo" => {
+            insert_bound(&mut constraints, "max", first);
+        }
+        other => {
+            return Err(invalid(format!(
+                "Unsupported DataValidation operator '{other}'"
+            )));
+        }
+    }
+    Ok(constraints)
+}
+
+fn length_constraints(
+    operator: &str,
+    formula1: &Value,
+    formula2: Option<&Value>,
+) -> Result<Map<String, Value>, ValidationError> {
+    if formula2.is_some() && !matches!(operator, "Between" | "NotBetween") {
+        return Err(invalid(
+            "formula2 is only valid with Between or NotBetween operators",
+        ));
+    }
+    let first = parse_bound(formula1, DateKind::Number, "formula1")?;
+    let first = match first {
+        ParsedBound::Literal(value) => {
+            ParsedBound::Literal(non_negative_integer(value, "formula1")? as f64)
+        }
+        ParsedBound::Formula(value) => ParsedBound::Formula(value),
+    };
+    let second = formula2
+        .map(|value| parse_bound(value, DateKind::Number, "formula2"))
+        .transpose()?;
+    let second = second.map(|value| match value {
+        ParsedBound::Literal(value) => {
+            non_negative_integer(value, "formula2").map(|value| ParsedBound::Literal(value as f64))
+        }
+        ParsedBound::Formula(value) => Ok(ParsedBound::Formula(value)),
+    });
+    let second = second.transpose()?;
+    let mut constraints = Map::new();
+    match operator {
+        "Between" => {
+            let second = second.ok_or_else(|| invalid("Between requires formula2"))?;
+            insert_bound(&mut constraints, "minLength", first);
+            insert_bound(&mut constraints, "maxLength", second);
+        }
+        "GreaterThanOrEqualTo" => {
+            insert_bound(&mut constraints, "minLength", first);
+        }
+        "LessThanOrEqualTo" => {
+            insert_bound(&mut constraints, "maxLength", first);
+        }
+        other => {
+            return Err(invalid(format!(
+                "Unsupported TextLength operator '{other}'"
+            )));
+        }
+    }
+    Ok(constraints)
+}
+
+fn insert_bound(constraints: &mut Map<String, Value>, key: &str, bound: ParsedBound) {
+    match bound {
+        ParsedBound::Literal(value) => {
+            constraints.insert(key.to_string(), json!(value));
+        }
+        ParsedBound::Formula(formula) => {
+            constraints
+                .entry("formulaBounds".to_string())
+                .or_insert_with(|| Value::Object(Map::new()));
+            if let Some(bounds) = constraints
+                .get_mut("formulaBounds")
+                .and_then(Value::as_object_mut)
+            {
+                bounds.insert(key.to_string(), Value::String(formula));
+            }
+        }
+    }
+}
+
+fn normalize_rule_value(value: &Value) -> Result<Value, ValidationError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid("DataValidation.rule must be an object"))?;
+    let mut output = Map::new();
+    for (kind, raw) in object {
+        let normalized = match kind.as_str() {
+            "wholeNumber" | "decimal" | "date" | "time" | "textLength" => {
+                normalize_basic_rule(raw)?
+            }
+            "list" => normalize_list_rule(raw)?,
+            "custom" => {
+                let custom = raw
+                    .as_object()
+                    .ok_or_else(|| invalid("DataValidation.custom must be an object"))?;
+                for key in custom.keys() {
+                    if key != "formula" {
+                        return Err(invalid(format!(
+                            "Unsupported DataValidation.custom property '{key}'"
+                        )));
+                    }
+                }
+                let formula = required_string(custom, "formula", "DataValidation.custom.formula")?;
+                json!({"formula": formula})
+            }
+            other => {
+                return Err(invalid(format!(
+                    "Unsupported DataValidation.rule property '{other}'"
+                )));
+            }
+        };
+        output.insert(kind.clone(), normalized);
+    }
+    if output.len() > 1 {
+        return Err(invalid(
+            "DataValidation.rule must contain exactly one validation type",
+        ));
+    }
+    Ok(Value::Object(output))
+}
+
+fn normalize_basic_rule(value: &Value) -> Result<Value, ValidationError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid("DataValidation rule criteria must be an object"))?;
+    for key in object.keys() {
+        if key != "formula1" && key != "formula2" && key != "operator" {
+            return Err(invalid(format!(
+                "Unsupported DataValidation rule property '{key}'"
+            )));
+        }
+    }
+    let mut output = Map::new();
+    for key in ["formula1", "formula2", "operator"] {
+        if let Some(value) = object.get(key) {
+            output.insert(key.to_string(), value.clone());
+        }
+    }
+    Ok(Value::Object(output))
+}
+
+fn normalize_list_rule(value: &Value) -> Result<Value, ValidationError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid("DataValidation.list must be an object"))?;
+    for key in object.keys() {
+        if key != "source" && key != "inCellDropDown" {
+            return Err(invalid(format!(
+                "Unsupported DataValidation.list property '{key}'"
+            )));
+        }
+    }
+    let source = object
+        .get("source")
+        .ok_or_else(|| invalid("DataValidation.list requires source"))?;
+    if !source.is_string() {
+        return Err(invalid("DataValidation.list.source must be a string"));
+    }
+    let dropdown = object
+        .get("inCellDropDown")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| invalid("DataValidation.list.inCellDropDown must be a boolean"))?;
+    Ok(json!({"source": source, "inCellDropDown": dropdown}))
+}
+
+fn normalize_error_alert(value: &Value) -> Result<Value, ValidationError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid("DataValidation.errorAlert must be an object"))?;
+    for key in object.keys() {
+        if !["message", "showAlert", "style", "title"].contains(&key.as_str()) {
+            return Err(invalid(format!(
+                "Unsupported DataValidation.errorAlert property '{key}'"
+            )));
+        }
+    }
+    let message = required_string(object, "message", "DataValidation.errorAlert.message")?;
+    let title = required_string(object, "title", "DataValidation.errorAlert.title")?;
+    let show_alert = object
+        .get("showAlert")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| invalid("DataValidation.errorAlert.showAlert must be a boolean"))?;
+    let style = required_string(object, "style", "DataValidation.errorAlert.style")?;
+    Ok(json!({
+        "message": message,
+        "showAlert": show_alert,
+        "style": style,
+        "title": title,
+    }))
+}
+
+fn normalize_prompt(value: &Value) -> Result<Value, ValidationError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid("DataValidation.prompt must be an object"))?;
+    for key in object.keys() {
+        if !["message", "showPrompt", "title"].contains(&key.as_str()) {
+            return Err(invalid(format!(
+                "Unsupported DataValidation.prompt property '{key}'"
+            )));
+        }
+    }
+    let message = required_string(object, "message", "DataValidation.prompt.message")?;
+    let title = required_string(object, "title", "DataValidation.prompt.title")?;
+    let show_prompt = object
+        .get("showPrompt")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| invalid("DataValidation.prompt.showPrompt must be a boolean"))?;
+    Ok(json!({
+        "message": message,
+        "showPrompt": show_prompt,
+        "title": title,
+    }))
+}
+
+fn required_string(
+    object: &Map<String, Value>,
+    key: &str,
+    property: &str,
+) -> Result<String, ValidationError> {
+    object
+        .get(key)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| invalid(format!("{property} must be a string")))
+}
+
+fn schema_id_for(bounds: Bounds) -> String {
+    format!(
+        "officejs-dv-{}-{}-{}-{}",
+        bounds.start_row, bounds.start_col, bounds.end_row, bounds.end_col
+    )
+}
+
+fn validation_text(value: &CellValue) -> String {
+    value
+        .coerce_to_string()
+        .map(|text| text.into_owned())
+        .unwrap_or_default()
+}
+
+fn invalid(message: impl Into<String>) -> ValidationError {
+    ValidationError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn unsupported(message: impl Into<String>) -> ValidationError {
+    ValidationError {
+        code: "InvalidArgument",
+        message: message.into(),
+    }
+}
+
+fn engine(error: ComputeApiError) -> ValidationError {
+    ValidationError {
+        code: "GeneralException",
+        message: error.to_string(),
+    }
+}
+
+fn encoding(error: serde_json::Error) -> ValidationError {
+    encoding_message(format!("Failed to encode validation schema: {error}"))
+}
+
+fn encoding_message(message: impl Into<String>) -> ValidationError {
+    ValidationError {
+        code: "GeneralException",
+        message: message.into(),
+    }
+}

--- a/compute/officejs/src/worksheets.js
+++ b/compute/officejs/src/worksheets.js
@@ -1,0 +1,283 @@
+(function (global) {
+  "use strict";
+
+  var Excel = global.Excel;
+  var OfficeExtension = global.OfficeExtension;
+  var Worksheet = Excel.Worksheet;
+  var WorksheetCollection = Excel.WorksheetCollection;
+  var officeJs = global.__mogOfficeJs;
+
+  officeJs.addScalarProperties(Worksheet.prototype, ["position", "visibility"]);
+
+  function ensureCollection(collection) {
+    if (collection._worksheetCollectionConfigured) return;
+
+    collection.context._queue.push({
+      op: "getWorksheetCollection",
+      id: collection._id,
+    });
+    collection._scalarProperties = collection._scalarProperties || [];
+    if (collection._scalarProperties.indexOf("items") < 0) {
+      collection._scalarProperties.push("items");
+    }
+
+    officeJs.configureCollection(collection, function (key) {
+      // Collection hydration deliberately enters the normal getItem path.
+      // That path allocates/registers a real Worksheet proxy and queues its
+      // host binding, preserving all regular object-path semantics.
+      return collection.getItem(String(key));
+    });
+    collection._worksheetCollectionConfigured = true;
+  }
+
+  // Keep the collection property present before its first load.  The shared
+  // collection helper supplies `_hydrateItems`; this descriptor supplies the
+  // normal Office.js unloaded-property behavior until that hydration occurs.
+  Object.defineProperty(WorksheetCollection.prototype, "items", {
+    configurable: true,
+    get: function () {
+      ensureCollection(this);
+      if (!this._loaded.items) {
+        throw new OfficeExtension.Error({
+          code: "PropertyNotLoaded",
+          message: "The worksheet collection property has not been loaded: items",
+        });
+      }
+      return this._items;
+    },
+  });
+
+  function newWorksheet(context) {
+    return new Worksheet(context, null);
+  }
+
+  function queueRelatedWorksheet(worksheet, op, visibleOnly, orNull) {
+    var payload = {
+      op: op,
+      id: worksheet._id,
+      worksheetId: worksheet._worksheetSourceId,
+      visibleOnly: visibleOnly === true,
+      orNull: orNull === true,
+    };
+    worksheet.context._queue.push(payload);
+    return worksheet;
+  }
+
+  // The runtime owns result allocation and hydration.  This adapter only
+  // keeps the worksheet operation's wire shape close to the method that
+  // returns it.
+  function newClientResult(context) {
+    return officeJs.createClientResult(context);
+  }
+
+  function resultId(result) {
+    return result._id;
+  }
+
+  // Worksheet scalar properties.  The base bootstrap defines name and id;
+  // name becomes configurable in the runtime so this extension can add the
+  // documented setter without replacing the Worksheet constructor.
+  var nameDescriptor = Object.getOwnPropertyDescriptor(Worksheet.prototype, "name");
+  if (nameDescriptor && !nameDescriptor.configurable) {
+    throw new Error(
+      "Worksheet.name must be configurable before the Office.js worksheet extension is loaded"
+    );
+  }
+  Object.defineProperty(Worksheet.prototype, "name", {
+    configurable: true,
+    enumerable: nameDescriptor ? nameDescriptor.enumerable : false,
+    get: nameDescriptor && nameDescriptor.get
+      ? nameDescriptor.get
+      : undefined,
+    set: function (value) {
+      this._name = value;
+      this._loaded.name = true;
+      this.context._queue.push({
+        op: "set",
+        id: this._id,
+        property: "name",
+        value: value,
+      });
+    },
+  });
+
+  function scalarProperty(name) {
+    Object.defineProperty(Worksheet.prototype, name, {
+      configurable: true,
+      get: function () {
+        if (!this._loaded[name]) {
+          throw new OfficeExtension.Error({
+            code: "PropertyNotLoaded",
+            message: "The worksheet property has not been loaded: " + name,
+          });
+        }
+        return this["_" + name];
+      },
+      set: function (value) {
+        this["_" + name] = value;
+        this._loaded[name] = true;
+        this.context._queue.push({
+          op: "set",
+          id: this._id,
+          property: name,
+          value: value,
+        });
+      },
+    });
+  }
+
+  scalarProperty("position");
+  scalarProperty("visibility");
+
+  Worksheet.prototype.toJSON = function () {
+    var data = {};
+    ["id", "name", "position", "visibility"].forEach(function (name) {
+      if (!this._loaded[name]) return;
+      data[name] = name === "id" ? this._idValue : this["_" + name];
+    }, this);
+    return data;
+  };
+
+  Worksheet.prototype.activate = function () {
+    this.context._queue.push({ op: "worksheetActivate", id: this._id });
+  };
+
+  Worksheet.prototype.delete = function () {
+    this.context._queue.push({ op: "worksheetDelete", id: this._id });
+  };
+
+  Worksheet.prototype.getNext = function (visibleOnly) {
+    var worksheet = newWorksheet(this.context);
+    worksheet._worksheetSourceId = this._id;
+    return queueRelatedWorksheet(
+      worksheet,
+      "worksheetGetNext",
+      visibleOnly,
+      false
+    );
+  };
+
+  Worksheet.prototype.getNextOrNullObject = function (visibleOnly) {
+    var worksheet = newWorksheet(this.context);
+    worksheet._worksheetSourceId = this._id;
+    return queueRelatedWorksheet(
+      worksheet,
+      "worksheetGetNext",
+      visibleOnly,
+      true
+    );
+  };
+
+  Worksheet.prototype.getPrevious = function (visibleOnly) {
+    var worksheet = newWorksheet(this.context);
+    worksheet._worksheetSourceId = this._id;
+    return queueRelatedWorksheet(
+      worksheet,
+      "worksheetGetPrevious",
+      visibleOnly,
+      false
+    );
+  };
+
+  Worksheet.prototype.getPreviousOrNullObject = function (visibleOnly) {
+    var worksheet = newWorksheet(this.context);
+    worksheet._worksheetSourceId = this._id;
+    return queueRelatedWorksheet(
+      worksheet,
+      "worksheetGetPrevious",
+      visibleOnly,
+      true
+    );
+  };
+
+  var collectionGetItem = WorksheetCollection.prototype.getItem;
+  WorksheetCollection.prototype.getItem = function (key) {
+    ensureCollection(this);
+    return collectionGetItem.call(this, key);
+  };
+
+  var collectionGetActiveWorksheet = WorksheetCollection.prototype.getActiveWorksheet;
+  WorksheetCollection.prototype.getActiveWorksheet = function () {
+    ensureCollection(this);
+    return collectionGetActiveWorksheet.call(this);
+  };
+
+  var collectionAdd = WorksheetCollection.prototype.add;
+  WorksheetCollection.prototype.add = function (name) {
+    ensureCollection(this);
+    return collectionAdd.call(this, name);
+  };
+
+  var collectionLoad = WorksheetCollection.prototype.load;
+  WorksheetCollection.prototype.load = function (props) {
+    ensureCollection(this);
+    return collectionLoad.call(this, props);
+  };
+
+  WorksheetCollection.prototype.getItemOrNullObject = function (key) {
+    ensureCollection(this);
+    var worksheet = newWorksheet(this.context);
+    this.context._queue.push({
+      op: "worksheetGetItemOrNullObject",
+      id: worksheet._id,
+      key: String(key),
+    });
+    return worksheet;
+  };
+
+  WorksheetCollection.prototype.getCount = function (visibleOnly) {
+    ensureCollection(this);
+    var result = newClientResult(this.context);
+    this.context._queue.push({
+      op: "worksheetCollectionGetCount",
+      collectionId: this._id,
+      resultId: resultId(result),
+      visibleOnly: visibleOnly === true,
+    });
+    return result;
+  };
+
+  function collectionEdge(collection, operation, visibleOnly, orNull) {
+    ensureCollection(collection);
+    var worksheet = newWorksheet(collection.context);
+    collection.context._queue.push({
+      op: operation,
+      collectionId: collection._id,
+      id: worksheet._id,
+      visibleOnly: visibleOnly === true,
+      orNull: orNull === true,
+    });
+    return worksheet;
+  }
+
+  WorksheetCollection.prototype.getFirst = function (visibleOnly) {
+    return collectionEdge(
+      this,
+      "worksheetCollectionGetFirst",
+      visibleOnly,
+      false
+    );
+  };
+
+  WorksheetCollection.prototype.getLast = function (visibleOnly) {
+    return collectionEdge(
+      this,
+      "worksheetCollectionGetLast",
+      visibleOnly,
+      false
+    );
+  };
+
+  WorksheetCollection.prototype.toJSON = function () {
+    ensureCollection(this);
+    if (!this._loaded.items) return {};
+    return {
+      items: (this._items || []).map(function (item) {
+        return item && typeof item.toJSON === "function" ? item.toJSON() : item;
+      }),
+    };
+  };
+
+  Excel.Worksheet = Worksheet;
+  Excel.WorksheetCollection = WorksheetCollection;
+})(globalThis);

--- a/compute/officejs/src/worksheets.rs
+++ b/compute/officejs/src/worksheets.rs
@@ -1,0 +1,612 @@
+//! Office.js worksheet lifecycle and collection helpers.
+//!
+//! The JavaScript Office.js layer owns request-context proxy objects.  This
+//! module owns the corresponding host-side references and deliberately
+//! resolves metadata from the compute engine on every operation.  In
+//! particular, a [`WorksheetRef`] is anchored by the engine's stable
+//! [`SheetId`], so a proxy remains valid after a rename or a tab move.
+
+use std::collections::HashMap;
+
+use compute_api::{ComputeApiError, Sheet, SheetId, Workbook};
+use serde::Serialize;
+use serde_json::{Value, json};
+
+/// Error returned by a worksheet host operation.
+///
+/// `code` contains the Office.js error code expected by the JavaScript
+/// request context.  Keeping this conversion at the Office.js boundary lets
+/// the compute API continue to expose its richer Rust error type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorksheetError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+/// A worksheet item in the collection hydration wire shape.
+///
+/// The collection host operation returns these records under
+/// `loaded[collectionId].items`.  The JavaScript hydration layer uses `key` to
+/// call the normal `WorksheetCollection.getItem` path, then seeds the listed
+/// scalar properties on that real proxy.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct WorksheetItem {
+    pub(crate) key: String,
+    pub(crate) properties: HashMap<String, Value>,
+}
+
+/// A host-side worksheet reference anchored to a stable engine sheet ID.
+#[derive(Clone)]
+pub(crate) struct WorksheetRef {
+    workbook: Workbook,
+    sheet: Sheet,
+}
+
+impl WorksheetRef {
+    /// Construct a worksheet reference from a workbook and a sheet handle.
+    pub(crate) fn new(workbook: Workbook, sheet: Sheet) -> Self {
+        Self { workbook, sheet }
+    }
+
+    /// Return the underlying compute-api sheet handle.
+    pub(crate) fn sheet(&self) -> Sheet {
+        self.sheet.clone()
+    }
+
+    /// Return the stable worksheet ID used by Office.js.
+    pub(crate) fn stable_id(&self) -> String {
+        self.sheet.id().to_uuid_string()
+    }
+
+    /// Load supported worksheet scalar properties from the current engine
+    /// state.
+    pub(crate) fn load(
+        &self,
+        properties: &[String],
+    ) -> Result<HashMap<String, Value>, WorksheetError> {
+        let mut result = HashMap::new();
+        for property in properties {
+            let value = match property.as_str() {
+                "id" => Value::String(self.stable_id()),
+                "name" => Value::String(self.name()?),
+                "position" => json!(self.position()?),
+                "visibility" => Value::String(visibility_token(&self.visibility()?).to_string()),
+                "isNullObject" => Value::Bool(false),
+                other => {
+                    return Err(unsupported_load_property("Worksheet", other));
+                }
+            };
+            result.insert(property.clone(), value);
+        }
+        Ok(result)
+    }
+
+    /// Set one of the supported worksheet scalar properties.
+    pub(crate) fn set(&self, property: &str, value: &Value) -> Result<(), WorksheetError> {
+        match property {
+            "name" => self.set_name(value),
+            "position" => self.set_position(value),
+            "visibility" => self.set_visibility(value),
+            other => Err(WorksheetError {
+                code: "InvalidArgument",
+                message: format!("Worksheet.{other} is read-only or unsupported"),
+            }),
+        }
+    }
+
+    /// Persist this worksheet as the active worksheet in workbook view state.
+    ///
+    /// The active marker is keyed by the stable sheet ID.  The selected-sheet
+    /// list is updated as well so persisted workbook view state remains
+    /// coherent for consumers that only understand the standard setting.
+    pub(crate) fn activate(&self) -> Result<(), WorksheetError> {
+        let position = self.position()? as u32;
+        let mut settings = self
+            .workbook
+            .settings()
+            .get_workbook_settings()
+            .map_err(compute_error)?;
+        let id = self.stable_id();
+        settings.selected_sheet_ids = Some(vec![id.clone()]);
+        settings
+            .custom_settings
+            .get_or_insert_with(HashMap::new)
+            .insert("mog.activeSheetId".to_string(), Value::String(id));
+        self.workbook
+            .settings()
+            .set_workbook_settings(settings)
+            .map_err(compute_error)?;
+        self.workbook
+            .settings()
+            .set_workbook_view_active_tab(position)
+            .map_err(compute_error)?;
+        Ok(())
+    }
+
+    /// Delete this worksheet, applying Office's lifecycle restrictions before
+    /// dispatching the persisted engine mutation.
+    pub(crate) fn delete(&self) -> Result<(), WorksheetError> {
+        let count = self.workbook.sheet_count().map_err(compute_error)?;
+        if count <= 1 {
+            return Err(WorksheetError {
+                code: "InvalidOperation",
+                message: "Cannot delete the last worksheet.".to_string(),
+            });
+        }
+
+        let deleted_id = self.stable_id();
+        let deleted_position = self.position()?;
+        let active_id = active(&self.workbook)
+            .ok()
+            .map(|worksheet| worksheet.stable_id());
+
+        // Office.js documents that deleting a VeryHidden worksheet fails.
+        // The compute engine can represent VeryHidden state but intentionally
+        // leaves this host-level rule to the API boundary.
+        if self.visibility()? == "veryHidden" {
+            return Err(WorksheetError {
+                code: "InvalidOperation",
+                message: "A VeryHidden worksheet cannot be deleted. Set its visibility to Hidden or Visible before deleting it.".to_string(),
+            });
+        }
+
+        self.workbook
+            .sheets()
+            .delete_sheet(self.sheet.id())
+            .map_err(compute_error)?;
+
+        if let Some(active_id) = active_id {
+            if active_id == deleted_id {
+                if let Some(replacement) =
+                    visible_replacement(&self.workbook, deleted_position, None)?
+                {
+                    replacement.activate()?;
+                }
+            } else if let Some(active_worksheet) = find_by_id(&self.workbook, &active_id)? {
+                persist_active_view_position(&active_worksheet)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Return the worksheet following this one in persisted tab order.
+    /// Hidden worksheets are skipped when `visible_only` is true.
+    pub(crate) fn next(&self, visible_only: bool) -> Result<Option<Self>, WorksheetError> {
+        let ordered = ordered(self.workbook.clone(), false)?;
+        let index = ordered
+            .iter()
+            .position(|worksheet| worksheet.same_sheet(self))
+            .ok_or_else(|| item_not_found(&self.stable_id()))?;
+        if !visible_only {
+            return Ok(ordered.get(index + 1).cloned());
+        }
+        for worksheet in ordered.iter().skip(index + 1) {
+            if worksheet.visibility()? == "visible" {
+                return Ok(Some(worksheet.clone()));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Return the worksheet preceding this one in persisted tab order.
+    /// Hidden worksheets are skipped when `visible_only` is true.
+    pub(crate) fn previous(&self, visible_only: bool) -> Result<Option<Self>, WorksheetError> {
+        let ordered = ordered(self.workbook.clone(), false)?;
+        let index = ordered
+            .iter()
+            .position(|worksheet| worksheet.same_sheet(self))
+            .ok_or_else(|| item_not_found(&self.stable_id()))?;
+        if !visible_only {
+            return Ok(index
+                .checked_sub(1)
+                .and_then(|previous| ordered.get(previous).cloned()));
+        }
+        for worksheet in ordered[..index].iter().rev() {
+            if worksheet.visibility()? == "visible" {
+                return Ok(Some(worksheet.clone()));
+            }
+        }
+        Ok(None)
+    }
+
+    fn same_sheet(&self, other: &Self) -> bool {
+        self.sheet.id() == other.sheet.id()
+    }
+
+    fn name(&self) -> Result<String, WorksheetError> {
+        self.sheet.name().map_err(compute_error)
+    }
+
+    fn position(&self) -> Result<usize, WorksheetError> {
+        let count = self.workbook.sheet_count().map_err(compute_error)?;
+        for index in 0..count {
+            let sheet = self.workbook.sheet_by_index(index).map_err(compute_error)?;
+            if sheet.id() == self.sheet.id() {
+                return Ok(index);
+            }
+        }
+        Err(item_not_found(&self.stable_id()))
+    }
+
+    fn visibility(&self) -> Result<String, WorksheetError> {
+        self.workbook
+            .sheets()
+            .get_sheet_visibility(self.sheet.id())
+            .map_err(compute_error)
+    }
+
+    fn set_name(&self, value: &Value) -> Result<(), WorksheetError> {
+        let name = required_string(value, "Worksheet.name")?;
+        validate_sheet_name(&self.workbook, self.sheet.id(), name)?;
+        self.workbook
+            .sheets()
+            .rename_sheet(self.sheet.id(), name)
+            .map_err(compute_error)?;
+        Ok(())
+    }
+
+    fn set_position(&self, value: &Value) -> Result<(), WorksheetError> {
+        let position = required_u32(value, "Worksheet.position")?;
+        let active_id = active(&self.workbook)
+            .ok()
+            .map(|worksheet| worksheet.stable_id());
+        self.workbook
+            .sheets()
+            .move_sheet(self.sheet.id(), position)
+            .map_err(compute_error)?;
+        if let Some(active_id) = active_id
+            && let Some(active_worksheet) = find_by_id(&self.workbook, &active_id)?
+        {
+            persist_active_view_position(&active_worksheet)?;
+        }
+        Ok(())
+    }
+
+    fn set_visibility(&self, value: &Value) -> Result<(), WorksheetError> {
+        let state = parse_visibility(value)?;
+        let old_visibility = self.visibility()?;
+        let self_id = self.stable_id();
+        let active_id = active(&self.workbook)
+            .ok()
+            .map(|worksheet| worksheet.stable_id());
+        if state != "visible" && old_visibility == "visible" {
+            let visible_count = ordered(self.workbook.clone(), true)?.len();
+            if visible_count <= 1 {
+                return Err(WorksheetError {
+                    code: "InvalidOperation",
+                    message: "At least one worksheet must remain visible.".to_string(),
+                });
+            }
+        }
+        self.workbook
+            .sheets()
+            .set_sheet_visibility(self.sheet.id(), state)
+            .map_err(compute_error)?;
+        if state != "visible"
+            && old_visibility == "visible"
+            && active_id.as_deref() == Some(self_id.as_str())
+            && let Some(replacement) =
+                visible_replacement(&self.workbook, self.position()?, Some(self.sheet.id()))?
+        {
+            replacement.activate()?;
+        }
+        Ok(())
+    }
+}
+
+/// Resolve a worksheet by name or stable ID.
+pub(crate) fn get_item(workbook: &Workbook, key: &str) -> Result<WorksheetRef, WorksheetError> {
+    for index in 0..workbook.sheet_count().map_err(compute_error)? {
+        let sheet = workbook.sheet_by_index(index).map_err(compute_error)?;
+        if sheet.id().to_uuid_string().eq_ignore_ascii_case(key)
+            || sheet
+                .name()
+                .map_err(compute_error)?
+                .eq_ignore_ascii_case(key)
+        {
+            return Ok(WorksheetRef::new(workbook.clone(), sheet));
+        }
+    }
+    Err(item_not_found(key))
+}
+
+/// Resolve a worksheet by name or stable ID, returning `None` for a missing
+/// item as required by `getItemOrNullObject`.
+pub(crate) fn get_item_or_null(
+    workbook: &Workbook,
+    key: &str,
+) -> Result<Option<WorksheetRef>, WorksheetError> {
+    match get_item(workbook, key) {
+        Ok(worksheet) => Ok(Some(worksheet)),
+        Err(error) if error.code == "ItemNotFound" => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// Resolve the persisted active worksheet.
+///
+/// Activation is represented by persisted workbook view state. A new blank
+/// workbook has a genuine engine default returned by `get_first_sheet_id`; it
+/// is used only when no persisted selection or workbook view exists.
+pub(crate) fn active(workbook: &Workbook) -> Result<WorksheetRef, WorksheetError> {
+    let settings = workbook
+        .settings()
+        .get_workbook_settings()
+        .map_err(compute_error)?;
+
+    if let Some(id) = settings
+        .custom_settings
+        .as_ref()
+        .and_then(|settings| settings.get("mog.activeSheetId"))
+        .and_then(Value::as_str)
+        && let Some(worksheet) = find_by_id(workbook, id)?
+    {
+        return Ok(worksheet);
+    }
+
+    if let Some(ids) = settings.selected_sheet_ids.as_ref() {
+        for id in ids {
+            if let Some(worksheet) = find_by_id(workbook, id)? {
+                return Ok(worksheet);
+            }
+        }
+    }
+
+    if let Some(active_tab) = workbook
+        .settings()
+        .get_workbook_view_active_tab()
+        .map_err(compute_error)?
+    {
+        let sheet = workbook
+            .sheet_by_index(active_tab as usize)
+            .map_err(compute_error)?;
+        return Ok(WorksheetRef::new(workbook.clone(), sheet));
+    }
+
+    if let Some(first_id) = workbook
+        .sheets()
+        .get_first_sheet_id()
+        .map_err(compute_error)?
+        && let Some(worksheet) = find_by_id(workbook, &first_id)?
+    {
+        return Ok(worksheet);
+    }
+
+    Err(WorksheetError {
+        code: "ItemNotFound",
+        message: "The workbook contains no worksheet that can be active.".to_string(),
+    })
+}
+
+/// Resolve every worksheet in persisted tab order, optionally skipping hidden
+/// worksheets.
+pub(crate) fn ordered(
+    workbook: Workbook,
+    visible_only: bool,
+) -> Result<Vec<WorksheetRef>, WorksheetError> {
+    let count = workbook.sheet_count().map_err(compute_error)?;
+    let mut worksheets = Vec::with_capacity(count);
+    for index in 0..count {
+        let sheet = workbook.sheet_by_index(index).map_err(compute_error)?;
+        let worksheet = WorksheetRef::new(workbook.clone(), sheet);
+        if visible_only && worksheet.visibility()? != "visible" {
+            continue;
+        }
+        worksheets.push(worksheet);
+    }
+    Ok(worksheets)
+}
+
+fn visible_replacement(
+    workbook: &Workbook,
+    start_position: usize,
+    skip_id: Option<&SheetId>,
+) -> Result<Option<WorksheetRef>, WorksheetError> {
+    let ordered = ordered(workbook.clone(), false)?;
+    let start_position = start_position.min(ordered.len());
+    for worksheet in ordered.iter().skip(start_position) {
+        if skip_id.is_some_and(|id| worksheet.sheet.id() == id) {
+            continue;
+        }
+        if worksheet.visibility()? == "visible" {
+            return Ok(Some(worksheet.clone()));
+        }
+    }
+    for worksheet in ordered[..start_position].iter().rev() {
+        if skip_id.is_some_and(|id| worksheet.sheet.id() == id) {
+            continue;
+        }
+        if worksheet.visibility()? == "visible" {
+            return Ok(Some(worksheet.clone()));
+        }
+    }
+    Ok(None)
+}
+
+fn persist_active_view_position(worksheet: &WorksheetRef) -> Result<(), WorksheetError> {
+    worksheet
+        .workbook
+        .settings()
+        .set_workbook_view_active_tab(worksheet.position()? as u32)
+        .map_err(compute_error)?;
+    Ok(())
+}
+
+/// Resolve the collection's loaded worksheet item records.
+///
+/// `properties` are the scalar properties requested for each item.  An empty
+/// list uses the worksheet scalar defaults (`id`, `name`, `position`, and
+/// `visibility`), matching a collection `$all` request at this narrow host
+/// surface.
+pub(crate) fn collection_items(
+    workbook: &Workbook,
+    properties: &[String],
+    visible_only: bool,
+) -> Result<Vec<WorksheetItem>, WorksheetError> {
+    let properties = normalize_collection_properties(properties)?;
+    let properties = if properties.is_empty() {
+        vec![
+            "id".to_string(),
+            "name".to_string(),
+            "position".to_string(),
+            "visibility".to_string(),
+        ]
+    } else {
+        properties
+    };
+    ordered(workbook.clone(), visible_only)?
+        .into_iter()
+        .map(|worksheet| {
+            let key = worksheet.stable_id();
+            let properties = worksheet.load(&properties)?;
+            Ok(WorksheetItem { key, properties })
+        })
+        .collect()
+}
+
+fn normalize_collection_properties(properties: &[String]) -> Result<Vec<String>, WorksheetError> {
+    let mut normalized = Vec::new();
+    for property in properties {
+        if property == "items" {
+            continue;
+        }
+        if let Some(item_property) = property.strip_prefix("items/") {
+            if item_property.is_empty() || item_property == "$all" {
+                continue;
+            }
+            normalized.push(item_property.to_string());
+            continue;
+        }
+        // Host integrations may already strip the `items/` prefix before
+        // calling this helper.  Accept those scalar names while rejecting
+        // workbook-collection properties that could otherwise be mistaken for
+        // item data.
+        if matches!(
+            property.as_str(),
+            "id" | "name" | "position" | "visibility" | "isNullObject"
+        ) {
+            normalized.push(property.clone());
+            continue;
+        }
+        return Err(unsupported_load_property("WorksheetCollection", property));
+    }
+    Ok(normalized)
+}
+
+fn find_by_id(workbook: &Workbook, id: &str) -> Result<Option<WorksheetRef>, WorksheetError> {
+    for index in 0..workbook.sheet_count().map_err(compute_error)? {
+        let sheet = workbook.sheet_by_index(index).map_err(compute_error)?;
+        if sheet.id().to_uuid_string().eq_ignore_ascii_case(id) {
+            return Ok(Some(WorksheetRef::new(workbook.clone(), sheet)));
+        }
+    }
+    Ok(None)
+}
+
+fn validate_sheet_name(
+    workbook: &Workbook,
+    sheet_id: &SheetId,
+    name: &str,
+) -> Result<(), WorksheetError> {
+    if name.is_empty() || name.chars().count() > 31 {
+        return Err(WorksheetError {
+            code: "InvalidArgument",
+            message: "Worksheet.name must contain 1 through 31 characters.".to_string(),
+        });
+    }
+    if name.chars().any(|character| ":\\/?*[]".contains(character)) {
+        return Err(WorksheetError {
+            code: "InvalidArgument",
+            message: "Worksheet.name contains a character that is not allowed in a worksheet name."
+                .to_string(),
+        });
+    }
+
+    for index in 0..workbook.sheet_count().map_err(compute_error)? {
+        let sheet = workbook.sheet_by_index(index).map_err(compute_error)?;
+        if sheet.id() == sheet_id {
+            continue;
+        }
+        if sheet
+            .name()
+            .map_err(compute_error)?
+            .eq_ignore_ascii_case(name)
+        {
+            return Err(WorksheetError {
+                code: "InvalidArgument",
+                message: format!("A worksheet named '{name}' already exists."),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn parse_visibility(value: &Value) -> Result<&'static str, WorksheetError> {
+    let token = value.as_str().ok_or_else(|| WorksheetError {
+        code: "InvalidArgument",
+        message: "Worksheet.visibility must be Visible, Hidden, or VeryHidden.".to_string(),
+    })?;
+    match token.to_ascii_lowercase().as_str() {
+        "visible" => Ok("visible"),
+        "hidden" => Ok("hidden"),
+        "veryhidden" => Ok("veryHidden"),
+        _ => Err(WorksheetError {
+            code: "InvalidArgument",
+            message: format!(
+                "Worksheet.visibility must be Visible, Hidden, or VeryHidden; got '{token}'."
+            ),
+        }),
+    }
+}
+
+fn visibility_token(state: &str) -> &'static str {
+    match state {
+        "hidden" => "Hidden",
+        "veryHidden" => "VeryHidden",
+        _ => "Visible",
+    }
+}
+
+fn required_string<'a>(value: &'a Value, property: &str) -> Result<&'a str, WorksheetError> {
+    value.as_str().ok_or_else(|| WorksheetError {
+        code: "InvalidArgument",
+        message: format!("{property} must be a string."),
+    })
+}
+
+fn required_u32(value: &Value, property: &str) -> Result<u32, WorksheetError> {
+    value
+        .as_u64()
+        .and_then(|value| u32::try_from(value).ok())
+        .ok_or_else(|| WorksheetError {
+            code: "InvalidArgument",
+            message: format!("{property} must be a non-negative integer."),
+        })
+}
+
+fn unsupported_load_property(object: &str, property: &str) -> WorksheetError {
+    WorksheetError {
+        code: "InvalidArgument",
+        message: format!("Unsupported {object} load property '{property}'"),
+    }
+}
+
+fn item_not_found(key: &str) -> WorksheetError {
+    WorksheetError {
+        code: "ItemNotFound",
+        message: format!("The requested worksheet doesn't exist. Name or ID: {key}"),
+    }
+}
+
+fn compute_error(error: ComputeApiError) -> WorksheetError {
+    let message = error.to_string();
+    let code = match error {
+        ComputeApiError::SheetNotFound { .. } => "ItemNotFound",
+        ComputeApiError::InvalidAddress { .. } | ComputeApiError::InvalidRange { .. } => {
+            "InvalidArgument"
+        }
+        ComputeApiError::InvalidOperation(_) => "InvalidOperation",
+        _ => "GeneralException",
+    };
+    WorksheetError { code, message }
+}

--- a/compute/officejs/tests/application_semantics.rs
+++ b/compute/officejs/tests/application_semantics.rs
@@ -1,0 +1,215 @@
+//! Application and workbook calculation semantics through the public
+//! Office.js request-context path.
+
+use mog::{run_office_js, run_office_js_with_workbook};
+use serde_json::json;
+
+#[test]
+fn application_navigation_is_context_canonical_and_loads_engine_settings() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async (context) => {
+          const application = context.application;
+          const workbookApplication = context.workbook.application;
+          application.load(["calculationMode", "calculationState"]);
+          context.workbook.load("usePrecisionAsDisplayed");
+          await context.sync();
+          return {
+            sameApplication: application === workbookApplication &&
+              application === context.workbook.application,
+            mode: application.calculationMode,
+            state: application.calculationState,
+            precision: context.workbook.usePrecisionAsDisplayed,
+            calculationType: Excel.CalculationType.fullRebuild,
+          };
+        });
+        "#,
+    )
+    .expect("application load should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "sameApplication": true,
+            "mode": "Automatic",
+            "state": "Done",
+            "precision": false,
+            "calculationType": "FullRebuild",
+        })
+    );
+}
+
+#[test]
+fn application_calculate_types_recalculate_real_engine_values() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async (context) => {
+          const application = context.application;
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          application.calculationMode = Excel.CalculationMode.manual;
+          sheet.getRange("A1").values = [[2]];
+          sheet.getRange("B1").formulas = [["=A1*3"]];
+          const initial = sheet.getRange("B1");
+          initial.load("values");
+          await context.sync();
+
+          sheet.getRange("A1").values = [[4]];
+          const stale = sheet.getRange("B1");
+          stale.load("values");
+          await context.sync();
+
+          application.calculate(Excel.CalculationType.recalculate);
+          const recalculated = sheet.getRange("B1");
+          recalculated.load("values");
+          application.load(["calculationMode", "calculationState"]);
+          await context.sync();
+
+          application.calculate("Full");
+          application.calculate("FullRebuild");
+          const rebuilt = sheet.getRange("B1");
+          rebuilt.load("values");
+          await context.sync();
+
+          return {
+            initial: initial.values,
+            stale: stale.values,
+            recalculated: recalculated.values,
+            rebuilt: rebuilt.values,
+            mode: application.calculationMode,
+            state: application.calculationState,
+          };
+        });
+        "#,
+    )
+    .expect("application calculation should use the engine");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "initial": [[6]],
+            "stale": [[6]],
+            "recalculated": [[12]],
+            "rebuilt": [[12]],
+            "mode": "Manual",
+            "state": "Done",
+        })
+    );
+}
+
+#[test]
+fn precision_and_iterative_settings_round_trip_through_engine() {
+    let (workbook, _) = compute_api::Workbook::blank().expect("blank workbook");
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const application = context.application;
+          const iterative = application.iterativeCalculation;
+          iterative.load(["enabled", "maxChange", "maxIteration"]);
+          context.workbook.load("usePrecisionAsDisplayed");
+          await context.sync();
+          const before = {
+            enabled: iterative.enabled,
+            maxChange: iterative.maxChange,
+            maxIteration: iterative.maxIteration,
+            precision: context.workbook.usePrecisionAsDisplayed,
+          };
+
+          iterative.enabled = true;
+          iterative.maxChange = 0.0005;
+          iterative.maxIteration = 20;
+          context.workbook.usePrecisionAsDisplayed = true;
+          iterative.load(["enabled", "maxChange", "maxIteration"]);
+          context.workbook.load("usePrecisionAsDisplayed");
+          await context.sync();
+          return {
+            before,
+            after: {
+              enabled: iterative.enabled,
+              maxChange: iterative.maxChange,
+              maxIteration: iterative.maxIteration,
+              precision: context.workbook.usePrecisionAsDisplayed,
+            },
+          };
+        });
+        "#,
+    )
+    .expect("calculation settings should round-trip");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "before": {
+                "enabled": false,
+                "maxChange": 0.001,
+                "maxIteration": 100,
+                "precision": false,
+            },
+            "after": {
+                "enabled": true,
+                "maxChange": 0.0005,
+                "maxIteration": 20,
+                "precision": true,
+            },
+        })
+    );
+}
+
+#[test]
+fn calculation_types_are_exact_and_date_system_is_not_invented() {
+    let output = run_office_js(
+        r#"
+        const context = new Excel.RequestContext();
+        const application = context.application;
+        let modeCode;
+        let calculateCode;
+        try { application.calculationMode = "automatic"; }
+        catch (error) { modeCode = error.code; }
+        try { application.calculate("rebuild"); }
+        catch (error) { calculateCode = error.code; }
+
+        const workbook = context.workbook;
+        workbook.load("date1904");
+        let dateCode;
+        try { await context.sync(); }
+        catch (error) { dateCode = error.code; }
+        return { modeCode, calculateCode, dateCode };
+        "#,
+    )
+    .expect("invalid calculation arguments should be reported");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "modeCode": "InvalidArgument",
+            "calculateCode": "InvalidArgument",
+            "dateCode": "ApiNotFound",
+        })
+    );
+}
+
+#[test]
+fn unloaded_application_and_precision_properties_keep_office_errors() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async (context) => {
+          let applicationCode;
+          let workbookCode;
+          try { context.application.calculationMode; }
+          catch (error) { applicationCode = error.code; }
+          try { context.workbook.usePrecisionAsDisplayed; }
+          catch (error) { workbookCode = error.code; }
+          return { applicationCode, workbookCode };
+        });
+        "#,
+    )
+    .expect("unloaded property errors should be catchable Office errors");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "applicationCode": "PropertyNotLoaded",
+            "workbookCode": "PropertyNotLoaded",
+        })
+    );
+}

--- a/compute/officejs/tests/border_semantics.rs
+++ b/compute/officejs/tests/border_semantics.rs
@@ -1,0 +1,305 @@
+//! OfficeJS RangeBorder regressions through the shipped QuickJS and compute
+//! border patch path.
+
+use compute_api::Workbook;
+use mog::run_office_js_with_workbook;
+use serde_json::{Value, json};
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn border_edges_interiors_and_diagonals_mutate_real_grid_state() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r##"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const range = sheet.getRange("B2:D4");
+          range.format.borders.getItem("EdgeTop").set({
+            color: "#112233", style: "Continuous", weight: "Thick", tintAndShade: 0.25
+          });
+          range.format.borders.getItem("EdgeBottom").set({
+            color: "#445566", style: "Double", weight: "Thin", tintAndShade: -0.25
+          });
+          range.format.borders.getItem("EdgeLeft").set({
+            color: "#778899", style: "Dash", weight: "Medium"
+          });
+          range.format.borders.getItem("EdgeRight").set({
+            color: "#AABBCC", style: "Dot", weight: "Thin"
+          });
+          range.format.borders.getItem("InsideVertical").set({
+            color: "#010203", style: "DashDot", weight: "Thin"
+          });
+          range.format.borders.getItem("InsideHorizontal").set({
+            color: "#040506", style: "SlantDashDot", weight: "Thin"
+          });
+          range.format.borders.getItem("DiagonalDown").set({
+            color: "#070809", style: "Dot", weight: "Thin"
+          });
+          range.format.borders.getItem("DiagonalUp").set({
+            color: "#070809", style: "Dot", weight: "Thin"
+          });
+          await context.sync();
+
+          const fresh = sheet.getRange("B2:D4");
+          const sides = ["EdgeTop", "EdgeBottom", "EdgeLeft", "EdgeRight",
+            "InsideVertical", "InsideHorizontal", "DiagonalDown", "DiagonalUp"];
+          const loaded = {};
+          sides.forEach(side => {
+            loaded[side] = fresh.format.borders.getItem(side);
+            loaded[side].load({ $all: true });
+          });
+          await context.sync();
+          const result = {};
+          sides.forEach(side => { result[side] = loaded[side].toJSON(); });
+          return result;
+        });
+        "##,
+    )
+    .expect("border writes and fresh reads should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "EdgeTop": {
+                "color": "#112233",
+                "sideIndex": "EdgeTop",
+                "style": "Continuous",
+                "tintAndShade": 0.25,
+                "weight": "Thick"
+            },
+            "EdgeBottom": {
+                "color": "#445566",
+                "sideIndex": "EdgeBottom",
+                "style": "Double",
+                "tintAndShade": -0.25,
+                "weight": "Thin"
+            },
+            "EdgeLeft": {
+                "color": "#778899",
+                "sideIndex": "EdgeLeft",
+                "style": "Dash",
+                "tintAndShade": 0,
+                "weight": "Medium"
+            },
+            "EdgeRight": {
+                "color": "#AABBCC",
+                "sideIndex": "EdgeRight",
+                "style": "Dot",
+                "tintAndShade": 0,
+                "weight": "Thin"
+            },
+            "InsideVertical": {
+                "color": "#010203",
+                "sideIndex": "InsideVertical",
+                "style": "DashDot",
+                "tintAndShade": 0,
+                "weight": "Thin"
+            },
+            "InsideHorizontal": {
+                "color": "#040506",
+                "sideIndex": "InsideHorizontal",
+                "style": "SlantDashDot",
+                "tintAndShade": 0,
+                "weight": "Thin"
+            },
+            "DiagonalDown": {
+                "color": "#070809",
+                "sideIndex": "DiagonalDown",
+                "style": "Dot",
+                "tintAndShade": 0,
+                "weight": "Thin"
+            },
+            "DiagonalUp": {
+                "color": "#070809",
+                "sideIndex": "DiagonalUp",
+                "style": "Dot",
+                "tintAndShade": 0,
+                "weight": "Thin"
+            }
+        })
+    );
+
+    let sheet = workbook.sheet_by_name("Sheet1").expect("Sheet1");
+    let top = serde_json::to_value(
+        sheet
+            .formats()
+            .get_cell_format(1, 1)
+            .expect("effective format at B2"),
+    )
+    .expect("format serializes");
+    assert_eq!(top["borders"]["top"]["style"], "thick");
+    assert_eq!(top["borders"]["top"]["color"], "#112233");
+    assert_eq!(top["borders"]["diagonalDown"], true);
+    assert_eq!(top["borders"]["diagonalUp"], true);
+
+    let interior = serde_json::to_value(
+        sheet
+            .formats()
+            .get_cell_format(2, 2)
+            .expect("effective format at C3"),
+    )
+    .expect("format serializes");
+    assert_eq!(interior["borders"]["vertical"]["style"], "dashDot");
+    assert_eq!(interior["borders"]["horizontal"]["style"], "slantDashDot");
+}
+
+#[test]
+fn border_collection_has_stable_items_order_and_default_item_properties() {
+    let output = mog::run_office_js(
+        r##"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const borders = sheet.getRange("A1:C3").format.borders;
+          let collectionCode;
+          let childCode;
+          try { borders.items; } catch (error) { collectionCode = error.code; }
+          const top = borders.getItemAt(0);
+          try { top.style; } catch (error) { childCode = error.code; }
+          // Office's plain `items` load uses each RangeBorder's declared
+          // scalar defaults.  An explicit items/<property> path remains a
+          // narrow projection.
+          borders.load(["count", "items"]);
+          await context.sync();
+          return {
+            collectionCode,
+            childCode,
+            count: borders.count,
+            itemCount: borders.items.length,
+            keys: borders.items.map(item => item.sideIndex),
+            first: borders.items[0].toJSON(),
+            last: borders.getItemAt(7).toJSON(),
+            types: {
+              collection: borders instanceof Excel.RangeBorderCollection,
+              border: top instanceof Excel.RangeBorder,
+              clientObject: top instanceof OfficeExtension.ClientObject
+            }
+          };
+        });
+        "##,
+    )
+    .expect("border collection load should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "collectionCode": "PropertyNotLoaded",
+            "childCode": "PropertyNotLoaded",
+            "count": 8,
+            "itemCount": 8,
+            "keys": [
+                "EdgeTop", "EdgeBottom", "EdgeLeft", "EdgeRight",
+                "InsideVertical", "InsideHorizontal", "DiagonalDown", "DiagonalUp"
+            ],
+            "first": {
+                "color": null,
+                "sideIndex": "EdgeTop",
+                "style": "None",
+                "tintAndShade": 0,
+                "weight": "Thin"
+            },
+            "last": {
+                "color": null,
+                "sideIndex": "DiagonalUp",
+                "style": "None",
+                "tintAndShade": 0,
+                "weight": "Thin"
+            },
+            "types": { "collection": true, "border": true, "clientObject": true }
+        })
+    );
+}
+
+#[test]
+fn border_reads_preserve_mixed_values_as_null() {
+    let output = mog::run_office_js(
+        r##"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1").format.borders.getItem("EdgeTop").set({
+            color: "#111111", style: "Continuous", weight: "Thin", tintAndShade: 0
+          });
+          sheet.getRange("B1").format.borders.getItem("EdgeTop").set({
+            color: "#222222", style: "Continuous", weight: "Medium", tintAndShade: 0.5
+          });
+          await context.sync();
+          // EdgeTop is the outer top edge of the selected range. Use two
+          // cells on that edge so both stored sides participate in the
+          // aggregate (A2 would be the bottom edge of A1:A2).
+          const mixed = sheet.getRange("A1:B1").format.borders.getItem("EdgeTop");
+          mixed.load({ $all: true });
+          await context.sync();
+          return mixed.toJSON();
+        });
+        "##,
+    )
+    .expect("mixed border load should succeed");
+
+    assert_eq!(output.value["sideIndex"], "EdgeTop");
+    assert_eq!(output.value["style"], "Continuous");
+    assert_eq!(output.value["color"], Value::Null);
+    assert_eq!(output.value["tintAndShade"], Value::Null);
+    assert_eq!(output.value["weight"], Value::Null);
+}
+
+#[test]
+fn collection_tint_write_updates_each_side_and_preserves_visual_fields() {
+    let output = mog::run_office_js(
+        r##"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const range = sheet.getRange("A1:B2");
+          range.format.borders.getItem("EdgeTop").set({
+            color: "#112233", style: "Continuous", weight: "Thick"
+          });
+          range.format.borders.getItem("EdgeBottom").set({
+            color: "#445566", style: "Dash", weight: "Medium"
+          });
+          await context.sync();
+
+          const borders = range.format.borders;
+          borders.tintAndShade = 0.5;
+          await context.sync();
+
+          const fresh = sheet.getRange("A1:B2");
+          const freshBorders = fresh.format.borders;
+          const top = freshBorders.getItem("EdgeTop");
+          const bottom = freshBorders.getItem("EdgeBottom");
+          top.load({ $all: true });
+          bottom.load({ $all: true });
+          freshBorders.load("tintAndShade");
+          await context.sync();
+          return {
+            collectionTint: freshBorders.tintAndShade,
+            top: top.toJSON(),
+            bottom: bottom.toJSON()
+          };
+        });
+        "##,
+    )
+    .expect("collection tint should apply through the production border path");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "collectionTint": 0.5,
+            "top": {
+                "color": "#112233",
+                "sideIndex": "EdgeTop",
+                "style": "Continuous",
+                "tintAndShade": 0.5,
+                "weight": "Thick"
+            },
+            "bottom": {
+                "color": "#445566",
+                "sideIndex": "EdgeBottom",
+                "style": "Dash",
+                "tintAndShade": 0.5,
+                "weight": "Medium"
+            }
+        })
+    );
+}

--- a/compute/officejs/tests/chart_axes_semantics.rs
+++ b/compute/officejs/tests/chart_axes_semantics.rs
@@ -1,0 +1,181 @@
+//! Production-path chart axis and axis-title semantics.
+
+use mog::run_office_js;
+use serde_json::json;
+
+#[test]
+fn axes_read_write_and_title_round_trip_from_fresh_proxies() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const source = sheet.getRange("A1:B4");
+        source.values = [["Month", "Revenue"], ["Jan", 10], ["Feb", 20], ["Mar", 30]];
+        const chart = sheet.charts.add(Excel.ChartType.columnClustered, source);
+        chart.name = "Axis chart";
+        await context.sync();
+
+        const axes = chart.axes;
+        const category = axes.categoryAxis;
+        const value = axes.valueAxis;
+        category.load(["type", "axisGroup", "visible", "minimum", "maximum", "majorUnit", "minorUnit", "numberFormat", "scaleType", "categoryType"]);
+        value.load(["type", "axisGroup", "visible", "minimum", "maximum", "majorUnit", "minorUnit", "numberFormat", "scaleType"]);
+        category.title.load(["text", "visible"]);
+        await context.sync();
+
+        category.visible = false;
+        category.minimum = 1;
+        category.maximum = 12;
+        category.majorUnit = 2;
+        category.minorUnit = 1;
+        category.numberFormat = "0";
+        category.title.text = "Months";
+        category.title.visible = true;
+        value.scaleType = Excel.ChartAxisScaleType.logarithmic;
+        value.logBase = 10;
+        value.minimum = 1;
+        value.maximum = 100;
+        value.numberFormat = "$#,##0";
+        value.title.text = "Revenue";
+        await context.sync();
+
+        const fresh = sheet.charts.getItem("Axis chart");
+        const freshCategory = fresh.axes.categoryAxis;
+        const freshValue = fresh.axes.valueAxis;
+        freshCategory.load(["type", "axisGroup", "visible", "minimum", "maximum", "majorUnit", "minorUnit", "numberFormat"]);
+        freshCategory.title.load(["text", "visible"]);
+        freshValue.load(["type", "axisGroup", "minimum", "maximum", "numberFormat", "scaleType", "logBase"]);
+        freshValue.title.load(["text", "visible"]);
+        await context.sync();
+        return {
+          category: freshCategory.toJSON(),
+          value: freshValue.toJSON(),
+          types: {
+            axes: axes instanceof Excel.ChartAxes,
+            category: category instanceof Excel.ChartAxis,
+            title: category.title instanceof Excel.ChartAxisTitle,
+          },
+        };
+      });
+    "#,
+    )
+    .expect("chart axis mutations should persist");
+
+    assert_eq!(
+        output.value["types"],
+        json!({"axes": true, "category": true, "title": true})
+    );
+    assert_eq!(output.value["category"]["type"], json!("Category"));
+    assert_eq!(output.value["category"]["axisGroup"], json!("Primary"));
+    assert_eq!(output.value["category"]["visible"], json!(false));
+    assert_eq!(output.value["category"]["minimum"], json!(1.0));
+    assert_eq!(output.value["category"]["maximum"], json!(12.0));
+    assert_eq!(output.value["category"]["majorUnit"], json!(2.0));
+    assert_eq!(output.value["category"]["minorUnit"], json!(1.0));
+    assert_eq!(output.value["category"]["numberFormat"], json!("0"));
+    assert_eq!(output.value["category"]["title"]["text"], json!("Months"));
+    assert_eq!(output.value["category"]["title"]["visible"], json!(true));
+    assert_eq!(output.value["value"]["type"], json!("Value"));
+    assert_eq!(output.value["value"]["scaleType"], json!("Logarithmic"));
+    assert_eq!(output.value["value"]["logBase"], json!(10.0));
+    assert_eq!(output.value["value"]["minimum"], json!(1.0));
+    assert_eq!(output.value["value"]["maximum"], json!(100.0));
+    assert_eq!(output.value["value"]["numberFormat"], json!("$#,##0"));
+    assert_eq!(output.value["value"]["title"]["text"], json!("Revenue"));
+}
+
+#[test]
+fn axis_enums_methods_and_auto_values_persist() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const source = sheet.getRange("A1:B3");
+        source.values = [["Category", "Value"], ["A", 1], ["B", 2]];
+        const chart = sheet.charts.add(Excel.ChartType.line, source);
+        chart.name = "Enum chart";
+        await context.sync();
+        const axis = chart.axes.valueAxis;
+        axis.displayUnit = Excel.ChartAxisDisplayUnit.millions;
+        axis.setCustomDisplayUnit(1000);
+        axis.position = Excel.ChartAxisPosition.minimum;
+        axis.setPositionAt(2.5);
+        axis.majorTickMark = Excel.ChartAxisTickMark.outside;
+        axis.minorTickMark = Excel.ChartAxisTickMark.inside;
+        axis.tickLabelPosition = Excel.ChartAxisTickLabelPosition.high;
+        axis.baseTimeUnit = Excel.ChartAxisTimeUnit.months;
+        axis.majorTimeUnitScale = Excel.ChartAxisTimeUnit.years;
+        axis.minorTimeUnitScale = Excel.ChartAxisTimeUnit.days;
+        axis.offset = 100;
+        axis.tickLabelSpacing = 2;
+        axis.tickMarkSpacing = 3;
+        axis.reversePlotOrder = true;
+        axis.isBetweenCategories = true;
+        axis.linkNumberFormat = true;
+        axis.showDisplayUnitLabel = true;
+        axis.minimum = "";
+        axis.maximum = "";
+        await context.sync();
+
+        const fresh = sheet.charts.getItem("Enum chart");
+        const freshAxis = fresh.axes.valueAxis;
+        freshAxis.load(["displayUnit", "customDisplayUnit", "position", "positionAt", "majorTickMark", "minorTickMark", "tickLabelPosition", "baseTimeUnit", "majorTimeUnitScale", "minorTimeUnitScale", "offset", "tickLabelSpacing", "tickMarkSpacing", "reversePlotOrder", "isBetweenCategories", "linkNumberFormat", "showDisplayUnitLabel", "minimum", "maximum"]);
+        await context.sync();
+        return freshAxis.toJSON();
+      });
+    "#,
+    )
+    .expect("axis enum setters should persist");
+
+    assert_eq!(output.value["displayUnit"], json!("Custom"));
+    assert_eq!(output.value["customDisplayUnit"], json!(1000.0));
+    assert_eq!(output.value["position"], json!("Minimum"));
+    assert_eq!(output.value["positionAt"], json!(2.5));
+    assert_eq!(output.value["majorTickMark"], json!("Outside"));
+    assert_eq!(output.value["minorTickMark"], json!("Inside"));
+    assert_eq!(output.value["tickLabelPosition"], json!("High"));
+    assert_eq!(output.value["majorTimeUnitScale"], json!("Years"));
+    assert_eq!(output.value["minorTimeUnitScale"], json!("Days"));
+    assert_eq!(output.value["offset"], json!(100));
+    assert_eq!(output.value["tickLabelSpacing"], json!(2));
+    assert_eq!(output.value["tickMarkSpacing"], json!(3));
+    assert_eq!(output.value["reversePlotOrder"], json!(true));
+    assert_eq!(output.value["isBetweenCategories"], json!(true));
+    assert_eq!(output.value["linkNumberFormat"], json!(true));
+    assert_eq!(output.value["showDisplayUnitLabel"], json!(true));
+    assert_eq!(output.value["minimum"], json!(0.0));
+    assert_eq!(output.value["maximum"], json!(0.0));
+}
+
+#[test]
+fn unavailable_axes_fail_explicitly_and_three_d_series_axis_is_available() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const source = sheet.getRange("A1:B3");
+        source.values = [["Category", "Value"], ["A", 1], ["B", 2]];
+        const pie = sheet.charts.add(Excel.ChartType.pie, source);
+        const threeD = sheet.charts.add(Excel.ChartType._3DColumnClustered, source);
+        await context.sync();
+        let pieCode;
+        try {
+          const axis = pie.axes.valueAxis;
+          axis.load("type");
+          await context.sync();
+        } catch (error) { pieCode = error.code; }
+        const series = threeD.axes.getItem(Excel.ChartAxisType.series);
+        series.load(["type", "axisGroup"]);
+        await context.sync();
+        return { pieCode, series: series.toJSON() };
+      });
+    "#,
+    )
+    .expect("axis availability should be reported by the host");
+
+    assert_eq!(output.value["pieCode"], json!("ItemNotFound"));
+    assert_eq!(
+        output.value["series"],
+        json!({"type": "Series", "axisGroup": "Primary"})
+    );
+}

--- a/compute/officejs/tests/chart_core_semantics.rs
+++ b/compute/officejs/tests/chart_core_semantics.rs
@@ -1,0 +1,193 @@
+//! Production-path Office.js chart collection and chart lifecycle semantics.
+
+use mog::run_office_js;
+use serde_json::json;
+
+#[test]
+fn chart_collection_adds_and_hydrates_core_properties() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const source = sheet.getRange("A1:B3");
+        source.values = [["Month", "Revenue"], ["Jan", 10], ["Feb", 20]];
+        const charts = sheet.charts;
+        const chart = charts.add(
+          Excel.ChartType.columnClustered,
+          source,
+          Excel.ChartSeriesBy.columns
+        );
+        chart.name = "Revenue chart";
+        chart.load(["id", "name", "chartType", "height", "width", "left", "top"]);
+        charts.load(["items/name", "items/chartType"]);
+        const count = charts.getCount();
+        await context.sync();
+        return {
+          count: count.value,
+          chart: chart.toJSON(),
+          collection: charts.toJSON(),
+          types: {
+            chart: chart instanceof Excel.Chart,
+            collection: charts instanceof Excel.ChartCollection,
+            clientObject: chart instanceof OfficeExtension.ClientObject,
+          },
+        };
+      });
+    "#,
+    )
+    .expect("chart creation should succeed");
+
+    assert_eq!(output.value["count"], json!(1));
+    assert_eq!(output.value["chart"]["name"], json!("Revenue chart"));
+    assert_eq!(output.value["chart"]["chartType"], json!("ColumnClustered"));
+    assert_eq!(output.value["chart"]["height"], json!(300.0));
+    assert_eq!(output.value["chart"]["width"], json!(400.0));
+    assert_eq!(output.value["chart"]["left"], json!(0.0));
+    assert_eq!(output.value["chart"]["top"], json!(0.0));
+    assert_eq!(
+        output.value["collection"]["items"][0],
+        json!({ "name": "Revenue chart", "chartType": "ColumnClustered" })
+    );
+    assert!(output.value["chart"]["id"]
+        .as_str()
+        .is_some_and(|id| id.starts_with("fobj-")));
+    assert_eq!(
+        output.value["types"],
+        json!({ "chart": true, "collection": true, "clientObject": true })
+    );
+}
+
+#[test]
+fn chart_lookup_by_name_id_index_and_or_null_use_persisted_identity() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const source = sheet.getRange("A1:B2");
+        source.values = [["Category", "Value"], ["A", 1]];
+        const charts = sheet.charts;
+        const first = charts.add(Excel.ChartType.barClustered, source);
+        const second = charts.add(Excel.ChartType.line, source);
+        first.name = "First chart";
+        second.name = "Second chart";
+        await context.sync();
+
+        first.load("id");
+        second.load("id");
+        await context.sync();
+
+        const byName = charts.getItem("First chart");
+        const byId = charts.getItem(first.id);
+        const byIndex = charts.getItemAt(1);
+        const missing = charts.getItemOrNullObject("missing");
+        byName.load(["id", "name"]);
+        byId.load(["id", "name"]);
+        byIndex.load(["id", "name"]);
+        missing.load("isNullObject");
+        await context.sync();
+        return {
+          firstId: first.id,
+          byName: byName.toJSON(),
+          byId: byId.toJSON(),
+          byIndex: byIndex.toJSON(),
+          missing: missing.isNullObject,
+        };
+      });
+    "#,
+    )
+    .expect("chart lookup should succeed");
+
+    assert_eq!(output.value["byName"]["name"], json!("First chart"));
+    assert_eq!(output.value["byName"]["id"], output.value["firstId"]);
+    assert_eq!(output.value["byId"]["id"], output.value["firstId"]);
+    assert_eq!(output.value["byIndex"]["name"], json!("Second chart"));
+    assert_eq!(output.value["missing"], json!(true));
+}
+
+#[test]
+fn chart_setters_set_data_set_position_and_delete_persist() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const firstSource = sheet.getRange("A1:B2");
+        firstSource.values = [["Category", "Value"], ["A", 1]];
+        const secondSource = sheet.getRange("D1:E3");
+        secondSource.values = [["Category", "Value"], ["A", 2], ["B", 3]];
+        const charts = sheet.charts;
+        const chart = charts.add(Excel.ChartType.line, firstSource);
+        chart.name = "Lifecycle";
+        chart.chartType = Excel.ChartType.area;
+        chart.width = 640;
+        chart.height = 360;
+        chart.left = 18;
+        chart.top = 24;
+        chart.setData(secondSource, Excel.ChartSeriesBy.rows);
+        chart.setPosition("B2", "E8");
+        await context.sync();
+
+        const fetched = charts.getItem("Lifecycle");
+        fetched.load(["id", "name", "chartType", "height", "width", "left", "top"]);
+        await context.sync();
+        const id = fetched.id;
+        fetched.delete();
+        await context.sync();
+        const missing = charts.getItemOrNullObject(id);
+        missing.load("isNullObject");
+        const count = charts.getCount();
+        await context.sync();
+        return { chart: fetched.toJSON(), missing: missing.isNullObject, count: count.value };
+      });
+    "#,
+    )
+    .expect("chart mutations should succeed");
+
+    assert_eq!(output.value["chart"]["name"], json!("Lifecycle"));
+    assert_eq!(output.value["chart"]["chartType"], json!("Area"));
+    assert_eq!(output.value["chart"]["width"], json!(256.0));
+    assert_eq!(output.value["chart"]["height"], json!(140.0));
+    assert!(output.value["chart"]["left"]
+        .as_f64()
+        .is_some_and(|value| value > 0.0));
+    assert!(output.value["chart"]["top"]
+        .as_f64()
+        .is_some_and(|value| value > 0.0));
+    assert_eq!(output.value["missing"], json!(true));
+    assert_eq!(output.value["count"], json!(0));
+}
+
+#[test]
+fn chart_arguments_reject_foreign_ranges_and_invalid_collection_indices() {
+    let output = run_office_js(
+        r#"
+      const first = new Excel.RequestContext();
+      const second = new Excel.RequestContext();
+      const sheet = first.workbook.worksheets.getItem("Sheet1");
+      const chartSource = sheet.getRange("A1:B2");
+      const foreign = second.workbook.worksheets.getItem("Sheet1").getRange("A1:B2");
+      const charts = sheet.charts;
+      let addCode;
+      let dataCode;
+      let indexCode;
+      try { charts.add(Excel.ChartType.line, foreign); }
+      catch (error) { addCode = error.code; }
+      const chart = charts.add(Excel.ChartType.line, chartSource);
+      try { chart.setData(foreign); }
+      catch (error) { dataCode = error.code; }
+      charts.getItemAt(-1);
+      try { await first.sync(); }
+      catch (error) { indexCode = error.code; }
+      return { addCode, dataCode, indexCode };
+    "#,
+    )
+    .expect("chart argument checks should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+        "addCode": "InvalidRequestContext",
+        "dataCode": "InvalidRequestContext",
+            "indexCode": "ItemNotFound",
+        })
+    );
+}

--- a/compute/officejs/tests/chart_series_semantics.rs
+++ b/compute/officejs/tests/chart_series_semantics.rs
@@ -1,0 +1,116 @@
+//! Production-path Office.js chart series collection and series semantics.
+
+use mog::run_office_js;
+use serde_json::json;
+
+#[test]
+fn chart_series_collection_adds_loads_and_binds_dimensions() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B4").values = [
+          ["Month", "Revenue"],
+          ["Jan", 10],
+          ["Feb", 20],
+          ["Mar", 30]
+        ];
+        const chart = sheet.charts.add(
+          Excel.ChartType.columnClustered,
+          sheet.getRange("A1"),
+          Excel.ChartSeriesBy.columns
+        );
+        const series = chart.series;
+        const revenue = series.add("Revenue");
+        revenue.setValues(sheet.getRange("B2:B4"));
+        revenue.setXAxisValues(sheet.getRange("A2:A4"));
+        revenue.chartType = Excel.ChartType.line;
+        revenue.axisGroup = Excel.ChartAxisGroup.secondary;
+        revenue.load(["name", "chartType", "axisGroup"]);
+
+        series.load(["count", "items/name", "items/chartType", "items/axisGroup"]);
+        const countResult = series.getCount();
+        const valuesResult = revenue.getDimensionValues(Excel.ChartSeriesDimension.values);
+        const categoriesResult = revenue.getDimensionValues(Excel.ChartSeriesDimension.categories);
+        const valuesSource = revenue.getDimensionDataSourceString(Excel.ChartSeriesDimension.values);
+        const categoriesSource = revenue.getDimensionDataSourceString(Excel.ChartSeriesDimension.categories);
+        const valuesType = revenue.getDimensionDataSourceType(Excel.ChartSeriesDimension.values);
+        await context.sync();
+        return {
+          count: series.count,
+          countResult: countResult.value,
+          items: series.items.map(item => item.toJSON()),
+          revenue: revenue.toJSON(),
+          values: valuesResult.value,
+          categories: categoriesResult.value,
+          valuesSource: valuesSource.value,
+          categoriesSource: categoriesSource.value,
+          valuesType: valuesType.value,
+          types: {
+            collection: series instanceof Excel.ChartSeriesCollection,
+            series: revenue instanceof Excel.ChartSeries,
+            clientObject: revenue instanceof OfficeExtension.ClientObject
+          }
+        };
+      });
+    "#,
+    )
+    .expect("chart series binding should succeed");
+
+    assert_eq!(output.value["count"], json!(1));
+    assert_eq!(output.value["countResult"], json!(1));
+    assert_eq!(output.value["items"][0]["name"], json!("Revenue"));
+    assert_eq!(output.value["items"][0]["chartType"], json!("Line"));
+    assert_eq!(output.value["items"][0]["axisGroup"], json!("Secondary"));
+    assert_eq!(output.value["revenue"]["name"], json!("Revenue"));
+    assert_eq!(output.value["values"], json!(["10", "20", "30"]));
+    assert_eq!(output.value["categories"], json!(["Jan", "Feb", "Mar"]));
+    assert_eq!(output.value["valuesSource"], json!("Sheet1!B2:B4"));
+    assert_eq!(output.value["categoriesSource"], json!("Sheet1!A2:A4"));
+    assert_eq!(output.value["valuesType"], json!("LocalRange"));
+    assert_eq!(
+        output.value["types"],
+        json!({ "collection": true, "series": true, "clientObject": true })
+    );
+}
+
+#[test]
+fn chart_series_collection_inserts_and_deletes_against_persisted_state() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const chart = sheet.charts.add(
+          Excel.ChartType.columnClustered,
+          sheet.getRange("A1")
+        );
+        const series = chart.series;
+        const first = series.add("First");
+        series.add("Last");
+        series.add("Middle", 1);
+        await context.sync();
+
+        series.load(["count", "items/name"]);
+        await context.sync();
+        const beforeDelete = series.items.map(item => item.name);
+        first.delete();
+        await context.sync();
+
+        series.load(["count", "items/name"]);
+        await context.sync();
+        return {
+          beforeDelete,
+          afterDelete: series.items.map(item => item.name),
+          count: series.count,
+          firstType: first instanceof Excel.ChartSeries
+        };
+      });
+    "#,
+    )
+    .expect("chart series collection mutation should succeed");
+
+    assert_eq!(output.value["beforeDelete"], json!(["First", "Middle", "Last"]));
+    assert_eq!(output.value["afterDelete"], json!(["Middle", "Last"]));
+    assert_eq!(output.value["count"], json!(2));
+    assert_eq!(output.value["firstType"], json!(true));
+}

--- a/compute/officejs/tests/comment_semantics.rs
+++ b/compute/officejs/tests/comment_semantics.rs
@@ -1,0 +1,174 @@
+//! Comment and reply regressions through the shipped Office.js runtime.
+
+use mog::run_office_js;
+use serde_json::json;
+
+#[test]
+fn comments_persist_through_collection_lookup_and_reply_lifecycle() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const comments = sheet.comments;
+          const root = comments.add(sheet.getRange("A1"), "root comment");
+          root.load("authorEmail,authorName,content,contentType,creationDate,id,resolved,richContent");
+          const count = comments.getCount();
+          await context.sync();
+
+          const reply = root.replies.add("first reply");
+          reply.load("authorEmail,authorName,content,contentType,creationDate,id,resolved,richContent");
+          const replyCount = root.replies.getCount();
+          root.replies.load("items");
+          await context.sync();
+
+          const byCell = comments.getItemByCell(sheet.getRange("A1"));
+          byCell.load("id,content");
+          const byReply = comments.getItemByReplyId(reply.id);
+          byReply.load("id");
+          await context.sync();
+
+          root.content = "edited root";
+          root.resolved = true;
+          reply.content = "edited reply";
+          root.load("content,resolved");
+          reply.load("content,resolved");
+          await context.sync();
+
+          const beforeDelete = {
+            root: root.toJSON(),
+            reply: reply.toJSON(),
+            replyCount: replyCount.value,
+            byCell: byCell.toJSON(),
+            byReply: byReply.toJSON(),
+            dateIsDate: root.creationDate instanceof Date,
+            types: {
+              workbookCollection: context.workbook.comments instanceof Excel.CommentCollection,
+              worksheetCollection: comments instanceof Excel.CommentCollection,
+              comment: root instanceof Excel.Comment,
+              replyCollection: root.replies instanceof Excel.CommentReplyCollection,
+              reply: reply instanceof Excel.CommentReply,
+              clientObject: root instanceof OfficeExtension.ClientObject
+            }
+          };
+
+          root.delete();
+          await context.sync();
+          const missing = comments.getItemOrNullObject(root.id);
+          missing.load("isNullObject");
+          const afterCount = comments.getCount();
+          await context.sync();
+          return {
+            beforeDelete,
+            afterDelete: {
+              isNullObject: missing.isNullObject,
+              count: afterCount.value
+            }
+          };
+        });
+        "#,
+    )
+    .expect("comment and reply lifecycle should succeed");
+
+    assert_eq!(
+        output.value["beforeDelete"]["root"]["authorName"],
+        json!("Unavailable")
+    );
+    assert_eq!(output.value["beforeDelete"]["root"]["authorEmail"], json!(""));
+    assert_eq!(
+        output.value["beforeDelete"]["root"]["content"],
+        json!("edited root")
+    );
+    assert_eq!(
+        output.value["beforeDelete"]["reply"]["content"],
+        json!("edited reply")
+    );
+    assert_eq!(output.value["beforeDelete"]["root"]["contentType"], json!("Plain"));
+    assert_eq!(output.value["beforeDelete"]["reply"]["contentType"], json!("Plain"));
+    assert_eq!(output.value["beforeDelete"]["root"]["resolved"], json!(true));
+    assert_eq!(output.value["beforeDelete"]["reply"]["resolved"], json!(true));
+    assert_eq!(output.value["beforeDelete"]["replyCount"], json!(1));
+    assert_eq!(
+        output.value["beforeDelete"]["byCell"]["content"],
+        json!("root comment")
+    );
+    assert_eq!(
+        output.value["beforeDelete"]["byReply"]["id"],
+        output.value["beforeDelete"]["root"]["id"]
+    );
+    assert_eq!(output.value["beforeDelete"]["dateIsDate"], json!(true));
+    assert_eq!(
+        output.value["beforeDelete"]["types"],
+        json!({
+            "workbookCollection": true,
+            "worksheetCollection": true,
+            "comment": true,
+            "replyCollection": true,
+            "reply": true,
+            "clientObject": true
+        })
+    );
+    assert_eq!(
+        output.value["afterDelete"],
+        json!({ "isNullObject": true, "count": 0 })
+    );
+}
+
+#[test]
+fn comments_support_plain_and_mention_content_payloads() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async context => {
+          const comments = context.workbook.comments;
+          const plain = comments.add(
+            "Sheet1!B2",
+            "plain",
+            Excel.ContentType.plain
+          );
+          const mention = comments.add(
+            "Sheet1!C3",
+            {
+              richContent: "hello Alice",
+              mentions: [{ id: 0, name: "Alice", email: "alice@example.com" }]
+            },
+            "Mention"
+          );
+          plain.load("content,contentType,mentions");
+          mention.load("content,contentType,mentions,richContent");
+          const count = comments.getCount();
+          await context.sync();
+          return {
+            plain: plain.toJSON(),
+            mention: mention.toJSON(),
+            count: count.value
+          };
+        });
+        "#,
+    )
+    .expect("comment content payloads should succeed");
+
+    assert_eq!(
+        output.value["plain"],
+        json!({
+            "content": "plain",
+            "contentType": "Plain",
+            "mentions": []
+        })
+    );
+    assert_eq!(
+        output.value["mention"]["content"],
+        json!("hello Alice")
+    );
+    assert_eq!(
+        output.value["mention"]["contentType"],
+        json!("Mention")
+    );
+    assert_eq!(
+        output.value["mention"]["mentions"][0],
+        json!({
+            "id": 0,
+            "name": "Alice",
+            "email": "alice@example.com"
+        })
+    );
+    assert_eq!(output.value["count"], json!(2));
+}

--- a/compute/officejs/tests/context_semantics.rs
+++ b/compute/officejs/tests/context_semantics.rs
@@ -1,0 +1,132 @@
+use mog::run_office_js;
+use serde_json::json;
+
+#[test]
+fn trace_is_queued_and_sync_errors_report_only_executed_messages() {
+    let output = run_office_js(
+        r#"
+      const context = new Excel.RequestContext();
+      const initial = context.debugInfo.pendingStatements;
+      const firstTrace = context.trace("before lookup");
+      const afterFirstTrace = context.debugInfo.pendingStatements;
+      context.workbook.worksheets.getItem("Missing");
+      context.trace("after failing lookup");
+
+      let failure;
+      try { await context.sync(); }
+      catch (error) {
+        failure = {
+          code: error.code,
+          traceMessages: error.traceMessages,
+          debugCode: error.debugInfo.code,
+          standard: error instanceof OfficeExtension.Error,
+        };
+      }
+
+      return {
+        traceReturnsVoid: firstTrace === undefined,
+        initialStatements: initial.length,
+        firstTraceStatements: afterFirstTrace.filter((statement) => statement === "context.trace();").length,
+        queuedTraceStatements: context.debugInfo.pendingStatements.filter((statement) => statement === "context.trace();").length,
+        failure,
+      };
+    "#,
+    )
+    .expect("Office.js trace script should succeed");
+
+    assert!(
+        output.stdout.is_empty(),
+        "context.trace must remain a queued request action, not console output"
+    );
+    assert_eq!(
+        output.value,
+        json!({
+            "traceReturnsVoid": true,
+            "initialStatements": 0,
+            "firstTraceStatements": 1,
+            "queuedTraceStatements": 0,
+            "failure": {
+                "code": "ItemNotFound",
+                "traceMessages": ["before lookup"],
+                "debugCode": "ItemNotFound",
+                "standard": true,
+            },
+        })
+    );
+}
+
+#[test]
+fn load_recursive_validates_options_before_queuing_a_bounded_query() {
+    let output = run_office_js(
+        r#"
+      const context = new Excel.RequestContext();
+      const range = context.workbook.worksheets.getItem("Sheet1").getRange("A1");
+
+      let invalidOptions;
+      try { context.loadRecursive(range, []); }
+      catch (error) { invalidOptions = { code: error.code, standard: error instanceof OfficeExtension.Error }; }
+
+      let invalidSelection;
+      try { context.loadRecursive(range, { Range: { select: 42 } }); }
+      catch (error) { invalidSelection = { code: error.code, standard: error instanceof OfficeExtension.Error }; }
+
+      let invalidObject;
+      try { context.loadRecursive({}, {}); }
+      catch (error) { invalidObject = { code: error.code, standard: error instanceof OfficeExtension.Error }; }
+
+      const returned = context.loadRecursive(range, {
+        Range: { select: ["values", "items/name"], expand: "format" },
+        RangeFormat: { select: "horizontalAlignment" },
+      }, 1);
+      const statements = context.debugInfo.pendingStatements;
+      return {
+        returnsVoid: returned === undefined,
+        invalidOptions,
+        invalidSelection,
+        invalidObject,
+        recursiveStatements: statements.filter((statement) => statement === "object.loadRecursive(...);").length,
+        traceStatements: statements.filter((statement) => statement === "context.trace();").length,
+      };
+    "#,
+    )
+    .expect("Office.js loadRecursive validation script should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "returnsVoid": true,
+            "invalidOptions": { "code": "InvalidArgument", "standard": true },
+            "invalidSelection": { "code": "InvalidArgument", "standard": true },
+            "invalidObject": { "code": "InvalidRequestContext", "standard": true },
+            "recursiveStatements": 1,
+            "traceStatements": 0,
+        })
+    );
+}
+
+#[test]
+fn load_recursive_loads_root_and_current_format_navigation_at_the_requested_depth() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const range = sheet.getRange("A1");
+        range.values = [[17]];
+        const format = range.format;
+
+        context.loadRecursive(range, {
+          Range: { select: "values", expand: "format" },
+          RangeFormat: "horizontalAlignment",
+        }, 1);
+        await context.sync();
+        return { values: range.values, alignment: format.horizontalAlignment };
+      });
+    "#,
+    )
+    .expect("Office.js recursive navigation script should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({ "values": [[17]], "alignment": "General" })
+    );
+}

--- a/compute/officejs/tests/enum_semantics.rs
+++ b/compute/officejs/tests/enum_semantics.rs
@@ -1,0 +1,87 @@
+//! OfficeJS enum values are loaded through the same embedded runtime path as scripts.
+
+use mog::run_office_js;
+use serde_json::json;
+
+#[test]
+fn generated_excel_enums_have_pinned_values_and_complete_shape() {
+    let output = run_office_js(
+        r#"
+        const enumNames = Object.keys(Excel).filter((name) => Excel[name] && typeof Excel[name] === "object");
+        let memberCount = 0;
+        for (const name of enumNames) memberCount += Object.keys(Excel[name]).length;
+        return {
+          enumCount: enumNames.length,
+          memberCount,
+          horizontal: Excel.HorizontalAlignment,
+          calculation: Excel.CalculationMode,
+          chartType: {
+            invalid: Excel.ChartType.invalid,
+            columnClustered: Excel.ChartType.columnClustered,
+            _3DColumnClustered: Excel.ChartType._3DColumnClustered,
+          },
+          clearApplyTo: Excel.ClearApplyTo,
+        };
+        "#,
+    )
+    .expect("generated enums should be available in the OfficeJS runtime");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "enumCount": 179,
+            "memberCount": 1999,
+            "horizontal": {
+                "general": "General",
+                "left": "Left",
+                "center": "Center",
+                "right": "Right",
+                "fill": "Fill",
+                "justify": "Justify",
+                "centerAcrossSelection": "CenterAcrossSelection",
+                "distributed": "Distributed",
+            },
+            "calculation": {
+                "automatic": "Automatic",
+                "automaticExceptTables": "AutomaticExceptTables",
+                "manual": "Manual",
+            },
+            "chartType": {
+                "invalid": "Invalid",
+                "columnClustered": "ColumnClustered",
+                "_3DColumnClustered": "3DColumnClustered",
+            },
+            "clearApplyTo": {
+                "all": "All",
+                "formats": "Formats",
+                "contents": "Contents",
+                "hyperlinks": "Hyperlinks",
+                "removeHyperlinks": "RemoveHyperlinks",
+                "resetContents": "ResetContents",
+            },
+        })
+    );
+}
+
+#[test]
+fn enum_installation_keeps_office_extension_runtime_classes() {
+    let output = run_office_js(
+        r#"
+        return {
+          clientObject: typeof OfficeExtension.ClientObject,
+          requestContext: typeof OfficeExtension.ClientRequestContext,
+          error: typeof OfficeExtension.Error,
+        };
+        "#,
+    )
+    .expect("OfficeExtension runtime should remain available alongside enum installation");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "clientObject": "function",
+            "requestContext": "function",
+            "error": "function",
+        })
+    );
+}

--- a/compute/officejs/tests/format_dimensions_semantics.rs
+++ b/compute/officejs/tests/format_dimensions_semantics.rs
@@ -1,0 +1,213 @@
+//! Office.js RangeFormat layout properties through the production runtime.
+
+use compute_api::Workbook;
+use mog::{run_office_js_with_workbook, OfficeJsError};
+use serde_json::json;
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn dimensions_use_office_point_units_and_mixed_ranges_return_null() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r###"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:B2").format.rowHeight = 18.5;
+          sheet.getRange("A1:B2").format.columnWidth = 12.75;
+          sheet.getRange("A2:B2").format.rowHeight = 22;
+          sheet.getRange("B2:B2").format.columnWidth = 15;
+          await context.sync();
+
+          const uniform = sheet.getRange("A1:B1");
+          const mixedRows = sheet.getRange("A1:B2");
+          const mixedColumns = sheet.getRange("A1:B2");
+          uniform.format.load("rowHeight,columnWidth,useStandardHeight,useStandardWidth");
+          mixedRows.format.load("rowHeight,useStandardHeight");
+          mixedColumns.format.load("columnWidth,useStandardWidth");
+          await context.sync();
+          return {
+            uniform: uniform.format.toJSON(),
+            mixedRows: mixedRows.format.toJSON(),
+            mixedColumns: mixedColumns.format.toJSON(),
+          };
+        });
+        "###,
+    )
+    .expect("dimension reads should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "uniform": {
+                "rowHeight": 18.5,
+                "columnWidth": 12.75,
+                "useStandardHeight": false,
+                "useStandardWidth": false,
+            },
+            "mixedRows": {
+                "rowHeight": null,
+                "useStandardHeight": null,
+            },
+            "mixedColumns": {
+                "columnWidth": null,
+                "useStandardWidth": null,
+            },
+        })
+    );
+}
+
+#[test]
+fn standard_dimension_setters_reset_custom_values_and_false_is_noop() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r###"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const row = sheet.getRange("4:4");
+          const column = sheet.getRange("C:C");
+          row.format.rowHeight = 31;
+          column.format.columnWidth = 17.25;
+          await context.sync();
+
+          row.format.useStandardHeight = false;
+          column.format.useStandardWidth = false;
+          await context.sync();
+          const custom = sheet.getRange("C4");
+          custom.format.load("rowHeight,columnWidth");
+          await context.sync();
+
+          row.format.useStandardHeight = true;
+          column.format.useStandardWidth = true;
+          await context.sync();
+          const standard = sheet.getRange("C4");
+          standard.format.load("rowHeight,columnWidth,useStandardHeight,useStandardWidth");
+          await context.sync();
+          return { custom: custom.format.toJSON(), standard: standard.format.toJSON() };
+        });
+        "###,
+    )
+    .expect("standard dimension setters should succeed");
+
+    let custom = output.value.get("custom").expect("custom dimensions");
+    assert_eq!(custom["rowHeight"], json!(31));
+    assert_eq!(custom["columnWidth"], json!(17.25));
+
+    let standard = output.value.get("standard").expect("standard dimensions");
+    assert_eq!(standard["rowHeight"], json!(15));
+    assert_eq!(standard["useStandardHeight"], json!(true));
+    assert_eq!(standard["useStandardWidth"], json!(true));
+    let standard_width = standard["columnWidth"].as_f64().expect("standard width");
+    assert!(standard_width > 0.0);
+    assert_ne!(standard_width, 17.25);
+}
+
+#[test]
+fn autofit_methods_update_real_layout_state_without_width_approximations() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r###"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:B2").values = [
+            ["A value long enough to require a wider column", "line one\nline two"] ,
+            ["short", "short"]
+          ];
+          const range = sheet.getRange("A1:B2");
+          range.format.wrapText = true;
+          range.format.autofitColumns();
+          range.format.autofitRows();
+          await context.sync();
+
+          const first = sheet.getRange("A1");
+          const second = sheet.getRange("B1");
+          first.format.load("rowHeight,columnWidth");
+          second.format.load("rowHeight,columnWidth");
+          await context.sync();
+          return { first: first.format.toJSON(), second: second.format.toJSON() };
+        });
+        "###,
+    )
+    .expect("autofit should use the production layout primitives");
+
+    for fitted in ["first", "second"] {
+        let object = output.value.get(fitted).expect("fitted format object");
+        let row_height = object["rowHeight"].as_f64().expect("fitted row height");
+        let column_width = object["columnWidth"].as_f64().expect("fitted column width");
+        assert!(row_height > 0.0);
+        assert!(column_width > 0.0);
+    }
+}
+
+#[test]
+fn full_row_and_column_formats_use_sparse_engine_layers() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r###"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A4:B4").values = [["row", 7]];
+          sheet.getRange("4:4").format.font.bold = true;
+          sheet.getRange("C:C").format.fill.color = "#123456";
+          sheet.getRange("4:4").format.rowHeight = 24;
+          sheet.getRange("C:C").format.columnWidth = 14.25;
+          await context.sync();
+
+          const rowCells = sheet.getRange("A4:B4");
+          const columnCell = sheet.getRange("C1");
+          rowCells.format.font.load("bold");
+          columnCell.format.fill.load("color");
+          rowCells.format.load("rowHeight");
+          columnCell.format.load("columnWidth");
+          rowCells.load("values");
+          await context.sync();
+          return {
+            values: rowCells.values,
+            rowBold: rowCells.format.font.toJSON(),
+            rowHeight: rowCells.format.toJSON().rowHeight,
+            columnColor: columnCell.format.fill.toJSON().color,
+            columnWidth: columnCell.format.toJSON().columnWidth,
+          };
+        });
+        "###,
+    )
+    .expect("whole row and column formatting should be sparse");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "values": [["row", 7]],
+            "rowBold": { "bold": true },
+            "rowHeight": 24,
+            "columnColor": "#123456",
+            "columnWidth": 14.25,
+        })
+    );
+}
+
+#[test]
+fn row_dimension_on_an_unbounded_row_axis_is_rejected_without_a_grid_walk() {
+    let error = run_office_js_with_workbook(
+        &blank_workbook(),
+        r###"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A:A").format.rowHeight = 22;
+          await context.sync();
+          return null;
+        });
+        "###,
+    )
+    .expect_err("an entire column cannot be expanded into one million row writes");
+
+    match error {
+        OfficeJsError::Script(message) => assert!(message.contains("InvalidArgument"), "{message}"),
+        other => panic!("unexpected error: {other:?}"),
+    }
+}

--- a/compute/officejs/tests/format_semantics.rs
+++ b/compute/officejs/tests/format_semantics.rs
@@ -1,0 +1,614 @@
+//! Office.js format regressions through the shipped QuickJS and compute-api path.
+
+use compute_api::Workbook;
+use mog::{run_office_js, run_office_js_with_workbook};
+use serde_json::{json, Value};
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn format_font_fill_and_protection_round_trip_all_exposed_fields() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r##"
+        return await Excel.run(async context => {
+          const range = context.workbook.worksheets.getItem("Sheet1").getRange("A1:B2");
+          range.format.set({
+            horizontalAlignment: "CenterAcrossSelection",
+            verticalAlignment: "Center",
+            wrapText: true,
+            autoIndent: true,
+            indentLevel: 7,
+            shrinkToFit: false,
+            textOrientation: -45,
+            readingOrder: "RightToLeft"
+          });
+          range.format.font.set({
+            bold: true,
+            color: "#123456",
+            italic: true,
+            name: "Arial",
+            size: 13.375,
+            underline: "DoubleAccountant",
+            strikethrough: true,
+            subscript: false,
+            superscript: true,
+            tintAndShade: 0.25
+          });
+          range.format.fill.set({
+            color: "#ABCDEF",
+            pattern: "LightDown",
+            patternColor: "#102030",
+            patternTintAndShade: -0.5,
+            tintAndShade: 0.75
+          });
+          range.format.protection.set({ locked: false, formulaHidden: true });
+          const shrinkOnly = context.workbook.worksheets.getItem("Sheet1").getRange("C1");
+          shrinkOnly.format.shrinkToFit = true;
+          await context.sync();
+
+          const fresh = context.workbook.worksheets.getItem("Sheet1").getRange("A1:B2");
+          fresh.format.load({ $all: true });
+          fresh.format.font.load({ $all: true });
+          fresh.format.fill.load({ $all: true });
+          fresh.format.protection.load({ $all: true });
+          const freshShrink = context.workbook.worksheets.getItem("Sheet1").getRange("C1");
+          freshShrink.format.load("shrinkToFit,wrapText");
+          await context.sync();
+          return {
+            format: fresh.format.toJSON(),
+            font: fresh.format.font.toJSON(),
+            fill: fresh.format.fill.toJSON(),
+            protection: fresh.format.protection.toJSON(),
+            shrinkOnly: freshShrink.format.toJSON(),
+            types: {
+              format: fresh.format instanceof Excel.RangeFormat,
+              font: fresh.format.font instanceof Excel.RangeFont,
+              fill: fresh.format.fill instanceof Excel.RangeFill,
+              protection: fresh.format.protection instanceof Excel.FormatProtection,
+              clientObject: fresh.format.font instanceof OfficeExtension.ClientObject
+            }
+          };
+        });
+        "##,
+    )
+    .expect("format write and load should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "format": {
+                "horizontalAlignment": "CenterAcrossSelection",
+                "verticalAlignment": "Center",
+                "wrapText": true,
+                "autoIndent": true,
+                "indentLevel": 7,
+                "shrinkToFit": false,
+                "textOrientation": -45,
+                "readingOrder": "RightToLeft",
+                "font": {
+                    "bold": true,
+                    "color": "#123456",
+                    "italic": true,
+                    "name": "Arial",
+                    "size": 13.375,
+                    "underline": "DoubleAccountant",
+                    "strikethrough": true,
+                    "subscript": false,
+                    "superscript": true,
+                    "tintAndShade": 0.25
+                },
+                "fill": {
+                    "color": "#ABCDEF",
+                    "pattern": "LightDown",
+                    "patternColor": "#102030",
+                    "patternTintAndShade": -0.5,
+                    "tintAndShade": 0.75
+                },
+                "protection": { "locked": false, "formulaHidden": true }
+            },
+            "font": {
+                "bold": true,
+                "color": "#123456",
+                "italic": true,
+                "name": "Arial",
+                "size": 13.375,
+                "underline": "DoubleAccountant",
+                "strikethrough": true,
+                "subscript": false,
+                "superscript": true,
+                "tintAndShade": 0.25
+            },
+            "fill": {
+                "color": "#ABCDEF",
+                "pattern": "LightDown",
+                "patternColor": "#102030",
+                "patternTintAndShade": -0.5,
+                "tintAndShade": 0.75
+            },
+            "protection": { "locked": false, "formulaHidden": true },
+            "shrinkOnly": { "shrinkToFit": true, "wrapText": false },
+            "types": {
+                "format": true,
+                "font": true,
+                "fill": true,
+                "protection": true,
+                "clientObject": true
+            }
+        })
+    );
+
+    // Verify the JavaScript adapter reached the real engine representation.
+    let sheet = workbook.sheet_by_name("Sheet1").expect("Sheet1");
+    let stored = serde_json::to_value(
+        sheet
+            .formats()
+            .get_cell_format(1, 1)
+            .expect("effective format at B2"),
+    )
+    .expect("format serializes");
+    assert_eq!(stored["horizontalAlign"], "centerContinuous");
+    assert_eq!(stored["verticalAlign"], "middle");
+    assert_eq!(stored["underlineType"], "doubleAccounting");
+    assert_eq!(stored["patternType"], "lightDown");
+    assert_eq!(stored["hidden"], true);
+}
+
+#[test]
+fn loaded_format_defaults_and_mixed_values_follow_office_contract() {
+    let output = run_office_js(
+        r##"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const defaults = sheet.getRange("A1");
+          defaults.format.load("horizontalAlignment,verticalAlignment,wrapText,autoIndent,indentLevel,shrinkToFit,textOrientation,readingOrder");
+          defaults.format.font.load("bold,color,italic,name,size,underline,strikethrough,subscript,superscript,tintAndShade");
+          defaults.format.protection.load("locked,formulaHidden");
+
+          sheet.getRange("A2").format.font.bold = true;
+          sheet.getRange("A3").format.font.bold = false;
+          sheet.getRange("A2").format.wrapText = true;
+          sheet.getRange("A3").format.wrapText = false;
+          sheet.getRange("A2").format.protection.locked = true;
+          sheet.getRange("A3").format.protection.locked = false;
+          await context.sync();
+
+          const mixed = sheet.getRange("A2:A3");
+          mixed.format.load("wrapText,verticalAlignment");
+          mixed.format.font.load("bold,name");
+          mixed.format.protection.load("locked,formulaHidden");
+          await context.sync();
+          return {
+            defaults: {
+              format: defaults.format.toJSON(),
+              font: defaults.format.font.toJSON(),
+              protection: defaults.format.protection.toJSON()
+            },
+            mixed: {
+              format: mixed.format.toJSON(),
+              font: mixed.format.font.toJSON(),
+              protection: mixed.format.protection.toJSON()
+            }
+          };
+        });
+        "##,
+    )
+    .expect("default and mixed format loads should succeed");
+
+    assert_eq!(
+        output.value["defaults"],
+        json!({
+            "format": {
+                "horizontalAlignment": "General",
+                "verticalAlignment": "Bottom",
+                "wrapText": false,
+                "autoIndent": false,
+                "indentLevel": 0,
+                "shrinkToFit": false,
+                "textOrientation": 0,
+                "readingOrder": "Context",
+                "font": {
+                    "bold": false,
+                    "color": "#000000",
+                    "italic": false,
+                    "name": "Calibri",
+                    "size": 11,
+                    "underline": "None",
+                    "strikethrough": false,
+                    "subscript": false,
+                    "superscript": false,
+                    "tintAndShade": 0
+                },
+                "protection": { "locked": true, "formulaHidden": false }
+            },
+            "font": {
+                "bold": false,
+                "color": "#000000",
+                "italic": false,
+                "name": "Calibri",
+                "size": 11,
+                "underline": "None",
+                "strikethrough": false,
+                "subscript": false,
+                "superscript": false,
+                "tintAndShade": 0
+            },
+            "protection": { "locked": true, "formulaHidden": false }
+        })
+    );
+    assert_eq!(output.value["mixed"]["format"]["wrapText"], Value::Null);
+    assert_eq!(
+        output.value["mixed"]["format"]["verticalAlignment"],
+        "Bottom"
+    );
+    assert_eq!(output.value["mixed"]["font"]["bold"], Value::Null);
+    assert_eq!(output.value["mixed"]["font"]["name"], "Calibri");
+    assert_eq!(output.value["mixed"]["protection"]["locked"], Value::Null);
+    assert_eq!(output.value["mixed"]["protection"]["formulaHidden"], false);
+}
+
+#[test]
+fn nested_range_load_routes_to_a_fresh_format_child_proxy() {
+    let output = run_office_js(
+        r##"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1").format.font.bold = true;
+          await context.sync();
+
+          const fresh = sheet.getRange("A1");
+          fresh.load({ format: { font: { bold: true } } });
+          await context.sync();
+          return {
+            bold: fresh.format.font.bold,
+            font: fresh.format.font.toJSON()
+          };
+        });
+        "##,
+    )
+    .expect("nested format load should reach the fresh font proxy");
+
+    assert_eq!(
+        output.value,
+        json!({ "bold": true, "font": { "bold": true } })
+    );
+}
+
+#[test]
+fn nested_range_format_set_and_client_object_copy_load_on_fresh_range() {
+    let output = run_office_js(
+        r##"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1");
+          source.format.set({
+            horizontalAlignment: "Right",
+            font: { bold: true, color: "#123456" },
+            fill: { color: "#ABCDEF", pattern: "Solid" },
+            protection: { locked: false, formulaHidden: true }
+          });
+          await context.sync();
+
+          const copied = sheet.getRange("B1");
+          copied.format.set(source.format);
+          await context.sync();
+
+          const fresh = sheet.getRange("B1");
+          fresh.format.load({
+            horizontalAlignment: true,
+            font: { bold: true, color: true },
+            fill: { color: true, pattern: true },
+            protection: { locked: true, formulaHidden: true }
+          });
+          await context.sync();
+          return {
+            format: fresh.format.toJSON(),
+            font: fresh.format.font.toJSON(),
+            fill: fresh.format.fill.toJSON(),
+            protection: fresh.format.protection.toJSON()
+          };
+        });
+        "##,
+    )
+    .expect("nested format set and copy should load on a fresh range");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "format": {
+                "horizontalAlignment": "Right",
+                "font": { "bold": true, "color": "#123456" },
+                "fill": { "color": "#ABCDEF", "pattern": "Solid" },
+                "protection": { "locked": false, "formulaHidden": true }
+            },
+            "font": { "bold": true, "color": "#123456" },
+            "fill": { "color": "#ABCDEF", "pattern": "Solid" },
+            "protection": { "locked": false, "formulaHidden": true }
+        })
+    );
+}
+
+#[test]
+fn fill_clear_removes_only_fill_fields() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r##"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const target = sheet.getRange("C4");
+          target.values = [[42]];
+          target.format.font.bold = true;
+          target.format.horizontalAlignment = "Right";
+          target.format.protection.locked = false;
+          target.format.fill.set({
+            color: "#FEDCBA", pattern: "Gray50", patternColor: "#010203",
+            patternTintAndShade: 0.2, tintAndShade: -0.2
+          });
+          await context.sync();
+          target.format.fill.clear();
+          await context.sync();
+
+          const fresh = sheet.getRange("C4");
+          fresh.load("values");
+          fresh.format.load("horizontalAlignment");
+          fresh.format.font.load("bold");
+          fresh.format.fill.load({ $all: true });
+          fresh.format.protection.load("locked");
+          await context.sync();
+          return {
+            values: fresh.values,
+            alignment: fresh.format.horizontalAlignment,
+            bold: fresh.format.font.bold,
+            locked: fresh.format.protection.locked,
+            fill: fresh.format.fill.toJSON()
+          };
+        });
+        "##,
+    )
+    .expect("fill-only clear should succeed");
+
+    assert_eq!(output.value["values"], json!([[42]]));
+    assert_eq!(output.value["alignment"], "Right");
+    assert_eq!(output.value["bold"], true);
+    assert_eq!(output.value["locked"], false);
+    assert_eq!(
+        output.value["fill"],
+        json!({
+            "color": null,
+            "pattern": "None",
+            "patternColor": null,
+            "patternTintAndShade": 0,
+            "tintAndShade": 0
+        })
+    );
+
+    let sheet = workbook.sheet_by_name("Sheet1").expect("Sheet1");
+    let stored = serde_json::to_value(
+        sheet
+            .formats()
+            .get_cell_format(3, 2)
+            .expect("effective format at C4"),
+    )
+    .expect("format serializes");
+    assert_eq!(stored["bold"], true);
+    assert_eq!(stored["horizontalAlign"], "right");
+    assert_eq!(stored["locked"], false);
+    assert!(stored.get("backgroundColor").is_none() || stored["backgroundColor"].is_null());
+}
+
+#[test]
+fn every_supported_fill_pattern_and_alignment_enum_round_trips() {
+    let output = run_office_js(
+        r##"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const patterns = [
+            "None", "Solid", "Gray50", "Gray75", "Gray25", "Horizontal",
+            "Vertical", "Down", "Up", "Checker", "SemiGray75",
+            "LightHorizontal", "LightVertical", "LightDown", "LightUp", "Grid",
+            "CrissCross", "Gray16", "Gray8"
+          ];
+          const horizontal = [
+            "General", "Left", "Center", "Right", "Fill", "Justify",
+            "CenterAcrossSelection", "Distributed"
+          ];
+          const vertical = ["Top", "Center", "Bottom", "Justify", "Distributed"];
+          const underline = ["None", "Single", "Double", "SingleAccountant", "DoubleAccountant"];
+          for (let i = 0; i < patterns.length; i++) {
+            sheet.getRange("A" + (i + 1)).format.fill.pattern = patterns[i];
+          }
+          for (let i = 0; i < horizontal.length; i++) {
+            sheet.getRange("B" + (i + 1)).format.horizontalAlignment = horizontal[i];
+          }
+          for (let i = 0; i < vertical.length; i++) {
+            sheet.getRange("C" + (i + 1)).format.verticalAlignment = vertical[i];
+          }
+          for (let i = 0; i < underline.length; i++) {
+            sheet.getRange("D" + (i + 1)).format.font.underline = underline[i];
+          }
+          await context.sync();
+
+          const read = async (column, count, child, property) => {
+            const values = [];
+            const refs = [];
+            for (let i = 0; i < count; i++) {
+              let ref = sheet.getRange(column + (i + 1)).format;
+              if (child) ref = ref[child];
+              ref.load(property);
+              refs.push(ref);
+            }
+            await context.sync();
+            for (let i = 0; i < refs.length; i++) values.push(refs[i][property]);
+            return values;
+          };
+          return {
+            patterns: await read("A", patterns.length, "fill", "pattern"),
+            horizontal: await read("B", horizontal.length, null, "horizontalAlignment"),
+            vertical: await read("C", vertical.length, null, "verticalAlignment"),
+            underline: await read("D", underline.length, "font", "underline")
+          };
+        });
+        "##,
+    )
+    .expect("all supported enum values should round-trip");
+
+    assert_eq!(
+        output.value["patterns"],
+        json!([
+            "None",
+            "Solid",
+            "Gray50",
+            "Gray75",
+            "Gray25",
+            "Horizontal",
+            "Vertical",
+            "Down",
+            "Up",
+            "Checker",
+            "SemiGray75",
+            "LightHorizontal",
+            "LightVertical",
+            "LightDown",
+            "LightUp",
+            "Grid",
+            "CrissCross",
+            "Gray16",
+            "Gray8"
+        ])
+    );
+    assert_eq!(
+        output.value["horizontal"],
+        json!([
+            "General",
+            "Left",
+            "Center",
+            "Right",
+            "Fill",
+            "Justify",
+            "CenterAcrossSelection",
+            "Distributed"
+        ])
+    );
+    assert_eq!(
+        output.value["vertical"],
+        json!(["Top", "Center", "Bottom", "Justify", "Distributed"])
+    );
+    assert_eq!(
+        output.value["underline"],
+        json!([
+            "None",
+            "Single",
+            "Double",
+            "SingleAccountant",
+            "DoubleAccountant"
+        ])
+    );
+}
+
+#[test]
+fn invalid_format_values_fail_at_sync_without_mutating_the_engine() {
+    let output = run_office_js(
+        r##"
+        const attempts = [
+          ["indent", range => range.format.indentLevel = 251],
+          ["orientation", range => range.format.textOrientation = 91],
+          ["font size", range => range.format.font.size = 0],
+          ["tint", range => range.format.fill.tintAndShade = 1.1],
+          ["gradient", range => range.format.fill.pattern = "LinearGradient"]
+        ];
+        const codes = [];
+        for (const attempt of attempts) {
+          try {
+            await Excel.run(async context => {
+              const range = context.workbook.worksheets.getItem("Sheet1").getRange("A1");
+              attempt[1](range);
+              await context.sync();
+            });
+          } catch (error) { codes.push([attempt[0], error.code]); }
+        }
+        return await Excel.run(async context => {
+          const range = context.workbook.worksheets.getItem("Sheet1").getRange("A1");
+          range.format.load("indentLevel,textOrientation");
+          range.format.font.load("size");
+          range.format.fill.load("pattern,tintAndShade");
+          await context.sync();
+          return { codes, format: range.format.toJSON(), font: range.format.font.toJSON(), fill: range.format.fill.toJSON() };
+        });
+        "##,
+    )
+    .expect("script should catch invalid format errors");
+
+    assert_eq!(
+        output.value["codes"],
+        json!([
+            ["indent", "InvalidArgument"],
+            ["orientation", "InvalidArgument"],
+            ["font size", "InvalidArgument"],
+            ["tint", "InvalidArgument"],
+            ["gradient", "InvalidArgument"]
+        ])
+    );
+    assert_eq!(
+        output.value["format"],
+        json!({
+            "indentLevel": 0,
+            "textOrientation": 0,
+            "font": { "size": 11 },
+            "fill": { "pattern": "None", "tintAndShade": 0 }
+        })
+    );
+    assert_eq!(output.value["font"], json!({"size": 11}));
+    assert_eq!(
+        output.value["fill"],
+        json!({"pattern": "None", "tintAndShade": 0})
+    );
+}
+
+#[test]
+fn format_set_rejects_unknown_properties_before_queueing_siblings() {
+    let output = run_office_js(
+        r##"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const range = sheet.getRange("A1");
+          const errors = [];
+
+          try {
+            range.format.set({ horizontalAlignment: "Right", unsupported: true });
+          } catch (error) {
+            errors.push(["format", error.code]);
+          }
+          range.format.load("horizontalAlignment");
+          await context.sync();
+
+          try {
+            range.format.font.set({ bold: true, unsupported: true });
+          } catch (error) {
+            errors.push(["font", error.code]);
+          }
+          range.format.font.load("bold");
+          await context.sync();
+
+          return {
+            errors,
+            horizontalAlignment: range.format.horizontalAlignment,
+            bold: range.format.font.bold
+          };
+        });
+        "##,
+    )
+    .expect("unknown format properties should fail before queueing siblings");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "errors": [["format", "InvalidArgument"], ["font", "InvalidArgument"]],
+            "horizontalAlignment": "General",
+            "bold": false
+        })
+    );
+}

--- a/compute/officejs/tests/hyperlink_semantics.rs
+++ b/compute/officejs/tests/hyperlink_semantics.rs
@@ -1,0 +1,270 @@
+//! Office.js `Range.hyperlink` semantics through the shipped host.
+
+use compute_api::Workbook;
+use mog::{OfficeJsError, run_office_js_with_workbook};
+use serde_json::json;
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn hyperlink_load_requires_sync_and_unlinked_ranges_return_an_empty_value() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async context => {
+          const range = context.workbook.worksheets.getItem("Sheet1").getRange("A1");
+          let beforeSync = null;
+          try {
+            void range.hyperlink;
+          } catch (error) {
+            beforeSync = error.code;
+          }
+          range.load("hyperlink");
+          await context.sync();
+          return { beforeSync, hyperlink: range.hyperlink };
+        });
+        "#,
+    )
+    .expect("unlinked hyperlink load should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "beforeSync": "PropertyNotLoaded",
+            "hyperlink": {}
+        })
+    );
+}
+
+#[test]
+fn hyperlink_round_trip_preserves_all_declared_fields_and_adjacent_cells() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const target = sheet.getRange("A1");
+          const adjacent = sheet.getRange("B1");
+          target.values = [["Keep target content"]];
+          target.numberFormat = [["0.00"]];
+          adjacent.values = [[42]];
+          adjacent.numberFormat = [["0%"]];
+          target.hyperlink = {
+            address: "https://example.com/docs",
+            screenTip: "Open documentation",
+            textToDisplay: "Read the docs"
+          };
+          await context.sync();
+
+          const fresh = sheet.getRange("A1:B1");
+          fresh.load("hyperlink,values,numberFormat");
+          await context.sync();
+          return {
+            hyperlink: fresh.hyperlink,
+            values: fresh.values,
+            numberFormat: fresh.numberFormat,
+            adjacent: {
+              value: fresh.values[0][1],
+              numberFormat: fresh.numberFormat[0][1]
+            }
+          };
+        });
+        "#,
+    )
+    .expect("hyperlink fields should round trip");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "hyperlink": {
+                "address": "https://example.com/docs",
+                "screenTip": "Open documentation",
+                "textToDisplay": "Read the docs"
+            },
+            "values": [["Keep target content", 42]],
+            "numberFormat": [["0.00", "0%"]],
+            "adjacent": { "value": 42, "numberFormat": "0%" }
+        })
+    );
+}
+
+#[test]
+fn internal_hyperlink_uses_document_reference_and_keeps_target_content() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          context.workbook.worksheets.add("Sheet2");
+          const target = sheet.getRange("C3");
+          target.values = [["Jump"]];
+          target.hyperlink = {
+            documentReference: "Sheet2!B2",
+            screenTip: "Go to the target",
+            textToDisplay: "Jump now"
+          };
+          await context.sync();
+
+          const fresh = sheet.getRange("C3");
+          fresh.load("hyperlink,values");
+          await context.sync();
+          return { hyperlink: fresh.hyperlink, values: fresh.values };
+        });
+        "#,
+    )
+    .expect("internal hyperlink should round trip");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "hyperlink": {
+                "documentReference": "Sheet2!B2",
+                "screenTip": "Go to the target",
+                "textToDisplay": "Jump now"
+            },
+            "values": [["Jump"]]
+        })
+    );
+}
+
+#[test]
+fn clear_hyperlinks_preserves_content_and_format_remove_hyperlinks_also_clears_format() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const range = sheet.getRange("A1:B1");
+          range.values = [["A", "B"]];
+          range.numberFormat = [["0.00", "0%"]];
+          sheet.getRange("A1").hyperlink = { address: "https://a.example" };
+          sheet.getRange("B1").hyperlink = { address: "https://b.example" };
+          await context.sync();
+
+          range.clear("Hyperlinks");
+          await context.sync();
+          const afterHyperlinks = sheet.getRange("A1:B1");
+          afterHyperlinks.load("hyperlink,values,numberFormat");
+          await context.sync();
+
+          sheet.getRange("A1").hyperlink = { address: "https://a.example" };
+          sheet.getRange("A1").clear("RemoveHyperlinks");
+          await context.sync();
+          const afterRemove = sheet.getRange("A1");
+          afterRemove.load("hyperlink,values,numberFormat");
+          await context.sync();
+
+          return {
+            afterHyperlinks: {
+              a: afterHyperlinks.hyperlink,
+              values: afterHyperlinks.values,
+              numberFormat: afterHyperlinks.numberFormat
+            },
+            afterRemove: {
+              hyperlink: afterRemove.hyperlink,
+              values: afterRemove.values,
+              numberFormat: afterRemove.numberFormat
+            }
+          };
+        });
+        "#,
+    )
+    .expect("hyperlink clear modes should preserve their documented fields");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "afterHyperlinks": {
+                "a": {},
+                "values": [["A", "B"]],
+                "numberFormat": [["0.00", "0%"]]
+            },
+            "afterRemove": {
+                "hyperlink": {},
+                "values": [["A"]],
+                "numberFormat": [["General"]]
+            }
+        })
+    );
+}
+
+#[test]
+fn hyperlink_set_supports_range_set_and_rejects_non_string_fields() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1");
+          source.values = [["Source"]];
+          source.hyperlink = {
+            address: "https://source.example",
+            screenTip: "Source tip",
+            textToDisplay: "Source link"
+          };
+          await context.sync();
+
+          const target = sheet.getRange("A2");
+          target.set(source);
+          await context.sync();
+          const fresh = sheet.getRange("A2");
+          fresh.load("hyperlink,values");
+          await context.sync();
+
+          let invalidCode = null;
+          try {
+            sheet.getRange("C1").hyperlink = { address: 42 };
+          } catch (error) {
+            invalidCode = error.code;
+          }
+          return { hyperlink: fresh.hyperlink, values: fresh.values, invalidCode };
+        });
+        "#,
+    )
+    .expect("Range.set should copy hyperlink values");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "hyperlink": {
+                "address": "https://source.example",
+                "screenTip": "Source tip",
+                "textToDisplay": "Source link"
+            },
+            "values": [["Source"]],
+            "invalidCode": "InvalidArgument"
+        })
+    );
+}
+
+#[test]
+fn hyperlink_on_unbounded_range_fails_at_sync() {
+    let workbook = blank_workbook();
+    let error = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async context => {
+          const range = context.workbook.worksheets.getItem("Sheet1").getRange();
+          range.hyperlink = { address: "https://example.com" };
+          await context.sync();
+          return true;
+        });
+        "#,
+    )
+    .expect_err("whole-sheet hyperlink writes must be rejected");
+
+    match error {
+        OfficeJsError::Script(message) => assert!(
+            message.contains("InvalidArgument"),
+            "unexpected unbounded hyperlink error: {message}"
+        ),
+        other => panic!("expected script error, got {other}"),
+    }
+}

--- a/compute/officejs/tests/lifecycle_semantics.rs
+++ b/compute/officejs/tests/lifecycle_semantics.rs
@@ -1,0 +1,163 @@
+use mog::run_office_js;
+use serde_json::json;
+
+#[test]
+fn tracked_objects_reject_unsupported_range_reference_lifetime() {
+    let output = run_office_js(
+        r#"
+      const context = new Excel.RequestContext();
+      const sheet = context.workbook.worksheets.getItem("Sheet1");
+      const range = sheet.getRange("A1");
+      const otherContext = new Excel.RequestContext();
+      const otherRange = otherContext.workbook.worksheets.getItem("Sheet1").getRange("B1");
+
+      let addRange;
+      try { context.trackedObjects.add(range); }
+      catch (error) { addRange = { code: error.code, standard: error instanceof OfficeExtension.Error }; }
+      let addRangeArray;
+      try { context.trackedObjects.add([sheet, range]); }
+      catch (error) { addRangeArray = error.code; }
+      let trackRange;
+      try { range.track(); }
+      catch (error) { trackRange = error.code; }
+      let removeRange;
+      try { context.trackedObjects.remove(range); }
+      catch (error) { removeRange = error.code; }
+      let untrackRange;
+      try { range.untrack(); }
+      catch (error) { untrackRange = error.code; }
+
+      // ClientObject tracking is a no-op for proxy types that do not expose
+      // the private reference-retention hook required by Office.js.
+      const addSheet = context.trackedObjects.add(sheet);
+      const removeSheet = context.trackedObjects.remove(sheet);
+      await context.sync();
+
+      // Ordinary range usage remains valid across explicit sync calls.  This
+      // is independent of the unsupported tracking API above.
+      range.values = [[17]];
+      await context.sync();
+      const afterSync = range.values;
+
+      const computed = sheet.getRange("B1");
+      computed.formulas = [["=17*2"]];
+      computed.load("values");
+      await context.sync();
+      const computedValue = computed.values;
+
+      let wrongContext;
+      try { context.trackedObjects.add(otherRange); }
+      catch (error) { wrongContext = error.code; }
+
+      return {
+        addRange,
+        addRangeArray,
+        trackRange,
+        removeRange,
+        untrackRange,
+        addSheetUndefined: addSheet === undefined,
+        removeSheetUndefined: removeSheet === undefined,
+        afterSync,
+        computedValue,
+        wrongContext,
+        trackedObjects: context.trackedObjects instanceof OfficeExtension.TrackedObjects,
+      };
+    "#,
+    )
+    .expect("Office.js lifecycle script should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "addRange": { "code": "ApiNotFound", "standard": true },
+            "addRangeArray": "ApiNotFound",
+            "trackRange": "ApiNotFound",
+            "removeRange": "ApiNotFound",
+            "untrackRange": "ApiNotFound",
+            "addSheetUndefined": true,
+            "removeSheetUndefined": true,
+            "afterSync": [[17]],
+            "computedValue": [[34]],
+            "wrongContext": "InvalidRequestContext",
+            "trackedObjects": true,
+        })
+    );
+}
+
+#[test]
+fn tracked_objects_reject_non_client_objects_without_partial_adds() {
+    let output = run_office_js(
+        r#"
+      const context = new Excel.RequestContext();
+      const range = context.workbook.worksheets.getItem("Sheet1").getRange("A1");
+      let invalid;
+      try { context.trackedObjects.add([range, {}]); }
+      catch (error) { invalid = { code: error.code, standard: error instanceof OfficeExtension.Error }; }
+
+      // The invalid array is rejected before capability checks, while a
+      // valid Range reports the unsupported reference-lifetime boundary.
+      let rangeUnsupported;
+      try { context.trackedObjects.add(range); }
+      catch (error) { rangeUnsupported = error.code; }
+      await context.sync();
+      return { invalid, rangeUnsupported, track: typeof range.track, untrack: typeof range.untrack };
+    "#,
+    )
+    .expect("Office.js lifecycle script should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "invalid": { "code": "InvalidArgument", "standard": true },
+            "rangeUnsupported": "ApiNotFound",
+            "track": "function",
+            "untrack": "function",
+        })
+    );
+}
+
+#[test]
+fn successful_sync_materializes_ordinary_unbound_proxies_without_reviving_failed_paths() {
+    let output = run_office_js(
+        r#"
+      const context = new Excel.RequestContext();
+      const workbook = context.workbook;
+      const worksheetCollection = workbook.worksheets;
+      const sheet = worksheetCollection.getItem("Sheet1");
+      const tables = sheet.tables;
+      await context.sync();
+
+      const ordinary = {
+        workbook: workbook.isNullObject,
+        worksheetCollection: worksheetCollection.isNullObject,
+        tables: tables.isNullObject,
+      };
+
+      const failedContext = new Excel.RequestContext();
+      const failedSheet = failedContext.workbook.worksheets.getItem("Missing");
+      let failedCode;
+      try { await failedContext.sync(); }
+      catch (error) { failedCode = error.code; }
+      await failedContext.sync();
+      let failedPathCode;
+      try { failedSheet.isNullObject; }
+      catch (error) { failedPathCode = error.code; }
+
+      return { ordinary, failedCode, failedPathCode };
+    "#,
+    )
+    .expect("Office.js lifecycle script should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "ordinary": {
+                "workbook": false,
+                "worksheetCollection": false,
+                "tables": false,
+            },
+            "failedCode": "ItemNotFound",
+            "failedPathCode": "PropertyNotLoaded",
+        })
+    );
+}

--- a/compute/officejs/tests/name_semantics.rs
+++ b/compute/officejs/tests/name_semantics.rs
@@ -1,0 +1,505 @@
+//! Named-item regressions through the shipped Office.js runtime.
+
+use mog::{OfficeJsError, run_office_js};
+use serde_json::json;
+
+#[test]
+fn named_range_add_loads_and_resolves_to_a_real_range() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1:B2");
+          source.values = [[10, 20], [30, 40]];
+          const named = context.workbook.names.add("Sales", source, "source range");
+          named.load("name,formula,value,type,scope,visible,comment");
+          const count = context.workbook.names.getCount();
+          await context.sync();
+
+          const resolved = named.getRange();
+          resolved.load("address,values");
+          await context.sync();
+          return {
+            named: named.toJSON(),
+            collection: context.workbook.names.toJSON(),
+            count: count.value,
+            resolved: { address: resolved.address, values: resolved.values },
+            types: {
+              collection: context.workbook.names instanceof Excel.NamedItemCollection,
+              item: named instanceof Excel.NamedItem,
+              range: resolved instanceof Excel.Range,
+              clientObject: named instanceof OfficeExtension.ClientObject
+            }
+          };
+        });
+        "#,
+    )
+    .expect("named range batch should succeed");
+
+    assert_eq!(
+        output.value["named"],
+        json!({
+            "name": "Sales",
+            "formula": "=Sheet1!$A$1:$B$2",
+            "value": "Sheet1!A1:B2",
+            "type": "Range",
+            "scope": "Workbook",
+            "visible": true,
+            "comment": "source range"
+        })
+    );
+    assert_eq!(output.value["count"], json!(1));
+    assert_eq!(
+        output.value["resolved"],
+        json!({
+            "address": "Sheet1!A1:B2",
+            "values": [[10, 20], [30, 40]]
+        })
+    );
+    assert_eq!(
+        output.value["types"],
+        json!({
+            "collection": true,
+            "item": true,
+            "range": true,
+            "clientObject": true
+        })
+    );
+}
+
+#[test]
+fn named_constants_cover_string_number_and_boolean_references() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async context => {
+          const names = context.workbook.names;
+          const number = names.add("IntegerValue", "=42");
+          const decimal = names.add("DecimalValue", "=1.25");
+          const flag = names.add("Enabled", "=TRUE");
+          const text = names.add("Label", "=\"hello\"");
+          const formula = names.addFormulaLocal("FormulaValue", "=2");
+          [number, decimal, flag, text, formula].forEach(item =>
+            item.load("name,formula,value,type,scope,visible,comment")
+          );
+          await context.sync();
+          return {
+            number: number.toJSON(),
+            decimal: decimal.toJSON(),
+            flag: flag.toJSON(),
+            text: text.toJSON(),
+            formula: formula.toJSON()
+          };
+        });
+        "#,
+    )
+    .expect("named constants batch should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "number": {
+                "name": "IntegerValue",
+                "formula": "=42",
+                "value": 42,
+                "type": "Integer",
+                "scope": "Workbook",
+                "visible": true,
+                "comment": ""
+            },
+            "decimal": {
+                "name": "DecimalValue",
+                "formula": "=1.25",
+                "value": 1.25,
+                "type": "Double",
+                "scope": "Workbook",
+                "visible": true,
+                "comment": ""
+            },
+            "flag": {
+                "name": "Enabled",
+                "formula": "=TRUE",
+                "value": true,
+                "type": "Boolean",
+                "scope": "Workbook",
+                "visible": true,
+                "comment": ""
+            },
+            "text": {
+                "name": "Label",
+                "formula": "=\"hello\"",
+                "value": "hello",
+                "type": "String",
+                "scope": "Workbook",
+                "visible": true,
+                "comment": ""
+            },
+            "formula": {
+                "name": "FormulaValue",
+                "formula": "=2",
+                "value": 2,
+                "type": "Integer",
+                "scope": "Workbook",
+                "visible": true,
+                "comment": ""
+            }
+        })
+    );
+}
+
+#[test]
+fn named_formula_values_evaluate_cells_names_and_recalculate() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1:A2");
+          source.values = [[2], [3]];
+          const total = context.workbook.names.add(
+            "Total",
+            "=SUM(Sheet1!$A$1:$A$2)"
+          );
+          const doubled = context.workbook.names.add("Doubled", "=Total*2");
+          total.load("formula,value,type");
+          doubled.load("formula,value,type");
+          await context.sync();
+          const first = { total: total.toJSON(), doubled: doubled.toJSON() };
+
+          doubled.formula = "=Total*3";
+          doubled.load("formula,value,type");
+          await context.sync();
+          const changed = doubled.toJSON();
+
+          source.values = [[5], [6]];
+          total.load("value,type");
+          doubled.load("value,type");
+          await context.sync();
+          return { first, changed, second: { total: total.toJSON(), doubled: doubled.toJSON() } };
+        });
+        "#,
+    )
+    .expect("named formulas should use the production evaluator");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "first": {
+                "total": {
+                    "formula": "=SUM(Sheet1!$A$1:$A$2)",
+                    "value": 5,
+                    "type": "Integer"
+                },
+                "doubled": {
+                    "formula": "=Total*2",
+                    "value": 10,
+                    "type": "Integer"
+                }
+            },
+            "changed": {
+                "formula": "=Total*3",
+                "value": 15,
+                "type": "Integer"
+            },
+            "second": {
+                "total": { "value": 11, "type": "Integer" },
+                "doubled": { "value": 33, "type": "Integer" }
+            }
+        })
+    );
+}
+
+#[test]
+fn named_item_worksheet_navigation_respects_scope_and_null_object_contract() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const global = context.workbook.names.add("GlobalName", "=42");
+          const local = sheet.names.add("LocalName", "=Sheet1!A1");
+          await context.sync();
+
+          const owner = local.worksheet;
+          owner.load("name");
+          const workbookNull = global.worksheetOrNullObject;
+          await context.sync();
+
+          let errorCode;
+          try {
+            const invalid = global.worksheet;
+            invalid.load("name");
+            await context.sync();
+          } catch (error) {
+            errorCode = error.code;
+          }
+          return {
+            owner: owner.name,
+            workbookNull: workbookNull.isNullObject,
+            errorCode
+          };
+        });
+        "#,
+    )
+    .expect("named item worksheet navigation should honor scope");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "owner": "Sheet1",
+            "workbookNull": true,
+            "errorCode": "InvalidOperation"
+        })
+    );
+}
+
+#[test]
+fn named_item_array_values_reads_real_range_values_and_types() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1:B2");
+          source.values = [[1, "text"], [2.5, false]];
+          const named = context.workbook.names.add("Matrix", source);
+          await context.sync();
+
+          const arrays = named.arrayValues;
+          arrays.load("values,types");
+          await context.sync();
+          return { arrays: arrays.toJSON(), named: named.toJSON() };
+        });
+        "#,
+    )
+    .expect("named item arrayValues should read a real range");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "arrays": {
+                "values": [[1, "text"], [2.5, false]],
+                "types": [["Integer", "String"], ["Double", "Boolean"]]
+            },
+            "named": {
+                "arrayValues": {
+                    "values": [[1, "text"], [2.5, false]],
+                    "types": [["Integer", "String"], ["Double", "Boolean"]]
+                }
+            }
+        })
+    );
+}
+
+#[test]
+fn named_item_array_values_reads_scalar_evaluator_results_and_recalculates() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1:A2");
+          source.values = [[2], [3]];
+          const total = context.workbook.names.add(
+            "ScalarTotal",
+            "=SUM(Sheet1!$A$1:$A$2)"
+          );
+          const constant = context.workbook.names.add("ScalarConstant", "=42");
+          await context.sync();
+
+          const totalValues = total.arrayValues;
+          const constantValues = constant.arrayValues;
+          totalValues.load("values,types");
+          constantValues.load("values,types");
+          await context.sync();
+          const initial = {
+            total: totalValues.toJSON(),
+            constant: constantValues.toJSON()
+          };
+
+          source.values = [[5], [6]];
+          totalValues.load("values,types");
+          await context.sync();
+          return { initial, changed: totalValues.toJSON() };
+        });
+        "#,
+    )
+    .expect("scalar named formulas should expose 1x1 arrayValues grids");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "initial": {
+                "total": { "values": [[5]], "types": [["Integer"]] },
+                "constant": { "values": [[42]], "types": [["Integer"]] }
+            },
+            "changed": { "values": [[11]], "types": [["Integer"]] }
+        })
+    );
+}
+
+#[test]
+fn delete_removes_name_and_missing_lookups_follow_office_errors() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async context => {
+          const names = context.workbook.names;
+          names.add("Temporary", "=Sheet1!A1");
+          await context.sync();
+
+          names.getItem("Temporary").delete();
+          await context.sync();
+
+          const nullItem = names.getItemOrNullObject("Temporary");
+          await context.sync();
+
+          let errorCode;
+          try {
+            const missing = names.getItem("Temporary");
+            missing.load("name");
+            await context.sync();
+          } catch (error) {
+            errorCode = error.code;
+          }
+          const count = names.getCount();
+          await context.sync();
+          return { isNullObject: nullItem.isNullObject, errorCode, count: count.value };
+        });
+        "#,
+    )
+    .expect("name deletion and missing lookup should be observable");
+
+    assert_eq!(
+        output.value,
+        json!({ "isNullObject": true, "errorCode": "ItemNotFound", "count": 0 })
+    );
+}
+
+#[test]
+fn named_item_set_updates_comment_and_visibility() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async context => {
+          const names = context.workbook.names;
+          names.add("Editable", "=Sheet1!A1", "before");
+          await context.sync();
+
+          const item = names.getItem("Editable");
+          item.comment = "after";
+          item.visible = false;
+          item.load("comment,visible");
+          await context.sync();
+          return item.toJSON();
+        });
+        "#,
+    )
+    .expect("named item setters should persist through compute-api");
+
+    assert_eq!(
+        output.value,
+        json!({ "comment": "after", "visible": false })
+    );
+}
+
+#[test]
+fn workbook_and_worksheet_collections_keep_scope_collisions_separate() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async context => {
+          const workbookNames = context.workbook.names;
+          const sheet = context.workbook.worksheets.add("Data");
+          workbookNames.add("Sales", "=Sheet1!A1");
+          sheet.names.add("Sales", "=Data!A1", "local");
+          await context.sync();
+
+          const global = workbookNames.getItem("sales");
+          const local = sheet.names.getItem("SALES");
+          global.load("formula,scope,comment");
+          local.load("formula,scope,comment");
+          const globalCount = workbookNames.getCount();
+          const localCount = sheet.names.getCount();
+          await context.sync();
+          const localCollection = sheet.names;
+          localCollection.load("items");
+          await context.sync();
+          return {
+            global: global.toJSON(),
+            local: local.toJSON(),
+            counts: { global: globalCount.value, local: localCount.value },
+            localItems: localCollection.toJSON()
+          };
+        });
+        "#,
+    )
+    .expect("workbook and worksheet name scopes should coexist");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "global": {
+                "formula": "=Sheet1!A1",
+                "scope": "Workbook",
+                "comment": ""
+            },
+            "local": {
+                "formula": "=Data!A1",
+                "scope": "Worksheet",
+                "comment": "local"
+            },
+            "counts": { "global": 1, "local": 1 },
+            "localItems": {
+                "items": [{
+                    "comment": "local",
+                    "formula": "=Data!A1",
+                    "name": "Sales",
+                    "scope": "Worksheet",
+                    "type": "Range",
+                    "value": "Data!A1",
+                    "visible": true
+                }]
+            }
+        })
+    );
+}
+
+#[test]
+fn named_item_cross_context_range_is_rejected_before_sync() {
+    let output = run_office_js(
+        r#"
+        const first = new Excel.RequestContext();
+        const second = new Excel.RequestContext();
+        const names = first.workbook.names;
+        const foreign = second.workbook.worksheets.getItem("Sheet1").getRange("A1");
+        let code;
+        try { names.add("CrossContext", foreign); }
+        catch (error) { code = error.code; }
+        const count = names.getCount();
+        await first.sync();
+        return { code, count: count.value };
+        "#,
+    )
+    .expect("cross-context validation should run in JavaScript");
+
+    assert_eq!(
+        output.value,
+        json!({ "code": "InvalidRequestContext", "count": 0 })
+    );
+}
+
+#[test]
+fn missing_name_errors_are_rich_api_script_errors() {
+    let error = run_office_js(
+        r#"
+        return await Excel.run(async context => {
+          const item = context.workbook.names.getItem("Missing");
+          item.load("name");
+          await context.sync();
+          return item.name;
+        });
+        "#,
+    )
+    .expect_err("getItem should fail at sync for missing names");
+
+    match error {
+        OfficeJsError::Script(message) => assert!(
+            message.contains("ItemNotFound"),
+            "unexpected missing-name error: {message}"
+        ),
+        other => panic!("expected script error, got {other}"),
+    }
+}

--- a/compute/officejs/tests/officejs.rs
+++ b/compute/officejs/tests/officejs.rs
@@ -61,7 +61,6 @@ fn unloaded_property_is_not_readable() {
         return await Excel.run(async (context) => {
           const sheet = context.workbook.worksheets.getItem("Sheet1");
           const range = sheet.getRange("A1");
-          range.values = [[1]];
           await context.sync();
           return range.values;
         });

--- a/compute/officejs/tests/pivot_hierarchies_semantics.rs
+++ b/compute/officejs/tests/pivot_hierarchies_semantics.rs
@@ -1,0 +1,199 @@
+//! Office.js PivotTable hierarchy collection contracts.
+//!
+//! These tests use the public Excel object model all the way through
+//! `run_office_js`: collection lookup, descriptor hydration, hierarchy
+//! mutation, and a read of the materialized output matrix are all request
+//! context operations.
+
+use mog::run_office_js;
+use serde_json::json;
+
+#[test]
+fn hierarchy_collections_load_current_items_and_compute_matrix() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const source = sheet.getRange("A1:C5");
+        source.values = [
+          ["Region", "Product", "Amount"],
+          ["East", "Pen", 4],
+          ["East", "Paper", 9],
+          ["West", "Pen", 12],
+          ["West", "Paper", 3]
+        ];
+        const pivot = sheet.pivotTables.add("SalesPivot", source, "E1");
+        await context.sync();
+
+        const region = pivot.hierarchies.getItem("Region");
+        const product = pivot.hierarchies.getItem("Product");
+        const amount = pivot.hierarchies.getItem("Amount");
+        pivot.rowHierarchies.add(region);
+        pivot.columnHierarchies.add(product);
+        const data = pivot.dataHierarchies.add(amount);
+        data.numberFormat = "0.00";
+        data.summarizeBy = Excel.AggregationFunction.sum;
+        await context.sync();
+
+        pivot.hierarchies.load(["count", "items/id", "items/name"]);
+        pivot.rowHierarchies.load(["count", "items/id", "items/name", "items/position"]);
+        pivot.columnHierarchies.load(["count", "items/id", "items/name", "items/position"]);
+        pivot.dataHierarchies.load([
+          "count",
+          "items/id",
+          "items/name",
+          "items/position",
+          "items/numberFormat",
+          "items/summarizeBy"
+        ]);
+        const allRegion = pivot.hierarchies.getItem("Region");
+        allRegion.load(["id", "name"]);
+        const dataAgain = pivot.dataHierarchies.getItem("Amount");
+        dataAgain.load(["id", "name", "position", "numberFormat", "summarizeBy", "field"]);
+        const matrix = sheet.getRange("E1:G4");
+        matrix.load("values");
+        await context.sync();
+
+        return {
+          allCount: pivot.hierarchies.count,
+          allNames: pivot.hierarchies.items.map(item => item.name),
+          allRegion: { id: allRegion.id, name: allRegion.name },
+          rowCount: pivot.rowHierarchies.count,
+          columnCount: pivot.columnHierarchies.count,
+          dataCount: pivot.dataHierarchies.count,
+          data: {
+            id: dataAgain.id,
+            name: dataAgain.name,
+            position: dataAgain.position,
+            numberFormat: dataAgain.numberFormat,
+            summarizeBy: dataAgain.summarizeBy,
+            field: dataAgain.field
+          },
+          matrix: matrix.values
+        };
+      });
+    "#,
+    )
+    .expect("pivot hierarchy collection batch should succeed");
+
+    assert_eq!(
+        output.value["allNames"],
+        json!(["Region", "Product", "Amount"])
+    );
+    assert_eq!(output.value["allCount"], json!(3));
+    assert_eq!(
+        output.value["allRegion"],
+        json!({"id": "Region", "name": "Region"})
+    );
+    assert_eq!(output.value["rowCount"], json!(1));
+    assert_eq!(output.value["columnCount"], json!(1));
+    assert_eq!(output.value["dataCount"], json!(1));
+    assert_eq!(output.value["data"]["id"], json!("Amount"));
+    assert_eq!(output.value["data"]["numberFormat"], json!("0.00"));
+    assert_eq!(output.value["data"]["summarizeBy"], json!("Sum"));
+    assert_eq!(
+        output.value["data"]["field"],
+        json!({"id": "Amount", "name": "Amount"})
+    );
+
+    // The matrix read proves that adding the hierarchy collections drives the
+    // production pivot engine; metadata alone would allow a value-only stub.
+    let matrix = output.value["matrix"].as_array().expect("matrix rows");
+    assert!(matrix.iter().flatten().any(|value| value == &json!(13)));
+    assert!(matrix.iter().flatten().any(|value| value == &json!(15)));
+}
+
+#[test]
+fn hierarchy_add_remove_and_fresh_reads_follow_area_state() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const source = sheet.getRange("A1:B4");
+        source.values = [
+          ["Region", "Amount"],
+          ["East", 4],
+          ["West", 12],
+          ["West", 3]
+        ];
+        const pivot = sheet.pivotTables.add("MovePivot", source, "D1");
+        await context.sync();
+
+        const region = pivot.hierarchies.getItem("Region");
+        const amount = pivot.hierarchies.getItem("Amount");
+        const row = pivot.rowHierarchies.add(region);
+        const data = pivot.dataHierarchies.add(amount);
+        await context.sync();
+
+        row.name = "Sales Region";
+        row.position = 0;
+        data.summarizeBy = Excel.AggregationFunction.average;
+        await context.sync();
+
+        pivot.rowHierarchies.remove(row);
+        pivot.dataHierarchies.remove(data);
+        pivot.columnHierarchies.add(region);
+        await context.sync();
+
+        const freshRowCount = pivot.rowHierarchies.getCount();
+        const freshColumnCount = pivot.columnHierarchies.getCount();
+        const freshDataCount = pivot.dataHierarchies.getCount();
+        pivot.columnHierarchies.load(["items/name", "items/position"]);
+        await context.sync();
+        return {
+          freshRowCount: freshRowCount.value,
+          freshColumnCount: freshColumnCount.value,
+          freshDataCount: freshDataCount.value,
+          columns: pivot.columnHierarchies.items.map(item => ({
+            name: item.name,
+            position: item.position
+          }))
+        };
+      });
+    "#,
+    )
+    .expect("pivot hierarchy movement batch should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "freshRowCount": 0,
+            "freshColumnCount": 1,
+            "freshDataCount": 0,
+            "columns": [{"name": "Region", "position": 0}]
+        })
+    );
+}
+
+#[test]
+fn hierarchy_lookup_and_enum_validation_preserve_office_errors() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B2").values = [["Region", "Amount"], ["East", 4]];
+        const pivot = sheet.pivotTables.add("ErrorPivot", sheet.getRange("A1:B2"), "D1");
+        await context.sync();
+
+        const missing = pivot.hierarchies.getItemOrNullObject("Missing");
+        missing.load("isNullObject");
+        let invalidEnum;
+        try {
+          const amount = pivot.dataHierarchies.add(pivot.hierarchies.getItem("Amount"));
+          amount.summarizeBy = "sum";
+        } catch (error) { invalidEnum = error.code; }
+        let wrongType;
+        try { pivot.hierarchies.getItem(1); }
+        catch (error) { wrongType = error.code; }
+        await context.sync();
+        return { missing: missing.isNullObject, invalidEnum, wrongType };
+      });
+    "#,
+    )
+    .expect("pivot hierarchy error batch should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({"missing": true, "invalidEnum": "InvalidArgument", "wrongType": "InvalidArgument"})
+    );
+}

--- a/compute/officejs/tests/protection_semantics.rs
+++ b/compute/officejs/tests/protection_semantics.rs
@@ -1,0 +1,281 @@
+//! Office.js worksheet/workbook protection semantics through the shipped host.
+
+use mog::run_office_js;
+use serde_json::json;
+
+#[test]
+fn worksheet_protection_loads_exact_options_and_fresh_proxy_state() {
+    let output = run_office_js(
+        r#"
+        await Excel.run(async context => {
+          const worksheet = context.workbook.worksheets.getItem("Sheet1");
+          worksheet.protection.protect({
+            allowAutoFilter: true,
+            allowDeleteColumns: true,
+            allowDeleteRows: false,
+            allowEditObjects: true,
+            allowEditScenarios: false,
+            allowFormatCells: true,
+            allowFormatColumns: false,
+            allowFormatRows: true,
+            allowInsertColumns: true,
+            allowInsertHyperlinks: false,
+            allowInsertRows: true,
+            allowPivotTables: true,
+            allowSort: true,
+            selectionMode: "Unlocked"
+          }, "secret");
+        });
+
+        return await Excel.run(async context => {
+          const worksheet = context.workbook.worksheets.getItem("Sheet1");
+          const protection = worksheet.protection;
+          protection.load(["protected", "isPasswordProtected", "options", "savedOptions"]);
+          await context.sync();
+          return {
+            type: protection instanceof Excel.WorksheetProtection,
+            clientObject: protection instanceof OfficeExtension.ClientObject,
+            protection: protection.toJSON(),
+            sameOptions: JSON.stringify(protection.options) === JSON.stringify(protection.savedOptions)
+          };
+        });
+        "#,
+    )
+    .expect("worksheet protection should persist");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "type": true,
+            "clientObject": true,
+            "protection": {
+                "protected": true,
+                "isPasswordProtected": true,
+                "options": {
+                    "allowAutoFilter": true,
+                    "allowDeleteColumns": true,
+                    "allowDeleteRows": false,
+                    "allowEditObjects": true,
+                    "allowEditScenarios": false,
+                    "allowFormatCells": true,
+                    "allowFormatColumns": false,
+                    "allowFormatRows": true,
+                    "allowInsertColumns": true,
+                    "allowInsertHyperlinks": false,
+                    "allowInsertRows": true,
+                    "allowPivotTables": true,
+                    "allowSort": true,
+                    "selectionMode": "Unlocked"
+                },
+                "savedOptions": {
+                    "allowAutoFilter": true,
+                    "allowDeleteColumns": true,
+                    "allowDeleteRows": false,
+                    "allowEditObjects": true,
+                    "allowEditScenarios": false,
+                    "allowFormatCells": true,
+                    "allowFormatColumns": false,
+                    "allowFormatRows": true,
+                    "allowInsertColumns": true,
+                    "allowInsertHyperlinks": false,
+                    "allowInsertRows": true,
+                    "allowPivotTables": true,
+                    "allowSort": true,
+                    "selectionMode": "Unlocked"
+                }
+            },
+            "sameOptions": true
+        })
+    );
+}
+
+#[test]
+fn worksheet_password_check_and_unprotect_use_engine_state() {
+    let output = run_office_js(
+        r#"
+        await Excel.run(async context => {
+          const worksheet = context.workbook.worksheets.getItem("Sheet1");
+          worksheet.protection.protect(undefined, "secret");
+        });
+
+        let checks;
+        await Excel.run(async context => {
+          const worksheet = context.workbook.worksheets.getItem("Sheet1");
+          const protection = worksheet.protection;
+          const right = protection.checkPassword("secret");
+          const wrong = protection.checkPassword("wrong");
+          const missing = protection.checkPassword();
+          protection.load(["protected", "isPasswordProtected"]);
+          await context.sync();
+          checks = {
+            protected: protection.protected,
+            isPasswordProtected: protection.isPasswordProtected,
+            right: right.value,
+            wrong: wrong.value,
+            missing: missing.value
+          };
+        });
+
+        let wrongUnprotect;
+        await Excel.run(async context => {
+          const worksheet = context.workbook.worksheets.getItem("Sheet1");
+          worksheet.protection.unprotect("wrong");
+          try {
+            await context.sync();
+          } catch (error) {
+            wrongUnprotect = error.code;
+          }
+        });
+
+        return await Excel.run(async context => {
+          const worksheet = context.workbook.worksheets.getItem("Sheet1");
+          const protection = worksheet.protection;
+          protection.load(["protected", "isPasswordProtected"]);
+          await context.sync();
+          return {
+            protected: checks.protected,
+            isPasswordProtected: checks.isPasswordProtected,
+            right: checks.right,
+            wrong: checks.wrong,
+            missing: checks.missing,
+            freshProtected: protection.protected,
+            freshIsPasswordProtected: protection.isPasswordProtected,
+            wrongUnprotect
+          };
+        });
+        "#,
+    )
+    .expect("password checks should use persisted protection");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "protected": true,
+            "isPasswordProtected": true,
+            "right": true,
+            "wrong": false,
+            "missing": false,
+            "freshProtected": true,
+            "freshIsPasswordProtected": true,
+            "wrongUnprotect": "InvalidArgument"
+        })
+    );
+}
+
+#[test]
+fn worksheet_unprotect_clears_password_and_fresh_proxy_reads_false() {
+    let output = run_office_js(
+        r#"
+        await Excel.run(async context => {
+          const worksheet = context.workbook.worksheets.getItem("Sheet1");
+          worksheet.protection.protect(undefined, "secret");
+        });
+        await Excel.run(async context => {
+          const worksheet = context.workbook.worksheets.getItem("Sheet1");
+          worksheet.protection.unprotect("secret");
+        });
+        return await Excel.run(async context => {
+          const worksheet = context.workbook.worksheets.getItem("Sheet1");
+          const protection = worksheet.protection;
+          protection.load(["protected", "isPasswordProtected"]);
+          await context.sync();
+          return protection.toJSON();
+        });
+        "#,
+    )
+    .expect("correct worksheet password should unprotect");
+
+    assert_eq!(
+        output.value,
+        json!({ "protected": false, "isPasswordProtected": false })
+    );
+}
+
+#[test]
+fn workbook_protection_round_trips_and_keeps_structure_enforced() {
+    let output = run_office_js(
+        r#"
+        await Excel.run(async context => {
+          context.workbook.protection.protect("book-secret");
+        });
+
+        let addError;
+        try {
+          await Excel.run(async context => {
+            context.workbook.worksheets.add("Blocked");
+            await context.sync();
+          });
+        } catch (error) {
+          addError = error.code;
+        }
+
+        let wrongPassword;
+        try {
+          await Excel.run(async context => {
+            context.workbook.protection.unprotect("wrong");
+            await context.sync();
+          });
+        } catch (error) {
+          wrongPassword = error.code;
+        }
+
+        await Excel.run(async context => {
+          context.workbook.protection.unprotect("book-secret");
+        });
+
+        return await Excel.run(async context => {
+          const protection = context.workbook.protection;
+          protection.load("protected");
+          await context.sync();
+          return {
+            type: protection instanceof Excel.WorkbookProtection,
+            clientObject: protection instanceof OfficeExtension.ClientObject,
+            protected: protection.protected,
+            addBlocked: typeof addError === "string",
+            wrongPassword
+          };
+        });
+        "#,
+    )
+    .expect("workbook protection should round trip");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "type": true,
+            "clientObject": true,
+            "protected": false,
+            "addBlocked": true,
+            "wrongPassword": "InvalidArgument"
+        })
+    );
+}
+
+#[test]
+fn protection_proxies_require_load_and_reject_unsupported_members() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async context => {
+          const worksheet = context.workbook.worksheets.getItem("Sheet1");
+          const protection = worksheet.protection;
+          let unloaded;
+          let pause;
+          let badOptions;
+          try { protection.protected; } catch (error) { unloaded = error.code; }
+          try { protection.canPauseProtection; } catch (error) { pause = error.code; }
+          try { protection.protect({ selectionMode: "invalid" }); } catch (error) { badOptions = error.code; }
+          return { unloaded, pause, badOptions };
+        });
+        "#,
+    )
+    .expect("protection proxy errors should be observable");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "unloaded": "PropertyNotLoaded",
+            "pause": "ApiNotFound",
+            "badOptions": "InvalidArgument"
+        })
+    );
+}

--- a/compute/officejs/tests/range_areas_semantics.rs
+++ b/compute/officejs/tests/range_areas_semantics.rs
@@ -1,0 +1,247 @@
+//! Office.js RangeAreas and RangeCollection behavior through the shipped
+//! production runtime.
+
+use compute_api::Workbook;
+use mog::{OfficeJsError, run_office_js_with_workbook};
+use serde_json::json;
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn get_ranges_loads_discontiguous_metadata_and_range_items() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:B2").values = [[1, 2], [3, 4]];
+          sheet.getRange("D1:D2").values = [[5], [6]];
+
+          const areas = sheet.getRanges("A1:B2; D1:D2");
+          areas.load("address,areaCount,cellCount,isEntireRow,isEntireColumn");
+          const count = areas.areas.getCount();
+          areas.areas.load(
+            "items/address,items/rowIndex,items/columnIndex,items/rowCount,items/columnCount,items/cellCount,items/values"
+          );
+          await context.sync();
+
+          return {
+            metadata: {
+              address: areas.address,
+              areaCount: areas.areaCount,
+              cellCount: areas.cellCount,
+              isEntireRow: areas.isEntireRow,
+              isEntireColumn: areas.isEntireColumn
+            },
+            count: count.value,
+            items: areas.areas.items.map((range) => ({
+              address: range.address,
+              rowIndex: range.rowIndex,
+              columnIndex: range.columnIndex,
+              rowCount: range.rowCount,
+              columnCount: range.columnCount,
+              cellCount: range.cellCount,
+              values: range.values
+            }))
+          };
+        });
+        "#,
+    )
+    .expect("RangeAreas metadata and collection items should load");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "metadata": {
+                "address": "Sheet1!A1:B2, Sheet1!D1:D2",
+                "areaCount": 2,
+                "cellCount": 6,
+                "isEntireRow": false,
+                "isEntireColumn": false
+            },
+            "count": 2,
+            "items": [
+                {
+                    "address": "Sheet1!A1:B2",
+                    "rowIndex": 0,
+                    "columnIndex": 0,
+                    "rowCount": 2,
+                    "columnCount": 2,
+                    "cellCount": 4,
+                    "values": [[1, 2], [3, 4]]
+                },
+                {
+                    "address": "Sheet1!D1:D2",
+                    "rowIndex": 0,
+                    "columnIndex": 3,
+                    "rowCount": 2,
+                    "columnCount": 1,
+                    "cellCount": 2,
+                    "values": [[5], [6]]
+                }
+            ]
+        })
+    );
+}
+
+#[test]
+fn range_collection_get_item_at_returns_a_real_range_proxy() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("B2:C2").values = [[10, 20]];
+          const collection = sheet.getRanges("A1:A1,B2:C2").areas;
+          const count = collection.getCount();
+          const second = collection.getItemAt(1);
+          second.load("address,values");
+          await context.sync();
+          return {
+            count: count.value,
+            isRange: second instanceof Excel.Range,
+            address: second.address,
+            values: second.values
+          };
+        });
+        "#,
+    )
+    .expect("RangeCollection.getItemAt should return a Range");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "count": 2,
+            "isRange": true,
+            "address": "Sheet1!B2:C2",
+            "values": [[10, 20]]
+        })
+    );
+}
+
+#[test]
+fn bounded_range_areas_clear_each_area_without_touching_other_cells() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:B1").values = [[1, 2]];
+          sheet.getRange("D1:E1").values = [[3, 4]];
+          sheet.getRange("C1").values = [[99]];
+          const areas = sheet.getRanges("A1:B1,D1:E1");
+          areas.clear("Contents");
+          await context.sync();
+
+          const fresh = sheet.getRange("A1:E1");
+          fresh.load("values");
+          await context.sync();
+          return fresh.values;
+        });
+        "#,
+    )
+    .expect("RangeAreas.clear should clear every bounded area");
+
+    assert_eq!(output.value, json!([["", "", 99, "", ""]]));
+}
+
+#[test]
+fn range_areas_intersection_or_null_preserves_intersection_areas() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRanges("A1:B2,C1:C2");
+          const hit = source.getIntersectionOrNullObject("B2:C3");
+          const miss = source.getIntersectionOrNullObject("E1:E3");
+          hit.load("address,areaCount,cellCount");
+          miss.load("isNullObject");
+          await context.sync();
+          return {
+            hit: {
+              address: hit.address,
+              areaCount: hit.areaCount,
+              cellCount: hit.cellCount
+            },
+            miss: miss.isNullObject
+          };
+        });
+        "#,
+    )
+    .expect("RangeAreas intersection should support null objects");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "hit": {
+                "address": "Sheet1!B2, Sheet1!C1:C2",
+                "areaCount": 2,
+                "cellCount": 3
+            },
+            "miss": true
+        })
+    );
+}
+
+#[test]
+fn omitted_range_areas_address_keeps_whole_sheet_bounded_by_metadata_only() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const areas = context.workbook.worksheets.getItem("Sheet1").getRanges();
+          areas.load("address,areaCount,cellCount");
+          await context.sync();
+          return {
+            address: areas.address,
+            areaCount: areas.areaCount,
+            cellCount: areas.cellCount
+          };
+        });
+        "#,
+    )
+    .expect("omitted RangeAreas address should load metadata");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "address": "Sheet1!1:1048576",
+            "areaCount": 1,
+            "cellCount": -1
+        })
+    );
+}
+
+#[test]
+fn malformed_range_areas_address_fails_at_sync() {
+    let workbook = blank_workbook();
+    let error = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const areas = context.workbook.worksheets.getItem("Sheet1").getRanges("A1,,B1");
+          areas.load("address");
+          await context.sync();
+        });
+        "#,
+    )
+    .expect_err("malformed RangeAreas address must fail");
+
+    match error {
+        OfficeJsError::Script(message) => {
+            assert!(
+                message.contains("InvalidArgument"),
+                "unexpected error: {message}"
+            );
+        }
+        other => panic!("expected script error, got {other}"),
+    }
+}

--- a/compute/officejs/tests/range_content.rs
+++ b/compute/officejs/tests/range_content.rs
@@ -1,0 +1,258 @@
+//! Office.js Range content projection tests.
+
+use compute_api::Workbook;
+use mog::{run_office_js_with_workbook, OfficeJsError};
+use serde_json::json;
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn range_content_reads_number_formats_display_text_and_value_types() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1").values = [[42]];
+          sheet.getRange("B1").values = [[45292]];
+          sheet.getRange("C1").values = [[true]];
+          sheet.getRange("A2").formulas = [["=\"\""]];
+          sheet.getRange("B2").formulas = [["=1/0"]];
+          sheet.getRange("C2").values = [["text"]];
+
+          const range = sheet.getRange("A1:C2");
+          range.numberFormat = [["0.00", "m/d/yyyy", null], [null, null, null]];
+          await context.sync();
+
+          const fresh = sheet.getRange("A1:C2");
+          fresh.load("numberFormat,text,valueTypes,values,formulas");
+          await context.sync();
+          return {
+            numberFormat: fresh.numberFormat,
+            text: fresh.text,
+            valueTypes: fresh.valueTypes,
+            values: fresh.values,
+            formulas: fresh.formulas
+          };
+        });
+        "#,
+    )
+    .expect("Range content projections should load");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "numberFormat": [
+                ["0.00", "m/d/yyyy", "General"],
+                ["General", "General", "General"]
+            ],
+            "text": [
+                ["42.00", "1/1/2024", "TRUE"],
+                ["", "#DIV/0!", "text"]
+            ],
+            "valueTypes": [
+                ["Integer", "Integer", "Boolean"],
+                ["String", "Error", "String"]
+            ],
+            "values": [
+                [42, 45292, true],
+                ["", "#DIV/0!", "text"]
+            ],
+            "formulas": [
+                [42, 45292, true],
+                ["=\"\"", "=1/0", "text"]
+            ]
+        })
+    );
+}
+
+#[test]
+fn range_set_copies_loaded_content_and_format_without_reading_unloaded_fields() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1:B1");
+          source.values = [[42, 0.5]];
+          source.numberFormat = [["0.00", "0%"]];
+          source.format.set({ wrapText: true });
+          await context.sync();
+
+          const sourceJson = source.toJSON();
+          const target = sheet.getRange("A2:B2");
+          target.set(source);
+          await context.sync();
+
+          const fresh = sheet.getRange("A2:B2");
+          fresh.load("values,numberFormat");
+          fresh.format.load("wrapText");
+          await context.sync();
+          return {
+            sourceJson,
+            hasUnloadedText: Object.prototype.hasOwnProperty.call(sourceJson, "text"),
+            values: fresh.values,
+            numberFormat: fresh.numberFormat,
+            wrapText: fresh.format.wrapText
+          };
+        });
+        "#,
+    )
+    .expect("Range.set and toJSON should preserve loaded fields");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "sourceJson": {
+                "values": [[42, 0.5]],
+                "numberFormat": [["0.00", "0%"]],
+                "format": { "wrapText": true }
+            },
+            "hasUnloadedText": false,
+            "values": [[42, 0.5]],
+            "numberFormat": [["0.00", "0%"]],
+            "wrapText": true
+        })
+    );
+}
+
+#[test]
+fn number_format_set_requires_exact_2d_shape_and_null_preserves_cells() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const target = sheet.getRange("A1:B1");
+          target.numberFormat = [["0.0", "0.00"]];
+          await context.sync();
+
+          target.numberFormat = [["0.000", null]];
+          await context.sync();
+
+          const fresh = sheet.getRange("A1:B1");
+          fresh.load("numberFormat");
+          await context.sync();
+          const preserved = fresh.numberFormat;
+
+          let shapeCode = null;
+          try {
+            sheet.getRange("A1:B1").numberFormat = [["0"]];
+            await context.sync();
+          } catch (error) {
+            shapeCode = error.code;
+          }
+
+          const afterError = sheet.getRange("A1:B1");
+          afterError.load("numberFormat");
+          await context.sync();
+          return { preserved, shapeCode, afterError: afterError.numberFormat };
+        });
+        "#,
+    )
+    .expect("numberFormat shape checks should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "preserved": [["0.000", "0.00"]],
+            "shapeCode": "InvalidArgument",
+            "afterError": [["0.000", "0.00"]]
+        })
+    );
+}
+
+#[test]
+fn clear_contents_preserves_format_and_clear_formats_preserves_contents() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const target = sheet.getRange("A1:B1");
+          target.values = [[42, 0.5]];
+          target.numberFormat = [["0.00", "0%"]];
+          await context.sync();
+
+          target.clear("Contents");
+          await context.sync();
+          const afterContents = sheet.getRange("A1:B1");
+          afterContents.load("values,numberFormat,valueTypes");
+          await context.sync();
+
+          target.values = [[42, 0.5]];
+          await context.sync();
+          target.clear("Formats");
+          await context.sync();
+          const afterFormats = sheet.getRange("A1:B1");
+          afterFormats.load("values,numberFormat,valueTypes");
+          await context.sync();
+
+          return {
+            afterContents: {
+              values: afterContents.values,
+              numberFormat: afterContents.numberFormat,
+              valueTypes: afterContents.valueTypes
+            },
+            afterFormats: {
+              values: afterFormats.values,
+              numberFormat: afterFormats.numberFormat,
+              valueTypes: afterFormats.valueTypes
+            }
+          };
+        });
+        "#,
+    )
+    .expect("content and format clear modes should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "afterContents": {
+                "values": [["", ""]],
+                "numberFormat": [["0.00", "0%"]],
+                "valueTypes": [["Empty", "Empty"]]
+            },
+            "afterFormats": {
+                "values": [[42, 0.5]],
+                "numberFormat": [["General", "General"]],
+                "valueTypes": [["Integer", "Double"]]
+            }
+        })
+    );
+}
+
+#[test]
+fn clear_modes_without_a_compute_primitive_fail_explicitly() {
+    let workbook = blank_workbook();
+    for mode in ["RemoveHyperlinks", "ResetContents"] {
+        let error = run_office_js_with_workbook(
+            &workbook,
+            &format!(
+                r#"
+                return await Excel.run(async (context) => {{
+                  const range = context.workbook.worksheets.getItem("Sheet1").getRange("A1");
+                  range.clear("{mode}");
+                  await context.sync();
+                }});
+                "#
+            ),
+        )
+        .expect_err("unsupported clear mode should fail");
+        match error {
+            OfficeJsError::Script(message) => {
+                assert!(
+                    message.contains("InvalidArgument"),
+                    "unexpected error: {message}"
+                );
+            }
+            other => panic!("expected script error, got {other}"),
+        }
+    }
+}

--- a/compute/officejs/tests/range_copy_semantics.rs
+++ b/compute/officejs/tests/range_copy_semantics.rs
@@ -1,0 +1,541 @@
+//! Office.js Range copy/move contract tests through the production runtime.
+
+use compute_api::Workbook;
+use mog::{run_office_js_with_workbook, OfficeJsError};
+use serde_json::json;
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn copy_from_all_rebases_formulas_and_copies_persistent_formats() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1:B2");
+          source.formulas = [["=10", "=A1+5"], ["=20", "=A2+5"]];
+          source.numberFormat = [["0.00", "0"], ["0", "0"]];
+          source.format.font.bold = true;
+          await context.sync();
+
+          const destination = sheet.getRange("D3:E4");
+          destination.copyFrom(source, "All");
+          await context.sync();
+
+          const fresh = sheet.getRange("D3:E4");
+          fresh.load("values,formulas,numberFormat");
+          fresh.format.font.load("bold");
+          const sourceFresh = sheet.getRange("A1:B2");
+          sourceFresh.load("formulas");
+          await context.sync();
+          return {
+            values: fresh.values,
+            formulas: fresh.formulas,
+            numberFormat: fresh.numberFormat,
+            bold: fresh.format.font.bold,
+            sourceFormulas: sourceFresh.formulas
+          };
+        });
+        "#,
+    )
+    .expect("copyFrom All should preserve formulas and formats");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "values": [[10, 15], [20, 25]],
+            "formulas": [["=10", "=D3+5"], ["=20", "=D4+5"]],
+            "numberFormat": [["0.00", "0"], ["0", "0"]],
+            "bold": true,
+            "sourceFormulas": [["=10", "=A1+5"], ["=20", "=A2+5"]]
+        })
+    );
+}
+
+#[test]
+fn copy_from_values_drops_formulas_and_skip_blanks_preserves_targets_when_transposed() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1:B2");
+          source.formulas = [["=1", ""], ["=3", "=4"]];
+
+          const destination = sheet.getRange("D1:E2");
+          destination.values = [[9, 8], [7, 6]];
+          await context.sync();
+
+          destination.copyFrom(source, "Values", true, true);
+          await context.sync();
+
+          const fresh = sheet.getRange("D1:E2");
+          fresh.load("values,formulas");
+          await context.sync();
+          return { values: fresh.values, formulas: fresh.formulas };
+        });
+        "#,
+    )
+    .expect("values copy with transpose and skipBlanks should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "values": [[1, 3], [7, 4]],
+            "formulas": [[1, 3], [7, 4]]
+        })
+    );
+}
+
+#[test]
+fn copy_from_expands_a_small_destination_and_repeats_exact_multiples() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1:B2");
+          source.values = [[1, 2], [3, 4]];
+          await context.sync();
+
+          // A one-cell destination expands to the source's 2x2 shape.
+          sheet.getRange("D1").copyFrom(source, "Values");
+          // A 2x4 destination receives two exact source tiles.
+          sheet.getRange("G1:J2").copyFrom(source, "Values");
+          await context.sync();
+
+          const expanded = sheet.getRange("D1:E2");
+          const repeated = sheet.getRange("G1:J2");
+          expanded.load("values");
+          repeated.load("values");
+          await context.sync();
+          return { expanded: expanded.values, repeated: repeated.values };
+        });
+        "#,
+    )
+    .expect("copyFrom should expand and repeat source shape");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "expanded": [[1, 2], [3, 4]],
+            "repeated": [[1, 2, 1, 2], [3, 4, 3, 4]]
+        })
+    );
+}
+
+#[test]
+fn copy_from_repeated_formula_tiles_rebase_each_tile_and_leave_source_unchanged() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1:B1");
+          source.formulas = [["=10", "=A1+5"]];
+          await context.sync();
+
+          // A 1x4 destination is an exact two-tile multiple of the 1x2
+          // source. Each formula must be rebased from its own tile origin.
+          sheet.getRange("D1:G1").copyFrom(source, "All");
+          await context.sync();
+
+          const repeated = sheet.getRange("D1:G1");
+          const sourceFresh = sheet.getRange("A1:B1");
+          repeated.load("values,formulas");
+          sourceFresh.load("values,formulas");
+          await context.sync();
+          return {
+            values: repeated.values,
+            formulas: repeated.formulas,
+            sourceValues: sourceFresh.values,
+            sourceFormulas: sourceFresh.formulas
+          };
+        });
+        "#,
+    )
+    .expect("repeated formula copy should preserve source and rebase each tile");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "values": [[10, 15, 10, 15]],
+            "formulas": [["=10", "=D1+5", "=10", "=F1+5"]],
+            "sourceValues": [[10, 15]],
+            "sourceFormulas": [["=10", "=A1+5"]]
+        })
+    );
+}
+
+#[test]
+fn copy_from_overlapping_formula_range_snapshots_source_before_writing() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1:B2");
+          source.formulas = [["=10", "=A1+5"], ["=20", "=A2+5"]];
+          await context.sync();
+
+          // B1:B2 overlaps the source's formula column. The production copy
+          // mutation must read all source formulas before writing B1:C2.
+          sheet.getRange("B1:C2").copyFrom(source, "All");
+          await context.sync();
+
+          const destination = sheet.getRange("B1:C2");
+          const sourceColumn = sheet.getRange("A1:A2");
+          destination.load("values,formulas");
+          sourceColumn.load("values,formulas");
+          await context.sync();
+          return {
+            destinationValues: destination.values,
+            destinationFormulas: destination.formulas,
+            sourceValues: sourceColumn.values,
+            sourceFormulas: sourceColumn.formulas
+          };
+        });
+        "#,
+    )
+    .expect("overlapping copy should snapshot formulas before writing");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "destinationValues": [[10, 15], [20, 25]],
+            "destinationFormulas": [["=10", "=B1+5"], ["=20", "=B2+5"]],
+            "sourceValues": [[10], [20]],
+            "sourceFormulas": [["=10"], ["=20"]]
+        })
+    );
+}
+
+#[test]
+fn copy_from_formats_only_keeps_target_content_and_persists_format_changes() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1");
+          source.values = [[11]];
+          source.numberFormat = [["$#,##0.00"]];
+          source.format.font.bold = true;
+
+          const destination = sheet.getRange("B1");
+          destination.values = [[22]];
+          destination.numberFormat = [["0"]];
+          destination.format.font.bold = false;
+          await context.sync();
+
+          destination.copyFrom(source, "Formats");
+          await context.sync();
+
+          const fresh = sheet.getRange("B1");
+          fresh.load("values,numberFormat");
+          fresh.format.font.load("bold");
+          await context.sync();
+          return {
+            values: fresh.values,
+            numberFormat: fresh.numberFormat,
+            bold: fresh.format.font.bold
+          };
+        });
+        "#,
+    )
+    .expect("formats-only copy should preserve destination values");
+
+    assert_eq!(
+        output.value,
+        json!({ "values": [[22]], "numberFormat": [["$#,##0.00"]], "bold": true })
+    );
+}
+
+#[test]
+fn copy_from_across_worksheets_rebinds_naked_formula_references_to_destination() {
+    let workbook = blank_workbook();
+    workbook
+        .sheets()
+        .create_sheet("Data")
+        .expect("create destination worksheet");
+
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sourceSheet = context.workbook.worksheets.getItem("Sheet1");
+          const destinationSheet = context.workbook.worksheets.getItem("Data");
+          const source = sourceSheet.getRange("A1:B1");
+          source.values = [[5, 0]];
+          source.getCell(0, 1).formulas = [["=A1+1"]];
+          await context.sync();
+
+          destinationSheet.getRange("D1").copyFrom(source, "Formulas");
+          await context.sync();
+
+          const fresh = destinationSheet.getRange("D1:E1");
+          fresh.load("values,formulas");
+          await context.sync();
+          return { values: fresh.values, formulas: fresh.formulas };
+        });
+        "#,
+    )
+    .expect("cross-worksheet copy should preserve formula semantics");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "values": [[5, 6]],
+            "formulas": [[5, "=D1+1"]]
+        })
+    );
+}
+
+#[test]
+fn copy_from_qualified_address_string_resolves_source_worksheet() {
+    let workbook = blank_workbook();
+    workbook
+        .sheets()
+        .create_sheet("Data")
+        .expect("create destination worksheet");
+
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sourceSheet = context.workbook.worksheets.getItem("Sheet1");
+          const destinationSheet = context.workbook.worksheets.getItem("Data");
+          sourceSheet.getRange("A1:B1").values = [[7, 8]];
+          await context.sync();
+
+          // A qualified string is resolved against the named source sheet,
+          // while the destination remains the Data worksheet.
+          destinationSheet.getRange("D1").copyFrom(
+            "Sheet1!A1:B1",
+            "Values"
+          );
+          await context.sync();
+
+          const destination = destinationSheet.getRange("D1:E1");
+          destination.load("values,formulas");
+          await context.sync();
+          return {
+            values: destination.values,
+            formulas: destination.formulas
+          };
+        });
+        "#,
+    )
+    .expect("qualified source address should resolve to its worksheet");
+
+    assert_eq!(
+        output.value,
+        json!({ "values": [[7, 8]], "formulas": [[7, 8]] })
+    );
+}
+
+#[test]
+fn move_to_preserves_cell_identity_formula_references_and_formats() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1");
+          source.values = [[10]];
+          source.numberFormat = [["0.00"]];
+          source.format.font.bold = true;
+          const dependent = sheet.getRange("B1");
+          dependent.formulas = [["=A1*2"]];
+          await context.sync();
+
+          source.moveTo(sheet.getRange("D1"));
+          await context.sync();
+
+          const oldCell = sheet.getRange("A1");
+          const movedCell = sheet.getRange("D1");
+          const dependentFresh = sheet.getRange("B1");
+          oldCell.load("values");
+          movedCell.load("values,formulas,numberFormat");
+          movedCell.format.font.load("bold");
+          dependentFresh.load("values,formulas");
+          await context.sync();
+          return {
+            oldValues: oldCell.values,
+            movedValues: movedCell.values,
+            movedFormulas: movedCell.formulas,
+            movedNumberFormat: movedCell.numberFormat,
+            movedBold: movedCell.format.font.bold,
+            dependentValues: dependentFresh.values,
+            dependentFormulas: dependentFresh.formulas
+          };
+        });
+        "#,
+    )
+    .expect("moveTo should use identity-preserving relocation");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "oldValues": [[""]],
+            "movedValues": [[10]],
+            "movedFormulas": [[10]],
+            "movedNumberFormat": [["0.00"]],
+            "movedBold": true,
+            "dependentValues": [[20]],
+            "dependentFormulas": [["=D1*2"]]
+        })
+    );
+}
+
+#[test]
+fn move_to_overlapping_multicell_range_preserves_identity_and_rewrites_dependents() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1:A3");
+          source.values = [[1], [2], [3]];
+          source.numberFormat = [["0.00"], ["0.00"], ["0.00"]];
+          source.format.font.bold = true;
+          const dependent = sheet.getRange("B1:B3");
+          dependent.formulas = [["=A1"], ["=A2"], ["=A3"]];
+          await context.sync();
+
+          // This overlaps the source on A2:A3. The Yrs relocation path must
+          // snapshot identities before moving and update dependent refs.
+          source.moveTo(sheet.getRange("A2"));
+          await context.sync();
+
+          const moved = sheet.getRange("A2:A4");
+          const oldCell = sheet.getRange("A1");
+          const dependents = sheet.getRange("B1:B3");
+          moved.load("values,formulas,numberFormat");
+          moved.format.font.load("bold");
+          oldCell.load("values");
+          dependents.load("values,formulas");
+          await context.sync();
+          return {
+            movedValues: moved.values,
+            movedFormulas: moved.formulas,
+            movedNumberFormat: moved.numberFormat,
+            movedBold: moved.format.font.bold,
+            oldValues: oldCell.values,
+            dependentValues: dependents.values,
+            dependentFormulas: dependents.formulas
+          };
+        });
+        "#,
+    )
+    .expect("overlapping move should preserve cell identity and references");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "movedValues": [[1], [2], [3]],
+            "movedFormulas": [[1], [2], [3]],
+            "movedNumberFormat": [["0.00"], ["0.00"], ["0.00"]],
+            "movedBold": true,
+            "oldValues": [[""]],
+            "dependentValues": [[1], [2], [3]],
+            "dependentFormulas": [["=A2"], ["=A3"], ["=A4"]]
+        })
+    );
+}
+
+#[test]
+fn copy_from_rejects_link_and_destination_overflow_without_partial_paste() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("A1:B1");
+          source.values = [[41, 42]];
+          await context.sync();
+
+          let linkCode = null;
+          try {
+            sheet.getRange("D1").copyFrom(source, "Link");
+            await context.sync();
+          } catch (error) {
+            linkCode = error.code;
+          }
+
+          let boundaryCode = null;
+          try {
+            sheet.getRange("XFD1").copyFrom(source, "Values");
+            await context.sync();
+          } catch (error) {
+            boundaryCode = error.code;
+          }
+
+          const fresh = sheet.getRange("XFD1");
+          const sourceFresh = sheet.getRange("A1:B1");
+          fresh.load("values");
+          sourceFresh.load("values");
+          await context.sync();
+          return {
+            linkCode,
+            boundaryCode,
+            destination: fresh.values,
+            source: sourceFresh.values
+          };
+        });
+        "#,
+    )
+    .expect("copyFrom boundary and unsupported mode checks should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "linkCode": "UnsupportedOperation",
+            "boundaryCode": "InvalidArgument",
+            "destination": [[""]],
+            "source": [[41, 42]]
+        })
+    );
+}
+
+#[test]
+fn copy_from_rejects_cross_context_range_synchronously() {
+    let workbook = blank_workbook();
+    let error = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const source = context.workbook.worksheets.getItem("Sheet1").getRange("A1");
+          const other = await Excel.run(async (otherContext) => {
+            return otherContext.workbook.worksheets.getItem("Sheet1").getRange("B1");
+          });
+          context.workbook.worksheets.getItem("Sheet1").getRange("C1").copyFrom(source);
+          // Keep this branch explicit in the contract: a range from another
+          // request context is rejected before it can enter the host batch.
+          context.workbook.worksheets.getItem("Sheet1").getRange("D1").copyFrom(other);
+          await context.sync();
+        });
+        "#,
+    )
+    .expect_err("cross-context Range.copyFrom should fail");
+
+    match error {
+        OfficeJsError::Script(message) => assert!(
+            message.contains("InvalidRequestContext"),
+            "unexpected cross-context error: {message}"
+        ),
+        other => panic!("expected script error, got {other}"),
+    }
+}

--- a/compute/officejs/tests/range_fill_semantics.rs
+++ b/compute/officejs/tests/range_fill_semantics.rs
@@ -1,0 +1,287 @@
+//! Office.js Range fill-family behavior through the shipped runtime.
+
+use compute_api::Workbook;
+use mog::{run_office_js_with_workbook, OfficeJsError};
+use serde_json::json;
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn auto_fill_copies_formulas_down_and_preserves_source_cells() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1").values = [[10]];
+          sheet.getRange("A2").values = [[20]];
+          sheet.getRange("B1").formulas = [["=A1*2"]];
+          sheet.getRange("B2").formulas = [["=A2*2"]];
+          await context.sync();
+
+          sheet.getRange("B1:B2").autoFill("B1:B5", Excel.AutoFillType.fillCopy);
+          await context.sync();
+
+          const result = sheet.getRange("B1:B5");
+          result.load("values,formulas");
+          await context.sync();
+          return { values: result.values, formulas: result.formulas };
+        });
+        "#,
+    )
+    .expect("formula autofill should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "values": [[20], [40], [60], [80], [100]],
+            "formulas": [["=A1*2"], ["=A2*2"], ["=A3*2"], ["=A4*2"], ["=A5*2"]]
+        })
+    );
+}
+
+#[test]
+fn auto_fill_series_and_exact_enum_members_work_in_both_directions() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:A2").values = [[2], [4]];
+          sheet.getRange("C4:C5").values = [[5], [3]];
+          sheet.getRange("E1:F1").values = [[1, 3]];
+          await context.sync();
+
+          sheet.getRange("A1:A2").autoFill("A1:A5", "FillSeries");
+          sheet.getRange("C4:C5").autoFill("C1:C5", Excel.AutoFillType.fillSeries);
+          sheet.getRange("E1:F1").autoFill("E1:I1", Excel.AutoFillType.fillSeries);
+          await context.sync();
+
+          const result = sheet.getRange("A1:I5");
+          result.load("values");
+          await context.sync();
+          return result.values;
+        });
+        "#,
+    )
+    .expect("series autofill should succeed");
+
+    assert_eq!(
+        output.value,
+        json!([
+            [2, "", 11, "", 1, 3, 5, 7, 9],
+            [4, "", 9, "", "", "", "", "", ""],
+            [6, "", 7, "", "", "", "", "", ""],
+            ["", "", 5, "", "", "", "", "", ""],
+            ["", "", 3, "", "", "", "", "", ""]
+        ])
+    );
+}
+
+#[test]
+fn auto_fill_rejects_invalid_shape_and_out_of_grid_destination_before_mutation() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:A2").values = [[1], [2]];
+          await context.sync();
+
+          const errors = [];
+          for (const destination of ["B1:B5", "A1:B5", "A1:A1048577"]) {
+            try {
+              sheet.getRange("A1:A2").autoFill(destination, Excel.AutoFillType.fillCopy);
+              await context.sync();
+            } catch (error) {
+              errors.push(error.code);
+            }
+          }
+
+          const result = sheet.getRange("A1:A2");
+          result.load("values");
+          await context.sync();
+          return { errors, values: result.values };
+        });
+        "#,
+    )
+    .expect("invalid autofill requests should be reported by sync");
+
+    assert_eq!(
+        output.value,
+        json!({ "errors": ["InvalidArgument", "InvalidArgument", "InvalidArgument"], "values": [[1], [2]] })
+    );
+}
+
+#[test]
+fn auto_fill_validates_exact_auto_fill_type_values() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:A2").values = [[1], [2]];
+          await context.sync();
+
+          const errors = [];
+          for (const kind of ["fillSeries", "FillNotAType", "FlashFill"]) {
+            try {
+              sheet.getRange("A1:A2").autoFill("A1:A4", kind);
+              await context.sync();
+            } catch (error) {
+              errors.push({ kind, code: error.code });
+            }
+          }
+          return errors;
+        });
+        "#,
+    )
+    .expect("AutoFillType validation should be deferred to sync");
+
+    assert_eq!(
+        output.value,
+        json!([
+            { "kind": "fillSeries", "code": "InvalidArgument" },
+            { "kind": "FillNotAType", "code": "InvalidArgument" },
+            { "kind": "FlashFill", "code": "UnsupportedOperation" }
+        ])
+    );
+}
+
+#[test]
+fn auto_fill_null_destination_uses_contiguous_neighboring_values() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:A2").values = [[10], [20]];
+          sheet.getRange("B1:B6").values = [[1], [2], [3], [4], [5], [6]];
+          await context.sync();
+
+          sheet.getRange("A1:A2").autoFill(null, Excel.AutoFillType.fillSeries);
+          await context.sync();
+
+          const result = sheet.getRange("A1:A6");
+          result.load("values");
+          await context.sync();
+          return result.values;
+        });
+        "#,
+    )
+    .expect("null destination autofill should use neighboring values");
+
+    assert_eq!(output.value, json!([[10], [20], [30], [40], [50], [60]]));
+}
+
+#[test]
+fn flash_fill_uses_the_populated_neighboring_column() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:A3").values = [["John Smith"], ["Jane Doe"], ["Bob Wilson"]];
+          sheet.getRange("B1").values = [["John"]];
+          const target = sheet.getRange("B1:B3");
+          await context.sync();
+
+          target.flashFill();
+          await context.sync();
+
+          const result = sheet.getRange("B1:B3");
+          result.load("values");
+          await context.sync();
+          return result.values;
+        });
+        "#,
+    )
+    .expect("flash fill should succeed");
+
+    assert_eq!(output.value, json!([["John"], ["Jane"], ["Bob"]]));
+}
+
+#[test]
+fn flash_fill_requires_one_bounded_column() {
+    let workbook = blank_workbook();
+    let error = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const target = context.workbook.worksheets.getItem("Sheet1").getRange("A1:B3");
+          target.flashFill();
+          await context.sync();
+        });
+        "#,
+    )
+    .expect_err("multi-column flash fill should fail");
+
+    match error {
+        OfficeJsError::Script(message) => assert!(message.contains("InvalidArgument"), "{message}"),
+        other => panic!("expected script error, got {other}"),
+    }
+}
+
+#[test]
+fn flash_fill_rejects_a_column_without_neighboring_data() {
+    let workbook = blank_workbook();
+    let error = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const target = context.workbook.worksheets.getItem("Sheet1").getRange("B1:B3");
+          target.values = [["John"], [null], [null]];
+          target.flashFill();
+          await context.sync();
+        });
+        "#,
+    )
+    .expect_err("flash fill without neighboring data should fail");
+
+    match error {
+        OfficeJsError::Script(message) => assert!(message.contains("InvalidArgument"), "{message}"),
+        other => panic!("expected script error, got {other}"),
+    }
+}
+
+#[test]
+fn no_directional_fill_methods_are_invented() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const range = context.workbook.worksheets.getItem("Sheet1").getRange("A1");
+          return {
+            autoFill: typeof range.autoFill,
+            flashFill: typeof range.flashFill,
+            fillDown: typeof range.fillDown,
+            fillRight: typeof range.fillRight,
+            fillUp: typeof range.fillUp,
+            fillLeft: typeof range.fillLeft
+          };
+        });
+        "#,
+    )
+    .expect("method surface observation should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "autoFill": "function",
+            "flashFill": "function",
+            "fillDown": "undefined",
+            "fillRight": "undefined",
+            "fillUp": "undefined",
+            "fillLeft": "undefined"
+        })
+    );
+}

--- a/compute/officejs/tests/range_metadata_semantics.rs
+++ b/compute/officejs/tests/range_metadata_semantics.rs
@@ -1,0 +1,223 @@
+//! Range metadata projections through the production Office.js runtime.
+
+use compute_api::Workbook;
+use mog::{OfficeJsError, run_office_js_with_workbook};
+use serde_json::json;
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn formulas_r1c1_reads_values_and_round_trips_relative_and_absolute_refs() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1").values = [[10]];
+          sheet.getRange("C1").values = [[5]];
+          sheet.getRange("B2").formulas = [["=A1+$C$1"]];
+          const before = sheet.getRange("A1:C2");
+          before.load("formulasR1C1");
+          await context.sync();
+
+          const target = sheet.getRange("B2");
+          target.formulasR1C1 = [["=R[-1]C[-1]+R1C3"]];
+          await context.sync();
+          const after = sheet.getRange("B2");
+          after.load("formulas,formulasR1C1,values");
+          await context.sync();
+          return { before: before.formulasR1C1, after: after.formulas, afterR1C1: after.formulasR1C1, value: after.values };
+        });
+        "#,
+    )
+    .expect("R1C1 formula projection should round-trip");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "before": [
+                [10, "", 5],
+                ["", "=R[-1]C[-1]+R1C3", ""]
+            ],
+            "after": [["=A1+$C$1"]],
+            "afterR1C1": [["=R[-1]C[-1]+R1C3"]],
+            "value": [[15]]
+        })
+    );
+}
+
+#[test]
+fn hidden_row_column_and_cell_aggregates_round_trip_with_mixed_states() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const row = sheet.getRange("2:2");
+          const column = sheet.getRange("B:B");
+          row.rowHidden = true;
+          column.columnHidden = true;
+          await context.sync();
+
+          const mixed = sheet.getRange("A1:C3");
+          const hiddenRow = sheet.getRange("2:2");
+          const entireColumn = sheet.getRange("B:B");
+          [mixed, hiddenRow, entireColumn].forEach((range) => range.load("hidden,rowHidden,columnHidden,isEntireRow,isEntireColumn"));
+          await context.sync();
+          const result = {
+            mixed: [mixed.hidden, mixed.rowHidden, mixed.columnHidden, mixed.isEntireRow, mixed.isEntireColumn],
+            hiddenRow: [hiddenRow.hidden, hiddenRow.rowHidden, hiddenRow.columnHidden, hiddenRow.isEntireRow, hiddenRow.isEntireColumn],
+            entireColumn: [entireColumn.hidden, entireColumn.rowHidden, entireColumn.columnHidden, entireColumn.isEntireRow, entireColumn.isEntireColumn]
+          };
+
+          row.rowHidden = false;
+          column.columnHidden = false;
+          await context.sync();
+          const visible = sheet.getRange("A1:C3");
+          visible.load("hidden,rowHidden,columnHidden");
+          await context.sync();
+          result.visible = [visible.hidden, visible.rowHidden, visible.columnHidden];
+          return result;
+        });
+        "#,
+    )
+    .expect("row and column visibility should round-trip");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "mixed": [null, null, null, false, false],
+            "hiddenRow": [true, true, null, true, false],
+            "entireColumn": [true, null, true, false, true],
+            "visible": [false, false, false]
+        })
+    );
+}
+
+#[test]
+fn number_format_categories_use_the_engine_format_detector() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r##"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const range = sheet.getRange("A1:L1");
+          range.numberFormat = [[
+            "General", "0.00", "$#,##0.00", "_($* #,##0.00_)",
+            "m/d/yyyy", "h:mm:ss", "0%", "# ?/?", "0.00E+00", "@", "00000", "???"
+          ]];
+          await context.sync();
+          const result = sheet.getRange("A1:L1");
+          result.load("numberFormatCategories");
+          await context.sync();
+          return result.numberFormatCategories;
+        });
+        "##,
+    )
+    .expect("number format categories should load");
+
+    assert_eq!(
+        output.value,
+        json!([[
+            "General",
+            "Number",
+            "Currency",
+            "Accounting",
+            "Date",
+            "Time",
+            "Percentage",
+            "Fraction",
+            "Scientific",
+            "Text",
+            "Special",
+            "Custom"
+        ]])
+    );
+}
+
+#[test]
+fn has_spill_reports_true_false_and_mixed_from_projection_regions() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1").formulas = [["=SEQUENCE(2,1)"]];
+          await context.sync();
+          const spill = sheet.getRange("A1:A2");
+          const empty = sheet.getRange("B1:B2");
+          const mixed = sheet.getRange("A1:B2");
+          [spill, empty, mixed].forEach((range) => range.load("hasSpill"));
+          await context.sync();
+          return [spill.hasSpill, empty.hasSpill, mixed.hasSpill];
+        });
+        "#,
+    )
+    .expect("spill metadata should load");
+
+    assert_eq!(output.value, json!([true, false, null]));
+}
+
+#[test]
+fn locale_properties_fail_explicitly_without_locale_context() {
+    for property in ["formulasLocal", "numberFormatLocal"] {
+        let source = format!(
+            r#"
+            return await Excel.run(async (context) => {{
+              const sheet = context.workbook.worksheets.getItem("Sheet1");
+              const range = sheet.getRange("A1");
+              range.load("{property}");
+              await context.sync();
+              return range.{property};
+            }});
+            "#
+        );
+        let error = run_office_js_with_workbook(&blank_workbook(), &source)
+            .expect_err("locale-aware metadata must not be silently aliased");
+        match error {
+            OfficeJsError::Script(message) => {
+                assert!(
+                    message.contains("InvalidArgument"),
+                    "unexpected error: {message}"
+                );
+                assert!(message.contains("locale"), "unexpected error: {message}");
+            }
+            other => panic!("expected script error, got {other:?}"),
+        }
+
+        let setter_value = if property == "formulasLocal" {
+            r#"[["=SUM(A1,1)"]]"#
+        } else {
+            r#"[["0,0"]]"#
+        };
+        let source = format!(
+            r#"
+            return await Excel.run(async (context) => {{
+              const sheet = context.workbook.worksheets.getItem("Sheet1");
+              const range = sheet.getRange("A1");
+              range.{property} = {setter_value};
+              await context.sync();
+              return true;
+            }});
+            "#
+        );
+        let error = run_office_js_with_workbook(&blank_workbook(), &source)
+            .expect_err("locale-aware metadata writes must not be silently aliased");
+        match error {
+            OfficeJsError::Script(message) => {
+                assert!(
+                    message.contains("InvalidArgument"),
+                    "unexpected error: {message}"
+                );
+                assert!(message.contains("locale"), "unexpected error: {message}");
+            }
+            other => panic!("expected script error, got {other:?}"),
+        }
+    }
+}

--- a/compute/officejs/tests/range_navigation.rs
+++ b/compute/officejs/tests/range_navigation.rs
@@ -1,0 +1,216 @@
+//! Worksheet/Range geometry through the production Office.js runtime.
+
+use compute_api::Workbook;
+use mog::{run_office_js_with_workbook, OfficeJsError};
+use serde_json::json;
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn range_navigation_returns_canonical_addresses_for_the_complete_family() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const source = sheet.getRange("C4:F8");
+          const worksheetCell = sheet.getCell(0, 0);
+          const cell = source.getCell(3, 4);
+          const row = source.getRow(1);
+          const column = source.getColumn(2);
+          const lastCell = source.getLastCell();
+          const lastRow = source.getLastRow();
+          const lastColumn = source.getLastColumn();
+          const offset = source.getOffsetRange(1, -1);
+          const resized = source.getResizedRange(-1, 2);
+          const absolute = source.getAbsoluteResizedRange(3, 2);
+          const above = source.getRowsAbove(2);
+          const aboveInside = source.getRowsAbove(-2);
+          const below = source.getRowsBelow(2);
+          const before = source.getColumnsBefore(2);
+          const after = source.getColumnsAfter(2);
+          const afterInside = source.getColumnsAfter(-2);
+          const bounding = source.getBoundingRect("G7:H9");
+          const intersection = source.getIntersection("D5:G7");
+          const entireRow = source.getEntireRow();
+          const entireColumn = source.getEntireColumn();
+          [worksheetCell, cell, row, column, lastCell, lastRow, lastColumn,
+           offset, resized, absolute, above, aboveInside, below, before, after,
+           afterInside, bounding, intersection, entireRow, entireColumn].forEach((range) => range.load("address"));
+          await context.sync();
+          return [worksheetCell.address, cell.address, row.address, column.address,
+            lastCell.address, lastRow.address, lastColumn.address, offset.address,
+            resized.address, absolute.address, above.address, aboveInside.address,
+            below.address, before.address, after.address, afterInside.address,
+            bounding.address, intersection.address, entireRow.address, entireColumn.address];
+        });
+        "#,
+    )
+    .expect("range navigation should succeed");
+
+    assert_eq!(
+        output.value,
+        json!([
+            "Sheet1!A1",
+            "Sheet1!G7",
+            "Sheet1!C5:F5",
+            "Sheet1!E4:E8",
+            "Sheet1!F8",
+            "Sheet1!C8:F8",
+            "Sheet1!F4:F8",
+            "Sheet1!B5:E9",
+            "Sheet1!C4:H7",
+            "Sheet1!C4:D6",
+            "Sheet1!C2:F3",
+            "Sheet1!C4:F5",
+            "Sheet1!C9:F10",
+            "Sheet1!A4:B8",
+            "Sheet1!G4:H8",
+            "Sheet1!E4:F8",
+            "Sheet1!C4:H9",
+            "Sheet1!D5:F7",
+            "Sheet1!4:8",
+            "Sheet1!C:F",
+        ])
+    );
+}
+
+#[test]
+fn worksheet_and_range_navigation_preserve_full_row_and_column_shapes() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const rows = sheet.getRange("4:8");
+          const columns = sheet.getRange("C:F");
+          const whole = sheet.getRange();
+          const rowCell = rows.getCell(2, 16383);
+          const rowLast = rows.getLastColumn();
+          const rowEntire = rows.getEntireRow();
+          const columnCell = columns.getCell(1048575, 1);
+          const columnLast = columns.getLastRow();
+          const columnEntire = columns.getEntireColumn();
+          const wholeRow = whole.getRow(4);
+          const wholeColumn = whole.getColumn(2);
+          [rowCell, rowLast, rowEntire, columnCell, columnLast, columnEntire,
+           wholeRow, wholeColumn].forEach((range) => range.load("address,rowIndex,columnIndex,rowCount,columnCount,cellCount"));
+          await context.sync();
+          return [
+            [rowCell.address, rowCell.rowCount, rowCell.columnCount],
+            [rowLast.address, rowLast.rowCount, rowLast.columnCount],
+            [rowEntire.address, rowEntire.rowCount, rowEntire.columnCount, rowEntire.cellCount],
+            [columnCell.address, columnCell.rowCount, columnCell.columnCount],
+            [columnLast.address, columnLast.rowCount, columnLast.columnCount],
+            [columnEntire.address, columnEntire.rowCount, columnEntire.columnCount, columnEntire.cellCount],
+            [wholeRow.address, wholeRow.rowCount, wholeRow.columnCount],
+            [wholeColumn.address, wholeColumn.rowCount, wholeColumn.columnCount],
+          ];
+        });
+        "#,
+    )
+    .expect("full row and column navigation should succeed");
+
+    assert_eq!(
+        output.value,
+        json!([
+            ["Sheet1!XFD6", 1, 1],
+            ["Sheet1!XFD4:XFD8", 5, 1],
+            ["Sheet1!4:8", 5, 16384, 81920],
+            ["Sheet1!D1048576", 1, 1],
+            ["Sheet1!C1048576:F1048576", 1, 4],
+            ["Sheet1!C:F", 1048576, 4, 4194304],
+            ["Sheet1!5:5", 1, 16384],
+            ["Sheet1!C:C", 1048576, 1],
+        ])
+    );
+}
+
+#[test]
+fn range_navigation_rejects_invalid_indices_and_grid_overflows_at_sync() {
+    let cases = [
+        ("getCell(-1, 0)", "getCell"),
+        ("getCell(0, 16384)", "getCell"),
+        ("getRow(5)", "getRow"),
+        ("getColumn(4)", "getColumn"),
+        ("getOffsetRange(-4, 0)", "getOffsetRange"),
+        ("getResizedRange(-5, 0)", "getResizedRange"),
+        ("getAbsoluteResizedRange(0, 1)", "getAbsoluteResizedRange"),
+        ("getRowsAbove()", "getRowsAbove"),
+        ("getColumnsBefore()", "getColumnsBefore"),
+    ];
+
+    for (expression, label) in cases {
+        let source = format!(
+            r#"
+            return await Excel.run(async (context) => {{
+              const sheet = context.workbook.worksheets.getItem("Sheet1");
+              const range = sheet.getRange("A1:D4");
+              const result = range.{expression};
+              result.load("address");
+              await context.sync();
+              return result.address;
+            }});
+            "#
+        );
+        let error = run_office_js_with_workbook(&blank_workbook(), &source)
+            .expect_err("invalid navigation should reject context.sync");
+        match error {
+            OfficeJsError::Script(message) => assert!(
+                message.contains("InvalidArgument"),
+                "{label} returned the wrong error: {message}"
+            ),
+            other => panic!("{label} returned unexpected error: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn range_navigation_rejects_non_intersecting_ranges_and_cross_grid_cells() {
+    let workbook = blank_workbook();
+    let non_intersection = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const result = sheet.getRange("A1:B2").getIntersection("D4:E5");
+          result.load("address");
+          await context.sync();
+          return result.address;
+        });
+        "#,
+    )
+    .expect_err("non-intersecting ranges should reject");
+    match non_intersection {
+        OfficeJsError::Script(message) => assert!(
+            message.contains("ItemNotFound"),
+            "unexpected intersection error: {message}"
+        ),
+        other => panic!("expected script error, got {other:?}"),
+    }
+
+    let overflow = run_office_js_with_workbook(
+        &blank_workbook(),
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const result = sheet.getRange("XFD1048576").getCell(1, 0);
+          result.load("address");
+          await context.sync();
+          return result.address;
+        });
+        "#,
+    )
+    .expect_err("cell outside the worksheet grid should reject");
+    match overflow {
+        OfficeJsError::Script(message) => assert!(
+            message.contains("InvalidArgument"),
+            "unexpected grid overflow error: {message}"
+        ),
+        other => panic!("expected script error, got {other:?}"),
+    }
+}

--- a/compute/officejs/tests/range_search_semantics.rs
+++ b/compute/officejs/tests/range_search_semantics.rs
@@ -1,0 +1,294 @@
+//! Office.js Range/Worksheet search and used-range semantics.
+
+use compute_api::Workbook;
+use mog::{OfficeJsError, run_office_js_with_workbook};
+use serde_json::json;
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn worksheet_and_range_used_ranges_intersect_sparse_engine_bounds() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("C3").values = [["far"]];
+          const worksheetUsed = sheet.getUsedRange();
+          const worksheetValuesOnly = sheet.getUsedRange(true);
+          const intersecting = sheet.getRange("B2:D4").getUsedRange();
+          const outside = sheet.getRange("A1:B2").getUsedRangeOrNullObject();
+          [worksheetUsed, worksheetValuesOnly, intersecting, outside].forEach((range) => {
+            range.load(["address", "isNullObject"]);
+          });
+          await context.sync();
+          return {
+            worksheetUsed: worksheetUsed.address,
+            worksheetValuesOnly: worksheetValuesOnly.address,
+            intersecting: intersecting.address,
+            outside: outside.isNullObject
+          };
+        });
+        "#,
+    )
+    .expect("used-range calls should resolve through the host");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "worksheetUsed": "Sheet1!C3",
+            "worksheetValuesOnly": "Sheet1!C3",
+            "intersecting": "Sheet1!C3",
+            "outside": true
+        })
+    );
+}
+
+#[test]
+fn used_range_tracks_far_sparse_cells_without_a_dense_grid_scan() {
+    let output = run_office_js_with_workbook(
+        &blank_workbook(),
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1").values = [["near"]];
+          sheet.getRange("XFD1048576").values = [["far"]];
+          const used = sheet.getUsedRange();
+          used.load("address");
+          await context.sync();
+          return used.address;
+        });
+        "#,
+    )
+    .expect("used range should use sparse engine bounds");
+
+    assert_eq!(output.value, json!("Sheet1!A1:XFD1048576"));
+}
+
+#[test]
+fn blank_worksheet_used_range_and_empty_range_follow_or_null_contract() {
+    let output = run_office_js_with_workbook(
+        &blank_workbook(),
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const worksheetUsed = sheet.getUsedRange();
+          worksheetUsed.load(["address", "isNullObject"]);
+          await context.sync();
+
+          const empty = sheet.getRange("B2:C3").getUsedRangeOrNullObject();
+          empty.load("isNullObject");
+          await context.sync();
+          let nonNullError;
+          try {
+            sheet.getRange("B2:C3").getUsedRange().load("address");
+            await context.sync();
+          } catch (error) {
+            nonNullError = error.code;
+          }
+          return {
+            worksheetUsed: worksheetUsed.address,
+            worksheetIsNull: worksheetUsed.isNullObject,
+            emptyIsNull: empty.isNullObject,
+            nonNullError
+          };
+        });
+        "#,
+    )
+    .expect("blank used-range semantics should be observable");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "worksheetUsed": "Sheet1!A1",
+            "worksheetIsNull": false,
+            "emptyIsNull": true,
+            "nonNullError": "ItemNotFound"
+        })
+    );
+}
+
+#[test]
+fn range_find_honors_complete_match_case_and_direction() {
+    let output = run_office_js_with_workbook(
+        &blank_workbook(),
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:A5").values = [["Alpha"], ["beta"], ["ALPHA"], ["alphabet"], ["gamma"]];
+          const range = sheet.getRange("A1:A5");
+          const exactForward = range.find("alpha", { completeMatch: true });
+          const exactCase = range.find("alpha", { completeMatch: true, matchCase: true });
+          const exactBackwards = range.find("alpha", { completeMatch: true, searchDirection: "Backwards" });
+          const partial = range.find("alp", { completeMatch: false });
+          [exactForward, exactCase, exactBackwards, partial].forEach((match) => match.load("address"));
+          await context.sync();
+          return [exactForward.address, exactCase.address, exactBackwards.address, partial.address];
+        });
+        "#,
+    )
+    .expect("Range.find criteria should resolve");
+
+    assert_eq!(
+        output.value,
+        json!(["Sheet1!A1", "Sheet1!A3", "Sheet1!A3", "Sheet1!A1"])
+    );
+}
+
+#[test]
+fn worksheet_find_all_returns_qualified_range_areas_and_or_null() {
+    let output = run_office_js_with_workbook(
+        &blank_workbook(),
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:C2").values = [["Alpha", "beta", "ALPHA"], ["alphabet", "gamma", null]];
+          const exact = sheet.findAll("alpha", { completeMatch: true });
+          const partial = sheet.findAll("alp", { matchCase: false });
+          const missing = sheet.findAllOrNullObject("absent", {});
+          exact.load("address");
+          partial.load("address");
+          missing.load("isNullObject");
+          await context.sync();
+          return {
+            exact: exact.address,
+            partial: partial.address,
+            missing: missing.isNullObject
+          };
+        });
+        "#,
+    )
+    .expect("Worksheet.findAll should resolve RangeAreas results");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "exact": "Sheet1!A1, Sheet1!C1",
+            "partial": "Sheet1!A1, Sheet1!C1, Sheet1!A2",
+            "missing": true
+        })
+    );
+}
+
+#[test]
+fn single_cell_find_starts_after_anchor_and_or_null_is_loaded() {
+    let output = run_office_js_with_workbook(
+        &blank_workbook(),
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:A3").values = [["hit"], ["miss"], ["hit"]];
+          const afterA1 = sheet.getRange("A1").find("hit", { completeMatch: true });
+          const missing = sheet.getRange("A1:A3").findOrNullObject("absent", {});
+          afterA1.load(["address"]);
+          missing.load(["isNullObject"]);
+          await context.sync();
+          return { afterA1: afterA1.address, missing: missing.isNullObject };
+        });
+        "#,
+    )
+    .expect("single-cell and OrNull find should resolve");
+
+    assert_eq!(
+        output.value,
+        json!({ "afterA1": "Sheet1!A3", "missing": true })
+    );
+}
+
+#[test]
+fn replace_all_is_deferred_and_scoped_to_range() {
+    let output = run_office_js_with_workbook(
+        &blank_workbook(),
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:A4").values = [["cat"], ["scatter"], ["CAT"], ["dog"]];
+          sheet.getRange("B1").values = [["cat"]];
+          const result = sheet.getRange("A1:A4").replaceAll("cat", "fox", { matchCase: false });
+          let beforeSync;
+          try { beforeSync = result.value; } catch (error) { beforeSync = error.code; }
+          await context.sync();
+          const values = sheet.getRange("A1:B4");
+          values.load("values");
+          await context.sync();
+          return { beforeSync, count: result.value, values: values.values };
+        });
+        "#,
+    )
+    .expect("replaceAll should queue a ClientResult and mutate through sync");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "beforeSync": "ValueNotLoaded",
+            "count": 3,
+            "values": [["fox", "cat"], ["sfoxter", ""], ["fox", ""], ["dog", ""]]
+        })
+    );
+}
+
+#[test]
+fn special_cells_returns_bounded_areas_and_rejects_unbounded_or_unsupported_types() {
+    let output = run_office_js_with_workbook(
+        &blank_workbook(),
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const range = sheet.getRange("A1:C3");
+          range.values = [["text", 1, true], [null, null, null], ["tail", null, null]];
+          sheet.getRange("B2").formulas = [["=1+1"]];
+          const constants = range.getSpecialCells("Constants");
+          const formulas = range.getSpecialCells("Formulas", "Numbers");
+          const blanks = range.getSpecialCellsOrNullObject("Blanks");
+          constants.load("address");
+          formulas.load("address");
+          blanks.load(["address", "isNullObject"]);
+          await context.sync();
+          return {
+            constants: constants.address,
+            formulas: formulas.address,
+            blanks: { address: blanks.address, isNullObject: blanks.isNullObject }
+          };
+        });
+        "#,
+    )
+    .expect("bounded primitive special cells should resolve");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "constants": "Sheet1!A1, Sheet1!B1, Sheet1!C1, Sheet1!A3",
+            "formulas": "Sheet1!B2",
+            "blanks": {
+                "address": "Sheet1!A2, Sheet1!C2, Sheet1!B3:C3",
+                "isNullObject": false
+            }
+        })
+    );
+}
+
+#[test]
+fn find_without_match_throws_item_not_found() {
+    let error = run_office_js_with_workbook(
+        &blank_workbook(),
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1").values = [["present"]];
+          const result = sheet.getRange("A1").find("missing", {});
+          result.load("address");
+          await context.sync();
+          return result.address;
+        });
+        "#,
+    )
+    .expect_err("non-OrNull find should reject when there is no match");
+
+    match error {
+        OfficeJsError::Script(message) => assert!(message.contains("ItemNotFound"), "{message}"),
+        other => panic!("expected script error, got {other:?}"),
+    }
+}

--- a/compute/officejs/tests/range_semantics.rs
+++ b/compute/officejs/tests/range_semantics.rs
@@ -1,0 +1,195 @@
+//! Foundational Worksheet/Range tests through the shipped Office.js runtime.
+
+use std::collections::HashMap;
+
+use compute_api::Workbook;
+use mog::{OfficeJsError, run_office_js_with_workbook};
+use serde_json::json;
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn bounded_range_loads_canonical_address_indexes_and_counts() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const range = sheet.getRange("$b$2:$D$5");
+          range.load("address,rowIndex,columnIndex,rowCount,columnCount,cellCount");
+          await context.sync();
+          return {
+            address: range.address,
+            rowIndex: range.rowIndex,
+            columnIndex: range.columnIndex,
+            rowCount: range.rowCount,
+            columnCount: range.columnCount,
+            cellCount: range.cellCount,
+          };
+        });
+        "#,
+    )
+    .expect("range metadata load should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "address": "Sheet1!B2:D5",
+            "rowIndex": 1,
+            "columnIndex": 1,
+            "rowCount": 4,
+            "columnCount": 3,
+            "cellCount": 12,
+        })
+    );
+}
+
+#[test]
+fn whole_worksheet_range_uses_excel_grid_counts_and_unbounded_values() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const range = sheet.getRange();
+          range.load("address,rowIndex,columnIndex,rowCount,columnCount,cellCount,values,formulas");
+          await context.sync();
+          return {
+            address: range.address,
+            rowIndex: range.rowIndex,
+            columnIndex: range.columnIndex,
+            rowCount: range.rowCount,
+            columnCount: range.columnCount,
+            cellCount: range.cellCount,
+            values: range.values,
+            formulas: range.formulas,
+          };
+        });
+        "#,
+    )
+    .expect("whole-sheet metadata load should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "address": "Sheet1!1:1048576",
+            "rowIndex": 0,
+            "columnIndex": 0,
+            "rowCount": 1_048_576,
+            "columnCount": 16_384,
+            "cellCount": -1,
+            "values": null,
+            "formulas": null,
+        })
+    );
+}
+
+#[test]
+fn worksheet_lookup_accepts_stable_id_and_common_case_insensitive_name() {
+    let workbook = blank_workbook();
+    workbook
+        .sheets()
+        .create_sheet("Data")
+        .expect("create Data sheet");
+    let data_id = workbook
+        .sheet_by_name("Data")
+        .expect("Data sheet")
+        .id()
+        .to_uuid_string();
+    let source = format!(
+        r#"
+        return await Excel.run(async (context) => {{
+          const byId = context.workbook.worksheets.getItem("{data_id}");
+          const byNameCase = context.workbook.worksheets.getItem("data");
+          byId.load("id,name");
+          byNameCase.load("id,name");
+          await context.sync();
+          return {{
+            byId: {{ id: byId.id, name: byId.name }},
+            byNameCase: {{ id: byNameCase.id, name: byNameCase.name }},
+          }};
+        }});
+        "#
+    );
+    let output = run_office_js_with_workbook(&workbook, &source)
+        .expect("worksheet ID and common name lookup should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "byId": { "id": data_id, "name": "Data" },
+            "byNameCase": { "id": data_id, "name": "Data" },
+        })
+    );
+}
+
+#[test]
+fn get_active_worksheet_uses_persisted_headless_active_sheet_state() {
+    let workbook = blank_workbook();
+    workbook
+        .sheets()
+        .create_sheet("Data")
+        .expect("create Data sheet");
+    let data_id = workbook
+        .sheet_by_name("Data")
+        .expect("Data sheet")
+        .id()
+        .to_uuid_string();
+    let mut settings = workbook
+        .settings()
+        .get_workbook_settings()
+        .expect("get workbook settings");
+    settings.selected_sheet_ids = Some(vec![data_id.clone()]);
+    settings.custom_settings = Some(HashMap::from([(
+        "mog.activeSheetId".to_string(),
+        json!(data_id.clone()),
+    )]));
+    workbook
+        .settings()
+        .set_workbook_settings(settings)
+        .expect("set active worksheet state");
+
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const active = context.workbook.worksheets.getActiveWorksheet();
+          active.load("id,name");
+          await context.sync();
+          return { id: active.id, name: active.name };
+        });
+        "#,
+    )
+    .expect("active worksheet lookup should succeed");
+
+    assert_eq!(output.value, json!({ "id": data_id, "name": "Data" }));
+}
+
+#[test]
+fn missing_worksheet_id_fails_at_sync_with_item_not_found() {
+    let workbook = blank_workbook();
+    let error = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const missing = context.workbook.worksheets.getItem("ffffffff-ffff-ffff-ffff-ffffffffffff");
+          missing.load("name");
+          await context.sync();
+          return missing.name;
+        });
+        "#,
+    )
+    .expect_err("missing worksheet must reject sync");
+
+    match error {
+        OfficeJsError::Script(message) => assert!(
+            message.contains("ItemNotFound"),
+            "unexpected missing-sheet error: {message}"
+        ),
+        other => panic!("expected script error, got {other}"),
+    }
+}

--- a/compute/officejs/tests/range_structure_semantics.rs
+++ b/compute/officejs/tests/range_structure_semantics.rs
@@ -1,0 +1,461 @@
+//! Office.js Range structural operations through the production host path.
+
+use compute_api::Workbook;
+use mog::{run_office_js_with_workbook, OfficeJsError};
+use serde_json::json;
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn insert_down_preserves_adjacent_cells_formulas_and_formats() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:B3").values = [[10, 100], [20, 200], [30, 300]];
+          sheet.getRange("A2").formulas = [["=A1+10"]];
+          sheet.getRange("A2").numberFormat = [["0.00"]];
+          await context.sync();
+
+          const inserted = sheet.getRange("A2").insert(Excel.InsertShiftDirection.down);
+          inserted.values = [[99]];
+          inserted.load("address");
+          await context.sync();
+
+          const read = sheet.getRange("A1:B4");
+          read.load("values,formulas,numberFormat");
+          await context.sync();
+          return {
+            insertedAddress: inserted.address,
+            values: read.values,
+            formulas: read.formulas,
+            numberFormat: read.numberFormat
+          };
+        });
+        "#,
+    )
+    .expect("insert down should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "insertedAddress": "Sheet1!A2",
+            "values": [[10, 100], [99, 200], [20, 300], [30, ""]],
+            "formulas": [[10, 100], [99, 200], ["=A1+10", 300], [30, ""]],
+            "numberFormat": [["General", "General"], ["General", "General"], ["0.00", "General"], ["General", "General"]]
+        })
+    );
+}
+
+#[test]
+fn insert_right_and_delete_left_keep_other_rows_and_formula_references() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:D2").values = [[1, 2, 3, 4], [10, 20, 30, 40]];
+          sheet.getRange("D1").formulas = [["=A1+B1+C1"]];
+          await context.sync();
+
+          sheet.getRange("B1").insert(Excel.InsertShiftDirection.right);
+          await context.sync();
+          const afterInsert = sheet.getRange("A1:E2");
+          afterInsert.load("values,formulas");
+          await context.sync();
+
+          sheet.getRange("B1").delete(Excel.DeleteShiftDirection.left);
+          await context.sync();
+          const afterDelete = sheet.getRange("A1:E2");
+          afterDelete.load("values,formulas");
+          await context.sync();
+          return { afterInsert: { values: afterInsert.values, formulas: afterInsert.formulas }, afterDelete: { values: afterDelete.values, formulas: afterDelete.formulas } };
+        });
+        "#,
+    )
+    .expect("insert right/delete left should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "afterInsert": {
+                "values": [[1, "", 2, 3, 6], [10, 20, 30, 40, ""]],
+                "formulas": [[1, "", 2, 3, "=A1+C1+D1"], [10, 20, 30, 40, ""]]
+            },
+            "afterDelete": {
+                "values": [[1, 2, 3, 6, ""], [10, 20, 30, 40, ""]],
+                "formulas": [[1, 2, 3, "=A1+B1+C1", ""], [10, 20, 30, 40, ""]]
+            }
+        })
+    );
+}
+
+#[test]
+fn delete_up_preserves_adjacent_columns_and_moved_formula_identity() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:B4").values = [[1, 10], [2, 20], [3, 30], [4, 40]];
+          sheet.getRange("A3").formulas = [["=A1+10"]];
+          await context.sync();
+
+          sheet.getRange("A2").delete(Excel.DeleteShiftDirection.up);
+          await context.sync();
+          const read = sheet.getRange("A1:B3");
+          read.load("values,formulas");
+          await context.sync();
+          return { values: read.values, formulas: read.formulas };
+        });
+        "#,
+    )
+    .expect("delete up should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "values": [[1, 10], [11, 20], [4, 40]],
+            "formulas": [[1, 10], ["=A1+10", 20], [4, 40]]
+        })
+    );
+}
+
+#[test]
+fn merge_unmerge_and_merge_across_follow_child_data_loss_semantics() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:C2").values = [["origin", "discarded", "also discarded"], ["row 2", "child", "child"]];
+          sheet.getRange("B1").formulas = [["=1+1"]];
+          sheet.getRange("D1:D2").values = [["adjacent 1"], ["adjacent 2"]];
+          await context.sync();
+
+          sheet.getRange("A1:C2").merge();
+          await context.sync();
+          const merged = sheet.getRange("A1:D2");
+          merged.load("values,formulas");
+          await context.sync();
+
+          sheet.getRange("A1:C2").unmerge();
+          await context.sync();
+          const unmerged = sheet.getRange("A1:D2");
+          unmerged.load("values,formulas");
+          await context.sync();
+
+          sheet.getRange("A3:C4").values = [["r3", "drop 3", "drop 3"], ["r4", "drop 4", "drop 4"]];
+          sheet.getRange("A3:C4").merge(true);
+          await context.sync();
+          const across = sheet.getRange("A3:D4");
+          across.load("values,formulas");
+          await context.sync();
+          return {
+            merged: { values: merged.values, formulas: merged.formulas },
+            unmerged: { values: unmerged.values, formulas: unmerged.formulas },
+            across: { values: across.values, formulas: across.formulas }
+          };
+        });
+        "#,
+    )
+    .expect("merge and unmerge should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "merged": {
+                "values": [["origin", "", "", "adjacent 1"], ["", "", "", "adjacent 2"]],
+                "formulas": [["origin", "", "", "adjacent 1"], ["", "", "", "adjacent 2"]]
+            },
+            "unmerged": {
+                "values": [["origin", "", "", "adjacent 1"], ["", "", "", "adjacent 2"]],
+                "formulas": [["origin", "", "", "adjacent 1"], ["", "", "", "adjacent 2"]]
+            },
+            "across": {
+                "values": [["r3", "", "", ""], ["r4", "", "", ""]],
+                "formulas": [["r3", "", "", ""], ["r4", "", "", ""]]
+            }
+        })
+    );
+}
+
+#[test]
+fn invalid_structural_ranges_and_shift_tokens_fail_without_mutation() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:C1").values = [[1, 2, 3]];
+          await context.sync();
+
+          const errors = [];
+          for (const action of [
+            () => sheet.getRange("B1:A1").insert("Down"),
+            () => sheet.getRange("A1").insert("Sideways"),
+            () => sheet.getRange("A1").delete("Diagonal"),
+            () => sheet.getRange("A1048577").merge()
+          ]) {
+            try {
+              action();
+              await context.sync();
+            } catch (error) {
+              errors.push(error.code);
+            }
+          }
+
+          const read = sheet.getRange("A1:C1");
+          read.load("values");
+          await context.sync();
+          return { errors, values: read.values };
+        });
+        "#,
+    )
+    .expect("invalid structural operations should be catchable");
+
+    assert_eq!(
+        output.value,
+        json!({ "errors": ["InvalidArgument", "InvalidArgument", "InvalidArgument", "InvalidArgument"], "values": [[1, 2, 3]] })
+    );
+}
+
+#[test]
+fn insert_result_is_a_live_blank_range_at_the_inserted_address() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:C1").values = [[1, 2, 3]];
+          await context.sync();
+
+          const inserted = sheet.getRange("B1:C1").insert(Excel.InsertShiftDirection.right);
+          inserted.values = [[20, 30]];
+          inserted.load("address,values,formulas");
+          await context.sync();
+          return { address: inserted.address, values: inserted.values, formulas: inserted.formulas };
+        });
+        "#,
+    )
+    .expect("insert result should remain a live Range proxy");
+
+    assert_eq!(
+        output.value,
+        json!({ "address": "Sheet1!B1:C1", "values": [[20, 30]], "formulas": [[20, 30]] })
+    );
+}
+
+#[test]
+fn structural_host_errors_keep_rich_api_error_shape() {
+    let workbook = blank_workbook();
+    let error = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const range = context.workbook.worksheets.getItem("Sheet1").getRange("B2:A1");
+          range.delete("Up");
+          await context.sync();
+        });
+        "#,
+    )
+    .expect_err("inverted structural range should reject at sync");
+
+    match error {
+        OfficeJsError::Script(message) => assert!(
+            message.contains("InvalidArgument"),
+            "expected Rich API InvalidArgument, got {message}"
+        ),
+        other => panic!("expected script error, got {other}"),
+    }
+}
+
+#[test]
+fn remove_duplicates_respects_relative_columns_headers_and_adjacent_cells() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:D5").values = [
+            ["left", "Name", "Keep", "right 1"],
+            ["left", "a", 1, "right 2"],
+            ["left", "a", 2, "right 3"],
+            ["left", "b", 3, "right 4"],
+            ["left", "b", 4, "right 5"]
+          ];
+          const result = sheet.getRange("B1:C5").removeDuplicates([0], true);
+          result.load("removed,uniqueRemaining");
+          let beforeSync;
+          try {
+            result.removed;
+          } catch (error) {
+            beforeSync = error.code;
+          }
+          await context.sync();
+
+          const read = sheet.getRange("A1:D5");
+          read.load("values");
+          await context.sync();
+          return {
+            beforeSync,
+            removed: result.removed,
+            uniqueRemaining: result.uniqueRemaining,
+            resultJson: result.toJSON(),
+            values: read.values
+          };
+        });
+        "#,
+    )
+    .expect("removeDuplicates should use the selected range and return its deferred result");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "beforeSync": "PropertyNotLoaded",
+            "removed": 2,
+            "uniqueRemaining": 2,
+            "resultJson": {"removed": 2, "uniqueRemaining": 2},
+            "values": [
+                ["left", "Name", "Keep", "right 1"],
+                ["left", "a", 1, "right 2"],
+                ["left", "b", 3, "right 3"],
+                ["left", "", "", "right 4"],
+                ["left", "", "", "right 5"]
+            ]
+        })
+    );
+}
+
+#[test]
+fn remove_duplicates_rejects_empty_or_out_of_range_column_selection() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:C3").values = [[1, "a", "keep"], [2, "a", "x"], [3, "b", "y"]];
+          const errors = [];
+          try {
+            sheet.getRange("B1:C3").removeDuplicates([], false);
+          } catch (error) {
+            errors.push(error.code);
+          }
+          try {
+            const invalid = sheet.getRange("B1:C3").removeDuplicates([2], false);
+            await context.sync();
+          } catch (error) {
+            errors.push(error.code);
+          }
+
+          const read = sheet.getRange("A1:C3");
+          read.load("values");
+          await context.sync();
+          return { errors, values: read.values };
+        });
+        "#,
+    )
+    .expect("invalid removeDuplicates selections should be catchable");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "errors": ["InvalidArgument", "InvalidArgument"],
+            "values": [[1, "a", "keep"], [2, "a", "x"], [3, "b", "y"]]
+        })
+    );
+}
+
+#[test]
+fn group_and_ungroup_use_row_and_column_outline_ranges_without_touching_cells() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:D5").values = [
+            ["r1", "a", 1, "tail 1"],
+            ["r2", "b", 2, "tail 2"],
+            ["r3", "c", 3, "tail 3"],
+            ["r4", "d", 4, "tail 4"],
+            ["r5", "e", 5, "tail 5"]
+          ];
+          sheet.getRange("2:3").group("ByRows");
+          sheet.getRange("B:C").group("ByColumns");
+          await context.sync();
+
+          sheet.getRange("2:3").ungroup("ByRows");
+          sheet.getRange("B:C").ungroup("ByColumns");
+          await context.sync();
+
+          const read = sheet.getRange("A1:D5");
+          read.load("values");
+          await context.sync();
+          return read.values;
+        });
+        "#,
+    )
+    .expect("row and column grouping should use SheetOutline");
+
+    assert_eq!(
+        output.value,
+        json!([
+            ["r1", "a", 1, "tail 1"],
+            ["r2", "b", 2, "tail 2"],
+            ["r3", "c", 3, "tail 3"],
+            ["r4", "d", 4, "tail 4"],
+            ["r5", "e", 5, "tail 5"]
+        ])
+    );
+}
+
+#[test]
+fn group_and_ungroup_reject_the_opposite_axis_for_entire_ranges() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:B2").values = [[1, 2], [3, 4]];
+          const errors = [];
+          for (const action of [
+            () => sheet.getRange("1:2").group("ByColumns"),
+            () => sheet.getRange("A:B").ungroup("ByRows")
+          ]) {
+            try {
+              action();
+              await context.sync();
+            } catch (error) {
+              errors.push(error.code);
+            }
+          }
+          const read = sheet.getRange("A1:B2");
+          read.load("values");
+          await context.sync();
+          return { errors, values: read.values };
+        });
+        "#,
+    )
+    .expect("opposite-axis group operations should be catchable");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "errors": ["InvalidArgument", "InvalidArgument"],
+            "values": [[1, 2], [3, 4]]
+        })
+    );
+}

--- a/compute/officejs/tests/runtime_semantics.rs
+++ b/compute/officejs/tests/runtime_semantics.rs
@@ -1,0 +1,229 @@
+use mog::run_office_js;
+use serde_json::json;
+
+#[test]
+fn caught_run_rejection_does_not_reject_the_script() {
+    let output = run_office_js(
+        r#"
+      let code;
+      try {
+        await Excel.run(async context => {
+          context.workbook.worksheets.getItem("Missing");
+          await context.sync();
+        });
+      } catch (error) { code = error.code; }
+      return { code, continued: true };
+    "#,
+    )
+    .unwrap();
+    assert_eq!(
+        output.value,
+        json!({"code":"ItemNotFound","continued":true})
+    );
+}
+
+#[test]
+fn explicit_context_load_defaults_and_sync_passthrough() {
+    let output = run_office_js(r#"
+      const context = new Excel.RequestContext();
+      const sheet = context.workbook.worksheets.getItem("Sheet1");
+      const loadResult = context.load(sheet);
+      const token = { marker: 42 };
+      const returned = await context.sync(token);
+      return { name: sheet.name, same: returned === token,
+        base: context instanceof OfficeExtension.ClientRequestContext,
+        distinctBase: Excel.RequestContext.prototype instanceof OfficeExtension.ClientRequestContext,
+        baseHasNoWorkbook: new OfficeExtension.ClientRequestContext().workbook === undefined,
+        loadReturnsVoid: loadResult === undefined };
+    "#).unwrap();
+    assert_eq!(
+        output.value,
+        json!({"name":"Sheet1","same":true,"base":true,
+        "distinctBase":true,"baseHasNoWorkbook":true,"loadReturnsVoid":true})
+    );
+}
+
+#[test]
+fn setter_cache_and_fresh_proxy_have_distinct_read_contracts() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const assigned = sheet.getRange("A1");
+        assigned.values = [[17]];
+        const before = assigned.values;
+        const fresh = sheet.getRange("A1");
+        let unloaded;
+        try { fresh.values; } catch (error) {
+          unloaded = error.code === "PropertyNotLoaded" && error instanceof OfficeExtension.Error;
+        }
+        context.load(fresh, { select: "values" });
+        await context.sync();
+        return { before, after: fresh.values, unloaded };
+      });
+    "#,
+    )
+    .unwrap();
+    assert_eq!(
+        output.value,
+        json!({"before":[[17]],"after":[[17]],"unloaded":true})
+    );
+}
+
+#[test]
+fn whole_worksheet_range_reads_unbounded_cell_properties_as_null() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const range = context.workbook.worksheets.getItem("Sheet1").getRange();
+        range.load(["values", "formulas"]);
+        await context.sync();
+        return { values: range.values, formulas: range.formulas };
+      });
+    "#,
+    )
+    .unwrap();
+    assert_eq!(output.value, json!({"values":null,"formulas":null}));
+}
+
+#[test]
+fn documented_run_overloads_reuse_the_expected_context() {
+    let output = run_office_js(r#"
+      const explicit = new Excel.RequestContext();
+      const sheet = explicit.workbook.worksheets.getItem("Sheet1");
+      let contextOverload;
+      await Excel.run(explicit, async context => {
+        contextOverload = context === explicit;
+        await context.sync();
+      });
+
+      let objectOverload;
+      await Excel.run(sheet, async context => {
+        objectOverload = context === explicit;
+        sheet.load("name");
+        await context.sync();
+      });
+
+      const first = sheet.getRange("A1");
+      const second = sheet.getRange("B1");
+      let arrayOverload;
+      await Excel.run([first, second], async context => {
+        arrayOverload = context === explicit;
+        first.values = [[1]];
+        second.values = [[2]];
+        await context.sync();
+      });
+
+      let optionsPreviousObjects;
+      await Excel.run({ previousObjects: [first, second], delayForCellEdit: false }, async context => {
+        optionsPreviousObjects = context === explicit;
+        await context.sync();
+      });
+
+      let optionsNewContext;
+      await Excel.run({ delayForCellEdit: true }, async context => {
+        optionsNewContext = context instanceof Excel.RequestContext && context !== explicit;
+        await context.sync();
+      });
+
+      const callbackResult = await Excel.run(async context => {
+        await context.sync();
+        return sheet.name;
+      });
+      return { contextOverload, objectOverload, arrayOverload,
+        optionsPreviousObjects, optionsNewContext, callbackResult };
+    "#).unwrap();
+
+    assert_eq!(
+        output.value,
+        json!({
+            "contextOverload": true,
+            "objectOverload": true,
+            "arrayOverload": true,
+            "optionsPreviousObjects": true,
+            "optionsNewContext": true,
+            "callbackResult": "Sheet1"
+        })
+    );
+}
+
+#[test]
+fn run_rejects_invalid_context_sets_and_nonpromise_callbacks() {
+    let output = run_office_js(
+        r#"
+      async function errorCode(action) {
+        try { await action(); }
+        catch (error) {
+          return error instanceof OfficeExtension.Error ? error.code : "wrong-error-type";
+        }
+        return "missing-error";
+      }
+
+      const firstContext = new Excel.RequestContext();
+      const secondContext = new Excel.RequestContext();
+      const first = firstContext.workbook.worksheets.getItem("Sheet1");
+      const second = secondContext.workbook.worksheets.getItem("Sheet1");
+
+      const mixed = await errorCode(() => Excel.run([first, second], async () => {}));
+      const empty = await errorCode(() => Excel.run([], async () => {}));
+      const nonPromise = await errorCode(() => Excel.run(() => 42));
+      const inventedBatch = await errorCode(() => Excel.run({ batch: async () => {} }));
+      return { mixed, empty, nonPromise, inventedBatch };
+    "#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        output.value,
+        json!({
+            "mixed": "InvalidRequestContext",
+            "empty": "InvalidArgument",
+            "nonPromise": "RunMustReturnPromise",
+            "inventedBatch": "InvalidArgument"
+        })
+    );
+}
+
+#[test]
+fn client_result_and_null_object_guards_use_structured_errors() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const result = new OfficeExtension.ClientResult();
+        const range = context.workbook.worksheets.getItem("Sheet1").getRange("A1");
+        let resultError;
+        let nullObjectError;
+        try { result.value; } catch (error) {
+          resultError = {
+            code: error.code,
+            location: error.debugInfo.errorLocation,
+            standard: error instanceof OfficeExtension.Error
+          };
+        }
+        try { range.isNullObject; } catch (error) {
+          nullObjectError = {
+            code: error.code,
+            standard: error instanceof OfficeExtension.Error
+          };
+        }
+        return { resultError, nullObjectError };
+      });
+    "#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        output.value,
+        json!({
+            "resultError": {
+                "code": "ValueNotLoaded",
+                "location": "clientResult.value",
+                "standard": true
+            },
+            "nullObjectError": {
+                "code": "PropertyNotLoaded",
+                "standard": true
+            }
+        })
+    );
+}

--- a/compute/officejs/tests/sheet_layout_semantics.rs
+++ b/compute/officejs/tests/sheet_layout_semantics.rs
@@ -1,0 +1,244 @@
+//! Worksheet view, freeze-pane, and PageLayout semantics through Office.js.
+
+use compute_api::Workbook;
+use mog::run_office_js_with_workbook;
+use serde_json::json;
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn freeze_panes_preserve_the_other_axis_and_read_from_fresh_proxies() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const worksheets = context.workbook.worksheets;
+          const sheet = worksheets.getItem("Sheet1");
+          sheet.freezePanes.freezeRows(2);
+          sheet.freezePanes.freezeColumns(3);
+          await context.sync();
+
+          const both = worksheets.getItem("Sheet1").freezePanes.getLocation();
+          both.load("address");
+          await context.sync();
+
+          // A zero row count clears only row freezing and retains columns.
+          const sameSheet = worksheets.getItem("Sheet1");
+          sameSheet.freezePanes.freezeRows(0);
+          await context.sync();
+          const columns = worksheets.getItem("Sheet1").freezePanes.getLocation();
+          columns.load("address");
+          await context.sync();
+
+          worksheets.getItem("Sheet1").freezePanes.unfreeze();
+          await context.sync();
+          const none = worksheets.getItem("Sheet1").freezePanes.getLocationOrNullObject();
+          none.load("isNullObject");
+          await context.sync();
+
+          return {
+            both: both.address,
+            columns: columns.address,
+            noFrozenPane: none.isNullObject,
+          };
+        });
+        "#,
+    )
+    .expect("freeze panes should preserve axes and fresh reads");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "both": "Sheet1!A1:C2",
+            "columns": "Sheet1!A:C",
+            "noFrozenPane": true,
+        })
+    );
+}
+
+#[test]
+fn freeze_at_uses_the_selected_range_bottom_and_right_boundaries() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.freezePanes.freezeAt(sheet.getRange("H2:K5"));
+          await context.sync();
+
+          const fresh = context.workbook.worksheets.getItem("Sheet1");
+          const location = fresh.freezePanes.getLocation();
+          location.load("address");
+          await context.sync();
+          return location.address;
+        });
+        "#,
+    )
+    .expect("freezeAt should persist the pane boundary");
+
+    assert_eq!(output.value, json!("Sheet1!A1:K5"));
+}
+
+#[test]
+fn worksheet_view_properties_round_trip_through_persisted_state() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r##"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.showGridlines = false;
+          sheet.showHeadings = false;
+          sheet.tabColor = "#4285f4";
+          await context.sync();
+
+          const fresh = context.workbook.worksheets.getItem("Sheet1");
+          fresh.load(["showGridlines", "showHeadings", "tabColor"]);
+          await context.sync();
+          return fresh.toJSON();
+        });
+        "##,
+    )
+    .expect("worksheet view properties should round-trip");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "showGridlines": false,
+            "showHeadings": false,
+            "tabColor": "#4285f4",
+        })
+    );
+}
+
+#[test]
+fn page_layout_scalars_round_trip_with_office_units_and_enum_tokens() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.pageLayout.set({
+            orientation: "Landscape",
+            paperSize: "A4",
+            printComments: "EndSheet",
+            printErrors: "Dash",
+            printGridlines: true,
+            printHeadings: true,
+            centerHorizontally: true,
+            centerVertically: true,
+            blackAndWhite: true,
+            draftMode: true,
+            firstPageNumber: 3,
+            printOrder: "OverThenDown",
+            printQuality: [300, 600],
+            topMargin: 72,
+            bottomMargin: 36,
+            leftMargin: 50.4,
+            rightMargin: 72,
+            headerMargin: 18,
+            footerMargin: 21.6,
+            zoom: { scale: 120 },
+          });
+          await context.sync();
+
+          const fresh = context.workbook.worksheets.getItem("Sheet1").pageLayout;
+          fresh.load([
+            "orientation", "paperSize", "printComments", "printErrors",
+            "printGridlines", "printHeadings", "centerHorizontally",
+            "centerVertically", "blackAndWhite", "draftMode", "firstPageNumber",
+            "printOrder", "printQuality", "topMargin", "bottomMargin",
+            "leftMargin", "rightMargin", "headerMargin", "footerMargin", "zoom",
+          ]);
+          await context.sync();
+          return fresh.toJSON();
+        });
+        "#,
+    )
+    .expect("PageLayout scalar fields should round-trip");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "orientation": "Landscape",
+            "paperSize": "A4",
+            "printComments": "EndSheet",
+            "printErrors": "Dash",
+            "printGridlines": true,
+            "printHeadings": true,
+            "centerHorizontally": true,
+            "centerVertically": true,
+            "blackAndWhite": true,
+            "draftMode": true,
+            "firstPageNumber": 3,
+            "printOrder": "OverThenDown",
+            "printQuality": [300, 600],
+            "topMargin": 72.0,
+            "bottomMargin": 36.0,
+            "leftMargin": 50.4,
+            "rightMargin": 72.0,
+            "headerMargin": 18.0,
+            "footerMargin": 21.6,
+            "zoom": {
+                "horizontalFitToPages": null,
+                "scale": 120,
+                "verticalFitToPages": null,
+            },
+        })
+    );
+}
+
+#[test]
+fn page_layout_print_area_titles_and_margins_use_typed_primitives() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const layout = context.workbook.worksheets.getItem("Sheet1").pageLayout;
+          layout.setPrintArea("B2:D8");
+          layout.setPrintTitleRows("1:2");
+          layout.setPrintTitleColumns("A:C");
+          layout.setPrintMargins("Inches", { top: 1, left: 0.5 });
+          await context.sync();
+
+          const fresh = context.workbook.worksheets.getItem("Sheet1").pageLayout;
+          const area = fresh.getPrintArea();
+          const rows = fresh.getPrintTitleRows();
+          const columns = fresh.getPrintTitleColumns();
+          area.load(["address", "areaCount"]);
+          rows.load("address");
+          columns.load("address");
+          await context.sync();
+
+          const settings = context.workbook.worksheets.getItem("Sheet1").pageLayout;
+          settings.load(["topMargin", "leftMargin"]);
+          await context.sync();
+          return {
+            area: area.toJSON(),
+            rows: rows.address,
+            columns: columns.address,
+            topMargin: settings.topMargin,
+            leftMargin: settings.leftMargin,
+          };
+        });
+        "#,
+    )
+    .expect("PageLayout print primitives should round-trip");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "area": { "address": "Sheet1!B2:D8", "areaCount": 1 },
+            "rows": "Sheet1!1:2",
+            "columns": "Sheet1!A:C",
+            "topMargin": 72.0,
+            "leftMargin": 36.0,
+        })
+    );
+}

--- a/compute/officejs/tests/sort_filter_semantics.rs
+++ b/compute/officejs/tests/sort_filter_semantics.rs
@@ -1,0 +1,197 @@
+//! Office.js RangeSort and Worksheet AutoFilter behavior through the shipped
+//! headless runtime.
+
+use mog::{OfficeJsError, run_office_js};
+use serde_json::json;
+
+#[test]
+fn range_sort_orders_rows_as_pairs_and_preserves_header() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const range = sheet.getRange("A1:C4");
+          range.values = [
+            ["Name", "Score", "Tag"],
+            ["Alice", 30, "a"],
+            ["Bob", 10, "b"],
+            ["Cara", 20, "c"]
+          ];
+          range.sort.apply([{ key: 1, ascending: true }], false, true);
+          range.load("values");
+          await context.sync();
+          return range.values;
+        });
+        "#,
+    )
+    .expect("Range.sort.apply should sort through compute-api");
+
+    assert_eq!(
+        output.value,
+        json!([
+            ["Name", "Score", "Tag"],
+            ["Bob", 10, "b"],
+            ["Cara", 20, "c"],
+            ["Alice", 30, "a"]
+        ])
+    );
+}
+
+#[test]
+fn auto_filter_values_hides_rows_and_clear_reveals_them() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const data = sheet.getRange("A1:B5");
+          data.values = [
+            ["Name", "Status"],
+            ["Alice", "Open"],
+            ["Bob", "Closed"],
+            ["Cara", "Open"],
+            ["Dan", "Pending"]
+          ];
+          const visibleCount = sheet.getRange("D1");
+          visibleCount.formulas = [["=SUBTOTAL(103,A2:A5)"]];
+          await context.sync();
+
+          const autoFilter = sheet.autoFilter;
+          autoFilter.apply("A1:B5", 1, {
+            filterOn: "Values",
+            values: ["Open"]
+          });
+          autoFilter.load(["enabled", "isDataFiltered", "criteria"]);
+          visibleCount.load("values");
+          await context.sync();
+          const filtered = {
+            count: visibleCount.values[0][0],
+            enabled: autoFilter.enabled,
+            isDataFiltered: autoFilter.isDataFiltered,
+            criteria: autoFilter.criteria
+          };
+
+          autoFilter.clearCriteria();
+          autoFilter.load(["enabled", "isDataFiltered", "criteria"]);
+          visibleCount.load("values");
+          await context.sync();
+          return {
+            filtered,
+            cleared: {
+              count: visibleCount.values[0][0],
+              enabled: autoFilter.enabled,
+              isDataFiltered: autoFilter.isDataFiltered,
+              criteria: autoFilter.criteria
+            }
+          };
+        });
+        "#,
+    )
+    .expect("AutoFilter values criteria should update row visibility");
+
+    assert_eq!(output.value["filtered"]["count"], json!(2));
+    assert_eq!(output.value["filtered"]["enabled"], json!(true));
+    assert_eq!(output.value["filtered"]["isDataFiltered"], json!(true));
+    assert_eq!(
+        output.value["filtered"]["criteria"],
+        json!([null, {"filterOn": "Values", "values": ["Open"]}])
+    );
+    assert_eq!(output.value["cleared"]["count"], json!(4));
+    assert_eq!(output.value["cleared"]["enabled"], json!(true));
+    assert_eq!(output.value["cleared"]["isDataFiltered"], json!(false));
+}
+
+#[test]
+fn auto_filter_custom_numeric_threshold_maps_to_condition_engine() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:B5").values = [
+            ["Name", "Score"],
+            ["Alice", 30],
+            ["Bob", 60],
+            ["Cara", 90],
+            ["Dan", 40]
+          ];
+          const visibleCount = sheet.getRange("D1");
+          visibleCount.formulas = [["=SUBTOTAL(103,A2:A5)"]];
+          await context.sync();
+
+          const autoFilter = sheet.autoFilter;
+          autoFilter.apply("A1:B5", 1, {
+            filterOn: "Custom",
+            criterion1: ">50"
+          });
+          autoFilter.load("criteria");
+          visibleCount.load("values");
+          await context.sync();
+          return { count: visibleCount.values[0][0], criteria: autoFilter.criteria };
+        });
+        "#,
+    )
+    .expect("AutoFilter custom threshold should update row visibility");
+
+    assert_eq!(output.value["count"], json!(2));
+    assert_eq!(
+        output.value["criteria"],
+        json!([null, {"filterOn": "Custom", "criterion1": ">50"}])
+    );
+}
+
+#[test]
+fn auto_filter_remove_disables_surface_and_rejects_unsupported_icons() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:B2").values = [["Name", "Status"], ["Alice", "Open"]];
+          const autoFilter = sheet.autoFilter;
+          autoFilter.apply("A1:B2");
+          autoFilter.remove();
+          autoFilter.load(["enabled", "isDataFiltered"]);
+          await context.sync();
+          let unsupported;
+          try {
+            autoFilter.apply("A1:B2", 1, {
+              filterOn: "Icon",
+              icon: { set: "ThreeArrows", index: 0 }
+            });
+            await context.sync();
+          } catch (error) {
+            unsupported = error.code;
+          }
+          return { enabled: autoFilter.enabled, isDataFiltered: autoFilter.isDataFiltered, unsupported };
+        });
+        "#,
+    )
+    .expect("AutoFilter remove should complete");
+
+    assert_eq!(
+        output.value,
+        json!({"enabled": false, "isDataFiltered": false, "unsupported": "UnsupportedOperation"})
+    );
+}
+
+#[test]
+fn range_sort_rejects_column_orientation_explicitly() {
+    let error = run_office_js(
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const range = sheet.getRange("A1:B2");
+          range.values = [["A", "B"], [1, 2]];
+          range.sort.apply([{ key: 0 }], false, false, "Columns");
+          await context.sync();
+        });
+        "#,
+    )
+    .expect_err("column orientation should be reported as unsupported");
+
+    match error {
+        OfficeJsError::Script(message) => {
+            assert!(message.contains("UnsupportedOperation"), "{message}");
+            assert!(message.contains("Columns"), "{message}");
+        }
+        other => panic!("expected script error, got {other}"),
+    }
+}

--- a/compute/officejs/tests/table_collection_semantics.rs
+++ b/compute/officejs/tests/table_collection_semantics.rs
@@ -1,0 +1,299 @@
+//! Office.js table row/column collection semantics.
+//!
+//! These tests deliberately go through `run_office_js`, including collection
+//! loading, child binding, and range access.  They are kept separate from the
+//! table lifecycle tests so a collection regression cannot hide behind the
+//! table proxy's scalar properties.
+
+use mog::run_office_js;
+use serde_json::json;
+
+#[test]
+fn fresh_collection_load_hydrates_columns_and_data_rows() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B4").values = [
+          ["Product", "Amount"],
+          ["Pen", 4],
+          ["Paper", 9],
+          ["Book", 12]
+        ];
+        const table = sheet.tables.add("A1:B4", true);
+        table.name = "Orders";
+
+        const columns = table.columns;
+        const rows = table.rows;
+        columns.load(["count", "items"]);
+        rows.load(["count", "items"]);
+        await context.sync();
+
+        const firstColumn = columns.items[0];
+        const numericLookup = columns.getItem(firstColumn.id);
+        numericLookup.load(["id", "index", "name"]);
+        const firstBody = firstColumn.getDataBodyRange();
+        firstBody.load(["address", "values"]);
+        await context.sync();
+
+        return {
+          columnCount: columns.count,
+          columns: columns.items.map(column => ({
+            id: column.id,
+            index: column.index,
+            name: column.name,
+            values: column.values
+          })),
+            rowCount: rows.count,
+            rows: rows.items.map(row => ({ index: row.index, values: row.values })),
+            numericLookup: {
+              id: numericLookup.id,
+              index: numericLookup.index,
+              name: numericLookup.name
+            },
+            firstBody: { address: firstBody.address, values: firstBody.values },
+            types: {
+            columns: columns instanceof Excel.TableColumnCollection,
+            column: columns.items[0] instanceof Excel.TableColumn,
+            rows: rows instanceof Excel.TableRowCollection,
+            row: rows.items[0] instanceof Excel.TableRow,
+            clientObject: rows.items[0] instanceof OfficeExtension.ClientObject
+          }
+        };
+      });
+    "#,
+    )
+    .expect("collection load should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "columnCount": 2,
+            "columns": [
+                {"id": output.value["columns"][0]["id"], "index": 0, "name": "Product", "values": [["Pen"], ["Paper"], ["Book"]]},
+                {"id": output.value["columns"][1]["id"], "index": 1, "name": "Amount", "values": [[4], [9], [12]]}
+            ],
+            "rowCount": 3,
+            "rows": [
+                {"index": 0, "values": [["Pen", 4]]},
+                {"index": 1, "values": [["Paper", 9]]},
+                {"index": 2, "values": [["Book", 12]]}
+            ],
+            "numericLookup": {
+                "id": output.value["columns"][0]["id"],
+                "index": 0,
+                "name": "Product"
+            },
+            "firstBody": {
+                "address": "Sheet1!A2:A4",
+                "values": [["Pen"], ["Paper"], ["Book"]]
+            },
+            "types": {
+                "columns": true,
+                "column": true,
+                "rows": true,
+                "row": true,
+                "clientObject": true
+            }
+        })
+    );
+    assert!(output.value["columns"][0]["id"].as_u64().is_some());
+    assert!(output.value["columns"][1]["id"].as_u64().is_some());
+    assert_ne!(
+        output.value["columns"][0]["id"],
+        output.value["columns"][1]["id"]
+    );
+}
+
+#[test]
+fn row_append_middle_insert_delete_preserve_neighbor_order_and_ranges() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:C5").values = [
+          ["Product", "Amount", "Side"],
+          ["A", 1, "side-1"],
+          ["B", 2, "side-2"],
+          ["C", 3, "side-3"],
+          ["tail", 99, "side-4"]
+        ];
+        const table = sheet.tables.add("A1:B4", true);
+        table.name = "Orders";
+        await context.sync();
+
+        table.rows.add(-1, [["D", 4]]);
+        await context.sync();
+        const afterAppend = table.getDataBodyRange();
+        afterAppend.load(["address", "values"]);
+        await context.sync();
+
+        table.rows.add(1, [["X", 10]]);
+        await context.sync();
+        const afterInsert = table.getDataBodyRange();
+        const sideAfterInsert = sheet.getRange("C1:C6");
+        afterInsert.load(["address", "values"]);
+        sideAfterInsert.load("values");
+        await context.sync();
+
+        table.rows.getItemAt(1).delete();
+        await context.sync();
+        const afterDelete = table.getDataBodyRange();
+        const sideAfterDelete = sheet.getRange("C1:C6");
+        afterDelete.load(["address", "values"]);
+        sideAfterDelete.load("values");
+        await context.sync();
+
+        return {
+          afterAppend: { address: afterAppend.address, values: afterAppend.values },
+          afterInsert: { address: afterInsert.address, values: afterInsert.values },
+          afterDelete: { address: afterDelete.address, values: afterDelete.values },
+          sideAfterInsert: sideAfterInsert.values,
+          sideAfterDelete: sideAfterDelete.values
+        };
+      });
+    "#,
+    )
+    .expect("row collection mutations should succeed");
+
+    assert_eq!(
+        output.value["afterAppend"],
+        json!({"address": "Sheet1!A2:B5", "values": [["A", 1], ["B", 2], ["C", 3], ["D", 4]]})
+    );
+    assert_eq!(
+        output.value["afterInsert"],
+        json!({"address": "Sheet1!A2:B6", "values": [["A", 1], ["X", 10], ["B", 2], ["C", 3], ["D", 4]]})
+    );
+    assert_eq!(
+        output.value["afterDelete"],
+        json!({"address": "Sheet1!A2:B5", "values": [["A", 1], ["B", 2], ["C", 3], ["D", 4]]})
+    );
+    assert_eq!(
+        output.value["sideAfterInsert"],
+        json!([["Side"], ["side-1"], [""], ["side-2"], ["side-3"], [""]])
+    );
+    assert_eq!(
+        output.value["sideAfterDelete"],
+        json!([
+            ["Side"],
+            ["side-1"],
+            ["side-2"],
+            ["side-3"],
+            [""],
+            ["side-4"]
+        ])
+    );
+}
+
+#[test]
+fn always_insert_false_uses_blank_space_and_shifts_occupied_neighbors() {
+    let empty_below = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:C3").values = [
+          ["Product", "Amount", "Side"],
+          ["A", 1, "side-1"],
+          ["B", 2, "side-2"]
+        ];
+        const table = sheet.tables.add("A1:B3", true);
+        const added = table.rows.add(-1, [["E", 5]], false);
+        added.load(["index", "values"]);
+        const body = table.getDataBodyRange();
+        const below = sheet.getRange("A4:C4");
+        body.load(["address", "values"]);
+        below.load("values");
+        await context.sync();
+        return {
+          added: { index: added.index, values: added.values },
+          body: { address: body.address, values: body.values },
+          below: below.values
+        };
+      });
+    "#,
+    )
+    .expect("alwaysInsert:false should use an empty row below the table");
+
+    assert_eq!(
+        empty_below.value,
+        json!({
+            "added": {"index": 2, "values": [["E", 5]]},
+            "body": {"address": "Sheet1!A2:B3", "values": [["A", 1], ["B", 2]]},
+            "below": [["E", 5, ""]]
+        })
+    );
+
+    let occupied_below = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:C4").values = [
+          ["Product", "Amount", "Side"],
+          ["A", 1, "side-1"],
+          ["B", 2, "side-2"],
+          ["tail", 99, "side-tail"]
+        ];
+        const table = sheet.tables.add("A1:B3", true);
+        const added = table.rows.add(-1, [["E", 5]], false);
+        added.load(["index", "values"]);
+        const body = table.getDataBodyRange();
+        const neighbors = sheet.getRange("A4:C5");
+        body.load(["address", "values"]);
+        neighbors.load("values");
+        await context.sync();
+        return {
+          added: { index: added.index, values: added.values },
+          body: { address: body.address, values: body.values },
+          neighbors: neighbors.values
+        };
+      });
+    "#,
+    )
+    .expect("alwaysInsert:false should shift occupied rows below the table");
+
+    assert_eq!(
+        occupied_below.value,
+        json!({
+            "added": {"index": 2, "values": [["E", 5]]},
+            "body": {"address": "Sheet1!A2:B3", "values": [["A", 1], ["B", 2]]},
+            "neighbors": [["E", 5, ""], ["tail", 99, "side-tail"]]
+        })
+    );
+}
+
+#[test]
+fn collection_children_reject_unloaded_reads_and_wrong_value_shapes() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B2").values = [["A", "B"], [1, 2]];
+        const table = sheet.tables.add("A1:B2", true);
+        await context.sync();
+
+        let unloaded;
+        try { table.columns.getItemAt(0).name; }
+        catch (error) { unloaded = error.code; }
+
+        let wrongShape;
+        try {
+          table.rows.getItemAt(0).values = [[1]];
+          await context.sync();
+        } catch (error) { wrongShape = error.code; }
+
+        let missing;
+        try {
+          table.columns.getItem("Missing");
+          await context.sync();
+        } catch (error) { missing = error.code; }
+        return { unloaded, wrongShape, missing };
+      });
+    "#,
+    )
+    .expect("collection error probes should be catchable");
+
+    assert_eq!(
+        output.value,
+        json!({"unloaded": "PropertyNotLoaded", "wrongShape": "InvalidArgument", "missing": "ItemNotFound"})
+    );
+}

--- a/compute/officejs/tests/table_filter_semantics.rs
+++ b/compute/officejs/tests/table_filter_semantics.rs
@@ -1,0 +1,189 @@
+use mog::run_office_js;
+use serde_json::json;
+
+#[test]
+fn table_sort_applies_to_data_rows_and_preserves_headers() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:C4").values = [
+          ["Name", "Score", "Group"],
+          ["first", 4, "A"],
+          ["second", 9, "B"],
+          ["third", 1, "C"]
+        ];
+        const table = sheet.tables.add("A1:C4", true);
+        table.name = "Scores";
+        table.sort.apply([{ key: 1, ascending: true }]);
+        const header = table.getHeaderRowRange();
+        const body = table.getDataBodyRange();
+        header.load("values");
+        body.load("values");
+        await context.sync();
+        return { header: header.values, body: body.values };
+      });
+    "#,
+    )
+    .expect("table sort should use the production range sorter");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "header": [["Name", "Score", "Group"]],
+            "body": [["third", 1, "C"], ["first", 4, "A"], ["second", 9, "B"]]
+        })
+    );
+}
+
+#[test]
+fn table_filter_values_and_custom_criteria_persist_and_clear() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B5").values = [
+          ["Status", "Amount"],
+          ["Open", 10],
+          ["Closed", 20],
+          ["Open", 30],
+          ["Pending", 40]
+        ];
+        const table = sheet.tables.add("A1:B5", true);
+        table.name = "Orders";
+
+        const status = table.columns.getItemAt(0).filter;
+        status.applyValuesFilter(["Open"]);
+        status.load("criteria");
+        await context.sync();
+        const valuesCriteria = status.criteria;
+
+        const amount = table.columns.getItemAt(1).filter;
+        amount.applyCustomFilter(">15", "<35", "And");
+        amount.load("criteria");
+        await context.sync();
+        const customCriteria = amount.criteria;
+
+        amount.clear();
+        amount.load("criteria");
+        await context.sync();
+        return { valuesCriteria, customCriteria, cleared: amount.criteria };
+      });
+    "#,
+    )
+    .expect("table filters should use durable SheetFilters state");
+
+    assert_eq!(
+        output.value["valuesCriteria"],
+        json!({"filterOn": "Values", "values": ["Open"]})
+    );
+    assert_eq!(
+        output.value["customCriteria"],
+        json!({
+            "filterOn": "Custom",
+            "criterion1": ">15",
+            "criterion2": "<35",
+            "operator": "And"
+        })
+    );
+    assert_eq!(
+        output.value["cleared"],
+        json!({"filterOn": "Values", "values": []})
+    );
+}
+
+#[test]
+fn table_filter_wrappers_cover_top_bottom_percent_and_dynamic_rules() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B6").values = [
+          ["Name", "Score"],
+          ["A", 1],
+          ["B", 2],
+          ["C", 3],
+          ["D", 4],
+          ["E", 5]
+        ];
+        const table = sheet.tables.add("A1:B6", true);
+        table.name = "Scores";
+        const filter = table.columns.getItemAt(1).filter;
+
+        filter.applyTopItemsFilter(2);
+        filter.load("criteria");
+        await context.sync();
+        const top = filter.criteria;
+
+        filter.applyBottomPercentFilter(40);
+        filter.load("criteria");
+        await context.sync();
+        const bottomPercent = filter.criteria;
+
+        filter.applyDynamicFilter("AboveAverage");
+        filter.load("criteria");
+        await context.sync();
+        return { top, bottomPercent, dynamic: filter.criteria };
+      });
+    "#,
+    )
+    .expect("table filter convenience methods should persist");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "top": {"filterOn": "TopItems", "criterion1": "2"},
+            "bottomPercent": {"filterOn": "BottomPercent", "criterion1": "40"},
+            "dynamic": {"filterOn": "Dynamic", "dynamicCriteria": "AboveAverage"}
+        })
+    );
+}
+
+#[test]
+fn table_sort_and_filter_reject_unsupported_or_out_of_bounds_descriptors() {
+    let output = run_office_js(
+        r#"
+      await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B3").values = [
+          ["Name", "Score"],
+          ["A", 2],
+          ["B", 1]
+        ];
+        const table = sheet.tables.add("A1:B3", true);
+        table.name = "Scores";
+        await context.sync();
+      });
+
+      let sortCode;
+      try {
+        await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const table = sheet.tables.getItem("Scores");
+          table.sort.apply([{ key: 2 }]);
+          await context.sync();
+        });
+      } catch (error) { sortCode = error.code; }
+
+      let iconCode;
+      try {
+        await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const table = sheet.tables.getItem("Scores");
+          table.columns.getItemAt(0).filter.applyIconFilter({
+            set: "ThreeArrows",
+            index: 0
+          });
+          await context.sync();
+        });
+      } catch (error) { iconCode = error.code; }
+      return { sortCode, iconCode };
+    "#,
+    )
+    .expect("descriptor failures should be observable at sync");
+
+    assert_eq!(
+        output.value,
+        json!({"sortCode": "InvalidArgument", "iconCode": "UnsupportedOperation"})
+    );
+}

--- a/compute/officejs/tests/table_semantics.rs
+++ b/compute/officejs/tests/table_semantics.rs
@@ -1,0 +1,646 @@
+use mog::run_office_js;
+use serde_json::json;
+
+#[test]
+fn table_add_load_rename_and_ranges_use_persistent_engine_state() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B3").values = [
+          ["Product", "Amount"],
+          ["Pen", 4],
+          ["Paper", 9]
+        ];
+        const table = sheet.tables.add("A1:B3", true);
+        table.name = "Orders";
+        table.load(["id", "name", "style", "showHeaders", "showTotals"]);
+        const all = table.getRange();
+        const header = table.getHeaderRowRange();
+        const body = table.getDataBodyRange();
+        all.load(["address", "values"]);
+        header.load(["address", "values"]);
+        body.load(["address", "values"]);
+        await context.sync();
+        return {
+          table: table.toJSON(),
+          stableId: table.id.indexOf("tbl-") === 0,
+          ranges: {
+            all: { address: all.address, values: all.values },
+            header: { address: header.address, values: header.values },
+            body: { address: body.address, values: body.values }
+          },
+          types: {
+            table: table instanceof Excel.Table,
+            collection: sheet.tables instanceof Excel.TableCollection,
+            clientObject: table instanceof OfficeExtension.ClientObject
+          }
+        };
+      });
+    "#,
+    )
+    .expect("table batch should succeed");
+
+    assert_eq!(output.value["table"]["name"], json!("Orders"));
+    assert_eq!(output.value["table"]["style"], json!("TableStyleMedium2"));
+    assert_eq!(output.value["table"]["showHeaders"], json!(true));
+    assert_eq!(output.value["table"]["showTotals"], json!(false));
+    assert_eq!(output.value["stableId"], json!(true));
+    assert_eq!(
+        output.value["ranges"]["all"]["address"],
+        json!("Sheet1!A1:B3")
+    );
+    assert_eq!(
+        output.value["ranges"]["header"]["values"],
+        json!([["Product", "Amount"]])
+    );
+    assert_eq!(
+        output.value["ranges"]["body"]["values"],
+        json!([["Pen", 4], ["Paper", 9]])
+    );
+    assert_eq!(
+        output.value["types"],
+        json!({
+            "table": true,
+            "collection": true,
+            "clientObject": true
+        })
+    );
+}
+
+#[test]
+fn range_overload_and_get_item_by_stable_id_survive_rename() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const source = sheet.getRange("C2:D4");
+        source.values = [["A", "B"], [1, 2], [3, 4]];
+        const created = sheet.tables.add(source, true);
+        created.load("id");
+        await context.sync();
+
+        const originalId = created.id;
+        created.name = "RenamedTable";
+        await context.sync();
+
+        const fetched = sheet.tables.getItem(originalId);
+        fetched.load(["id", "name"]);
+        const body = fetched.getDataBodyRange();
+        body.load(["address", "values"]);
+        await context.sync();
+        return { originalId, fetchedId: fetched.id, name: fetched.name,
+          address: body.address, values: body.values };
+      });
+    "#,
+    )
+    .expect("stable-id lookup should succeed");
+
+    assert_eq!(output.value["fetchedId"], output.value["originalId"]);
+    assert_eq!(output.value["name"], json!("RenamedTable"));
+    assert_eq!(output.value["address"], json!("Sheet1!C3:D4"));
+    assert_eq!(output.value["values"], json!([[1, 2], [3, 4]]));
+}
+
+#[test]
+fn table_add_without_source_headers_generates_headers_and_shifts_data() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B2").values = [[1, 2], [3, 4]];
+        const table = sheet.tables.add("A1:B2", false);
+        table.load("showHeaders");
+        const full = table.getRange();
+        const header = table.getHeaderRowRange();
+        const body = table.getDataBodyRange();
+        full.load(["address", "values"]);
+        header.load("values");
+        body.load("values");
+        await context.sync();
+        return {
+          showHeaders: table.showHeaders,
+          address: full.address,
+          full: full.values,
+          header: header.values,
+          body: body.values
+        };
+      });
+    "#,
+    )
+    .expect("header generation should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "showHeaders": true,
+            "address": "Sheet1!A1:B3",
+            "full": [["Column1", "Column2"], [1, 2], [3, 4]],
+            "header": [["Column1", "Column2"]],
+            "body": [[1, 2], [3, 4]]
+        })
+    );
+}
+
+#[test]
+fn rejected_headerless_overlap_does_not_shift_worksheet_data() {
+    let output = run_office_js(
+        r#"
+      await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:C3").values = [
+          ["A", "B", "side"],
+          [1, 2, "below"],
+          ["tailA", "tailB", "tailC"]
+        ];
+        const existing = sheet.tables.add("A1:B2", true);
+        existing.name = "Existing";
+        await context.sync();
+      });
+
+      let code;
+      try {
+        await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.tables.add("A1:B2", false);
+          await context.sync();
+        });
+      } catch (error) { code = error.code; }
+
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        const cells = sheet.getRange("A1:C3");
+        const existing = sheet.tables.getItem("Existing");
+        const tableRange = existing.getRange();
+        cells.load("values");
+        tableRange.load("address");
+        await context.sync();
+        return { code, values: cells.values, tableAddress: tableRange.address };
+      });
+    "#,
+    )
+    .expect("overlap rejection should be observable without corrupting data");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "code": "InvalidArgument",
+            "values": [
+                ["A", "B", "side"],
+                [1, 2, "below"],
+                ["tailA", "tailB", "tailC"]
+            ],
+            "tableAddress": "Sheet1!A1:B2"
+        })
+    );
+}
+
+#[test]
+fn table_scalar_setters_persist_for_fresh_proxies() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B2").values = [["A", "B"], [1, 2]];
+        const created = sheet.tables.add("A1:B2", true);
+        created.name = "Styled";
+        created.style = "TableStyleLight1";
+        created.showHeaders = false;
+        created.showTotals = true;
+        await context.sync();
+
+        const fetched = sheet.tables.getItem("Styled");
+        fetched.load(["name", "style", "showHeaders", "showTotals"]);
+        await context.sync();
+        return fetched.toJSON();
+      });
+    "#,
+    )
+    .expect("table setters should persist");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "name": "Styled",
+            "style": "TableStyleLight1",
+            "showHeaders": false,
+            "showTotals": true
+        })
+    );
+}
+
+#[test]
+fn table_style_flags_load_from_engine_metadata_and_serialize() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B2").values = [["A", "B"], [1, 2]];
+        const table = sheet.tables.add("A1:B2", true);
+        table.load([
+          "highlightFirstColumn",
+          "highlightLastColumn",
+          "showBandedRows",
+          "showBandedColumns",
+          "showFilterButton"
+        ]);
+        await context.sync();
+        return table.toJSON();
+      });
+    "#,
+    )
+    .expect("table style flags should load");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "highlightFirstColumn": false,
+            "highlightLastColumn": false,
+            "showBandedRows": true,
+            "showBandedColumns": false,
+            "showFilterButton": true
+        })
+    );
+}
+
+#[test]
+fn table_style_flags_set_allowlist_round_trips_through_engine() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B2").values = [["A", "B"], [1, 2]];
+        const table = sheet.tables.add("A1:B2", true);
+        table.name = "Styled";
+        await context.sync();
+
+        table.set({
+          highlightFirstColumn: true,
+          highlightLastColumn: true,
+          showBandedRows: false,
+          showBandedColumns: true,
+          showFilterButton: false
+        });
+        await context.sync();
+
+        const fresh = sheet.tables.getItem("Styled");
+        fresh.load([
+          "highlightFirstColumn",
+          "highlightLastColumn",
+          "showBandedRows",
+          "showBandedColumns",
+          "showFilterButton"
+        ]);
+        await context.sync();
+        return fresh.toJSON();
+      });
+    "#,
+    )
+    .expect("table style flags should persist");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "highlightFirstColumn": true,
+            "highlightLastColumn": true,
+            "showBandedRows": false,
+            "showBandedColumns": true,
+            "showFilterButton": false
+        })
+    );
+}
+
+#[test]
+fn table_filter_button_set_requires_a_header_row() {
+    let output = run_office_js(
+        r#"
+      let code;
+      await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B2").values = [["A", "B"], [1, 2]];
+        const table = sheet.tables.add("A1:B2", true);
+        await context.sync();
+
+        table.showHeaders = false;
+        await context.sync();
+        try {
+          table.showFilterButton = false;
+          await context.sync();
+        } catch (error) { code = error.code; }
+      });
+      return code;
+    "#,
+    )
+    .expect("filter button header validation should be observable");
+
+    assert_eq!(output.value, json!("InvalidArgument"));
+}
+
+#[test]
+fn table_get_item_reports_office_item_not_found() {
+    let output = run_office_js(
+        r#"
+      let code;
+      try {
+        await Excel.run(async context => {
+          context.workbook.worksheets.getItem("Sheet1").tables.getItem("Missing");
+          await context.sync();
+        });
+      } catch (error) { code = error.code; }
+      return code;
+    "#,
+    )
+    .expect("script should catch lookup rejection");
+
+    assert_eq!(output.value, json!("ItemNotFound"));
+}
+
+#[test]
+fn table_add_rejects_a_range_from_another_request_context() {
+    let output = run_office_js(
+        r#"
+      const first = new Excel.RequestContext();
+      const second = new Excel.RequestContext();
+      const sheet = first.workbook.worksheets.getItem("Sheet1");
+      const foreign = second.workbook.worksheets.getItem("Sheet1").getRange("A1:B2");
+      let code;
+      try { sheet.tables.add(foreign, true); }
+      catch (error) { code = error.code; }
+      const source = sheet.getRange("A1:B2");
+      source.values = [["kept", 1], ["data", 2]];
+      await first.sync();
+      const cells = sheet.getRange("A1:B2");
+      const tables = sheet.tables;
+      cells.load("values");
+      tables.load("count");
+      await first.sync();
+      return {
+        code,
+        values: cells.values,
+        tableCount: tables.count,
+        api: {
+          collection: tables instanceof Excel.TableCollection,
+          clientObject: tables instanceof OfficeExtension.ClientObject
+        }
+      };
+    "#,
+    )
+    .expect("script should catch the cross-context error");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "code": "InvalidRequestContext",
+            "values": [["kept", 1], ["data", 2]],
+            "tableCount": 0,
+            "api": {"collection": true, "clientObject": true}
+        })
+    );
+}
+
+#[test]
+fn workbook_and_worksheet_table_collections_hydrate_items_and_counts() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B2").values = [["A", "B"], [1, 2]];
+        sheet.getRange("D1:E2").values = [["C", "D"], [3, 4]];
+        sheet.tables.add("A1:B2", true).name = "First";
+        sheet.tables.add("D1:E2", true).name = "Second";
+        await context.sync();
+
+        const workbookTables = context.workbook.tables;
+        const worksheetTables = sheet.tables;
+        workbookTables.load(["count", "items/id", "items/name"]);
+        worksheetTables.load(["count", "items/name"]);
+        const workbookCount = workbookTables.getCount();
+        const worksheetCount = worksheetTables.getCount();
+        const second = workbookTables.getItemAt(1);
+        second.load(["id", "name"]);
+        const missing = worksheetTables.getItemOrNullObject("Missing");
+        missing.load("isNullObject");
+        await context.sync();
+        return {
+          workbookCount: workbookCount.value,
+          worksheetCount: worksheetCount.value,
+          workbookItems: workbookTables.items.map(table => ({
+            type: table instanceof Excel.Table,
+            id: table.id,
+            name: table.name
+          })),
+          worksheetItems: worksheetTables.items.map(table => table.name),
+          second: second.toJSON(),
+          missing: missing.isNullObject,
+          collectionTypes: {
+            workbook: workbookTables instanceof Excel.TableCollection,
+            worksheet: worksheetTables instanceof Excel.TableCollection
+          }
+        };
+      });
+    "#,
+    )
+    .expect("workbook and worksheet table collections should succeed");
+
+    assert_eq!(output.value["workbookCount"], json!(2));
+    assert_eq!(output.value["worksheetCount"], json!(2));
+    assert_eq!(
+        output.value["workbookItems"]
+            .as_array()
+            .expect("workbook items")
+            .iter()
+            .map(|item| item["name"].clone())
+            .collect::<Vec<_>>(),
+        vec![json!("First"), json!("Second")]
+    );
+    assert!(output.value["workbookItems"]
+        .as_array()
+        .expect("workbook items")
+        .iter()
+        .all(|item| item["type"] == json!(true)));
+    assert_eq!(output.value["worksheetItems"], json!(["First", "Second"]));
+    assert_eq!(output.value["second"]["name"], json!("Second"));
+    assert_eq!(output.value["missing"], json!(true));
+    assert_eq!(
+        output.value["collectionTypes"],
+        json!({"workbook": true, "worksheet": true})
+    );
+}
+
+#[test]
+fn workbook_table_add_uses_active_sheet_for_unqualified_and_address_sheet_for_qualified() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const first = context.workbook.worksheets.getItem("Sheet1");
+        const second = context.workbook.worksheets.add("Second Sheet");
+        second.getRange("A1:B2").values = [["C", "D"], [3, 4]];
+        second.activate();
+        first.activate();
+        await context.sync();
+
+        const tables = context.workbook.tables;
+        const unqualified = tables.add("A1:B2", true);
+        unqualified.name = "ActiveTable";
+        const qualified = tables.add("'Second Sheet'!A1:B2", true);
+        qualified.name = "QualifiedTable";
+        await context.sync();
+
+        const firstRange = first.getRange("A1:B2");
+        const secondRange = second.getRange("A1:B2");
+        const firstTable = first.tables.getItem("ActiveTable");
+        const secondTable = second.tables.getItem("QualifiedTable");
+        firstRange.load("values");
+        secondRange.load("values");
+        firstTable.load("id");
+        secondTable.load("id");
+        await context.sync();
+        return {
+          first: { values: firstRange.values, table: firstTable.id },
+          second: { values: secondRange.values, table: secondTable.id },
+          types: {
+            workbook: tables instanceof Excel.TableCollection,
+            first: first.tables instanceof Excel.TableCollection,
+            second: second.tables instanceof Excel.TableCollection
+          }
+        };
+      });
+    "#,
+    )
+    .expect("workbook table address scoping should succeed");
+
+    assert_eq!(output.value["first"]["values"], json!([["", ""], ["", ""]]));
+    assert_eq!(
+        output.value["second"]["values"],
+        json!([["C", "D"], [3, 4]])
+    );
+    assert!(output.value["first"]["table"]
+        .as_str()
+        .is_some_and(|id| id.starts_with("tbl-")));
+    assert!(output.value["second"]["table"]
+        .as_str()
+        .is_some_and(|id| id.starts_with("tbl-")));
+    assert_eq!(
+        output.value["types"],
+        json!({"workbook": true, "first": true, "second": true})
+    );
+}
+
+#[test]
+fn table_delete_preserves_cells_and_removes_fresh_lookup() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B3").values = [["A", "B"], [1, 2], [3, 4]];
+        const table = sheet.tables.add("A1:B3", true);
+        table.name = "Orders";
+        await context.sync();
+
+        table.delete();
+        await context.sync();
+
+        const cells = sheet.getRange("A1:B3");
+        const missing = sheet.tables.getItemOrNullObject("Orders");
+        cells.load("values");
+        missing.load("isNullObject");
+        await context.sync();
+        return { cells: cells.values, missing: missing.isNullObject };
+      });
+    "#,
+    )
+    .expect("table delete should preserve values");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "cells": [["A", "B"], [1, 2], [3, 4]],
+            "missing": true
+        })
+    );
+}
+
+#[test]
+fn table_convert_to_range_returns_preserved_range_and_total_row_range() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:B3").values = [["A", "B"], [1, 2], [3, 4]];
+        const table = sheet.tables.add("A1:B3", true);
+        table.name = "Orders";
+        table.showTotals = true;
+        const totals = table.getTotalRowRange();
+        totals.load("address");
+        await context.sync();
+
+        const converted = table.convertToRange();
+        converted.load(["address", "values"]);
+        const missing = sheet.tables.getItemOrNullObject("Orders");
+        missing.load("isNullObject");
+        await context.sync();
+        return {
+          totals: totals.address,
+          converted: { address: converted.address, values: converted.values },
+          missing: missing.isNullObject
+        };
+      });
+    "#,
+    )
+    .expect("table conversion should preserve the full range");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "totals": "Sheet1!A4:B4",
+            "converted": {
+                "address": "Sheet1!A1:B4",
+                "values": [["A", "B"], [1, 2], [3, 4], ["", ""]]
+            },
+            "missing": true
+        })
+    );
+}
+
+#[test]
+fn table_resize_supports_range_and_string_overloads() {
+    let output = run_office_js(
+        r#"
+      return await Excel.run(async context => {
+        const sheet = context.workbook.worksheets.getItem("Sheet1");
+        sheet.getRange("A1:C4").values = [
+          ["A", "B", "C"],
+          [1, 2, 3],
+          [4, 5, 6],
+          [7, 8, 9]
+        ];
+        const table = sheet.tables.add("A1:B3", true);
+        table.name = "Orders";
+        table.resize("A1:C4");
+        await context.sync();
+
+        const range = sheet.getRange("A1:C5");
+        table.resize(range);
+        const full = table.getRange();
+        full.load(["address", "values"]);
+        await context.sync();
+        return { address: full.address, values: full.values };
+      });
+    "#,
+    )
+    .expect("table resize overloads should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "address": "Sheet1!A1:C5",
+            "values": [
+                ["A", "B", "C"],
+                [1, 2, 3],
+                [4, 5, 6],
+                [7, 8, 9],
+                ["", "", ""]
+            ]
+        })
+    );
+}

--- a/compute/officejs/tests/validation_semantics.rs
+++ b/compute/officejs/tests/validation_semantics.rs
@@ -1,0 +1,371 @@
+//! Office.js Range.dataValidation behavior through the shipped runtime.
+
+use mog::run_office_js;
+use serde_json::json;
+
+#[test]
+fn data_validation_rule_families_round_trip_through_fresh_proxies() {
+    let output = run_office_js(
+        r#"
+        await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:A2").dataValidation.set({
+            rule: { wholeNumber: { operator: "Between", formula1: 1, formula2: 10 } },
+            ignoreBlanks: false,
+            errorAlert: {
+              message: "Use an integer from 1 through 10",
+              showAlert: true,
+              style: "Stop",
+              title: "Whole number"
+            },
+            prompt: {
+              message: "Enter a whole number",
+              showPrompt: true,
+              title: "Input"
+            }
+          });
+          sheet.getRange("B1:B2").dataValidation.set({
+            rule: { decimal: { operator: "GreaterThanOrEqualTo", formula1: 0.5 } }
+          });
+          sheet.getRange("C1:C2").dataValidation.set({
+            rule: { date: { operator: "Between", formula1: "2024-01-01", formula2: "2024-12-31" } }
+          });
+          sheet.getRange("D1:D2").dataValidation.set({
+            rule: { time: { operator: "GreaterThanOrEqualTo", formula1: "08:00" } }
+          });
+          sheet.getRange("E1:E2").dataValidation.set({
+            rule: { textLength: { operator: "Between", formula1: 2, formula2: 5 } }
+          });
+          sheet.getRange("F1:F2").dataValidation.set({
+            rule: { list: { source: "Red,Green,Blue", inCellDropDown: false } }
+          });
+          sheet.getRange("G1:G2").dataValidation.set({
+            rule: { custom: { formula: "=ISNUMBER(A1)" } }
+          });
+        });
+
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const result = {};
+          ["A1:A2", "B1:B2", "C1:C2", "D1:D2", "E1:E2", "F1:F2", "G1:G2"]
+            .forEach((address, index) => {
+              const validation = sheet.getRange(address).dataValidation;
+              validation.load(["rule", "errorAlert", "ignoreBlanks", "prompt", "type"]);
+              result[index] = validation;
+            });
+          await context.sync();
+          return result;
+        });
+        "#,
+    )
+    .expect("data validation families should persist");
+
+    assert_eq!(output.value["0"]["type"], json!("WholeNumber"));
+    assert_eq!(
+        output.value["0"]["rule"]["wholeNumber"],
+        json!({
+            "operator": "Between",
+            "formula1": "=1",
+            "formula2": "=10"
+        })
+    );
+    assert_eq!(output.value["0"]["ignoreBlanks"], json!(false));
+    assert_eq!(
+        output.value["0"]["errorAlert"],
+        json!({
+            "message": "Use an integer from 1 through 10",
+            "showAlert": true,
+            "style": "Stop",
+            "title": "Whole number"
+        })
+    );
+    assert_eq!(
+        output.value["0"]["prompt"],
+        json!({
+            "message": "Enter a whole number",
+            "showPrompt": true,
+            "title": "Input"
+        })
+    );
+
+    assert_eq!(output.value["1"]["type"], json!("Decimal"));
+    assert_eq!(
+        output.value["1"]["rule"]["decimal"],
+        json!({
+            "operator": "GreaterThanOrEqualTo",
+            "formula1": "=0.5"
+        })
+    );
+    assert_eq!(output.value["2"]["type"], json!("Date"));
+    assert_eq!(
+        output.value["2"]["rule"]["date"],
+        json!({
+            "operator": "Between",
+            "formula1": "=45292",
+            "formula2": "=45657"
+        })
+    );
+    assert_eq!(output.value["3"]["type"], json!("Time"));
+    assert_eq!(
+        output.value["3"]["rule"]["time"],
+        json!({
+            "operator": "GreaterThanOrEqualTo",
+            "formula1": "=0.3333333333333333"
+        })
+    );
+    assert_eq!(output.value["4"]["type"], json!("TextLength"));
+    assert_eq!(
+        output.value["4"]["rule"]["textLength"],
+        json!({
+            "operator": "Between",
+            "formula1": "=2",
+            "formula2": "=5"
+        })
+    );
+    assert_eq!(output.value["5"]["type"], json!("List"));
+    assert_eq!(
+        output.value["5"]["rule"]["list"],
+        json!({
+            "source": "Red,Green,Blue",
+            "inCellDropDown": false
+        })
+    );
+    assert_eq!(output.value["6"]["type"], json!("Custom"));
+    assert_eq!(
+        output.value["6"]["rule"]["custom"],
+        json!({"formula": "=ISNUMBER(A1)"})
+    );
+}
+
+#[test]
+fn data_validation_list_dropdown_false_survives_fresh_engine_round_trip() {
+    let output = run_office_js(
+        r#"
+        await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("H1:H2").dataValidation.rule = {
+            list: { source: "Red,Green,Blue", inCellDropDown: false }
+          };
+        });
+
+        return await Excel.run(async context => {
+          const validation = context.workbook.worksheets
+            .getItem("Sheet1").getRange("H1:H2").dataValidation;
+          validation.load("rule");
+          await context.sync();
+          return validation.toJSON();
+        });
+        "#,
+    )
+    .expect("list dropdown setting should survive a fresh engine round trip");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "rule": {
+                "list": {
+                    "source": "Red,Green,Blue",
+                    "inCellDropDown": false
+                }
+            }
+        })
+    );
+}
+
+#[test]
+fn data_validation_bound_formulas_round_trip_as_strings() {
+    let output = run_office_js(
+        r#"
+        await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:A2").dataValidation.rule = {
+            wholeNumber: {
+              operator: "Between",
+              formula1: sheet.getRange("J1"),
+              formula2: "=SUM(J1:J2)"
+            }
+          };
+          sheet.getRange("B1:B2").dataValidation.rule = {
+            decimal: { operator: "GreaterThanOrEqualTo", formula1: "=J1" }
+          };
+          sheet.getRange("C1:C2").dataValidation.rule = {
+            date: { operator: "GreaterThanOrEqualTo", formula1: "=DATE(2024,1,1)" }
+          };
+          sheet.getRange("D1:D2").dataValidation.rule = {
+            time: { operator: "GreaterThanOrEqualTo", formula1: "=TIME(8,0,0)" }
+          };
+          sheet.getRange("E1:E2").dataValidation.rule = {
+            textLength: {
+              operator: "Between",
+              formula1: "=1+1",
+              formula2: "=1+4"
+            }
+          };
+        });
+
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          const result = {};
+          ["A1:A2", "B1:B2", "C1:C2", "D1:D2", "E1:E2"]
+            .forEach((address, index) => {
+              const validation = sheet.getRange(address).dataValidation;
+              validation.load("rule");
+              result[index] = validation;
+            });
+          await context.sync();
+          return result;
+        });
+        "#,
+    )
+    .expect("formula bounds should survive the durable validation round trip");
+
+    assert_eq!(
+        output.value["0"]["rule"]["wholeNumber"],
+        json!({
+            "operator": "Between",
+            "formula1": "=J1",
+            "formula2": "=SUM(J1:J2)"
+        })
+    );
+    assert_eq!(
+        output.value["1"]["rule"]["decimal"],
+        json!({"operator": "GreaterThanOrEqualTo", "formula1": "=J1"})
+    );
+    assert_eq!(
+        output.value["2"]["rule"]["date"],
+        json!({"operator": "GreaterThanOrEqualTo", "formula1": "=DATE(2024,1,1)"})
+    );
+    assert_eq!(
+        output.value["3"]["rule"]["time"],
+        json!({"operator": "GreaterThanOrEqualTo", "formula1": "=TIME(8,0,0)"})
+    );
+    assert_eq!(
+        output.value["4"]["rule"]["textLength"],
+        json!({
+            "operator": "Between",
+            "formula1": "=1+1",
+            "formula2": "=1+4"
+        })
+    );
+}
+
+#[test]
+fn data_validation_bound_formulas_are_evaluated_dynamically() {
+    let output = run_office_js(
+        r#"
+        await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1").values = [[5]];
+          sheet.getRange("J1").values = [[3]];
+          sheet.getRange("A1").dataValidation.rule = {
+            wholeNumber: { operator: "GreaterThanOrEqualTo", formula1: "=J1" }
+          };
+        });
+
+        const before = await Excel.run(async context => {
+          const validation = context.workbook.worksheets
+            .getItem("Sheet1").getRange("A1").dataValidation;
+          validation.load("valid");
+          await context.sync();
+          return validation.valid;
+        });
+
+        await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("J1").values = [[6]];
+        });
+
+        const after = await Excel.run(async context => {
+          const validation = context.workbook.worksheets
+            .getItem("Sheet1").getRange("A1").dataValidation;
+          validation.load("valid");
+          await context.sync();
+          return validation.valid;
+        });
+        return { before, after };
+        "#,
+    )
+    .expect("formula bounds should be evaluated against current referenced cells");
+
+    assert_eq!(output.value, json!({"before": true, "after": false}));
+}
+
+#[test]
+fn data_validation_clear_removes_the_rule_for_fresh_proxies() {
+    let output = run_office_js(
+        r#"
+        await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1").dataValidation.rule = {
+            wholeNumber: { operator: "EqualTo", formula1: 7 }
+          };
+        });
+        await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1").dataValidation.clear();
+        });
+        return await Excel.run(async context => {
+          const validation = context.workbook.worksheets
+            .getItem("Sheet1").getRange("A1").dataValidation;
+          validation.load(["type", "rule", "ignoreBlanks"]);
+          await context.sync();
+          return validation.toJSON();
+        });
+        "#,
+    )
+    .expect("clear should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "type": "None",
+            "rule": {},
+            "ignoreBlanks": true
+        })
+    );
+}
+
+#[test]
+fn data_validation_valid_reports_mixed_cells() {
+    let output = run_office_js(
+        r#"
+        return await Excel.run(async context => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:A2").values = [[3], [99]];
+          const validation = sheet.getRange("A1:A2").dataValidation;
+          validation.rule = {
+            wholeNumber: { operator: "Between", formula1: 1, formula2: 10 }
+          };
+          validation.load("valid");
+          await context.sync();
+          return validation.valid;
+        });
+        "#,
+    )
+    .expect("valid should be evaluated");
+
+    assert_eq!(output.value, json!(null));
+}
+
+#[test]
+fn data_validation_rejects_unknown_rule_members() {
+    let output = run_office_js(
+        r#"
+        let code;
+        try {
+          await Excel.run(async context => {
+            const validation = context.workbook.worksheets
+              .getItem("Sheet1").getRange("A1").dataValidation;
+            validation.rule = { wholeNumber: { operator: "Between", formula1: 1, formula2: 2, extra: 1 } };
+            await context.sync();
+          });
+        } catch (error) {
+          code = error.code;
+        }
+        return code;
+        "#,
+    )
+    .expect("script should catch invalid rule");
+
+    assert_eq!(output.value, json!("InvalidArgument"));
+}

--- a/compute/officejs/tests/value_semantics.rs
+++ b/compute/officejs/tests/value_semantics.rs
@@ -1,0 +1,218 @@
+//! Office.js range value regressions through the shipped QuickJS/host path.
+
+use compute_api::Workbook;
+use mog::run_office_js_with_workbook;
+use serde_json::{Value, json};
+
+fn blank_workbook() -> Workbook {
+    Workbook::blank().expect("blank workbook").0
+}
+
+#[test]
+fn values_preserve_javascript_scalar_types_and_formula_intent() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:F1").values = [["001", "TRUE", "1.5", true, false, 7.25]];
+          sheet.getRange("A2:F2").formulas = [["=F1*2", "001", "", null, null, null]];
+          await context.sync();
+
+          const read = sheet.getRange("A1:F2");
+          read.load("values");
+          read.load({ select: "formulas" });
+          await context.sync();
+          return { values: read.values, formulas: read.formulas };
+        });
+        "#,
+    )
+    .expect("typed Office.js write should succeed");
+
+    assert_eq!(
+        output.value["values"],
+        json!([
+            ["001", "TRUE", "1.5", true, false, 7.25],
+            [14.5, "001", "", "", "", ""]
+        ])
+    );
+    assert_eq!(
+        output.value["formulas"],
+        json!([
+            ["001", "TRUE", "1.5", true, false, 7.25],
+            ["=F1*2", "001", "", "", "", ""]
+        ])
+    );
+}
+
+#[test]
+fn values_formula_markers_are_distinct_from_literal_strings() {
+    // Microsoft documents +, -, and = as Range.values formula markers. It
+    // does not document editor-style apostrophe stripping for this API; the
+    // apostrophe expectation below is a provisional local policy pending a
+    // recorded Excel host observation.
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:E1").values = [[10, "=A1*2", "+A1*3", "-A1", "'001"]];
+          await context.sync();
+          const read = sheet.getRange("A1:E1");
+          read.load("values,formulas");
+          await context.sync();
+          return { values: read.values, formulas: read.formulas };
+        });
+        "#,
+    )
+    .expect("formula-marker Office.js write should succeed");
+
+    assert_eq!(output.value["values"], json!([[10, 20, 30, -10, "'001"]]));
+    assert_eq!(
+        output.value["formulas"],
+        json!([[10, "=A1*2", "=+A1*3", "=-A1", "'001"]])
+    );
+}
+
+#[test]
+fn null_entries_preserve_cells_and_blank_reads_are_empty_strings() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:D4").values = [
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+            [9, 10, 11, 12],
+            [13, 14, 15, 16]
+          ];
+          await context.sync();
+
+          sheet.getRange("B2:C3").values = [[null, ""], [99, null]];
+          await context.sync();
+
+          const read = sheet.getRange("A1:D4");
+          read.load("values, formulas");
+          await context.sync();
+          return { values: read.values, formulas: read.formulas };
+        });
+        "#,
+    )
+    .expect("null-preserving Office.js write should succeed");
+
+    let expected_values = json!([
+        [1, 2, 3, 4],
+        [5, 6, "", 8],
+        [9, 99, 11, 12],
+        [13, 14, 15, 16]
+    ]);
+    assert_eq!(output.value["values"], expected_values);
+    assert_eq!(output.value["formulas"], expected_values);
+}
+
+#[test]
+fn multiple_loads_for_one_proxy_accumulate_properties() {
+    let workbook = blank_workbook();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1").formulas = [["=1+2"]];
+          await context.sync();
+
+          const read = sheet.getRange("A1");
+          read.load("values");
+          read.load(["formulas"]);
+          await context.sync();
+          return { values: read.values, formulas: read.formulas };
+        });
+        "#,
+    )
+    .expect("independent loads should merge");
+
+    assert_eq!(
+        output.value,
+        json!({ "values": [[3]], "formulas": [["=1+2"]] })
+    );
+}
+
+#[test]
+fn invalid_grids_are_rejected_without_mutating_target_or_neighbors() {
+    // Range property setters take a 2-D array representing the target range.
+    // These cases cover every structural mismatch around a 2x2 target:
+    // non-grid, empty, empty row, too few/many rows, too few/many columns,
+    // and ragged rows. Each case is executed by run_office_js_with_workbook,
+    // then the complete sentinel neighborhood is read through Office.js.
+    let cases: &[(&str, &str)] = &[
+        ("null property", "null"),
+        ("one dimensional", "[1, 2]"),
+        ("empty grid", "[]"),
+        ("empty row", "[[]]"),
+        ("undersized rows", "[[101, 102]]"),
+        ("undersized columns", "[[101], [102]]"),
+        ("oversized rows", "[[101, 102], [103, 104], [105, 106]]"),
+        ("oversized columns", "[[101, 102, 103], [104, 105, 106]]"),
+        ("ragged short", "[[101, 102], [103]]"),
+        ("ragged long", "[[101], [102, 103]]"),
+    ];
+    let sentinels = json!([
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+        [13, 14, 15, 16]
+    ]);
+
+    for (name, payload) in cases {
+        let workbook = blank_workbook();
+        let source = format!(
+            r#"
+            await Excel.run(async (context) => {{
+              const sheet = context.workbook.worksheets.getItem("Sheet1");
+              sheet.getRange("A1:D4").values = [
+                [1, 2, 3, 4],
+                [5, 6, 7, 8],
+                [9, 10, 11, 12],
+                [13, 14, 15, 16]
+              ];
+              await context.sync();
+            }});
+
+            let errorCode = null;
+            try {{
+              await Excel.run(async (context) => {{
+                const sheet = context.workbook.worksheets.getItem("Sheet1");
+                sheet.getRange("B2:C3").values = {payload};
+                await context.sync();
+              }});
+            }} catch (error) {{
+              errorCode = error && error.code;
+            }}
+
+            return await Excel.run(async (context) => {{
+              const sheet = context.workbook.worksheets.getItem("Sheet1");
+              const read = sheet.getRange("A1:D4");
+              read.load("values");
+              await context.sync();
+              return {{ errorCode, values: read.values }};
+            }});
+            "#
+        );
+        let output = run_office_js_with_workbook(&workbook, &source)
+            .unwrap_or_else(|error| panic!("{name}: script should catch shape error: {error}"));
+
+        assert_eq!(
+            output.value["errorCode"],
+            Value::String("InvalidArgument".to_string()),
+            "{name}: expected InvalidArgument"
+        );
+        assert_eq!(
+            output.value["values"], sentinels,
+            "{name}: invalid grid changed target or neighboring cells"
+        );
+    }
+}

--- a/compute/officejs/tests/worksheet_semantics.rs
+++ b/compute/officejs/tests/worksheet_semantics.rs
@@ -1,0 +1,428 @@
+//! Worksheet and WorksheetCollection lifecycle semantics through the shipped
+//! Office.js runtime.
+
+use std::collections::HashMap;
+
+use compute_api::Workbook;
+use mog::{OfficeJsError, run_office_js_with_workbook};
+use serde_json::json;
+
+fn workbook_with_sheets(names: &[&str]) -> Workbook {
+    let workbook = Workbook::blank().expect("blank workbook").0;
+    for name in names.iter().skip(1) {
+        workbook
+            .sheets()
+            .create_sheet(name)
+            .expect("create worksheet");
+    }
+    workbook
+}
+
+fn set_active(workbook: &Workbook, id: &str) {
+    let mut settings = workbook
+        .settings()
+        .get_workbook_settings()
+        .expect("get workbook settings");
+    settings.selected_sheet_ids = Some(vec![id.to_string()]);
+    settings.custom_settings = Some(HashMap::from([(
+        "mog.activeSheetId".to_string(),
+        json!(id),
+    )]));
+    workbook
+        .settings()
+        .set_workbook_settings(settings)
+        .expect("set active worksheet");
+}
+
+#[test]
+fn worksheet_lifecycle_preserves_stable_id_and_tab_order() {
+    let workbook = workbook_with_sheets(&["Sheet1", "Data", "Summary"]);
+    let expected_id = workbook
+        .sheet_by_name("Data")
+        .expect("Data worksheet")
+        .id()
+        .to_uuid_string();
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const worksheets = context.workbook.worksheets;
+          const data = worksheets.getItem("Data");
+          data.load(["id", "name", "position", "visibility"]);
+          await context.sync();
+
+          const stableId = data.id;
+          data.name = "Renamed";
+          data.position = 0;
+          data.visibility = Excel.SheetVisibility.hidden;
+          await context.sync();
+
+          const fresh = worksheets.getItem(stableId);
+          fresh.load(["id", "name", "position", "visibility"]);
+          await context.sync();
+          return {
+            before: { id: stableId, name: "Data", position: 1, visibility: "Visible" },
+            after: fresh.toJSON(),
+            sameId: fresh.id === stableId,
+          };
+        });
+        "#,
+    )
+    .expect("worksheet lifecycle should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "before": { "id": expected_id.clone(), "name": "Data", "position": 1, "visibility": "Visible" },
+            "after": { "id": expected_id, "name": "Renamed", "position": 0, "visibility": "Hidden" },
+            "sameId": true,
+        })
+    );
+}
+
+#[test]
+fn worksheet_collection_loads_real_item_proxies_in_tab_order() {
+    let workbook = workbook_with_sheets(&["Sheet1", "Data", "Summary"]);
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const worksheets = context.workbook.worksheets;
+          worksheets.load("items/name,items/id,items/position");
+          await context.sync();
+          return {
+            items: worksheets.items.map((worksheet) => ({
+              type: worksheet instanceof Excel.Worksheet,
+              clientObject: worksheet instanceof OfficeExtension.ClientObject,
+              name: worksheet.name,
+              id: worksheet.id,
+              position: worksheet.position,
+            })),
+            collection: worksheets.toJSON().items.map((worksheet) => worksheet.name),
+          };
+        });
+        "#,
+    )
+    .expect("worksheet collection load should succeed");
+
+    assert_eq!(
+        output.value["items"]
+            .as_array()
+            .expect("items array")
+            .iter()
+            .map(|item| item["name"].as_str().expect("name").to_string())
+            .collect::<Vec<_>>(),
+        vec!["Sheet1", "Data", "Summary"]
+    );
+    assert!(
+        output.value["items"]
+            .as_array()
+            .expect("items array")
+            .iter()
+            .all(|item| item["type"] == json!(true) && item["clientObject"] == json!(true))
+    );
+    assert_eq!(
+        output.value["collection"],
+        json!(["Sheet1", "Data", "Summary"])
+    );
+}
+
+#[test]
+fn worksheet_collection_count_edges_and_or_null_follow_order_and_visibility() {
+    let workbook = workbook_with_sheets(&["Sheet1", "Data", "Summary"]);
+    let summary_id = workbook
+        .sheet_by_name("Summary")
+        .expect("Summary worksheet")
+        .id()
+        .to_uuid_string();
+    set_active(&workbook, &summary_id);
+
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const worksheets = context.workbook.worksheets;
+          const data = worksheets.getItem("Data");
+          data.visibility = Excel.SheetVisibility.hidden;
+          await context.sync();
+
+          const allCount = worksheets.getCount();
+          const visibleCount = worksheets.getCount(true);
+          const first = worksheets.getFirst(true);
+          const last = worksheets.getLast(true);
+          const next = data.getNext(true);
+          const previous = data.getPrevious(true);
+          const beyond = worksheets.getItem("Summary").getNextOrNullObject();
+          const missing = worksheets.getItemOrNullObject("Missing");
+          first.load("name");
+          last.load("name");
+          next.load(["name", "visibility"]);
+          previous.load(["name", "visibility"]);
+          await context.sync();
+          return {
+            allCount: allCount.value,
+            visibleCount: visibleCount.value,
+            first: first.name,
+            last: last.name,
+            next: next.toJSON(),
+            previous: previous.toJSON(),
+            beyond: beyond.isNullObject,
+            missing: missing.isNullObject,
+          };
+        });
+        "#,
+    )
+    .expect("worksheet collection edge methods should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "allCount": 3,
+            "visibleCount": 2,
+            "first": "Sheet1",
+            "last": "Summary",
+            "next": { "name": "Summary", "visibility": "Visible" },
+            "previous": { "name": "Sheet1", "visibility": "Visible" },
+            "beyond": true,
+            "missing": true,
+        })
+    );
+}
+
+#[test]
+fn worksheet_activation_uses_persisted_state_and_delete_errors_match_office() {
+    let workbook = workbook_with_sheets(&["Sheet1", "Data"]);
+    let data_id = workbook
+        .sheet_by_name("Data")
+        .expect("Data worksheet")
+        .id()
+        .to_uuid_string();
+    set_active(&workbook, &data_id);
+
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const worksheets = context.workbook.worksheets;
+          const active = worksheets.getActiveWorksheet();
+          active.load(["id", "name"]);
+          await context.sync();
+          const first = worksheets.getItem("Sheet1");
+          first.activate();
+          await context.sync();
+          const after = worksheets.getActiveWorksheet();
+          after.load("name");
+          await context.sync();
+
+          const veryHidden = worksheets.getItem("Data");
+          veryHidden.visibility = Excel.SheetVisibility.veryHidden;
+          await context.sync();
+          let veryHiddenDelete;
+          try {
+            veryHidden.delete();
+            await context.sync();
+          } catch (error) { veryHiddenDelete = error.code; }
+          return { active: active.toJSON(), after: after.name, veryHiddenDelete };
+        });
+        "#,
+    )
+    .expect("worksheet activation should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "active": { "id": data_id, "name": "Data" },
+            "after": "Sheet1",
+            "veryHiddenDelete": "InvalidOperation",
+        })
+    );
+}
+
+#[test]
+fn worksheet_blank_default_active_and_hide_switches_to_neighbor() {
+    let workbook = workbook_with_sheets(&["Sheet1", "Data", "Summary"]);
+    let data_id = workbook
+        .sheet_by_name("Data")
+        .expect("Data worksheet")
+        .id()
+        .to_uuid_string();
+
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const worksheets = context.workbook.worksheets;
+          const initial = worksheets.getActiveWorksheet();
+          initial.load("name");
+          await context.sync();
+
+          initial.visibility = Excel.SheetVisibility.hidden;
+          await context.sync();
+
+          const after = worksheets.getActiveWorksheet();
+          after.load(["id", "name", "position", "visibility"]);
+          await context.sync();
+          return { initial: initial.name, after: after.toJSON() };
+        });
+        "#,
+    )
+    .expect("blank workbook active worksheet should use the production default");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "initial": "Sheet1",
+            "after": {
+                "id": data_id,
+                "name": "Data",
+                "position": 1,
+                "visibility": "Visible",
+            },
+        })
+    );
+    assert_eq!(
+        workbook
+            .settings()
+            .get_workbook_view_active_tab()
+            .expect("read persisted active view"),
+        Some(1)
+    );
+}
+
+#[test]
+fn worksheet_active_reads_persisted_workbook_view_tab() {
+    let workbook = workbook_with_sheets(&["Sheet1", "Data", "Summary"]);
+    workbook
+        .settings()
+        .set_workbook_view_active_tab(2)
+        .expect("set persisted workbook view");
+
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const active = context.workbook.worksheets.getActiveWorksheet();
+          active.load(["id", "name", "position"]);
+          await context.sync();
+          return active.toJSON();
+        });
+        "#,
+    )
+    .expect("persisted workbook view should select its active tab");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "id": workbook
+                .sheet_by_name("Summary")
+                .expect("Summary worksheet")
+                .id()
+                .to_uuid_string(),
+            "name": "Summary",
+            "position": 2,
+        })
+    );
+}
+
+#[test]
+fn worksheet_delete_active_switches_to_neighbor_and_updates_view() {
+    let workbook = workbook_with_sheets(&["Sheet1", "Data", "Summary"]);
+    let data_id = workbook
+        .sheet_by_name("Data")
+        .expect("Data worksheet")
+        .id()
+        .to_uuid_string();
+    set_active(&workbook, &data_id);
+
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const worksheets = context.workbook.worksheets;
+          const active = worksheets.getActiveWorksheet();
+          active.delete();
+          await context.sync();
+
+          const after = worksheets.getActiveWorksheet();
+          after.load(["name", "position"]);
+          await context.sync();
+          return after.toJSON();
+        });
+        "#,
+    )
+    .expect("deleting the active worksheet should select a neighbor");
+
+    assert_eq!(output.value, json!({ "name": "Summary", "position": 1 }));
+    assert_eq!(
+        workbook
+            .settings()
+            .get_workbook_view_active_tab()
+            .expect("read persisted active view"),
+        Some(1)
+    );
+}
+
+#[test]
+fn worksheet_delete_last_sheet_is_rejected_at_sync() {
+    let workbook = Workbook::blank().expect("blank workbook").0;
+    let error = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          context.workbook.worksheets.getItem("Sheet1").delete();
+          await context.sync();
+          return "unexpected success";
+        });
+        "#,
+    )
+    .expect_err("deleting the only worksheet must fail");
+
+    match error {
+        OfficeJsError::Script(message) => assert!(
+            message.contains("InvalidOperation"),
+            "unexpected delete error: {message}"
+        ),
+        other => panic!("expected script error, got {other}"),
+    }
+}
+
+#[test]
+fn fresh_worksheet_proxy_requires_load_for_new_scalars() {
+    let workbook = workbook_with_sheets(&["Sheet1", "Data"]);
+    let output = run_office_js_with_workbook(
+        &workbook,
+        r#"
+        return await Excel.run(async (context) => {
+          const worksheet = context.workbook.worksheets.getItem("Data");
+          const fresh = context.workbook.worksheets.getItem("Data");
+          worksheet.load(["position", "visibility"]);
+          await context.sync();
+          let unloadedPosition;
+          let unloadedVisibility;
+          let unloadedItems;
+          try { fresh.position; } catch (error) { unloadedPosition = error.code; }
+          try { fresh.visibility; } catch (error) { unloadedVisibility = error.code; }
+          try { context.workbook.worksheets.items; } catch (error) { unloadedItems = error.code; }
+          return {
+            position: worksheet.position,
+            visibility: worksheet.visibility,
+            unloadedPosition,
+            unloadedVisibility,
+            unloadedItems,
+          };
+        });
+        "#,
+    )
+    .expect("fresh worksheet proxy contract should succeed");
+
+    assert_eq!(
+        output.value,
+        json!({
+            "position": 1,
+            "visibility": "Visible",
+            "unloadedPosition": "PropertyNotLoaded",
+            "unloadedVisibility": "PropertyNotLoaded",
+            "unloadedItems": "PropertyNotLoaded",
+        })
+    );
+}

--- a/compute/officejs/third-party/office-js-types-LICENSE.txt
+++ b/compute/officejs/third-party/office-js-types-LICENSE.txt
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -36,8 +36,10 @@ await Excel.run(async (context) => {
 });
 ```
 
-`Range.values` and `Range.formulas` are queued until `context.sync()`. Reading a
-property requires `load` plus `sync`; unloaded properties throw.
+`Range.values` and `Range.formulas` writes are queued until `context.sync()`.
+The assigning proxy caches the assigned value immediately. To read the engine's
+result, obtain a fresh proxy and call `load` plus `sync`, as above. Reading an
+unloaded property on a fresh proxy throws.
 
 ## Tests
 

--- a/domain-types/src/domain/validation/conversion.rs
+++ b/domain-types/src/domain/validation/conversion.rs
@@ -102,8 +102,16 @@ impl RangeSchema {
             return None;
         }
 
-        let rule =
-            build_validation_rule(self.schema.schema_type, self.schema.constraints.as_ref())?;
+        let show_dropdown = self
+            .ui
+            .as_ref()
+            .and_then(|ui| ui.show_dropdown)
+            .unwrap_or(true);
+        let rule = build_validation_rule(
+            self.schema.schema_type,
+            self.schema.constraints.as_ref(),
+            show_dropdown,
+        )?;
 
         let error_style: ErrorStyle = self.enforcement.unwrap_or(EnforcementLevel::Strict).into();
 
@@ -148,6 +156,7 @@ impl RangeSchema {
 fn build_validation_rule(
     schema_type: Option<SchemaType>,
     constraints: Option<&SchemaConstraints>,
+    show_dropdown: bool,
 ) -> Option<ValidationRule> {
     let c = constraints;
 
@@ -155,14 +164,14 @@ fn build_validation_rule(
         let formula1 = format!("\"{}\"", vals.join(","));
         return Some(ValidationRule::List {
             formula1,
-            show_dropdown: true,
+            show_dropdown,
         });
     }
 
     if let Some(formula) = c.and_then(|c| c.enum_source_formula.as_ref()) {
         return Some(ValidationRule::List {
             formula1: formula.clone(),
-            show_dropdown: true,
+            show_dropdown,
         });
     }
 
@@ -174,7 +183,7 @@ fn build_validation_rule(
     {
         return Some(ValidationRule::List {
             formula1: a1,
-            show_dropdown: true,
+            show_dropdown,
         });
     }
 
@@ -256,37 +265,35 @@ fn numeric_operator_and_formulas(
         None => return (ValidationOperator::Between, String::new(), None),
     };
 
-    if let Some(v) = c.equal {
-        return (ValidationOperator::Equal, v.to_string(), None);
+    if let Some(v) = formula_bound(c, "equal", c.equal) {
+        return (ValidationOperator::Equal, v, None);
     }
-    if let Some(v) = c.not_equal {
-        return (ValidationOperator::NotEqual, v.to_string(), None);
+    if let Some(v) = formula_bound(c, "notEqual", c.not_equal) {
+        return (ValidationOperator::NotEqual, v, None);
     }
-    if let (Some(lo), Some(hi)) = (c.not_between_min, c.not_between_max) {
-        return (
-            ValidationOperator::NotBetween,
-            lo.to_string(),
-            Some(hi.to_string()),
-        );
+    if let (Some(lo), Some(hi)) = (
+        formula_bound(c, "notBetweenMin", c.not_between_min),
+        formula_bound(c, "notBetweenMax", c.not_between_max),
+    ) {
+        return (ValidationOperator::NotBetween, lo, Some(hi));
     }
-    if let (Some(lo), Some(hi)) = (c.min, c.max) {
-        return (
-            ValidationOperator::Between,
-            lo.to_string(),
-            Some(hi.to_string()),
-        );
+    if let (Some(lo), Some(hi)) = (
+        formula_bound(c, "min", c.min),
+        formula_bound(c, "max", c.max),
+    ) {
+        return (ValidationOperator::Between, lo, Some(hi));
     }
-    if let Some(v) = c.exclusive_min {
-        return (ValidationOperator::GreaterThan, v.to_string(), None);
+    if let Some(v) = formula_bound(c, "exclusiveMin", c.exclusive_min) {
+        return (ValidationOperator::GreaterThan, v, None);
     }
-    if let Some(v) = c.min {
-        return (ValidationOperator::GreaterThanOrEqual, v.to_string(), None);
+    if let Some(v) = formula_bound(c, "min", c.min) {
+        return (ValidationOperator::GreaterThanOrEqual, v, None);
     }
-    if let Some(v) = c.exclusive_max {
-        return (ValidationOperator::LessThan, v.to_string(), None);
+    if let Some(v) = formula_bound(c, "exclusiveMax", c.exclusive_max) {
+        return (ValidationOperator::LessThan, v, None);
     }
-    if let Some(v) = c.max {
-        return (ValidationOperator::LessThanOrEqual, v.to_string(), None);
+    if let Some(v) = formula_bound(c, "max", c.max) {
+        return (ValidationOperator::LessThanOrEqual, v, None);
     }
 
     (ValidationOperator::Between, String::new(), None)
@@ -300,18 +307,17 @@ fn text_length_operator_and_formulas(
         None => return (ValidationOperator::Between, String::new(), None),
     };
 
-    if let (Some(lo), Some(hi)) = (c.min_length, c.max_length) {
-        return (
-            ValidationOperator::Between,
-            lo.to_string(),
-            Some(hi.to_string()),
-        );
+    if let (Some(lo), Some(hi)) = (
+        formula_bound(c, "minLength", c.min_length.map(|value| value as f64)),
+        formula_bound(c, "maxLength", c.max_length.map(|value| value as f64)),
+    ) {
+        return (ValidationOperator::Between, lo, Some(hi));
     }
-    if let Some(v) = c.min_length {
-        return (ValidationOperator::GreaterThanOrEqual, v.to_string(), None);
+    if let Some(v) = formula_bound(c, "minLength", c.min_length.map(|value| value as f64)) {
+        return (ValidationOperator::GreaterThanOrEqual, v, None);
     }
-    if let Some(v) = c.max_length {
-        return (ValidationOperator::LessThanOrEqual, v.to_string(), None);
+    if let Some(v) = formula_bound(c, "maxLength", c.max_length.map(|value| value as f64)) {
+        return (ValidationOperator::LessThanOrEqual, v, None);
     }
 
     (ValidationOperator::Between, String::new(), None)
@@ -403,35 +409,49 @@ fn operator_formulas_to_numeric_constraints(
     formula2: Option<&str>,
 ) -> SchemaConstraints {
     let mut c = SchemaConstraints::default();
-    let f1: Option<f64> = formula1.parse().ok();
-    let f2: Option<f64> = formula2.and_then(|s| s.parse().ok());
+    let f1 = parse_numeric_formula(formula1);
+    let f2 = formula2.and_then(parse_numeric_formula);
 
     match operator {
         ValidationOperator::Between => {
             c.min = f1;
             c.max = f2;
+            retain_formula_bound(&mut c, "min", formula1, f1);
+            if let Some(formula2) = formula2 {
+                retain_formula_bound(&mut c, "max", formula2, f2);
+            }
         }
         ValidationOperator::NotBetween => {
             c.not_between_min = f1;
             c.not_between_max = f2;
+            retain_formula_bound(&mut c, "notBetweenMin", formula1, f1);
+            if let Some(formula2) = formula2 {
+                retain_formula_bound(&mut c, "notBetweenMax", formula2, f2);
+            }
         }
         ValidationOperator::Equal => {
             c.equal = f1;
+            retain_formula_bound(&mut c, "equal", formula1, f1);
         }
         ValidationOperator::NotEqual => {
             c.not_equal = f1;
+            retain_formula_bound(&mut c, "notEqual", formula1, f1);
         }
         ValidationOperator::GreaterThan => {
             c.exclusive_min = f1;
+            retain_formula_bound(&mut c, "exclusiveMin", formula1, f1);
         }
         ValidationOperator::GreaterThanOrEqual => {
             c.min = f1;
+            retain_formula_bound(&mut c, "min", formula1, f1);
         }
         ValidationOperator::LessThan => {
             c.exclusive_max = f1;
+            retain_formula_bound(&mut c, "exclusiveMax", formula1, f1);
         }
         ValidationOperator::LessThanOrEqual => {
             c.max = f1;
+            retain_formula_bound(&mut c, "max", formula1, f1);
         }
     }
     c
@@ -444,23 +464,87 @@ fn operator_formulas_to_length_constraints(
     formula2: Option<&str>,
 ) -> SchemaConstraints {
     let mut c = SchemaConstraints::default();
-    let f1: Option<usize> = formula1.parse().ok();
-    let f2: Option<usize> = formula2.and_then(|s| s.parse().ok());
+    let f1 = parse_length_formula(formula1);
+    let f2 = formula2.and_then(parse_length_formula);
 
     match operator {
         ValidationOperator::Between => {
             c.min_length = f1;
             c.max_length = f2;
+            retain_formula_bound(&mut c, "minLength", formula1, f1.map(|value| value as f64));
+            if let Some(formula2) = formula2 {
+                retain_formula_bound(&mut c, "maxLength", formula2, f2.map(|value| value as f64));
+            }
         }
         ValidationOperator::GreaterThanOrEqual => {
             c.min_length = f1;
+            retain_formula_bound(&mut c, "minLength", formula1, f1.map(|value| value as f64));
         }
         ValidationOperator::LessThanOrEqual => {
             c.max_length = f1;
+            retain_formula_bound(&mut c, "maxLength", formula1, f1.map(|value| value as f64));
         }
         _ => {
             c.min_length = f1;
+            retain_formula_bound(&mut c, "minLength", formula1, f1.map(|value| value as f64));
         }
     }
     c
+}
+
+fn formula_bound(
+    constraints: &SchemaConstraints,
+    key: &str,
+    literal: Option<f64>,
+) -> Option<String> {
+    constraints
+        .formula_bounds
+        .as_ref()
+        .and_then(|bounds| bounds.get(key).cloned())
+        .or_else(|| literal.map(|value| value.to_string()))
+}
+
+fn parse_numeric_formula(value: &str) -> Option<f64> {
+    value
+        .trim()
+        .strip_prefix('=')
+        .unwrap_or(value.trim())
+        .trim()
+        .parse::<f64>()
+        .ok()
+        .filter(|value| value.is_finite())
+}
+
+fn parse_length_formula(value: &str) -> Option<usize> {
+    let value = parse_numeric_formula(value)?;
+    if value < 0.0 || value.fract() != 0.0 || value > usize::MAX as f64 {
+        return None;
+    }
+    Some(value as usize)
+}
+
+fn retain_formula_bound(
+    constraints: &mut SchemaConstraints,
+    key: &str,
+    formula: &str,
+    parsed: Option<f64>,
+) {
+    if parsed.is_some() {
+        return;
+    }
+    let raw = formula.trim();
+    if raw.is_empty() {
+        return;
+    }
+    constraints
+        .formula_bounds
+        .get_or_insert_with(Default::default)
+        .insert(
+            key.to_string(),
+            if raw.starts_with('=') {
+                raw.to_string()
+            } else {
+                format!("={raw}")
+            },
+        );
 }

--- a/domain-types/src/domain/validation/schema_types.rs
+++ b/domain-types/src/domain/validation/schema_types.rs
@@ -180,6 +180,17 @@ pub struct SchemaConstraints {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enum_source_formula: Option<String>,
 
+    /// Original formula operands for range validation bounds.
+    ///
+    /// Numeric and text-length bounds are also represented by the typed
+    /// fields above when a literal can be parsed. Formula operands such as
+    /// `=A1` and `=SUM(A1:A3)` cannot be reduced to those fields without
+    /// losing their dynamic behavior, so they are retained here by the
+    /// validation conversion boundary. Keys use the corresponding
+    /// camelCase constraint names (`min`, `max`, `minLength`, and so on).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub formula_bounds: Option<HashMap<String, String>>,
+
     // Uniqueness
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unique: Option<bool>,


### PR DESCRIPTION
## What changed

Adds the Office.js alignment checkpoint for the headless runtime. The production host now carries the worksheet, range, names, tables, formatting, validation, border, and extension dispatch paths, with table row add hydration and qualified workbook table addresses preserved in the sync response.

The follow-up dispatch commit also keeps inherited `isNullObject` out of strict family `load` adapters while returning the Office.js boolean at the binding boundary.

## Validation

- `rustfmt --edition 2021 --check compute/officejs/src/dispatch.rs`
- `node --check compute/officejs/src/bootstrap.js`
- Cargo gates were left to the root agent per the parallel workstream instruction. The latest root gate is currently blocked in `compute-api` because `YrsComputeEngine::set_hyperlink_with_metadata` is not yet available.
