### PR TITLE
Add calipers as a git submodule and a root test runner

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "calipers"]
+	path = calipers
+	url = git@github.com:fundamental-research-labs/calipers.git

--- a/run-calipers-tests.sh
+++ b/run-calipers-tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+git -C "${root}" submodule update --init -- calipers
+cd "${root}/calipers"
+exec go test ./... "$@"


### PR DESCRIPTION
Record [fundamental-research-labs/calipers](https://github.com/fundamental-research-labs/calipers) as a git submodule and add `run-calipers-tests.sh` so Mog can initialize that checkout and run its Go test suite.

The runner is a thin wrapper: resolve the repo root, `git submodule update --init -- calipers`, then `go test ./...` in the submodule (extra args are forwarded).

Calipers is a private org repo. Clones without org credentials will fail `git submodule update`. This PR does not add a Mog `save`/`run` CLI, CI wiring, or `calipers verify` against Excel goldens.

### Validation

- `./run-calipers-tests.sh` twice from the mog repo root, both exit 0
- Six calipers packages reported `ok` on each run (`cmd/calipers`, `internal/cases`, `internal/compare`, `internal/engine`, `internal/excel`, `internal/golden`)