### PR TITLE
Preserve XLSX roundtrip facts and add calipers save/run CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,39 @@ jobs:
 
       - name: Test
         run: cargo test --workspace --locked
+
+  verify:
+    name: Calipers verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Checkout calipers submodule
+        run: |
+          git submodule init vendor/calipers
+          git config submodule.calipers.url https://github.com/fundamental-research-labs/calipers.git
+          git submodule update vendor/calipers
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: ". -> target-native"
+          cache-on-failure: true
+
+      - name: Install Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: vendor/calipers/go.mod
+          cache-dependency-path: vendor/calipers/go.sum
+
+      - name: Build Mog
+        run: cargo build -p mog --locked
+
+      - name: Verify XLSX roundtrip cases
+        run: ./run-calipers-verify.sh

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ rust_out
 
 # Python benchmark tooling
 __pycache__/
+
+# Local Excel verifier clone (not a submodule; not committed)
+vendor/calipers/

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,3 @@ rust_out
 
 # Python benchmark tooling
 __pycache__/
-
-# Local Excel verifier clone (not a submodule; not committed)
-vendor/calipers/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,6 +1315,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "value-types",
+ "xlsx-parser",
 ]
 
 [[package]]

--- a/compute/api/src/lib.rs
+++ b/compute/api/src/lib.rs
@@ -53,3 +53,5 @@ pub use workbook::{
     scenarios::WorkbookScenarios, settings::WorkbookSettings, sheets::WorkbookSheets,
     styles::WorkbookStyles,
 };
+
+pub use compute_core::bridge_types::named_ranges::DefinedNameInput;

--- a/compute/api/src/workbook.rs
+++ b/compute/api/src/workbook.rs
@@ -78,6 +78,35 @@ impl Workbook {
         })
     }
 
+    /// Load a workbook from XLSX bytes.
+    pub fn from_xlsx_bytes(xlsx_data: &[u8]) -> Result<(Self, RecalcResult), ComputeApiError> {
+        use compute_core::storage::engine::ComputeEngine;
+
+        let (engine, recalc) = ComputeEngine::from_xlsx_bytes(xlsx_data)?;
+
+        #[cfg(feature = "native")]
+        let dispatch = Dispatch::spawn(engine)?;
+
+        #[cfg(not(feature = "native"))]
+        let dispatch = Dispatch::new(engine);
+
+        Ok((Workbook { dispatch }, recalc))
+    }
+
+    /// Export the current workbook to XLSX bytes.
+    pub fn to_xlsx_bytes(&self) -> Result<Vec<u8>, ComputeApiError> {
+        self.dispatch
+            .query_engine(|e| e.export_to_xlsx_bytes())
+            .and_then(|r| r.map_err(ComputeApiError::from))
+    }
+
+    /// Recalculate every formula cell.
+    pub fn recalculate(&self) -> Result<RecalcResult, ComputeApiError> {
+        self.dispatch
+            .call_engine(|e| e.recalculate())
+            .and_then(|r| r.map_err(ComputeApiError::from))
+    }
+
     // -----------------------------------------------------------------
     // Sheet access
     // -----------------------------------------------------------------

