### PR TITLE
Add GitHub Actions CI to build Mog and run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
 
       - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           # Workspace cargo config sets build.target-dir = "target-native".
           workspaces: ". -> target-native"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Workspace cargo config sets build.target-dir = "target-native".
+          workspaces: ". -> target-native"
+          cache-on-failure: true
+
+      - name: Build Mog
+        run: cargo build -p mog --locked
+
+      - name: Test
+        run: cargo test --workspace --locked

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ cargo test -p mog
 cargo test -p compute-api
 ```
 
+Pull requests and `main` run `cargo build -p mog --locked` and
+`cargo test --workspace --locked` on GitHub Actions.
+
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
Adds a basic public CI gate so pull requests can be merged with a real build and test run.

## What it runs

On pull requests, `main`, and `workflow_dispatch`:

- `cargo build -p mog --locked`
- `cargo test --workspace --locked`

This uses the GitHub-hosted `ubuntu-latest` runner (no paid minutes on this public repo).

## Caching

Rust builds are cached with [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache), which is the standard GitHub Actions cache for Cargo. The cache key includes the toolchain and lockfile, and it persists `~/.cargo` plus dependency artifacts under `target-native` (the workspace `build.target-dir`). Workspace crates themselves are not cached, which is the recommended setup.

`cache-on-failure` is on so a first-run compile is kept even if a test fails.

## Why workspace tests

The README smoke tests (`-p mog` / `-p compute-api`) are not enough to merge parser/engine PRs. Workspace tests are the gate that would have caught the `engine.mirror()` compile break in #362 against current `main`.