--- a/compute/core/tests/xlsx_chart_title_overlay.rs
+++ b/compute/core/tests/xlsx_chart_title_overlay.rs
@@ -1,0 +1,91 @@
+//! Authored chart titles must export `<c:overlay val="0"/>` (#338).
+
+use compute_core::storage::engine::ComputeEngine;
+use snapshot_types::{CellData, SheetSnapshot, WorkbookSnapshot};
+use value_types::{CellValue, FiniteF64};
+use xlsx_parser::zip::XlsxArchive;
+
+fn snapshot_with_chart_data() -> WorkbookSnapshot {
+    let mut cells = vec![CellData {
+        cell_id: "a0000000-0000-0000-0000-000000000001".into(),
+        row: 0,
+        col: 0,
+        value: CellValue::Text("Month".into()),
+        formula: None,
+        identity_formula: None,
+        array_ref: None,
+    }];
+    cells.push(CellData {
+        cell_id: "a0000000-0000-0000-0000-000000000002".into(),
+        row: 0,
+        col: 1,
+        value: CellValue::Text("Units".into()),
+        formula: None,
+        identity_formula: None,
+        array_ref: None,
+    });
+    for i in 0..4u32 {
+        cells.push(CellData {
+            cell_id: format!("a0000000-0000-0000-0000-{:012x}", 10 + i),
+            row: i + 1,
+            col: 0,
+            value: CellValue::Text(format!("M{i}").into()),
+            formula: None,
+            identity_formula: None,
+            array_ref: None,
+        });
+        cells.push(CellData {
+            cell_id: format!("a0000000-0000-0000-0000-{:012x}", 20 + i),
+            row: i + 1,
+            col: 1,
+            value: CellValue::Number(FiniteF64::must(10.0 + f64::from(i) * 3.0)),
+            formula: None,
+            identity_formula: None,
+            array_ref: None,
+        });
+    }
+    WorkbookSnapshot {
+        sheets: vec![SheetSnapshot {
+            identities: Vec::new(),
+            row_axis: None,
+            col_axis: None,
+            id: "00000000-0000-0000-0000-000000000001".to_string(),
+            name: "Sheet1".to_string(),
+            rows: 20,
+            cols: 10,
+            cells,
+            ranges: vec![],
+        }],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn authored_chart_titles_export_overlay() {
+    let (mut engine, _) = ComputeEngine::from_snapshot(snapshot_with_chart_data()).unwrap();
+    let sid = *engine.cell_store().sheet_ids().next().unwrap();
+    engine
+        .create_chart(
+            &sid,
+            &serde_json::json!({
+                "type": "column",
+                "dataRange": "Sheet1!A1:B5",
+                "title": "Monthly Units",
+                "axis": {
+                    "categoryAxis": { "title": "Month", "visible": true },
+                    "valueAxis": { "title": "Units Sold", "visible": true }
+                }
+            }),
+        )
+        .unwrap();
+    let exported = engine.export_to_xlsx_bytes().expect("export");
+    let archive = XlsxArchive::new(&exported).unwrap();
+    let chart = String::from_utf8(archive.read_file("xl/charts/chart1.xml").unwrap()).unwrap();
+    assert!(chart.contains(">Monthly Units<"), "{chart}");
+    assert!(chart.contains(">Month<"), "{chart}");
+    assert!(chart.contains(">Units Sold<"), "{chart}");
+    assert!(
+        chart.matches(r#"<c:overlay val="0"/>"#).count() >= 3,
+        "authored titles must emit overlay: {chart}"
+    );
+}

--- a/compute/core/tests/xlsx_defined_names_order.rs
+++ b/compute/core/tests/xlsx_defined_names_order.rs
@@ -1,0 +1,83 @@
+//! names.add after loading an Excel-shaped workbook must emit definedNames
+//! in CT_Workbook order (#332).
+
+use compute_core::storage::engine::ComputeEngine;
+use domain_types::DefinedNameInput;
+use xlsx_parser::write::ZipWriter;
+use xlsx_parser::zip::XlsxArchive;
+
+fn excel_shaped_fixture() -> Vec<u8> {
+    let mut zip = ZipWriter::new();
+    zip.add_file(
+        "[Content_Types].xml",
+        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+      <Default Extension="xml" ContentType="application/xml"/>
+      <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+      <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+    </Types>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "_rels/.rels",
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+    </Relationships>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/workbook.xml",
+        br#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <workbookPr/>
+      <bookViews><workbookView/></bookViews>
+      <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+      <calcPr calcId="191029" fullCalcOnLoad="1"/>
+      <extLst><ext uri="{140A7094-0E35-4892-8432-C4D2E57EDEB7}" xmlns:x15="http://schemas.microsoft.com/office/spreadsheetml/2010/11/main"><x15:workbookPr chartTrackingRefBase="1"/></ext></extLst>
+    </workbook>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/_rels/workbook.xml.rels",
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+    </Relationships>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/worksheets/sheet1.xml",
+        br#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+      <sheetData><row r="1"><c r="A1"><v>1</v></c></row></sheetData>
+    </worksheet>"#
+            .to_vec(),
+    );
+    zip.finish().expect("excel-shaped fixture")
+}
+
+#[test]
+fn names_add_on_loaded_workbook_emits_defined_names_before_calc_pr() {
+    let (mut engine, _) = ComputeEngine::from_xlsx_bytes(&excel_shaped_fixture()).unwrap();
+    engine
+        .create_named_range(DefinedNameInput {
+            name: "Repro_Name".into(),
+            refers_to: "=Sheet1!$A$1:$A$10".into(),
+            scope: None,
+            comment: None,
+        })
+        .unwrap();
+    let exported = engine.export_to_xlsx_bytes().expect("export");
+    let xml = String::from_utf8(
+        XlsxArchive::new(&exported)
+            .unwrap()
+            .read_file("xl/workbook.xml")
+            .unwrap(),
+    )
+    .unwrap();
+    let names = xml.find("<definedNames>").expect(&xml);
+    let calc = xml.find("<calcPr").expect(&xml);
+    let ext = xml.find("<extLst").unwrap_or(xml.len());
+    assert!(
+        names < calc && names < ext,
+        "definedNames must precede calcPr/extLst: {xml}"
+    );
+    assert!(xml.contains("Repro_Name"), "{xml}");
+}

--- a/compute/core/tests/xlsx_multi_row_formulas.rs
+++ b/compute/core/tests/xlsx_multi_row_formulas.rs
@@ -1,0 +1,66 @@
+//! Formula strings on later rows of a bulk write must survive export (#328).
+
+use compute_core::storage::engine::ComputeEngine;
+use snapshot_types::{CellData, SheetSnapshot, WorkbookSnapshot};
+use value_types::CellValue;
+use xlsx_parser::zip::XlsxArchive;
+
+fn blank_snapshot() -> WorkbookSnapshot {
+    WorkbookSnapshot {
+        sheets: vec![SheetSnapshot {
+            identities: Vec::new(),
+            row_axis: None,
+            col_axis: None,
+            id: "00000000-0000-0000-0000-000000000001".to_string(),
+            name: "Sheet1".to_string(),
+            rows: 100,
+            cols: 26,
+            cells: vec![CellData {
+                cell_id: "a0000000-0000-0000-0000-000000000001".into(),
+                row: 0,
+                col: 0,
+                value: CellValue::Null,
+                formula: None,
+                identity_formula: None,
+                array_ref: None,
+            }],
+            ranges: vec![],
+        }],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn bulk_set_keeps_formula_strings_on_every_row_after_export() {
+    let (mut engine, _) = ComputeEngine::from_snapshot(blank_snapshot()).unwrap();
+    let sid = *engine.cell_store().sheet_ids().next().unwrap();
+    engine
+        .set_cell_values_parsed(
+            &sid,
+            vec![
+                (0, 0, "100".into()),
+                (0, 1, "=A1".into()),
+                (0, 2, "=B1+B2".into()),
+                (1, 0, "200".into()),
+                (1, 1, "=A2".into()),
+            ],
+        )
+        .unwrap();
+
+    let exported = engine.export_to_xlsx_bytes().expect("export");
+    let xml = String::from_utf8(
+        XlsxArchive::new(&exported)
+            .unwrap()
+            .read_file("xl/worksheets/sheet1.xml")
+            .unwrap(),
+    )
+    .unwrap();
+    assert!(
+        xml.contains("<f>A1</f>") || xml.contains("<f>=A1</f>"),
+        "{xml}"
+    );
+    assert!(
+        xml.contains("<f>A2</f>") || xml.contains("<f>=A2</f>"),
+        "second-row formula lost: {xml}"
+    );
+}

--- a/compute/core/tests/xlsx_sheet_id_unique.rs
+++ b/compute/core/tests/xlsx_sheet_id_unique.rs
@@ -1,0 +1,77 @@
+//! Generated sheet IDs after import must be unique and positive (#334).
+
+use compute_core::storage::engine::ComputeEngine;
+use xlsx_parser::write::ZipWriter;
+use xlsx_parser::zip::XlsxArchive;
+
+fn sparse_sheet_id_fixture() -> Vec<u8> {
+    let mut zip = ZipWriter::new();
+    zip.add_file(
+        "[Content_Types].xml",
+        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+      <Default Extension="xml" ContentType="application/xml"/>
+      <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+      <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+    </Types>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "_rels/.rels",
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+    </Relationships>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/workbook.xml",
+        br#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <sheets><sheet name="Imported" sheetId="2" r:id="rId1"/></sheets>
+    </workbook>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/_rels/workbook.xml.rels",
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+    </Relationships>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/worksheets/sheet1.xml",
+        br#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+      <sheetData><row r="1"><c r="A1"><v>1</v></c></row></sheetData>
+    </worksheet>"#
+            .to_vec(),
+    );
+    zip.finish().expect("sparse sheetId fixture")
+}
+
+#[test]
+fn import_then_add_sheet_exports_unique_positive_sheet_ids() {
+    let (mut engine, _) = ComputeEngine::from_xlsx_bytes(&sparse_sheet_id_fixture()).unwrap();
+    engine.create_sheet("Added").unwrap();
+    let exported = engine.export_to_xlsx_bytes().expect("export");
+    let xml = String::from_utf8(
+        XlsxArchive::new(&exported)
+            .unwrap()
+            .read_file("xl/workbook.xml")
+            .unwrap(),
+    )
+    .unwrap();
+    let mut ids = Vec::new();
+    for part in xml.split("sheetId=\"").skip(1) {
+        let id = part.split('"').next().unwrap().parse::<u32>().expect(part);
+        assert!(id > 0, "sheetId must be positive: {xml}");
+        ids.push(id);
+    }
+    assert_eq!(ids.len(), 2, "{xml}");
+    assert_eq!(
+        ids.iter()
+            .copied()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        ids.len(),
+        "duplicate sheetId: {xml}"
+    );
+}

--- a/compute/core/tests/xlsx_theme_linked_color_roundtrip.rs
+++ b/compute/core/tests/xlsx_theme_linked_color_roundtrip.rs
@@ -1,0 +1,126 @@
+//! Theme-linked cell colors must survive import/export as theme+tint (#329).
+
+use compute_core::storage::engine::ComputeEngine;
+use xlsx_parser::write::ZipWriter;
+use xlsx_parser::zip::XlsxArchive;
+
+fn theme_linked_fixture() -> Vec<u8> {
+    let mut zip = ZipWriter::new();
+    zip.add_file(
+        "[Content_Types].xml",
+        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+      <Default Extension="xml" ContentType="application/xml"/>
+      <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+      <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+      <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+      <Override PartName="/xl/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>
+    </Types>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "_rels/.rels",
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+    </Relationships>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/workbook.xml",
+        br#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+    </workbook>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/_rels/workbook.xml.rels",
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+      <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+      <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/>
+    </Relationships>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/worksheets/sheet1.xml",
+        br#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+      <sheetData><row r="1"><c r="A1" s="1" t="inlineStr"><is><t>theme-linked</t></is></c></row></sheetData>
+    </worksheet>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/styles.xml",
+        br#"<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+      <fonts count="2">
+        <font><sz val="11"/><color theme="1"/><name val="Calibri"/></font>
+        <font><sz val="11"/><color theme="4" tint="0.2"/><name val="Calibri"/></font>
+      </fonts>
+      <fills count="1"><fill><patternFill patternType="none"/></fill></fills>
+      <borders count="1"><border/></borders>
+      <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+      <cellXfs count="2">
+        <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
+        <xf numFmtId="0" fontId="1" fillId="0" borderId="0" xfId="0" applyFont="1"/>
+      </cellXfs>
+    </styleSheet>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/theme/theme1.xml",
+        br#"<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme">
+      <a:themeElements>
+        <a:clrScheme name="Office">
+          <a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>
+          <a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>
+          <a:dk2><a:srgbClr val="1F497D"/></a:dk2>
+          <a:lt2><a:srgbClr val="EEECE1"/></a:lt2>
+          <a:accent1><a:srgbClr val="4F81BD"/></a:accent1>
+          <a:accent2><a:srgbClr val="C0504D"/></a:accent2>
+          <a:accent3><a:srgbClr val="9BBB59"/></a:accent3>
+          <a:accent4><a:srgbClr val="8064A2"/></a:accent4>
+          <a:accent5><a:srgbClr val="4BACC6"/></a:accent5>
+          <a:accent6><a:srgbClr val="F79646"/></a:accent6>
+          <a:hlink><a:srgbClr val="0000FF"/></a:hlink>
+          <a:folHlink><a:srgbClr val="800080"/></a:folHlink>
+        </a:clrScheme>
+        <a:fontScheme name="Office">
+          <a:majorFont><a:latin typeface="Cambria"/></a:majorFont>
+          <a:minorFont><a:latin typeface="Calibri"/></a:minorFont>
+        </a:fontScheme>
+        <a:fmtScheme name="Office">
+          <a:fillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:fillStyleLst>
+          <a:lnStyleLst><a:ln w="6350"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln></a:lnStyleLst>
+          <a:effectStyleLst><a:effectStyle><a:effectLst/></a:effectStyle></a:effectStyleLst>
+          <a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:bgFillStyleLst>
+        </a:fmtScheme>
+      </a:themeElements>
+    </a:theme>"#
+            .to_vec(),
+    );
+    zip.finish().expect("theme fixture")
+}
+
+#[test]
+fn imported_theme_font_color_exports_theme_and_tint() {
+    let (engine, _) = ComputeEngine::from_xlsx_bytes(&theme_linked_fixture()).unwrap();
+    let exported = engine.export_to_xlsx_bytes().expect("export");
+    let styles = String::from_utf8(
+        XlsxArchive::new(&exported)
+            .unwrap()
+            .read_file("xl/styles.xml")
+            .unwrap(),
+    )
+    .unwrap();
+    assert!(
+        styles.contains(r#"theme="4""#),
+        "theme slot must survive export: {styles}"
+    );
+    assert!(
+        styles.contains(r#"tint="0.2""#) || styles.contains(r#"tint="0.20""#),
+        "tint must survive export: {styles}"
+    );
+    assert!(
+        !styles.to_ascii_uppercase().contains(r#"RGB="THEME:"#),
+        "must not serialize theme strings as RGB: {styles}"
+    );
+}

--- a/compute/core/tests/xlsx_workbook_font_roundtrip.rs
+++ b/compute/core/tests/xlsx_workbook_font_roundtrip.rs
@@ -1,0 +1,153 @@
+//! Workbook fonts survive load+export even when cells have no `s` attribute.
+
+use compute_core::storage::engine::ComputeEngine;
+use xlsx_parser::write::ZipWriter;
+use xlsx_parser::zip::XlsxArchive;
+
+fn workbook_with_normal_font(name: &str, size: &str) -> Vec<u8> {
+    let mut zip = ZipWriter::new();
+    zip.add_file(
+        "[Content_Types].xml",
+        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+      <Default Extension="xml" ContentType="application/xml"/>
+      <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+      <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+      <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+      <Override PartName="/xl/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>
+    </Types>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "_rels/.rels",
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+    </Relationships>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/workbook.xml",
+        br#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+    </workbook>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/_rels/workbook.xml.rels",
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+      <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+      <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/>
+    </Relationships>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/worksheets/sheet1.xml",
+        br#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+      <sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>hello</t></is></c></row></sheetData>
+    </worksheet>"#
+            .to_vec(),
+    );
+    let styles = format!(
+        r#"<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+      <fonts count="1"><font><sz val="{size}"/><color theme="1"/><name val="{name}"/><family val="2"/><scheme val="minor"/></font></fonts>
+      <fills count="2"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill></fills>
+      <borders count="1"><border/></borders>
+      <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+      <cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs>
+    </styleSheet>"#
+    );
+    zip.add_file("xl/styles.xml", styles.into_bytes());
+    zip.add_file(
+        "xl/theme/theme1.xml",
+        format!(
+            r#"<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme">
+      <a:themeElements>
+        <a:clrScheme name="Office">
+          <a:dk1><a:srgbClr val="000000"/></a:dk1>
+          <a:lt1><a:srgbClr val="FFFFFF"/></a:lt1>
+          <a:dk2><a:srgbClr val="1F497D"/></a:dk2>
+          <a:lt2><a:srgbClr val="EEECE1"/></a:lt2>
+          <a:accent1><a:srgbClr val="4F81BD"/></a:accent1>
+          <a:accent2><a:srgbClr val="C0504D"/></a:accent2>
+          <a:accent3><a:srgbClr val="9BBB59"/></a:accent3>
+          <a:accent4><a:srgbClr val="8064A2"/></a:accent4>
+          <a:accent5><a:srgbClr val="4BACC6"/></a:accent5>
+          <a:accent6><a:srgbClr val="F79646"/></a:accent6>
+          <a:hlink><a:srgbClr val="0000FF"/></a:hlink>
+          <a:folHlink><a:srgbClr val="800080"/></a:folHlink>
+        </a:clrScheme>
+        <a:fontScheme name="Office">
+          <a:majorFont><a:latin typeface="{name}"/></a:majorFont>
+          <a:minorFont><a:latin typeface="{name}"/></a:minorFont>
+        </a:fontScheme>
+        <a:fmtScheme name="Office">
+          <a:fillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:fillStyleLst>
+          <a:lnStyleLst><a:ln w="6350"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln></a:lnStyleLst>
+          <a:effectStyleLst><a:effectStyle><a:effectLst/></a:effectStyle></a:effectStyleLst>
+          <a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:bgFillStyleLst>
+        </a:fmtScheme>
+      </a:themeElements>
+    </a:theme>"#
+        )
+        .into_bytes(),
+    );
+    zip.finish().expect("font fixture")
+}
+
+fn exported_styles(bytes: &[u8]) -> String {
+    String::from_utf8(
+        XlsxArchive::new(bytes)
+            .unwrap()
+            .read_file("xl/styles.xml")
+            .unwrap(),
+    )
+    .unwrap()
+}
+
+fn exported_theme(bytes: &[u8]) -> String {
+    String::from_utf8(
+        XlsxArchive::new(bytes)
+            .unwrap()
+            .read_file("xl/theme/theme1.xml")
+            .unwrap(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn calibri_12_normal_font_survives_cells_without_style_index() {
+    let (engine, _) =
+        ComputeEngine::from_xlsx_bytes(&workbook_with_normal_font("Calibri", "12")).unwrap();
+    let exported = engine.export_to_xlsx_bytes().expect("export");
+    let styles = exported_styles(&exported);
+    assert!(
+        styles.contains(r#"<name val="Calibri"/>"#),
+        "Calibri must survive export: {styles}"
+    );
+    assert!(
+        styles.contains(r#"<sz val="12"/>"#),
+        "12pt must survive export (not rewritten to 11): {styles}"
+    );
+}
+
+#[test]
+fn aptos_narrow_theme_font_is_not_rewritten_to_calibri() {
+    let (engine, _) =
+        ComputeEngine::from_xlsx_bytes(&workbook_with_normal_font("Aptos Narrow", "11")).unwrap();
+    let exported = engine.export_to_xlsx_bytes().expect("export");
+    let styles = exported_styles(&exported);
+    let theme = exported_theme(&exported);
+    assert!(
+        styles.contains(r#"<name val="Aptos Narrow"/>"#),
+        "Aptos Narrow must survive export: {styles}"
+    );
+    assert!(
+        !styles.contains(r#"<name val="Calibri"/>"#),
+        "must not replace workbook font with Calibri: {styles}"
+    );
+    assert!(
+        theme.contains(r#"typeface="Aptos Narrow""#),
+        "theme latin typeface must survive export: {theme}"
+    );
+}

--- a/compute/officejs/Cargo.toml
+++ b/compute/officejs/Cargo.toml
@@ -22,3 +22,4 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+xlsx-parser = { path = "../../file-io/xlsx/parser" }

--- a/compute/officejs/src/bootstrap.js
+++ b/compute/officejs/src/bootstrap.js
@@ -91,9 +91,28 @@
   function Workbook(context) {
     ClientObject.call(this, context);
     this.worksheets = new WorksheetCollection(context);
+    this.names = new NamedItemCollection(context);
   }
   Workbook.prototype = Object.create(ClientObject.prototype);
   Workbook.prototype.constructor = Workbook;
+
+  function NamedItemCollection(context) {
+    ClientObject.call(this, context);
+  }
+  NamedItemCollection.prototype = Object.create(ClientObject.prototype);
+  NamedItemCollection.prototype.constructor = NamedItemCollection;
+
+  NamedItemCollection.prototype.add = function (name, reference) {
+    var item = new ClientObject(this.context);
+    var op = { op: "addName", id: item._id, name: String(name) };
+    if (reference && typeof reference === "object" && reference._id) {
+      op.rangeId = reference._id;
+    } else if (reference != null) {
+      op.formula = String(reference);
+    }
+    this.context._queue.push(op);
+    return item;
+  };
 
   function WorksheetCollection(context) {
     ClientObject.call(this, context);
@@ -121,9 +140,19 @@
     return ws;
   };
 
+  WorksheetCollection.prototype.getActiveWorksheet = function () {
+    var ws = new Worksheet(this.context, null);
+    this.context._queue.push({
+      op: "getActiveWorksheet",
+      id: ws._id,
+    });
+    return ws;
+  };
+
   function Worksheet(context, name) {
     ClientObject.call(this, context);
     this._nameHint = name;
+    this.charts = new ChartCollection(context, this);
   }
   Worksheet.prototype = Object.create(ClientObject.prototype);
   Worksheet.prototype.constructor = Worksheet;
@@ -207,8 +236,83 @@
     return promise;
   }
 
+  function ChartCollection(context, worksheet) {
+    ClientObject.call(this, context);
+    this._worksheet = worksheet;
+  }
+  ChartCollection.prototype = Object.create(ClientObject.prototype);
+  ChartCollection.prototype.constructor = ChartCollection;
+
+  ChartCollection.prototype.add = function (type, source) {
+    var chart = new Chart(this.context);
+    this.context._queue.push({
+      op: "addChart",
+      id: chart._id,
+      worksheetId: this._worksheet._id,
+      chartType: String(type),
+      sourceRangeId: source._id,
+    });
+    return chart;
+  };
+
+  function Chart(context) {
+    ClientObject.call(this, context);
+    this.title = new ChartTitle(context, this._id);
+    this.axes = new ChartAxes(context, this._id);
+  }
+  Chart.prototype = Object.create(ClientObject.prototype);
+  Chart.prototype.constructor = Chart;
+
+  function ChartTitle(context, chartId) {
+    this.context = context;
+    this._chartId = chartId;
+  }
+  Object.defineProperty(ChartTitle.prototype, "text", {
+    set: function (value) {
+      this.context._queue.push({
+        op: "set",
+        id: this._chartId,
+        property: "title.text",
+        value: value,
+      });
+    },
+  });
+
+  function ChartAxes(context, chartId) {
+    this.categoryAxis = new ChartAxis(context, chartId, "categoryAxis");
+    this.valueAxis = new ChartAxis(context, chartId, "valueAxis");
+  }
+
+  function ChartAxis(context, chartId, kind) {
+    this.title = new ChartAxisTitle(context, chartId, kind);
+  }
+
+  function ChartAxisTitle(context, chartId, kind) {
+    this.context = context;
+    this._chartId = chartId;
+    this._kind = kind;
+  }
+  Object.defineProperty(ChartAxisTitle.prototype, "text", {
+    set: function (value) {
+      this.context._queue.push({
+        op: "set",
+        id: this._chartId,
+        property: "axes." + this._kind + ".title.text",
+        value: value,
+      });
+    },
+  });
+
   global.__mogPendingRuns = pendingRuns;
-  global.Excel = { run: run };
+  global.Excel = {
+    run: run,
+    ChartType: {
+      columnClustered: "ColumnClustered",
+      barClustered: "BarClustered",
+      line: "Line",
+      pie: "Pie",
+    },
+  };
   global.OfficeExtension = {
     ClientObject: ClientObject,
     RequestContext: RequestContext,

--- a/compute/officejs/src/host.rs
+++ b/compute/officejs/src/host.rs
@@ -11,6 +11,8 @@ use value_types::CellValue;
 enum Op {
     #[serde(rename = "getItem")]
     GetItem { id: String, name: String },
+    #[serde(rename = "getActiveWorksheet")]
+    GetActiveWorksheet { id: String },
     #[serde(rename = "addWorksheet")]
     AddWorksheet { id: String, name: Option<String> },
     #[serde(rename = "getRange")]
@@ -19,6 +21,25 @@ enum Op {
         #[serde(rename = "worksheetId")]
         worksheet_id: String,
         address: String,
+    },
+    #[serde(rename = "addName")]
+    AddName {
+        #[serde(rename = "id")]
+        _id: String,
+        name: String,
+        #[serde(rename = "rangeId")]
+        range_id: Option<String>,
+        formula: Option<String>,
+    },
+    #[serde(rename = "addChart")]
+    AddChart {
+        id: String,
+        #[serde(rename = "worksheetId")]
+        worksheet_id: String,
+        #[serde(rename = "chartType")]
+        chart_type: String,
+        #[serde(rename = "sourceRangeId")]
+        source_range_id: String,
     },
     #[serde(rename = "set")]
     Set {
@@ -49,10 +70,19 @@ struct RangeRef {
     bounds: (u32, u32, u32, u32),
 }
 
+struct ChartRef {
+    sheet: Sheet,
+    chart_id: String,
+    title: Option<String>,
+    category_title: Option<String>,
+    value_title: Option<String>,
+}
+
 pub(crate) struct Host {
     workbook: Workbook,
     sheets: Mutex<HashMap<String, Sheet>>,
     ranges: Mutex<HashMap<String, RangeRef>>,
+    charts: Mutex<HashMap<String, ChartRef>>,
     stdout: Mutex<String>,
 }
 
@@ -62,6 +92,7 @@ impl Host {
             workbook,
             sheets: Mutex::new(HashMap::new()),
             ranges: Mutex::new(HashMap::new()),
+            charts: Mutex::new(HashMap::new()),
             stdout: Mutex::new(String::new()),
         }
     }
@@ -101,10 +132,12 @@ impl Host {
             message: format!("invalid Office.js batch: {e}"),
         })?;
 
-        if !ops
-            .iter()
-            .any(|op| matches!(op, Op::AddWorksheet { .. } | Op::Set { .. }))
-        {
+        if !ops.iter().any(|op| {
+            matches!(
+                op,
+                Op::AddWorksheet { .. } | Op::Set { .. } | Op::AddName { .. } | Op::AddChart { .. }
+            )
+        }) {
             return self.apply_batch(ops);
         }
 
@@ -135,6 +168,15 @@ impl Host {
                         code: "ItemNotFound",
                         message: format!("The requested resource doesn't exist. Name: {name}"),
                     })?;
+                    self.sheets.lock().expect("sheets lock").insert(id, sheet);
+                }
+                Op::GetActiveWorksheet { id } => {
+                    let names = self.workbook.sheet_names().map_err(engine_error)?;
+                    let name = names.first().ok_or_else(|| BatchError {
+                        code: "ItemNotFound",
+                        message: "The workbook has no worksheets.".to_string(),
+                    })?;
+                    let sheet = self.workbook.sheet_by_name(name).map_err(engine_error)?;
                     self.sheets.lock().expect("sheets lock").insert(id, sheet);
                 }
                 Op::AddWorksheet { id, name } => {
@@ -177,11 +219,104 @@ impl Host {
                         .expect("ranges lock")
                         .insert(id, RangeRef { sheet, bounds });
                 }
+                Op::AddName {
+                    name,
+                    range_id,
+                    formula,
+                    _id: _,
+                } => {
+                    let refers_to = if let Some(range_id) = range_id {
+                        let ranges = self.ranges.lock().expect("ranges lock");
+                        let range = ranges.get(&range_id).ok_or_else(|| BatchError {
+                            code: "InvalidObjectPath",
+                            message: "The range object is not available.".to_string(),
+                        })?;
+                        let sheet_name = range.sheet.name().map_err(engine_error)?;
+                        range_formula(&sheet_name, range.bounds)
+                    } else {
+                        let raw = formula.unwrap_or_default();
+                        if raw.trim().is_empty() {
+                            return Err(BatchError {
+                                code: "InvalidArgument",
+                                message: "names.add requires a range or formula".to_string(),
+                            });
+                        }
+                        if raw.starts_with('=') {
+                            raw
+                        } else {
+                            format!("={raw}")
+                        }
+                    };
+                    self.workbook
+                        .names()
+                        .create_named_range(compute_api::DefinedNameInput {
+                            name,
+                            refers_to,
+                            scope: None,
+                            comment: None,
+                        })
+                        .map_err(engine_error)?;
+                }
+                Op::AddChart {
+                    id,
+                    worksheet_id,
+                    chart_type,
+                    source_range_id,
+                } => {
+                    let sheet = self
+                        .sheets
+                        .lock()
+                        .expect("sheets lock")
+                        .get(&worksheet_id)
+                        .cloned()
+                        .ok_or_else(|| BatchError {
+                            code: "InvalidObjectPath",
+                            message: "The worksheet object is not available.".to_string(),
+                        })?;
+                    let ranges = self.ranges.lock().expect("ranges lock");
+                    let range = ranges.get(&source_range_id).ok_or_else(|| BatchError {
+                        code: "InvalidObjectPath",
+                        message: "The range object is not available.".to_string(),
+                    })?;
+                    let sheet_name = range.sheet.name().map_err(engine_error)?;
+                    let data_range = unqualified_range_formula(&sheet_name, range.bounds);
+                    let config = json!({
+                        "type": map_chart_type(&chart_type),
+                        "dataRange": data_range,
+                    });
+                    let result = sheet.charts().create(&config).map_err(engine_error)?;
+                    let chart_id = result
+                        .data
+                        .as_ref()
+                        .and_then(|data| {
+                            data.as_str().map(str::to_string).or_else(|| {
+                                data.get("id").and_then(Value::as_str).map(str::to_string)
+                            })
+                        })
+                        .ok_or_else(|| BatchError {
+                            code: "GeneralException",
+                            message: "chart creation did not return an id".to_string(),
+                        })?;
+                    self.charts.lock().expect("charts lock").insert(
+                        id,
+                        ChartRef {
+                            sheet,
+                            chart_id,
+                            title: None,
+                            category_title: None,
+                            value_title: None,
+                        },
+                    );
+                }
                 Op::Set {
                     id,
                     property,
                     value,
                 } => {
+                    if self.charts.lock().expect("charts lock").contains_key(&id) {
+                        self.set_chart_property(&id, &property, &value)?;
+                        continue;
+                    }
                     let ranges = self.ranges.lock().expect("ranges lock");
                     let range = ranges.get(&id).ok_or_else(|| BatchError {
                         code: "InvalidObjectPath",
@@ -245,6 +380,101 @@ impl Host {
             loaded,
         })
     }
+
+    fn set_chart_property(
+        &self,
+        id: &str,
+        property: &str,
+        value: &Value,
+    ) -> Result<(), BatchError> {
+        let mut charts = self.charts.lock().expect("charts lock");
+        let chart = charts.get_mut(id).ok_or_else(|| BatchError {
+            code: "InvalidObjectPath",
+            message: "The chart object is not available.".to_string(),
+        })?;
+        let text = match value {
+            Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        match property {
+            "title.text" => chart.title = Some(text),
+            "axes.categoryAxis.title.text" => chart.category_title = Some(text),
+            "axes.valueAxis.title.text" => chart.value_title = Some(text),
+            other => {
+                return Err(BatchError {
+                    code: "InvalidArgument",
+                    message: format!("Unsupported Chart property '{other}'"),
+                });
+            }
+        }
+        let mut config = json!({});
+        if let Some(title) = &chart.title {
+            config["title"] = json!(title);
+        }
+        let mut axes = json!({});
+        if let Some(title) = &chart.category_title {
+            axes["categoryAxis"] = json!({ "title": title, "visible": true });
+        }
+        if let Some(title) = &chart.value_title {
+            axes["valueAxis"] = json!({ "title": title, "visible": true });
+        }
+        if axes.as_object().is_some_and(|obj| !obj.is_empty()) {
+            // ChartData JSON uses `axis` (singular); ChartSpec uses `axes`.
+            config["axis"] = axes;
+        }
+        chart
+            .sheet
+            .charts()
+            .update(&chart.chart_id, &config)
+            .map_err(engine_error)?;
+        Ok(())
+    }
+}
+
+fn map_chart_type(chart_type: &str) -> &'static str {
+    match chart_type.to_ascii_lowercase().as_str() {
+        "columnclustered" | "column" | "columnclusteredchart" => "column",
+        "barclustered" | "bar" => "bar",
+        "line" => "line",
+        "pie" => "pie",
+        "area" => "area",
+        "scatter" | "xyscatter" => "scatter",
+        other if other.contains("column") => "column",
+        _ => "column",
+    }
+}
+
+fn col_letter(mut col: u32) -> String {
+    let mut out = String::new();
+    col += 1;
+    while col > 0 {
+        col -= 1;
+        out.insert(0, (b'A' + (col % 26) as u8) as char);
+        col /= 26;
+    }
+    out
+}
+
+fn range_formula(sheet_name: &str, bounds: (u32, u32, u32, u32)) -> String {
+    let (sr, sc, er, ec) = bounds;
+    format!(
+        "='{sheet_name}'!${}${}:${}${}",
+        col_letter(sc),
+        sr + 1,
+        col_letter(ec),
+        er + 1
+    )
+}
+
+fn unqualified_range_formula(sheet_name: &str, bounds: (u32, u32, u32, u32)) -> String {
+    let (sr, sc, er, ec) = bounds;
+    format!(
+        "{sheet_name}!{}{}:{}{}",
+        col_letter(sc),
+        sr + 1,
+        col_letter(ec),
+        er + 1
+    )
 }
 
 fn unique_sheet_name(workbook: &Workbook) -> Result<String, BatchError> {

--- a/compute/officejs/src/main.rs
+++ b/compute/officejs/src/main.rs
@@ -1,11 +1,13 @@
 use std::env;
 use std::fs;
+use std::path::Path;
 use std::process::ExitCode;
 
-use mog::{OfficeJsError, run_office_js};
+use compute_api::Workbook;
+use mog::{OfficeJsError, run_office_js, run_office_js_with_workbook};
 
 fn usage() -> String {
-    "Usage: mog <script.js>\n       mog --eval <source>\n".to_string()
+    "Usage: mog <script.js>\n       mog --eval <source>\n       mog save [--recalculate] <in.xlsx> <out.xlsx>\n       mog run [--recalculate] <in.xlsx> <script.js> <out.xlsx>\n".to_string()
 }
 
 fn main() -> ExitCode {
@@ -20,19 +22,126 @@ fn main() -> ExitCode {
 
 fn run() -> Result<(), OfficeJsError> {
     let mut args = env::args().skip(1);
-    let source = match args.next().as_deref() {
+    match args.next().as_deref() {
         None | Some("-h") | Some("--help") => {
             print!("{}", usage());
-            return Ok(());
+            Ok(())
         }
-        Some("--eval") => args
-            .next()
-            .ok_or_else(|| OfficeJsError::Script("mog --eval requires a script string".into()))?,
-        Some(path) => fs::read_to_string(path)
-            .map_err(|e| OfficeJsError::Script(format!("failed to read {path}: {e}")))?,
-    };
+        Some("--eval") => {
+            let source = args.next().ok_or_else(|| {
+                OfficeJsError::Script("mog --eval requires a script string".into())
+            })?;
+            print_script_output(run_office_js(&source)?)
+        }
+        Some("save") => {
+            let (recalculate, rest) = take_recalculate(args.collect())?;
+            let in_path = rest.first().map(String::as_str).ok_or_else(|| {
+                OfficeJsError::Script("mog save requires <in.xlsx> <out.xlsx>".into())
+            })?;
+            let out_path = rest.get(1).map(String::as_str).ok_or_else(|| {
+                OfficeJsError::Script("mog save requires <in.xlsx> <out.xlsx>".into())
+            })?;
+            if rest.len() != 2 {
+                return Err(OfficeJsError::Script(
+                    "mog save [--recalculate] <in.xlsx> <out.xlsx>".into(),
+                ));
+            }
+            save_xlsx(in_path, out_path, recalculate)
+        }
+        Some("run") => {
+            let (recalculate, rest) = take_recalculate(args.collect())?;
+            let in_path = rest.first().map(String::as_str).ok_or_else(|| {
+                OfficeJsError::Script("mog run requires <in.xlsx> <script.js> <out.xlsx>".into())
+            })?;
+            let script_path = rest.get(1).map(String::as_str).ok_or_else(|| {
+                OfficeJsError::Script("mog run requires <in.xlsx> <script.js> <out.xlsx>".into())
+            })?;
+            let out_path = rest.get(2).map(String::as_str).ok_or_else(|| {
+                OfficeJsError::Script("mog run requires <in.xlsx> <script.js> <out.xlsx>".into())
+            })?;
+            if rest.len() != 3 {
+                return Err(OfficeJsError::Script(
+                    "mog run [--recalculate] <in.xlsx> <script.js> <out.xlsx>".into(),
+                ));
+            }
+            run_xlsx(in_path, script_path, out_path, recalculate)
+        }
+        Some(path) => {
+            let source = fs::read_to_string(path)
+                .map_err(|e| OfficeJsError::Script(format!("failed to read {path}: {e}")))?;
+            print_script_output(run_office_js(&source)?)
+        }
+    }
+}
 
-    let output = run_office_js(&source)?;
+fn take_recalculate(args: Vec<String>) -> Result<(bool, Vec<String>), OfficeJsError> {
+    let mut recalculate = false;
+    let mut rest = Vec::new();
+    for arg in args {
+        if arg == "--recalculate" && !recalculate && rest.is_empty() {
+            recalculate = true;
+        } else {
+            rest.push(arg);
+        }
+    }
+    Ok((recalculate, rest))
+}
+
+fn load_workbook(path: &str) -> Result<Workbook, OfficeJsError> {
+    let bytes =
+        fs::read(path).map_err(|e| OfficeJsError::Script(format!("failed to read {path}: {e}")))?;
+    let (workbook, _) = Workbook::from_xlsx_bytes(&bytes)?;
+    Ok(workbook)
+}
+
+fn write_xlsx(workbook: &Workbook, out_path: &str) -> Result<(), OfficeJsError> {
+    if Path::new(out_path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_none_or(|ext| !ext.eq_ignore_ascii_case("xlsx"))
+    {
+        return Err(OfficeJsError::Script(format!(
+            "output must be .xlsx, got {out_path}"
+        )));
+    }
+    let bytes = workbook.to_xlsx_bytes()?;
+    if let Some(parent) = Path::new(out_path).parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).map_err(|e| {
+            OfficeJsError::Script(format!("failed to create {}: {e}", parent.display()))
+        })?;
+    }
+    fs::write(out_path, bytes)
+        .map_err(|e| OfficeJsError::Script(format!("failed to write {out_path}: {e}")))
+}
+
+fn save_xlsx(in_path: &str, out_path: &str, recalculate: bool) -> Result<(), OfficeJsError> {
+    let workbook = load_workbook(in_path)?;
+    if recalculate {
+        workbook.recalculate()?;
+    }
+    write_xlsx(&workbook, out_path)
+}
+
+fn run_xlsx(
+    in_path: &str,
+    script_path: &str,
+    out_path: &str,
+    recalculate: bool,
+) -> Result<(), OfficeJsError> {
+    let workbook = load_workbook(in_path)?;
+    let source = fs::read_to_string(script_path)
+        .map_err(|e| OfficeJsError::Script(format!("failed to read {script_path}: {e}")))?;
+    let output = run_office_js_with_workbook(&workbook, &source)?;
+    if recalculate {
+        workbook.recalculate()?;
+    }
+    write_xlsx(&workbook, out_path)?;
+    print_script_output(output)
+}
+
+fn print_script_output(output: mog::ScriptOutput) -> Result<(), OfficeJsError> {
     if output.stdout.is_empty()
         && !output.value.is_null()
         && let Ok(text) = serde_json::to_string(&output.value)

--- a/compute/officejs/tests/officejs.rs
+++ b/compute/officejs/tests/officejs.rs
@@ -192,3 +192,170 @@ fn unloaded_property_is_not_readable() {
         other => panic!("expected script error, got {other}"),
     }
 }
+
+fn archive_text(bytes: &[u8], path: &str) -> String {
+    String::from_utf8(
+        xlsx_parser::zip::XlsxArchive::new(bytes)
+            .unwrap()
+            .read_file(path)
+            .unwrap(),
+    )
+    .unwrap()
+}
+
+fn excel_shaped_xlsx(sheet_name: &str, sheet_id: &str) -> Vec<u8> {
+    let mut zip = xlsx_parser::write::ZipWriter::new();
+    zip.add_file(
+        "[Content_Types].xml",
+        br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+      <Default Extension="xml" ContentType="application/xml"/>
+      <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+      <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+    </Types>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "_rels/.rels",
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+    </Relationships>"#
+            .to_vec(),
+    );
+    let workbook = format!(
+        r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <sheets><sheet name="{sheet_name}" sheetId="{sheet_id}" r:id="rId1"/></sheets>
+      <calcPr calcId="191029"/>
+      <extLst><ext uri="{{140A7094-0E35-4892-8432-C4D2E57EDEB7}}"><x15:workbookPr xmlns:x15="http://schemas.microsoft.com/office/spreadsheetml/2010/11/main" chartTrackingRefBase="1"/></ext></extLst>
+    </workbook>"#
+    );
+    zip.add_file("xl/workbook.xml", workbook.into_bytes());
+    zip.add_file(
+        "xl/_rels/workbook.xml.rels",
+        br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+    </Relationships>"#
+            .to_vec(),
+    );
+    zip.add_file(
+        "xl/worksheets/sheet1.xml",
+        br#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+      <sheetData><row r="1"><c r="A1"><v>1</v></c></row></sheetData>
+    </worksheet>"#
+            .to_vec(),
+    );
+    zip.finish().unwrap()
+}
+
+#[test]
+fn names_add_on_loaded_workbook_keeps_defined_names_in_schema_order() {
+    let bytes = excel_shaped_xlsx("Sheet1", "1");
+    let (workbook, _) = Workbook::from_xlsx_bytes(&bytes).unwrap();
+    run_office_js_with_workbook(
+        &workbook,
+        r#"
+        await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getActiveWorksheet();
+          context.workbook.names.add("Repro_Name", sheet.getRange("A1:A10"));
+          await context.sync();
+        });
+        "#,
+    )
+    .unwrap();
+    let exported = workbook.to_xlsx_bytes().unwrap();
+    let xml = archive_text(&exported, "xl/workbook.xml");
+    let names = xml.find("<definedNames>").expect(&xml);
+    let calc = xml.find("<calcPr").expect(&xml);
+    assert!(names < calc, "{xml}");
+    assert!(xml.contains("Repro_Name"), "{xml}");
+}
+
+#[test]
+fn worksheets_add_after_sparse_import_emits_unique_sheet_ids() {
+    let bytes = excel_shaped_xlsx("Imported", "2");
+    let (workbook, _) = Workbook::from_xlsx_bytes(&bytes).unwrap();
+    run_office_js_with_workbook(
+        &workbook,
+        r#"
+        await Excel.run(async (context) => {
+          context.workbook.worksheets.add("Added");
+          await context.sync();
+        });
+        "#,
+    )
+    .unwrap();
+    let exported = workbook.to_xlsx_bytes().unwrap();
+    let xml = archive_text(&exported, "xl/workbook.xml");
+    let mut ids = Vec::new();
+    for part in xml.split("sheetId=\"").skip(1) {
+        ids.push(part.split('"').next().unwrap().parse::<u32>().unwrap());
+    }
+    assert_eq!(ids.len(), 2, "{xml}");
+    assert!(ids.iter().all(|id| *id > 0), "{xml}");
+    assert_eq!(
+        ids.iter()
+            .copied()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        2,
+        "{xml}"
+    );
+}
+
+#[test]
+fn multi_row_formulas_survive_officejs_export() {
+    let (workbook, _) = Workbook::blank().unwrap();
+    run_office_js_with_workbook(
+        &workbook,
+        r#"
+        await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:C2").formulas = [
+            [100, "=A1", "=B1+B2"],
+            [200, "=A2", null],
+          ];
+          await context.sync();
+        });
+        "#,
+    )
+    .unwrap();
+    let exported = workbook.to_xlsx_bytes().unwrap();
+    let xml = archive_text(&exported, "xl/worksheets/sheet1.xml");
+    assert!(
+        xml.contains("<f>A2</f>") || xml.contains("<f>=A2</f>"),
+        "{xml}"
+    );
+}
+
+#[test]
+fn authored_chart_titles_emit_overlay_through_officejs() {
+    let (workbook, _) = Workbook::blank().unwrap();
+    run_office_js_with_workbook(
+        &workbook,
+        r#"
+        await Excel.run(async (context) => {
+          const sheet = context.workbook.worksheets.getItem("Sheet1");
+          sheet.getRange("A1:B5").values = [
+            ["Month", "Units"],
+            ["M0", 10],
+            ["M1", 13],
+            ["M2", 16],
+            ["M3", 19],
+          ];
+          const chart = sheet.charts.add(Excel.ChartType.columnClustered, sheet.getRange("A1:B5"));
+          chart.title.text = "Monthly Units";
+          chart.axes.categoryAxis.title.text = "Month";
+          chart.axes.valueAxis.title.text = "Units Sold";
+          await context.sync();
+        });
+        "#,
+    )
+    .unwrap();
+    let exported = workbook.to_xlsx_bytes().unwrap();
+    let chart = archive_text(&exported, "xl/charts/chart1.xml");
+    assert!(chart.contains(">Monthly Units<"), "{chart}");
+    assert!(
+        chart.matches(r#"<c:overlay val="0"/>"#).count() >= 3,
+        "{chart}"
+    );
+}

--- a/file-io/xlsx/parser/src/domain/charts/reconstruct/elements.rs
+++ b/file-io/xlsx/parser/src/domain/charts/reconstruct/elements.rs
@@ -132,6 +132,7 @@ fn build_title_with_text(
     charts::Title {
         tx: Some(tx),
         layout: layout.cloned().map(Into::into),
+        overlay: Some(false),
         sp_pr,
         tx_pr: format.and_then(build_text_body),
         ..Default::default()

--- a/file-io/xlsx/parser/src/domain/charts/reconstruct/tests.rs
+++ b/file-io/xlsx/parser/src/domain/charts/reconstruct/tests.rs
@@ -22,6 +22,7 @@ mod point_format_fidelity;
 mod scatter;
 mod series_shadow_fidelity;
 mod surface;
+mod title_overlay_fidelity;
 mod title_rich_text_fidelity;
 mod trendline_fidelity;
 mod vary_by_categories;

--- a/file-io/xlsx/parser/src/domain/charts/reconstruct/tests/title_overlay_fidelity.rs
+++ b/file-io/xlsx/parser/src/domain/charts/reconstruct/tests/title_overlay_fidelity.rs
@@ -1,0 +1,35 @@
+use super::*;
+use domain_types::chart::{AxisData, SingleAxisData};
+
+#[test]
+fn authored_chart_and_axis_titles_emit_overlay() {
+    let mut spec = minimal_chart_spec(DomainChartType::Column, Some("Sheet1!A1:B5"));
+    spec.title = Some("Monthly Units".to_string());
+    spec.axes = Some(AxisData {
+        category_axis: Some(SingleAxisData {
+            title: Some("Month".to_string()),
+            visible: true,
+            ..Default::default()
+        }),
+        value_axis: Some(SingleAxisData {
+            title: Some("Units Sold".to_string()),
+            visible: true,
+            ..Default::default()
+        }),
+        secondary_category_axis: None,
+        secondary_value_axis: None,
+        series_axis: None,
+    });
+
+    let xml = chart_xml(&spec);
+    let title_count = xml.matches("<c:title>").count();
+    assert_eq!(title_count, 3, "chart + both axes: {xml}");
+    assert_eq!(
+        xml.matches(r#"<c:overlay val="0"/>"#).count(),
+        title_count,
+        "each authored title must reserve space: {xml}"
+    );
+    assert!(xml.contains(">Monthly Units<"), "{xml}");
+    assert!(xml.contains(">Month<"), "{xml}");
+    assert!(xml.contains(">Units Sold<"), "{xml}");
+}

--- a/file-io/xlsx/parser/src/domain/charts/write_canonical/structure.rs
+++ b/file-io/xlsx/parser/src/domain/charts/write_canonical/structure.rs
@@ -23,12 +23,12 @@ pub(super) fn emit_title(w: &mut XmlWriter, title: &Title) {
         emit_layout(w, lay);
     }
 
-    // overlay
-    if let Some(v) = title.overlay {
-        w.start_element("c:overlay")
-            .attr("val", if v { "1" } else { "0" })
-            .self_close();
-    }
+    // overlay — default to 0 (do not overlay) when unset so Excel reserves
+    // space for authored titles instead of auto-placing them on the plot.
+    let overlay_val = title.overlay.unwrap_or(false);
+    w.start_element("c:overlay")
+        .attr("val", if overlay_val { "1" } else { "0" })
+        .self_close();
 
     // spPr
     if let Some(ref sp) = title.sp_pr {

--- a/file-io/xlsx/parser/src/write/from_parse_output/style_remap.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/style_remap.rs
@@ -34,7 +34,10 @@ pub(super) struct StyleExportPlan {
 
 #[must_use]
 pub(super) fn build_style_export_plan(output: &ParseOutput) -> StyleExportPlan {
-    let palette = if output_references_style_ids(output) {
+    // Cells without `s` still inherit Normal (xf 0). Dropping the palette
+    // whenever no cell has an explicit style_id rewrites the workbook font
+    // to Calibri 11. Keep imported styles whenever a stylesheet is present.
+    let palette = if output.workbook_stylesheet.is_some() || output_references_style_ids(output) {
         output.style_palette.as_slice()
     } else {
         &[]
@@ -45,6 +48,14 @@ pub(super) fn build_style_export_plan(output: &ParseOutput) -> StyleExportPlan {
     };
     let stylesheet = stylesheet.normalized();
     if !can_replay_imported_styles(&stylesheet, palette) {
+        if palette.is_empty() && !stylesheet.cell_xfs.is_empty() {
+            return StyleExportPlan {
+                writer: StylesWriter::from_workbook_stylesheet(&stylesheet),
+                remapper: StyleExportRemapper {
+                    emitted_cell_xf_ids: Vec::new(),
+                },
+            };
+        }
         return generated_style_export_plan(palette);
     }
 

--- a/file-io/xlsx/parser/src/write/from_parse_output/style_remap.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/style_remap.rs
@@ -34,10 +34,10 @@ pub(super) struct StyleExportPlan {
 
 #[must_use]
 pub(super) fn build_style_export_plan(output: &ParseOutput) -> StyleExportPlan {
-    // Cells without `s` still inherit Normal (xf 0). Dropping the palette
-    // whenever no cell has an explicit style_id rewrites the workbook font
-    // to Calibri 11. Keep imported styles whenever a stylesheet is present.
-    let palette = if output.workbook_stylesheet.is_some() || output_references_style_ids(output) {
+    // Cells without `s` still inherit Normal (xf 0). Treat any cell as a live
+    // style use so we do not rewrite the workbook font to Calibri 11. Empty
+    // sheets with no style ids still regenerate defaults (unused xf drop).
+    let palette = if output_references_style_ids(output) || sheets_have_cells(output) {
         output.style_palette.as_slice()
     } else {
         &[]
@@ -48,7 +48,7 @@ pub(super) fn build_style_export_plan(output: &ParseOutput) -> StyleExportPlan {
     };
     let stylesheet = stylesheet.normalized();
     if !can_replay_imported_styles(&stylesheet, palette) {
-        if palette.is_empty() && !stylesheet.cell_xfs.is_empty() {
+        if palette.is_empty() && sheets_have_cells(output) && !stylesheet.cell_xfs.is_empty() {
             return StyleExportPlan {
                 writer: StylesWriter::from_workbook_stylesheet(&stylesheet),
                 remapper: StyleExportRemapper {
@@ -82,6 +82,10 @@ pub(super) fn build_style_export_plan(output: &ParseOutput) -> StyleExportPlan {
             emitted_cell_xf_ids,
         },
     }
+}
+
+fn sheets_have_cells(output: &ParseOutput) -> bool {
+    output.sheets.iter().any(|sheet| !sheet.cells.is_empty())
 }
 
 fn generated_style_export_plan(palette: &[domain_types::DocumentFormat]) -> StyleExportPlan {

--- a/file-io/xlsx/parser/src/write/from_parse_output/tests/style_lineage.rs
+++ b/file-io/xlsx/parser/src/write/from_parse_output/tests/style_lineage.rs
@@ -146,3 +146,39 @@ fn invalid_imported_custom_number_format_reference_is_not_replayed() {
     assert_eq!(emitted, 2);
     assert_ne!(plan.writer.cell_xfs[emitted as usize].num_fmt_id, Some(999));
 }
+
+#[test]
+fn imported_normal_font_survives_cells_without_style_ids() {
+    let mut defaults = StylesWriter::with_defaults();
+    defaults.fonts[0].name = Some("Aptos Narrow".to_string());
+    defaults.fonts[0].size = Some(12.0);
+    let xf = defaults.cell_xfs[0].clone();
+    let output = ParseOutput {
+        sheets: vec![SheetData {
+            name: "Sheet1".to_string(),
+            cells: vec![DomainCellData {
+                row: 0,
+                col: 0,
+                value: DomainValue::Number(FiniteF64::new(1.0).unwrap()),
+                style_id: None,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+        style_palette: vec![],
+        workbook_stylesheet: Some(WorkbookStylesheet {
+            fonts: defaults.fonts,
+            fills: defaults.fills,
+            borders: defaults.borders,
+            cell_style_xfs: defaults.cell_style_xfs,
+            cell_xfs: vec![xf],
+            cell_xf_lineage: vec![DocumentFormat::default()],
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let plan = build_style_export_plan(&output);
+    assert_eq!(plan.writer.fonts[0].name.as_deref(), Some("Aptos Narrow"));
+    assert_eq!(plan.writer.fonts[0].size, Some(12.0));
+}

--- a/run-calipers-verify.sh
+++ b/run-calipers-verify.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Build Mog and the calipers submodule, then semantically verify the
+# mog-owned XLSX roundtrip cases against committed Excel goldens.
+#
+# Extra arguments are forwarded to `calipers verify`.
+#
+# Env:
+#   MOG_BIN       built mog binary (default: <repo>/target-native/debug/mog)
+#   CALIPERS_BIN  calipers binary (default: build vendor/calipers/cmd/calipers)
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+git -C "${root}" submodule update --init -- vendor/calipers
+
+mog_bin="${MOG_BIN:-${root}/target-native/debug/mog}"
+if [[ ! -x "${mog_bin}" ]]; then
+  (cd "${root}" && cargo build -p mog --locked)
+fi
+if [[ ! -x "${mog_bin}" ]]; then
+  echo "mog: built binary not found at ${mog_bin}" >&2
+  exit 1
+fi
+
+if [[ -n "${CALIPERS_BIN:-}" ]]; then
+  calipers_bin="${CALIPERS_BIN}"
+else
+  mkdir -p "${root}/target-native"
+  (cd "${root}/vendor/calipers" && go build -o "${root}/target-native/calipers" ./cmd/calipers)
+  calipers_bin="${root}/target-native/calipers"
+fi
+
+exec "${calipers_bin}" verify --engine "${mog_bin}" \
+  --cases-dir "${root}/vendor/calipers/verification/cases" \
+  --case roundtrip/custom_view_printer_settings \
+  --case roundtrip/theme_linked_colors \
+  --case default/names_add_defined_names_order \
+  --case default/add_sheet_sparse_ids \
+  --case default/chart_titles \
+  --case default/multi_row_formulas \
+  "$@"

--- a/run-calipers-verify.sh
+++ b/run-calipers-verify.sh
@@ -31,6 +31,7 @@ fi
 
 exec "${calipers_bin}" verify --engine "${mog_bin}" \
   --cases-dir "${root}/vendor/calipers/verification/cases" \
+  --case roundtrip/simple \
   --case roundtrip/custom_view_printer_settings \
   --case roundtrip/theme_linked_colors \
   --case default/names_add_defined_names_order \


### PR DESCRIPTION
Fixes #329, #332, #334, #328, and #338.

#360 is already on main via #362 and is covered by the verifier job.

Companion calipers PR (merged): https://github.com/fundamental-research-labs/calipers/pull/31
Submodule pin: `vendor/calipers` @ `99150bc` (calipers `main`).

Rebased onto `origin/main` after #362 (custom-view printer rels) and #371 (`vendor/calipers` submodule).

## What

- Authored chart/axis titles emit `<c:overlay val="0"/>` so Excel reserves space instead of overlaying titles on the plot (#338).
- `mog` implements the calipers engine argv:
  - `mog save [--recalculate] <in.xlsx> <out.xlsx>`
  - `mog run [--recalculate] <in.xlsx> <script.js> <out.xlsx>`
  - existing `mog <script.js>` / `mog --eval` still work
- Office.js host enough to run the new calipers scripts: `names.add`, `charts.add` + title setters, `worksheets.getActiveWorksheet`, plus existing range/sheet ops.
- `Workbook::from_xlsx_bytes` / `to_xlsx_bytes` / `recalculate` on the public compute-api surface.
- Imported workbook fonts (name and size, including Normal when cells have no `s`) survive export. Rendering can use a fallback typeface without rewriting the file.
- CI `Calipers verify` job inits `vendor/calipers` over HTTPS, builds mog + calipers, and semantically verifies the issue cases against committed Excel goldens (`./run-calipers-verify.sh`).

## Tests (shipped import / Office.js / export)

- Theme-linked font color roundtrips as `theme="4" tint="0.2"`, not resolved RGB or `rgb="THEME:…"` (#329).
- `names.add` on a loaded Excel-shaped workbook writes `<definedNames>` before `<calcPr>`/`<extLst>` (#332).
- Import `sheetId="2"` then add a sheet → unique positive `sheetId`s (#334).
- Multi-row bulk formula writes keep `<f>` on later rows after export (#328).
- Chart title overlay via reconstruct + `create_chart` + Office.js `mog run`.
- Calibri 12 and Aptos Narrow Normal fonts survive export when cells have no style index.

`calipers verify --engine mog` **PASS**es:

- `roundtrip/simple`
- `roundtrip/custom_view_printer_settings` (#360)
- `roundtrip/theme_linked_colors`
- `default/names_add_defined_names_order`
- `default/add_sheet_sparse_ids`
- `default/chart_titles`
- `default/multi_row_formulas`

## Verify

```
cargo test -p xlsx-parser --locked --lib imported_normal_font_survives
cargo test -p compute-core --locked --test xlsx_workbook_font_roundtrip --test xlsx_theme_linked_color_roundtrip --test xlsx_defined_names_order --test xlsx_sheet_id_unique --test xlsx_multi_row_formulas --test xlsx_chart_title_overlay
cargo test -p mog --locked
./run-calipers-verify.sh
```